### PR TITLE
[WFLY-14079] Remove the override to TLS 1.1

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/GenerateWSKeyStores.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/GenerateWSKeyStores.java
@@ -19,16 +19,12 @@ package org.jboss.as.test.integration.ws.wsse;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.net.InetAddress;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
-import java.util.Collections;
 
 import javax.security.auth.x500.X500Principal;
 
-import org.wildfly.security.x500.GeneralName;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
-import org.wildfly.security.x500.cert.SubjectAlternativeNamesExtension;
 
 /**
  * Generates the keystores and truststore needed for the ws tests
@@ -55,13 +51,12 @@ public class GenerateWSKeyStores {
     }
 
     private static SelfSignedX509CertificateAndSigningKey createSelfSigned() {
-        X500Principal DN = new X500Principal("CN=localhost, OU=JBoss, O=Red Hat, L=Milan, ST=MI, C=IT");
+        X500Principal DN = new X500Principal("CN=Alessio, OU=JBoss, O=Red Hat, L=Milan, ST=MI, C=IT");
 
         return SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(DN)
                 .setKeyAlgorithmName("RSA")
                 .setSignatureAlgorithmName("SHA256withRSA")
-                .addExtension(new SubjectAlternativeNamesExtension(false, Collections.singletonList(new GeneralName.IPAddress(InetAddress.getLoopbackAddress().getHostAddress()))))
                 .build();
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
@@ -117,10 +117,6 @@ public class WSBearerElytronSecurityPropagationTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -132,13 +128,10 @@ public class WSBearerElytronSecurityPropagationTestCase {
             WSTrustTestUtils.setupWsseAndSTSClientBearer((BindingProvider) proxy, bus);
             assertEquals("alice&alice", proxy.sayHello());
 
+        } catch (Exception e) {
+            throw e;
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
@@ -117,10 +117,6 @@ public class WSBearerSecurityPropagationTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -132,13 +128,10 @@ public class WSBearerSecurityPropagationTestCase {
             WSTrustTestUtils.setupWsseAndSTSClientBearer((BindingProvider) proxy, bus);
             assertEquals("alice&alice", proxy.sayHello());
 
+        } catch (Exception e) {
+            throw e;
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
@@ -479,12 +479,10 @@ public class WSTrustTestCase {
     @OperateOnDeployment(HOLDER_OF_KEY_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testHolderOfKey() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
 
         Bus bus = BusFactory.newInstance().createBus();
         try {
+
             BusFactory.setThreadDefaultBus(bus);
 
             final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/holderofkeywssecuritypolicy", "HolderOfKeyService");
@@ -497,11 +495,6 @@ public class WSTrustTestCase {
 
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 
@@ -539,10 +532,6 @@ public class WSTrustTestCase {
     @OperateOnDeployment(BEARER_SERVER_DEP)
     @WrapThreadContextClassLoader
     public void testBearer() throws Exception {
-        // TLSv1.2 seems buggy on JDK-11 (Invalid ECDH ServerKeyExchange signature)
-        String originalProtocols = System.getProperty("https.protocols");
-        System.setProperty("https.protocols", "TLSv1.1");
-
         Bus bus = BusFactory.newInstance().createBus();
         try {
             BusFactory.setThreadDefaultBus(bus);
@@ -554,13 +543,10 @@ public class WSTrustTestCase {
             WSTrustTestUtils.setupWsseAndSTSClientBearer((BindingProvider) proxy, bus);
             assertEquals("Bearer WS-Trust Hello World!", proxy.sayHello());
 
+        } catch (Exception e) {
+            throw e;
         } finally {
             bus.shutdown(true);
-            if (originalProtocols == null) {
-                System.clearProperty("https.protocols");
-            } else {
-                System.setProperty("https.protocols", originalProtocols);
-            }
         }
     }
 


### PR DESCRIPTION
During the testing of WildFly against Java 11 an issue was found using TLS 1.2 so the test was temporarily updated to force it to use TLS 1.1 - that is now causing issues on the latest OpenJDK 8 however the temporary workaround can now be reverted.

https://issues.redhat.com/browse/WFLY-14079

Revert "[WFLY-10945] JDK-11 - ws test failures - alternative name, TLSv1.2 workaround"

This reverts commit d16b5a3e3c892abd22eacc7764e92447033d2f6a.


