### PR TITLE
[WFLY-14018] Allow injection for Validator/Converter/Behavior if managed=true

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/FacesConverterInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/FacesConverterInjectionTestCase.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.injection;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.beans11.BeansDescriptor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case for a FacesConverter injected using annotation=true.
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class FacesConverterInjectionTestCase {
+
+    private static final String TEST_NAME = "FacesConverterInjectionTestCase";
+
+    @ArquillianResource
+    @OperateOnDeployment(TEST_NAME)
+    private URL url;
+
+    private static Asset createBeansXml(String beanDiscoveryMode) {
+        return new StringAsset(Descriptors.create(BeansDescriptor.class)
+                .version("1.1")
+                .beanDiscoveryMode(beanDiscoveryMode)
+                .exportAsString());
+    }
+
+    @Deployment(name = TEST_NAME)
+    public static Archive<?> deploy() {
+        final Package resourcePackage = FacesConverterInjectionTestCase.class.getPackage();
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, TEST_NAME + ".war")
+                .addClasses(JSF23ConfigurationBean.class, URLConverter.class, URLConverter.class, UrlConverterBean.class)
+                .addAsWebResource(resourcePackage, "url.xhtml", "url.xhtml")
+                .addAsWebInfResource(resourcePackage, "web.xml", "web.xml")
+                .addAsWebInfResource(createBeansXml("all"), "beans.xml");
+        return archive;
+    }
+
+    private void test(String urlToCheck, String containsText) throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpUriRequest getRequest = new HttpGet(url.toExternalForm() + "faces/url.xhtml");
+            try (CloseableHttpResponse getResponse = client.execute(getRequest)) {
+                MatcherAssert.assertThat("GET success", getResponse.getStatusLine().getStatusCode(), CoreMatchers.equalTo(HttpURLConnection.HTTP_OK));
+                String text = EntityUtils.toString(getResponse.getEntity());
+                Document doc = Jsoup.parse(text);
+                Element form = doc.select("form").first();
+                MatcherAssert.assertThat("form is included in the response", form, CoreMatchers.notNullValue());
+                List<NameValuePair> params = new ArrayList<>();
+                for (Element input : form.select("input")) {
+                    String value = input.attr("value");
+                    if (value != null && !value.isEmpty()) {
+                        params.add(new BasicNameValuePair(input.attr("name"), value));
+                    } else {
+                        params.add(new BasicNameValuePair(input.attr("name"), urlToCheck));
+                    }
+                }
+                Assert.assertFalse("Form paramaters are filled", params.isEmpty());
+                URI uri = new URIBuilder().setScheme(url.getProtocol())
+                        .setHost(url.getHost()).setPort(url.getPort())
+                        .setPath(form.attr("action")).build();
+                HttpPost postRequest = new HttpPost(uri);
+                postRequest.setEntity(new UrlEncodedFormEntity(params));
+                try (CloseableHttpResponse postResponse = client.execute(postRequest)) {
+                    MatcherAssert.assertThat("POST success", postResponse.getStatusLine().getStatusCode(), CoreMatchers.equalTo(HttpURLConnection.HTTP_OK));
+                    text = EntityUtils.toString(postResponse.getEntity());
+                    MatcherAssert.assertThat("Expected text is in POST response", text, CoreMatchers.containsString(containsText));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testConverterSuccess() throws Exception {
+        test("http://wildfly.org/index.html", "Valid URL.");
+    }
+
+    @Test
+    public void testConverterError() throws Exception {
+        test("http://wildfly.org:wrong/index.html", "Invalid URL:");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/JSF23ConfigurationBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/JSF23ConfigurationBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.injection;
+
+import static javax.faces.annotation.FacesConfig.Version;
+
+import javax.faces.annotation.FacesConfig;
+
+/**
+ * Configuration bean to specify JSF 2.3 version.
+ *
+ * @author rmartinc
+ */
+@FacesConfig(
+        // Activates CDI build-in beans that provide the injection this project
+        version = Version.JSF_2_3
+)
+public class JSF23ConfigurationBean {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/URLConverter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/URLConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.injection;
+
+import java.net.URI;
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+/**
+ * Converter that converts an object into an URL.
+ *
+ * @author rmartinc
+ */
+@FacesConverter(value = "urlConverter", managed = true)
+public class URLConverter implements Converter {
+
+    public URLConverter() {
+    }
+
+    @Override
+    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+        try {
+            URI uri = new URI(value).parseServerAuthority();
+            return uri.toURL();
+        } catch (Exception e) {
+            context.addMessage(component.getClientId(context), new FacesMessage("Invalid URL:", e.getMessage()));
+            return null;
+        }
+    }
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, Object value) {
+        return value.toString();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/UrlConverterBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/UrlConverterBean.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020. Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.injection;
+
+import java.net.URL;
+import javax.enterprise.context.RequestScoped;
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.FacesConverter;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Converter bean used in the url.xhtml.
+ *
+ * @author rmartinc
+ */
+@Named(value="urlConverterBean")
+@RequestScoped
+public class UrlConverterBean {
+
+    @Inject
+    @FacesConverter(value = "urlConverter", managed = true)
+    private URLConverter urlConverter;
+
+    @Inject
+    private FacesContext context;
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String submit(UIComponent component) {
+        URL url = (URL) urlConverter.getAsObject(context, component, value);
+        if (url != null) {
+            // do whatever with the URL
+            context.addMessage(component.getClientId(context), new FacesMessage("Valid URL.", ""));
+        }
+        return "";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/url.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/url.xhtml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!--
+    Copyright (c) 2020. Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+    <h:head>
+        <title>CDI URL Validator</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <h:outputLabel for="url">Type URL </h:outputLabel>
+            <h:inputText id="url" value="#{urlConverterBean.value}"/>
+            <h:commandButton id="submit" action="#{urlConverterBean.submit(component)}" value="Submit"/>
+            <h:messages layout="table" globalOnly="false" showDetail="true" showSummary="true" />
+        </h:form>
+    </h:body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/web.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="4.0" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+
+  <welcome-file-list>
+    <welcome-file>/faces/url.xhtml</welcome-file>
+  </welcome-file-list>
+
+  <servlet>
+    <servlet-name>Faces Servlet</servlet-name>
+    <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>/faces/*</url-pattern>
+  </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14018

Minor change to allow injection of Validator/Converter/Behavior if the `managed` property is `true`. If it's one of those components and the property is true the exception is not thrown (continue) and weld tries to inject that object as usual.

@fjuma check this when you have time. As in the previous JSF issue no hurries at all. With this fix included I can run all the mojarra TS that is executed when a PR is sent in upstream (eclipse).