### PR TITLE
WFLY-13307 Throw javax.ejb.ConcurrentAccessTimeoutException if bean lookup times out due to concurrent access by another cluster member

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
@@ -36,6 +36,7 @@
     </resources>
 
     <dependencies>
+        <module name="javax.ejb.api"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13307