### PR TITLE
WFLY-13056 Add missing permission to access internal jaxp packages fo…

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import javax.xml.namespace.QName;
 import javax.xml.ws.Service;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -51,8 +52,12 @@ public class EJBEndpointTestCase extends BasicTests {
     public static Archive<?> deployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jaxws-basic-ejb.jar")
                 .addClasses(EndpointIface.class, EJBEndpoint.class, HelloObject.class);
-        // EJBEndpoint#helloError needs getClassLoader permission for SOAPFactory.newInstance() invocation which is not supposed(??? at least it seems so) to be called from deployments
-        jar.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
+        if (SystemUtils.JAVA_VENDOR.startsWith("IBM")) {
+            jar.addAsManifestResource(createPermissionsXmlAsset(
+                    // With IBM JDK + SecurityManager, EJBEndpoint#helloError needs accessClassInPackage permission for
+                    // SOAPFactory.newInstance() invocation to access internal jaxp packages
+                    new RuntimePermission("accessClassInPackage.com.sun.org.apache.xerces.internal.jaxp")), "permissions.xml");
+        }
         return jar;
     }
 


### PR DESCRIPTION
…r IBM JDK

Issue: https://issues.redhat.com/browse/WFLY-13056
Add missing permission to access internal jaxp packages for IBM JDK
