### PR TITLE
Revert "Ignore DynamicJNDIContextEJBInvocationTestCase"

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PassivationConfigurationSetup.class)
-@Ignore("WFLY-12512")
 public class DynamicJNDIContextEJBInvocationTestCase {
 
     private static final Logger logger = Logger.getLogger(DynamicJNDIContextEJBInvocationTestCase.class);


### PR DESCRIPTION
This reverts commit 6674703cfee9731bcb4a99864610c402d17188dc.

When I reported https://issues.redhat.com/browse/WFLY-12512 I ignored a failing test. It looks like the ultimate fix didn't re-enable.  I found an old branch sitting around in my checkout and noticed this; let's see if re-enabling works.