### PR TITLE
[WFLY-14111] Fix for 10 flaky tests due to AbstractUndertowSubsystemTestCase.java

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -22,7 +22,6 @@
 package org.wildfly.extension.undertow;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +128,7 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
         Host host = (Host) awaitServiceValue(hostSC);
         if (flag == 1) {
             Assert.assertEquals(3, host.getAllAliases().size());
-            Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));
+            Assert.assertTrue(host.getAllAliases().contains("default-alias"));
         }
 
         final ServiceName locationServiceName = UndertowService.locationServiceName(virtualHostName, "default-virtual-host", "/");


### PR DESCRIPTION
The test `org.wildfly.extension.undertow.AbstractUndertowSubsystemTestCase#testRuntime` is flaky because it has `Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1))` where `getAllAliases()` returns `HashSet`, so the test checks that "default-alias" is at the second index of the list formed from the set. However, per the documentation "HashSet makes no guarantees as to the iteration order of the set", so converting the `HashSet` into a `List` doesn't ensure the deterministic order of elements, and `get(1)` may return a different value. The modified code checks that "default-alias" is in the `HashSet` itself.

The modified code helps with the following 10 flaky tests in subclasses of `AbstractUndertowSubsystemTestCase`:
* `org.wildfly.extension.undertow.UndertowSubsystem100TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem30TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem80TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem90TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem60TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem70TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem50TestCase#testRuntime` 
* `org.wildfly.extension.undertow.UndertowSubsystem31TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem40TestCase#testRuntime`
* `org.wildfly.extension.undertow.UndertowSubsystem110TestCase#testRuntime`
