### PR TITLE
[WFLY-14060] Upgrade Hibernate ORM to 5.3.19.Final for Jakarta EE 9 schema parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.18.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.19.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.21.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14060
[HHH-14196 ](https://github.com/hibernate/hibernate-orm/commit/06fdd27b3d12d92d95e8184cf757f35556fe8f52)

This should help with EE-9 work as well as bring in the latest Hibernate ORM 5.3.x changes