### PR TITLE
[WFLY-14075] Remove TLS 1.1 workaround from WS tests

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
@@ -117,10 +117,6 @@ public class WSBearerElytronSecurityPropagationTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -134,11 +130,6 @@ public class WSBearerElytronSecurityPropagationTestCase {
 
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
@@ -117,10 +117,6 @@ public class WSBearerSecurityPropagationTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -134,11 +130,6 @@ public class WSBearerSecurityPropagationTestCase {
 
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
@@ -479,10 +479,6 @@ public class WSTrustTestCase {
     @OperateOnDeployment(HOLDER_OF_KEY_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testHolderOfKey() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -497,11 +493,6 @@ public class WSTrustTestCase {
 
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 
@@ -539,10 +530,6 @@ public class WSTrustTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -556,11 +543,6 @@ public class WSTrustTestCase {
 
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14075

TLS 1.1 doesn't work on RHEL8&OpenJDK11.

This PR removs TLS 1.1 workaround from WS tests that was introduced in [WFLY-10945](https://issues.redhat.com/browse/WFLY-10945) ([PR](https://github.com/wildfly/wildfly/pull/11613)). Newer TLS version didn't work on OpenJDK11 two years ago, but it works now with OpenJDK 11.0.8