### PR TITLE
[WFLY-14106] Use ee.maven.groupId instead of project.groupId for wild…

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -70,7 +70,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>test</scope>
             <exclusions>


### PR DESCRIPTION
…fly-testsuite-shared dependency on dist module

Jira issue: https://issues.redhat.com/browse/WFLY-14106
