### PR TITLE
[21.x] WFLY-14080 Upgrade Hibernate ORM to 5.3.20.Final to fix CVE-2020-25638

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.18.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.20.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.21.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14080

Upstream: #13712

@Sanne @scottmarlow FYI