### PR TITLE
[WFLY-12503] Turn off the default surefire execution when the 'elytron', 'security.manager' and 'bootable.jar' profiles are used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9761,6 +9761,20 @@
         </profile>
 
         <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
+        </profile>
+
+        <profile>
             <id>victims-scan</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,15 @@
         <testsuite.ee.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.ee.galleon.pack.artifactId>
         <testsuite.ee.galleon.pack.version>${full.maven.version}</testsuite.ee.galleon.pack.version>
 
+        <!-- Properties that set the phase used for different plugin executions.
+             Profiles can override the values here to enable/disable executions.
+             A value of 'none' disables the execution; to enable set the value to the
+             normal phase for the goal.
+             This setup allows the bulk of the execution configuration to be in the
+             default build config (and thus shared in different profiles) while
+             still being easily disabled in profiles where it is not wanted. -->
+        <surefire.default-test.phase>test</surefire.default-test.phase>
+
         <!--
             *Plugin* Dependency versions. Please keep alphabetical.
 
@@ -9602,6 +9611,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Surefire runs a 'default-test' execution by default.
+                             Configure it here to use a property to set the phase for that execution.
+                             Default value of the property is the normal 'test' phase
+                             (see 'properties' declarations in this pom.)
+                             Profiles can set the property to 'none' to disable this execution -->
+                        <id>default-test</id>
+                        <phase>${surefire.default-test.phase}</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -9665,25 +9685,10 @@
                 <wildfly.web.build.output.dir>${wildfly.build.output.dir}</wildfly.web.build.output.dir>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
                 <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
+                <!-- Disable the surefire tests (at least the default ones) for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         
         <profile>
@@ -9706,24 +9711,11 @@
                     <name>ts.layers</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
         </profile>
 
         <profile>
@@ -9733,24 +9725,11 @@
                     <name>ts.standalone.microprofile</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -9733,6 +9733,20 @@
         </profile>
 
         <profile>
+            <id>elytron.profile</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
+        </profile>
+
+        <profile>
             <id>victims-scan</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -9747,6 +9747,20 @@
         </profile>
 
         <profile>
+            <id>security.manager.profile</id>
+            <activation>
+                <property>
+                    <name>security.manager</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Disable the default surefire tests  for all modules except for
+                     those where this profile turns them on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
+        </profile>
+
+        <profile>
             <id>victims-scan</id>
             <activation>
                 <property>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -316,6 +316,10 @@
                     <exists>${ts.elytron.cli}</exists>
                 </file>
             </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -303,6 +303,10 @@
                     <exists>${ts.elytron.cli}</exists>
                 </file>
             </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -40,6 +40,8 @@
         <bootable-jar-cloud-profile-packaging.phase>none</bootable-jar-cloud-profile-packaging.phase>
         <bootable-jar-legacy-security-packaging.phase>none</bootable-jar-legacy-security-packaging.phase>
         <bootable-jar-copy-module-files.phase>none</bootable-jar-copy-module-files.phase>
+        <!-- Disable the default surefire test execution. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <dependencies>
@@ -1090,14 +1092,6 @@
                         <!-- Here we just have executions -->
                         <executions combine.children="append">
 
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>test</phase>
@@ -1347,6 +1341,7 @@
                                         </includes>
                                     </configuration>
                                 </execution>
+                                <!-- Disable the other standard executions -->
                                 <execution>
                                     <id>basic-integration-default-web.surefire</id>
                                     <phase>none</phase>
@@ -1423,10 +1418,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
@@ -2384,10 +2375,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
@@ -3534,10 +3521,6 @@
                         <executions>
                             <!-- Disable the standard test executions. -->
                             <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
                             </execution>
@@ -3642,11 +3625,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <!--<phase>none</phase>-->

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -53,6 +53,8 @@
         <bootable-jar-load-balancer-packaging.phase>none</bootable-jar-load-balancer-packaging.phase>
         <bootable-jar-configure-windows-paths.phase>none</bootable-jar-configure-windows-paths.phase>
         <bootable-jar-web-passivation-packaging.phase>none</bootable-jar-web-passivation-packaging.phase>
+        <!-- Disable the default surefire test execution. All profiles use custom executions. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <dependencies>
@@ -362,33 +364,6 @@
         </plugins>
     </build>
     <profiles>
-        <!-- Skip the default 'test' surefire goal if using -Dts.noClustering -->
-        <profile>
-            <id>ts.clustering.integration.tests.skip.profile</id>
-            <activation>
-                <property>
-                    <name>ts.noClustering</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions combine.children="append">
-                            <!-- Disable default-test surefire execution which would fail otherwise. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <!-- Common step to prepare servers in use by all non-Galleon tests -->
         <profile>
@@ -570,14 +545,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
@@ -652,14 +619,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha-infinispan-server</id>
@@ -724,14 +683,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.fullha</id>
@@ -795,14 +746,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Single node clustering tests. -->
                             <execution>
                                 <id>ts.surefire.clustering.single</id>
@@ -1617,10 +1560,6 @@
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
                             <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>
                             </execution>
@@ -1844,10 +1783,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>
@@ -2230,10 +2165,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -427,7 +427,10 @@
                         <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <execution>
-                                <phase>process-test-resources</phase>
+                                <!-- run in test-compile instead of process-test-resources
+                                     as getting correct execution order of different process-test-resources
+                                     executions has proven problematic when different profiles are used. -->
+                                <phase>test-compile</phase>
                                 <goals>
                                     <goal>execute-commands</goal>
                                 </goals>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -554,10 +554,9 @@
                             </systemPropertyVariables>
                         </configuration>
                         <executions>
-                            <!-- Re-enable the defaut test execution but exclude tests incompatible with this configxf. -->
+                            <!-- Run the default test execution but exclude tests incompatible with this config. -->
                             <execution>
                                 <id>default-test</id>
-                                <phase>test</phase>
                                 <configuration>
                                     <excludes combine-children="append">
                                         <!-- Needs batch -->
@@ -685,13 +684,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!-- Enable the default tests (which the parent pom turns off for this profile) -->
+                            <!-- Configure the default tests -->
                             <execution>
                                 <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
                                         <install.dir>${project.build.directory}/${wildfly.instance.name}</install.dir>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -28,6 +28,8 @@
         <ts.elytron.cli>ssl-enable-elytron.cli</ts.elytron.cli>
         <wildfly>wildfly</wildfly>
         <wildfly.config.dir>${basedir}/target/${wildfly}/standalone/configuration</wildfly.config.dir>
+        <!-- Disable the default surefire test execution. All profiles use custom executions. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
     <dependencies>
         <dependency>
@@ -144,14 +146,6 @@
                         </configuration>
                         <executions combine.children="append">
 
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi node clustering tests. -->
                             <execution>
                                 <id>tests-iiop-multi-node.surefire</id>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -315,5 +315,35 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- profile to configure WildFly to use Elytron instead of legacy security: -Delytron -->
+        <profile>
+            <id>elytron.profile</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+                <file>
+                    <exists>${ts.elytron.cli}</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <!-- run in test-compile instead of process-test-resources
+                                     as we want this to run after build-manual-mode-servers
+                                     has created all the servers other than target/wildfly -->
+                                <phase>test-compile</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -244,30 +244,32 @@
                         <id>default-test</id>
                         <configuration>
                             <excludes>
+                                <!-- In this module default-test runs against standalone-microprofile.xml
+                                     Exclude tests from that execution that require functionality not in that config. -->
                                 <exclude>org/wildfly/test/integration/microprofile/jwt/ejb/JWTEJBTestCase.java</exclude>
                             </excludes>
                         </configuration>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
                     </execution>
+                    <!-- An execution analogous to default-test but separately customizable -->
                     <execution>
                         <id>layers-test</id>
+                        <!-- Disabled by default; relevant profiles enable it -->
                         <phase>none</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                     </execution>
+                    <!-- An execution analogous to default-test but uses standalone.xml -->
                     <execution>
+                        <id>standalone-enabled-microprofile-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
                         <configuration>
                             <systemPropertyVariables>
                                 <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                             </systemPropertyVariables>
                         </configuration>
-                        <id>standalone-enabled-microprofile-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -364,7 +366,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Enable the layers-test surefire execution -->
+                        <!-- Enable the layers-test surefire execution; disable others. -->
                         <executions>
                             <execution>
                                 <id>layers-test</id>
@@ -483,7 +485,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Enable the layers-test surefire execution -->
+                        <!-- Enable the layers-test surefire execution, disable others -->
                         <executions>
                             <execution>
                                 <id>layers-test</id>
@@ -569,7 +571,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!--Re-enable the default surefire execution. -->
+                            <!--Re-enable the default surefire execution, disable others. -->
                             <execution>
                                 <id>default-test</id>
                                 <phase>test</phase>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -332,7 +332,11 @@
                 <property>
                     <name>ts.bootable</name>
                 </property>
-            </activation>           
+            </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <modules>
                 <module>basic</module>
                 <module>clustering</module>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -289,6 +289,10 @@
                     <exists>${ts.elytron.cli}</exists>
                 </file>
             </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -359,30 +359,6 @@
     <profiles>
 
         <profile>
-            <id>not.standalone.microprofile.profile</id>
-            <activation>
-                <property>
-                    <name>!ts.standalone.microprofile</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <!--Re-enable the default surefire execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
             <id>standalone.microprofile.profile</id>
             <activation>
                 <property>
@@ -605,9 +581,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
                             <!-- Tests against the install without legacy security -->
                             <!-- Reuse the microprofile.surefire execution as the valid tests are the same.

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -435,30 +435,6 @@
         </profile>
 
         <profile>
-            <id>not.standalone.microprofile.profile</id>
-            <activation>
-                <property>
-                    <name>!ts.standalone.microprofile</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <!--Re-enable the default surefire execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
             <id>standalone.microprofile.profile</id>
             <activation>
                 <property>
@@ -801,9 +777,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
 
                             <!-- Tests against the datasource-web-server without legacy security -->
@@ -1307,9 +1280,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
 
                             <!-- Tests against the datasource-web-server without legacy security -->

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -238,9 +238,6 @@
                             <!-- Disable default-test execution. -->
                             <execution>
                                 <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                                 <phase>none</phase>
                             </execution>
 

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -58,7 +58,8 @@
              Provisioning executions using the wildfly-test-galleon-pack are handled separately from others. -->
         <provisioning.phase>none</provisioning.phase>
         <provisioning.phase.preview.excluded>none</provisioning.phase.preview.excluded>
-        <surefire.phase>none</surefire.phase>
+        <!-- Don't run the default surefire execution unless a profile enables it -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <profiles>
@@ -73,7 +74,7 @@
                 <!-- Turn on normal plugin execution by changing the phase props from 'none' -->
                 <provisioning.phase>compile</provisioning.phase>
                 <provisioning.phase.preview.excluded>compile</provisioning.phase.preview.excluded>
-                <surefire.phase>test</surefire.phase>
+                <surefire.default-test.phase>test</surefire.default-test.phase>
             </properties>
         </profile>
 
@@ -2493,12 +2494,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>${surefire.phase}</phase>
-                            </execution>
-                        </executions>
                         <configuration>
                             <systemPropertyVariables>
                                 <!-- maven.local.repo is set in parent pom.xml, system property surefire.system.args -->

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -169,6 +169,10 @@
                     <exists>${ts.elytron.cli}</exists>
                 </file>
             </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -631,6 +631,8 @@
             <properties>
                 <jboss.args>-secmgr</jboss.args>
                 <jboss.domain.server.args>-secmgr</jboss.domain.server.args>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
             </properties>
         </profile>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-12503

Don't waste resources running tests whose behavior is unaltered by custom testsuite profiles. The non-customized CI jobs cover those.