### PR TITLE
[WFLY-14081] Upgrade WildFly Core 13.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14081

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

This PR supersedes #13715: the maven artifacts for 13.0.2.Final were containing XSD schemas from the master branch.
This 13.0.3.Final version corresponds to the same code but with clean Maven artifacts

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.3.Final
Diff to previous integrated released: https://github.com/wildfly/wildfly-core/compare/13.0.1.Final...13.0.3.Final

---

## Release Notes - WildFly Core - Version 13.0.3.Final

* No changes

## Release Notes - WildFly Core - Version 13.0.2.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5158'>WFCORE-5158</a>] -         Upgrade Apache HTTP Client to 4.5.13
</li>
</ul>
                                                                                                                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4216'>WFCORE-4216</a>] -         HTTPSManagementInterfaceTestCase fails with Elytron profile
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5155'>WFCORE-5155</a>] -         A NullPointException was found in a wildfly-jar-maven-plugin test
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5167'>WFCORE-5167</a>] -         Do not depend on org.apache.directory.server:apacheds-all as this is a shaded jar which conflicts with other dependencies.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5174'>WFCORE-5174</a>] -         KeyStoresTestCase wrongly rounds days which leads to a failure in case of different daylight saving time
</li>
</ul>
                                                                
