### PR TITLE
[WFLY-14078] Check if the subsystem default security domain was mapped to an Elytron domain before applying for the component.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
@@ -130,12 +130,12 @@ public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcesso
             }
 
             final boolean useDefaultElytronMapping;
-            // Only apply a default domain to the whole deployment if no legacy domain was defined.
-            if (!legacyDomainDefined && selectedElytronDomainName == null && defaultDomainMapping != null) {
+            if (selectedElytronDomainName == null && defaultDomainMapping != null) {
                 selectedElytronDomainName = defaultSecurityDomain;
                 selectedElytronDomainConfig = defaultDomainMapping;
                 elytronDomainServiceName = defaultElytronDomainServiceName;
-                useDefaultElytronMapping = true;
+                // Only apply a default domain to the whole deployment if no legacy domain was defined.
+                useDefaultElytronMapping = !legacyDomainDefined;
             } else {
                 useDefaultElytronMapping = false;
             }


### PR DESCRIPTION
Just submitting the PR now as locally I am running into a number of failures in allTests related to the latest OpenJDK release.

https://issues.redhat.com/browse/WFLY-14078