### PR TITLE
[WFLY-14135] Do not overwrite the default-stateful-bean-access-timeou…

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -8,7 +8,7 @@
     </dependencies>
 
     <feature spec="subsystem.ejb3">
-        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-stateful-bean-access-timeout" value="5000"/>
         <param name="default-sfsb-cache" value="distributable"/>
     </feature>
 

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
@@ -4,7 +4,7 @@
         <layer name="transactions"/>
     </dependencies>
     <feature spec="subsystem.ejb3">
-        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-stateful-bean-access-timeout" value="5000"/>
         <param name="default-sfsb-cache" value="simple"/>
     </feature>
     <!-- Infinispan cache configuration used for local SFSB caching -->


### PR DESCRIPTION
…t on ejb-dist-cache/ejb-local-cache Galleon layers

Jira issue: https://issues.redhat.com/browse/WFLY-14135