### PR TITLE
[WFLY-14083] Update the signature algorithm to allow use with TLS 1.2

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/ListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/ListenerTestCase.java
@@ -110,7 +110,7 @@ public class ListenerTestCase extends ContainerResourceMgmtTestBase {
     private static final String TEST_CLIENT_2_DN = "CN=Test Client 2, OU=JBoss, O=Red Hat, L=Raleigh, ST=North Carolina, C=US";
     private static final String AS_7_DN = "CN=AS7, OU=JBoss, O=Red Hat, L=Raleigh, ST=North Carolina, C=US";
 
-    private static final String SHA_1_RSA = "SHA1withRSA";
+    private static final String SHA_256_RSA = "SHA256withRSA";
 
     private static KeyStore loadKeyStore() throws Exception{
         KeyStore ks = KeyStore.getInstance("JKS");
@@ -122,7 +122,7 @@ public class ListenerTestCase extends ContainerResourceMgmtTestBase {
         return SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(new X500Principal(DN))
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName(SHA_1_RSA)
+                .setSignatureAlgorithmName(SHA_256_RSA)
                 .build();
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14083

This is addressing another failure on OpenJDK 1.8.0_272 but we need the CI run on the older version first to double check no regression that way either.