### PR TITLE
[WFLY-14094]: Potential memory leak when using opentracing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
         <version.io.netty>4.1.51.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>
-        <version.io.opentracing.interceptors>0.0.4</version.io.opentracing.interceptors>
+        <version.io.opentracing.interceptors>0.0.4.1</version.io.opentracing.interceptors>
         <version.io.opentracing.jaxrs2>0.4.1</version.io.opentracing.jaxrs2>
         <version.io.opentracing.tracerresolver>0.1.5</version.io.opentracing.tracerresolver>
         <version.io.opentracing.servlet>0.2.3</version.io.opentracing.servlet>


### PR DESCRIPTION
* Upgrade opentracing-interceptors to 0.0.4.1

Jira: https://issues.redhat.com/browse/WFLY-14094
        https://issues.redhat.com/browse/WFLY-14128
