### PR TITLE
WFLY-14118 Distributed session manager can throw UnsupportedOperationException on concurrent calls to HttpServletRequest.getSession(...) for a given session

### DIFF
--- a/clustering/ee/cache/src/main/java/org/wildfly/clustering/ee/cache/ConcurrentManager.java
+++ b/clustering/ee/cache/src/main/java/org/wildfly/clustering/ee/cache/ConcurrentManager.java
@@ -43,7 +43,10 @@ public class ConcurrentManager<K, V> implements Manager<K, V> {
     private final BiFunction<K, Map.Entry<Integer, V>, Map.Entry<Integer, V>> addFunction = new BiFunction<K, Map.Entry<Integer, V>, Map.Entry<Integer, V>>() {
         @Override
         public Map.Entry<Integer, V> apply(K id, Map.Entry<Integer, V> entry) {
-            return entry != null ? new AbstractMap.SimpleImmutableEntry<>(Integer.valueOf(entry.getKey().intValue() + 1), entry.getValue()) : new VolatileEntry<>(new Integer(0));
+            if (entry == null) return new VolatileEntry<>(new Integer(0));
+            Integer count = Integer.valueOf(entry.getKey().intValue() + 1);
+            V value = entry.getValue();
+            return (value != null) ? new AbstractMap.SimpleImmutableEntry<>(count, value) : new VolatileEntry<>(count);
         }
     };
     private final Consumer<V> createTask;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14118