### PR TITLE
[WFLY-14010] Upgrade Mojarra to 2.3.14.SP02

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <version.com.squareup.okhttp3>3.9.0</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.1</version.com.sun.activation.jakarta.activation>
-        <version.com.sun.faces>2.3.14.SP01</version.com.sun.faces>
+        <version.com.sun.faces>2.3.14.SP02</version.com.sun.faces>
         <version.com.sun.istack>3.0.10</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.13</version.com.sun.xml.fastinfoset>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14010

Mojarra 2.3.14.SP02 contains a fix for the following issue:
* [WFLY-13792](https://issues.redhat.com/browse/WFLY-13792) - JSF deployment failure due to UnsupportedOperationException when javax.faces.FACELETS_VIEW_MAPPINGS is defined

The changes can be seen here:
https://github.com/jboss/mojarra/compare/2.3.14.SP01...2.3.14.SP02