### PR TITLE
WFLY-14063 Clustering metric AttributeDefinitions should be registered as metrics, not as read-only attributes.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/MetricHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/MetricHandler.java
@@ -63,7 +63,7 @@ public class MetricHandler<C> extends AbstractRuntimeOnlyHandler implements Regi
     @Override
     public void register(ManagementResourceRegistration registration) {
         for (Metric<C> metric : this.metrics) {
-            registration.registerReadOnlyAttribute(metric.getDefinition(), this);
+            registration.registerMetric(metric.getDefinition(), this);
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14063