### PR TITLE
[WFCORE-482] Add the not referenced log4j2 modules to the LayersTestC…

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -64,7 +64,11 @@ public class LayersTestCase {
         // injected by server in UndertowHttpManagementService
         "org.jboss.as.domain-http-error-context",
         // injected by logging
+        "org.apache.logging.log4j.api",
+        // injected by logging
         "org.jboss.logging.jul-to-slf4j-stub",
+        // injected by logging
+        "org.jboss.logmanager.log4j2",
         // injected by logging
         "org.slf4j.ext",
         // injected by logging


### PR DESCRIPTION
…ase.

This will be required for https://issues.redhat.com/browse/WFCORE-482 to get the `LayersTestCase` to pass. See https://github.com/wildfly/wildfly-core/pull/4384.
