### PR TITLE
Fix for WFLY-14120, Upgrade to galleon-plugins 5.0.0.Beta2

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -271,6 +271,7 @@
                             <task-properties>
                                 <jakarta.transform.artifacts>true</jakarta.transform.artifacts>
                                 <jakarta.transform.modules>false</jakarta.transform.modules>
+                                <jakarta.transform.artifacts.suffix>-ee9</jakarta.transform.artifacts.suffix>
                                 <product.release.version>${preview.dist.product.release.version}</product.release.version>
                             </task-properties>
                             <jakarta-transform>true</jakarta-transform>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>5.0.0.Beta1</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.0.0.Beta2</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14120

Rename transformed artifacts and latest Batavia release.

Diff between releases: https://github.com/wildfly/galleon-plugins/compare/5.0.0.Beta1...5.0.0.Beta2
