### PR TITLE
[WFLY-14115] Multinode tests failures: grant delete permission for EJ…

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpDescriptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpDescriptorTestCase.java
@@ -83,12 +83,12 @@ public class EjbOverHttpDescriptorTestCase {
         jar.addClasses(EjbOverHttpDescriptorTestCase.class);
         jar.addAsManifestResource("META-INF/jboss-ejb-client-http-connections.xml", "jboss-ejb-client.xml")
                 .addAsManifestResource("ejb-http-wildfly-config.xml", "wildfly-config.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
-                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
-                        new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
-                                "connect,resolve")),
+                .addAsManifestResource(
+                        createPermissionsXmlAsset(
+                                createFilePermission("read,write,delete",
+                                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
+                                new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
+                                        "connect,resolve")),
                         "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
@@ -140,12 +140,12 @@ public class EjbOverHttpTestCase {
         jar.addClasses(EjbOverHttpTestCase.class);
         jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml")
                 .addAsManifestResource("ejb-http-wildfly-config.xml", "wildfly-config.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
-                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
-                        new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
-                                "connect,resolve")),
+                .addAsManifestResource(
+                        createPermissionsXmlAsset(
+                                createFilePermission("read,write,delete",
+                                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
+                                new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
+                                        "connect,resolve")),
                         "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
@@ -79,12 +79,12 @@ public class EjbOverHttpWrongCredentialsTestCase {
         jar.addClasses(EjbOverHttpTestCase.class);
         jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml")
                 .addAsManifestResource("ejb-http-wildfly-config-wrong.xml", "wildfly-config.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
-                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
-                        new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
-                                "connect,resolve")),
+                .addAsManifestResource(
+                        createPermissionsXmlAsset(
+                                createFilePermission("read,write,delete",
+                                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
+                                new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort,
+                                        "connect,resolve")),
                         "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
@@ -27,8 +27,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
-
+import java.util.Arrays;
 import java.util.Collections;
 import javax.ejb.EJBException;
 import javax.naming.InitialContext;
@@ -122,6 +124,11 @@ public class RemoteLocalCallProfileTestCase {
         JavaArchive jar = createJar(ARCHIVE_NAME_CLIENT);
         jar.addClasses(RemoteLocalCallProfileTestCase.class);
         jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml");
+        jar.addAsManifestResource(
+                createPermissionsXmlAsset(
+                        createFilePermission("delete",
+                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
+                "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
@@ -22,9 +22,11 @@
 
 package org.jboss.as.test.multinode.remotecall;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.security.SecurityPermission;
+import java.util.Arrays;
 import javax.ejb.EJBException;
 import javax.naming.InitialContext;
 
@@ -73,6 +75,8 @@ public class RemoteLocalCallTestCase {
         jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         jar.addAsManifestResource(
                 createPermissionsXmlAsset(
+                        createFilePermission("delete",
+                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
                         new SecurityPermission("putProviderProperty.WildFlyElytron")),
                 "permissions.xml");
         return jar;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
@@ -40,6 +40,10 @@ import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import java.io.IOException;
+import java.util.Arrays;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A simple EJB Remoting transaction context propagation in JTS style from one AS7 server to another.
@@ -69,6 +73,11 @@ public class TransactionInvocationTestCase {
         jar.addClasses(ClientEjb.class, TransactionalRemote.class, TransactionInvocationTestCase.class,
                 TransactionalStatefulRemote.class);
         jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
+        jar.addAsManifestResource(
+                createPermissionsXmlAsset(
+                        createFilePermission("delete",
+                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
+                "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/nooutbound/TransactionContextRemoteCallTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/nooutbound/TransactionContextRemoteCallTestCase.java
@@ -22,9 +22,11 @@
 
 package org.jboss.as.test.multinode.transaction.nooutbound;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
+import java.util.Arrays;
 import java.util.PropertyPermission;
 
 import javax.ejb.EJBException;
@@ -68,6 +70,7 @@ public class TransactionContextRemoteCallTestCase {
                     TransactionContextRemoteCallTestCase.class)
             .addAsManifestResource(new StringAsset("Dependencies: org.wildfly.http-client.transaction\n"), "MANIFEST.MF")
             .addAsManifestResource(createPermissionsXmlAsset(
+                    createFilePermission("delete", "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
                     new SocketPermission(TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0")) + ":" + serverPort, "connect,resolve"),
                     new PropertyPermission("node1", "read")
                 ), "permissions.xml");


### PR DESCRIPTION
…B XA recovery log files

https://issues.redhat.com/browse/WFLY-14115

This PR is an alternative to: https://github.com/wildfly/wildfly-http-client/pull/45
I believe we should just provide the tests with required permissions. I have checked that it prevents the hang.