### PR TITLE
[WFLY-14043] Use the globally registered security Providers instead of using ServiceLoader discovery for client side SSLContext in this test.

### DIFF
--- a/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/ssl/wildfly-config-correct-truststore-correct-host.xml
+++ b/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/ssl/wildfly-config-correct-truststore-correct-host.xml
@@ -17,11 +17,17 @@
                 <key-store-ssl-certificate key-store-name="keystore">
                     <key-store-clear-password password="123456" />
                 </key-store-ssl-certificate>
+                <providers>
+                    <global/>
+                </providers>
             </ssl-context>
             <ssl-context name="client-context-without-truststore">
                 <key-store-ssl-certificate key-store-name="keystore">
                     <key-store-clear-password password="123456" />
                 </key-store-ssl-certificate>
+                <providers>
+                    <global/>
+                </providers>
             </ssl-context>
         </ssl-contexts>
         <ssl-context-rules>

--- a/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/ssl/wildfly-config-correct-truststore.xml
+++ b/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/ssl/wildfly-config-correct-truststore.xml
@@ -17,6 +17,9 @@
                 <key-store-ssl-certificate key-store-name="keystore">
                     <key-store-clear-password password="123456" />
                 </key-store-ssl-certificate>
+                <providers>
+                    <global/>
+                </providers>
             </ssl-context>
         </ssl-contexts>
         <ssl-context-rules>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14043