### PR TITLE
[WFLY-14163] Remove the BouncyCastle dependency definitions as these are defined in WildFly Core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,6 @@
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bitbucket.jose4j>0.7.0</version.org.bitbucket.jose4j>
-        <version.org.bouncycastle>1.65</version.org.bouncycastle>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
@@ -5645,24 +5644,6 @@
                         <artifactId>jakarta.xml.bind-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcmail-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This will depend on https://github.com/wildfly/wildfly-core/pull/4417

https://issues.redhat.com/browse/WFLY-14163