### PR TITLE
WFLY-14084 HotRod session manager missing subsequent HttpSessionAttributeListener notifications when using ATTRIBUTE granularity

### DIFF
--- a/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheMap.java
+++ b/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheMap.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ee.hotrod;
+
+import java.util.Map;
+
+import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIteratorSet;
+
+/**
+ * Map view of a remote cache that forces return values where necessary.
+ * @author Paul Ferraro
+ */
+public class RemoteCacheMap<K, V> implements Map<K, V> {
+    private final RemoteCache<K, V> cache;
+
+    public RemoteCacheMap(RemoteCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public int size() {
+        return this.cache.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.cache.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return this.cache.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return this.cache.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return this.cache.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return this.cache.withFlags(Flag.FORCE_RETURN_VALUE).put(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return this.cache.withFlags(Flag.FORCE_RETURN_VALUE).remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        this.cache.putAll(map);
+    }
+
+    @Override
+    public void clear() {
+        this.cache.clear();
+    }
+
+    @Override
+    public CloseableIteratorSet<K> keySet() {
+        return this.cache.keySet();
+    }
+
+    @Override
+    public CloseableIteratorCollection<V> values() {
+        return this.cache.values();
+    }
+
+    @Override
+    public CloseableIteratorSet<Entry<K, V>> entrySet() {
+        return this.cache.entrySet();
+    }
+}

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/fine/FineSessionAttributesFactory.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/fine/FineSessionAttributesFactory.java
@@ -33,6 +33,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.wildfly.clustering.ee.Immutability;
 import org.wildfly.clustering.ee.MutatorFactory;
 import org.wildfly.clustering.ee.cache.CacheProperties;
+import org.wildfly.clustering.ee.hotrod.RemoteCacheMap;
 import org.wildfly.clustering.ee.hotrod.RemoteCacheMutatorFactory;
 import org.wildfly.clustering.marshalling.spi.Marshaller;
 import org.wildfly.clustering.web.cache.session.CompositeImmutableSession;
@@ -117,7 +118,7 @@ public class FineSessionAttributesFactory<S, C, L, V> implements SessionAttribut
     @Override
     public SessionAttributes createSessionAttributes(String id, Map<String, UUID> names, ImmutableSessionMetaData metaData, C context) {
         SessionAttributeActivationNotifier notifier = new ImmutableSessionAttributeActivationNotifier<>(this.provider, new CompositeImmutableSession(id, metaData, this.createImmutableSessionAttributes(id, names)), context);
-        return new FineSessionAttributes<>(new SessionAttributeNamesKey(id), names, this.namesCache, getKeyFactory(id), this.attributeCache.withFlags(Flag.FORCE_RETURN_VALUE), this.marshaller, this.mutatorFactory, this.immutability, this.properties, notifier);
+        return new FineSessionAttributes<>(new SessionAttributeNamesKey(id), names, this.namesCache, getKeyFactory(id), new RemoteCacheMap<>(this.attributeCache), this.marshaller, this.mutatorFactory, this.immutability, this.properties, notifier);
     }
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
@@ -21,14 +21,12 @@
  */
 package org.jboss.as.test.clustering.cluster.web.expiration;
 
+import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.runner.RunWith;
 
-@RunWith(Arquillian.class)
 public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
 
     private static final String MODULE_NAME = FineSessionExpirationTestCase.class.getSimpleName();
@@ -47,5 +45,9 @@ public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
 
     static WebArchive getDeployment() {
         return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-fine.xml", "jboss-web.xml");
+    }
+
+    public FineSessionExpirationTestCase() {
+        super(TransactionMode.TRANSACTIONAL);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/RecordingWebListener.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/RecordingWebListener.java
@@ -35,11 +35,11 @@ import javax.servlet.http.HttpSessionListener;
 @WebListener
 public class RecordingWebListener implements HttpSessionListener, HttpSessionAttributeListener {
 
-    public static BlockingQueue<String> createdSessions = new LinkedBlockingQueue<>();
-    public static BlockingQueue<String> destroyedSessions = new LinkedBlockingQueue<>();
-    public static ConcurrentMap<String, BlockingQueue<String>> addedAttributes = new ConcurrentHashMap<>();
-    public static ConcurrentMap<String, BlockingQueue<String>> removedAttributes = new ConcurrentHashMap<>();
-    public static ConcurrentMap<String, BlockingQueue<String>> replacedAttributes = new ConcurrentHashMap<>();
+    public static final BlockingQueue<String> createdSessions = new LinkedBlockingQueue<>();
+    public static final BlockingQueue<String> destroyedSessions = new LinkedBlockingQueue<>();
+    public static final ConcurrentMap<String, BlockingQueue<String>> addedAttributes = new ConcurrentHashMap<>();
+    public static final ConcurrentMap<String, BlockingQueue<String>> removedAttributes = new ConcurrentHashMap<>();
+    public static final ConcurrentMap<String, BlockingQueue<String>> replacedAttributes = new ConcurrentHashMap<>();
 
     private static void record(HttpSessionBindingEvent event, ConcurrentMap<String, BlockingQueue<String>> attributes) {
         BlockingQueue<String> set = new LinkedBlockingQueue<>();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractSessionExpirationTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.web.remote;
+
+import org.infinispan.transaction.TransactionMode;
+import org.jboss.as.test.clustering.cluster.web.expiration.SessionExpirationTestCase;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+/**
+ * @author Paul Ferraro
+ */
+public abstract class AbstractSessionExpirationTestCase extends SessionExpirationTestCase {
+
+    @ClassRule
+    public static final TestRule INFINISPAN_SERVER_RULE = infinispanServerTestRule();
+
+    public AbstractSessionExpirationTestCase() {
+        super(TransactionMode.NON_TRANSACTIONAL);
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,17 +19,22 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.clustering.cluster.web.expiration;
 
-import org.infinispan.transaction.TransactionMode;
+package org.jboss.as.test.clustering.cluster.web.remote;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
+/**
+ * @author Paul Ferraro
+ */
+@ServerSetup({ InfinispanServerSetupTask.class, LocalRoutingServerSetup.class })
+public class CoarseHotRodSessionExpirationTestCase extends AbstractSessionExpirationTestCase {
 
-    private static final String MODULE_NAME = CoarseSessionExpirationTestCase.class.getSimpleName();
+    private static final String MODULE_NAME = CoarseHotRodSessionExpirationTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
@@ -44,10 +49,6 @@ public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
-    }
-
-    public CoarseSessionExpirationTestCase() {
-        super(TransactionMode.TRANSACTIONAL);
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_coarse.xml", "jboss-all.xml");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,17 +19,22 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.clustering.cluster.web.expiration;
 
-import org.infinispan.transaction.TransactionMode;
+package org.jboss.as.test.clustering.cluster.web.remote;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
+/**
+ * @author Paul Ferraro
+ */
+@ServerSetup({ InfinispanServerSetupTask.class, LocalRoutingServerSetup.class })
+public class FineHotRodSessionExpirationTestCase extends AbstractSessionExpirationTestCase {
 
-    private static final String MODULE_NAME = CoarseSessionExpirationTestCase.class.getSimpleName();
+    private static final String MODULE_NAME = FineHotRodSessionExpirationTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
@@ -44,10 +49,6 @@ public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
-    }
-
-    public CoarseSessionExpirationTestCase() {
-        super(TransactionMode.TRANSACTIONAL);
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_fine.xml", "jboss-all.xml");
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14084