### PR TITLE
[WFLY-14166] Upgrade WildFly Core 14.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>14.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>14.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14166

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/14.0.0.Beta3
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/14.0.0.Beta2...14.0.0.Beta3

---


## Release Notes - WildFly Core - Version 14.0.0.Beta3
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5171'>WFCORE-5171</a>] -         Upgrade XNIO to 3.8.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5188'>WFCORE-5188</a>] -         Upgrade JBoss Modules from 1.10.2.Final to 1.11.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5197'>WFCORE-5197</a>] -         Upgrade WildFly Elytron to 1.13.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5204'>WFCORE-5204</a>] -         Upgrade jakarta.inject-api 1.0.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5208'>WFCORE-5208</a>] -         Upgrade WildFly OpenSSL to 2.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5209'>WFCORE-5209</a>] -         Upgrade WildFly Elytron to 1.14.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5126'>WFCORE-5126</a>] -         WARN if user tries to set unrealistic io subsystem stack-size
</li>
</ul>
                                                                                                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5009'>WFCORE-5009</a>] -         Enhance JBoss CLI generic &quot;command&quot; with support for existing resource
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5095'>WFCORE-5095</a>] -         Add the ability to make use of an automatically generated self-signed certificate with Elytron
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3090'>WFCORE-3090</a>] -         Make script messages around process restarts consistent
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5151'>WFCORE-5151</a>] -         dir-contexts referral-mode attribute upper/lower case discrepancy
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5181'>WFCORE-5181</a>] -         Expression properties with trailing whitespaces are resolved to a trimmed value
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5187'>WFCORE-5187</a>] -         RemoteSshGitRepositoryTestCase does not work with non-localhost hostname
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5191'>WFCORE-5191</a>] -         Scripts module of WF-TS fails with &quot;-DreuseForks=false&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5193'>WFCORE-5193</a>] -         Testsuite: make IS_J9_JVM variable more robust
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5194'>WFCORE-5194</a>] -         Elytron Subsystem TlsTestCase fails on Fedora 33 using OpenJDK 8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5195'>WFCORE-5195</a>] -         Elytron Subsystem LdapTestCase fails on openjdk version &quot;1.8.0_272&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5207'>WFCORE-5207</a>] -         add missing WildFly20.0 &amp; 21.0 value to the host-release type 
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-482'>WFCORE-482</a>] -         Add log4j2 support for WildFly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5210'>WFCORE-5210</a>] -         Add a new Phase ID STRUCTURE_EE_DEFAULT_BINDINGS_CONFIG
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5211'>WFCORE-5211</a>] -         Add new Phases for base metrics and health subsystems
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5213'>WFCORE-5213</a>] -         Move &quot;org.bouncycastle:bcmail-jdk15on&quot; Dependency Management to WildFly Core
</li>
</ul>
                                                        