### PR TITLE
[WFLY-14022] Enable a way to ignore the MixedDomainDeployment700TestCase due to ARTEMIS-2800.

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
@@ -110,7 +110,9 @@ class OldVersionCopier {
     private Path expandAsInstance(Version.AsVersion version) {
         createIfNotExists(targetOldVersions);
 
-        Path file = oldVersionsBaseDir.resolve(version.getZipFileName());
+
+        final String path = resolveZipFileName(version);
+        Path file = oldVersionsBaseDir.resolve(path);
         if (Files.notExists(file)) {
             throw new RuntimeException("Old version not found in " + file.toAbsolutePath().toString());
         }
@@ -216,6 +218,14 @@ class OldVersionCopier {
 
         }
         return result;
+    }
+
+    private static String resolveZipFileName(final Version.AsVersion requested) {
+        final String value = System.getProperty("override.mixed.domain." + requested.getVersion());
+        if (value != null) {
+            return value;
+        }
+        return requested.getZipFileName();
     }
 
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
@@ -39,6 +39,9 @@ public class MixedDomainDeployment700TestCase extends MixedDomainDeploymentTest 
     public static void beforeClass() {
         // WFLY-12649 -- embedded broker doesn't start correctly on an EAP 7.0.0 server running on OpenJ9
         Assume.assumeFalse(TestSuiteEnvironment.isJ9Jvm());
+        // WFLY-14022 -- 7.0.0.GA under certain JDK and Linux kernel versions expose ARTEMIS-2800
+        final String value = System.getProperty("ignore.ARTEMIS-2800");
+        Assume.assumeFalse(value != null && (value.isEmpty() || Boolean.parseBoolean(value)));
 
         MixedDomain700TestSuite.initializeDomain();
     }


### PR DESCRIPTION
The first commit just allows the mixed-domain server to be overridden.
https://issues.redhat.com/browse/WFLY-14021
https://issues.redhat.com/browse/WFLY-14022