### PR TITLE
[21.x] [WFLY-14022] Enable a way to ignore the MixedDomainDeployment700TestC…

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
@@ -39,6 +39,9 @@ public class MixedDomainDeployment700TestCase extends MixedDomainDeploymentTest 
     public static void beforeClass() {
         // WFLY-12649 -- embedded broker doesn't start correctly on an EAP 7.0.0 server running on OpenJ9
         Assume.assumeFalse(TestSuiteEnvironment.isJ9Jvm());
+        // WFLY-14022 -- 7.0.0.GA under certain JDK and Linux kernel versions expose ARTEMIS-2800
+        final String value = System.getProperty("ignore.ARTEMIS-2800");
+        Assume.assumeFalse(value != null && (value.isEmpty() || Boolean.parseBoolean(value)));
 
         MixedDomain700TestSuite.initializeDomain();
     }


### PR DESCRIPTION
…ase due to ARTEMIS-2800.

https://issues.redhat.com/browse/WFLY-14022

Upstream PR: https://github.com/wildfly/wildfly/pull/13681