### PR TITLE
Protect Managed*ExecutorServiceImpl life cycle methods

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedExecutorServiceImpl.java
@@ -24,8 +24,10 @@ package org.jboss.as.ee.concurrent;
 
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.jboss.as.ee.logging.EeLogger;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -111,5 +113,45 @@ public class ManagedExecutorServiceImpl extends org.glassfish.enterprise.concurr
      */
     public ManagedExecutorRuntimeStats getRuntimeStats() {
         return runtimeStats;
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final void shutdown() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final List<Runnable> shutdownNow() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean isShutdown() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean isTerminated() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -23,11 +23,13 @@ package org.jboss.as.ee.concurrent;
 
 import static org.jboss.as.ee.concurrent.SecurityIdentityUtils.doIdentityWrap;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.jboss.as.ee.logging.EeLogger;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 
 import javax.enterprise.concurrent.LastExecution;
 import javax.enterprise.concurrent.Trigger;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
@@ -118,6 +120,46 @@ public class ManagedScheduledExecutorServiceImpl extends org.glassfish.enterpris
      */
     public ManagedExecutorRuntimeStats getRuntimeStats() {
         return runtimeStats;
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final void shutdown() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final List<Runnable> shutdownNow() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean isShutdown() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean isTerminated() {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
+    }
+
+    /**
+     * Life cycle operations disabled for handing out to application components.
+     */
+    @Override
+    public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw EeLogger.ROOT_LOGGER.lifecycleOperationNotSupported();
     }
 
     /**

--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -1175,4 +1175,7 @@ public interface EeLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 127, value = "Invalid '%s' name segment for env, name can't start with '/' prefix, prefix has been removed")
     void invalidNamePrefix(String name);
+
+    @Message(id = 128, value = "Lifecycle operation not supported")
+    IllegalStateException lifecycleOperationNotSupported();
 }

--- a/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
+++ b/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
@@ -55,7 +55,6 @@ managed-executor-service.hung-thread-count=The number of executor threads that a
 managed-executor-service.max-thread-count=The largest number of executor threads.
 managed-executor-service.task-count=The approximate total number of tasks that have ever been submitted for execution.
 managed-executor-service.thread-count=The current number of executor threads.
-managed-executor-service.refuse-lifecycle-operation=Lifecycle operation not supported.
 
 managed-scheduled-executor-service=A managed scheduled executor service
 managed-scheduled-executor-service.add=Adds the scheduled executor

--- a/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
+++ b/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
@@ -55,6 +55,7 @@ managed-executor-service.hung-thread-count=The number of executor threads that a
 managed-executor-service.max-thread-count=The largest number of executor threads.
 managed-executor-service.task-count=The approximate total number of tasks that have ever been submitted for execution.
 managed-executor-service.thread-count=The current number of executor threads.
+managed-executor-service.refuse-lifecycle-operation=Lifecycle operation not supported.
 
 managed-scheduled-executor-service=A managed scheduled executor service
 managed-scheduled-executor-service.add=Adds the scheduled executor


### PR DESCRIPTION
Change WildFly implementation of ManagedExecutorServiceImpl and ManagedScheduledExecutorService according to org.glassfish.enterprise.concurrent.AbstractManagedExecutorServiceAdapter
Fixes [WFLY-14057](https://issues.redhat.com/browse/WFLY-14057)
