### PR TITLE
[WFLY-14109] Upgrade Mojarra to 3.0.0.SP02 in the EE9 feature pack

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -51,7 +51,7 @@
         <full.ee-9-api.license.directory>${basedir}/src/license</full.ee-9-api.license.directory>
 
 
-        <version.com.sun.faces>3.0.0.SP01</version.com.sun.faces>
+        <version.com.sun.faces>3.0.0.SP02</version.com.sun.faces>
         <version.com.sun.activation.jakarta.activation>2.0.0</version.com.sun.activation.jakarta.activation>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0-RC1</version.jakarta.authorization.jakarta-authorization-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14109

Mojarra 3.0.0.SP02 is based off the upstream 3.0.0-RC5 release. The complete list of changes included in Mojarra 3.0.0.SP02 can be seen here:

https://github.com/jboss/mojarra/compare/3.0.0.SP01...3.0.0.SP02