### PR TITLE
[WFLY-14161] Upgrade jboss-ejb-client to 4.0.37.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.36.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.37.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14161

The reason of this upgrade is:
https://issues.redhat.com/browse/EJBCLIENT-389 (related to https://issues.redhat.com/browse/EAPSUP-320, https://issues.redhat.com/browse/JBEAP-20583)
