### PR TITLE
[WFLY-14025] Added tests for cases when default datasource binding is removed from ee subsystem

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSServlet.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@WebServlet(name = "DefaultDSServlet", urlPatterns = {"/defaultDS"}, loadOnStartup = 1)
+public class DefaultDSServlet extends HttpServlet {
+
+    @Resource()
+    private DataSource dataSource;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        // this is expected to be null because default datasource binding was removed from ee subsystem
+        Assert.assertNull(dataSource);
+        try {
+            new InitialContext().lookup("java:comp/env/dataSource");
+            Assert.fail("Lookup should fail!");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+        }
+        out.print("OK");
+        out.flush();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithCtxListenerServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithCtxListenerServlet.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@WebServlet(name = "DefaultDSWithCtxListenerServlet", urlPatterns = {"/defaultDSWithCtxListener"}, loadOnStartup = 1)
+public class DefaultDSWithCtxListenerServlet extends HttpServlet {
+
+    @Resource(name = "ds")
+    private DataSource dataSource;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        // this is expected to be null because default datasource binding was removed from ee subsystem
+        Assert.assertNull(dataSource);
+        // the ds injection can be done in a ServeltContextListener just like what spring does
+        Assert.assertNotNull(getServletContext().getAttribute("lookupDS"));
+        // but it looks like java:comp/env/ds does not work
+        try {
+            new InitialContext().lookup("java:comp/env/ds");
+            Assert.fail("java:comp/env/ds should not be available ??");
+        } catch (NamingException e) {
+            Assert.assertTrue(e.getMessage().contains("env/ds"));
+        }
+        out.print("OK");
+        out.flush();
+    }
+
+    // this simulates spring context which does resource injection.
+    @WebListener
+    public static class CtxListener implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent sce) {
+            try {
+                Object obj = new InitialContext().lookup("java:jboss/datasources/ExampleDS");
+                sce.getServletContext().setAttribute("lookupDS", obj);
+            } catch (NamingException e) {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithNameServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithNameServlet.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+public class DefaultDSWithNameServlet extends HttpServlet {
+
+    private boolean hasLookup;
+
+    @Resource(name = "ds")
+    private DataSource dataSource;
+
+    @Override
+    public void init() throws ServletException {
+        try {
+            hasLookup = Boolean.parseBoolean(getServletConfig().getInitParameter("hasLookup"));
+        } catch (Exception e) {
+            hasLookup = false;
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        if (hasLookup) {
+            if (dataSource == null) {
+                throw new ServletException("dataSource is null when lookup is defined in jboss-web.xml");
+            }
+        } else {
+            if (dataSource != null) {
+                throw new ServletException("No lookup is defined, dataSource should be null");
+            }
+        }
+
+        if (hasLookup) {
+            try {
+                Assert.assertNotNull(new InitialContext().lookup("java:comp/env/ds"));
+            } catch (NamingException e) {
+                throw new IOException("Cannot lookup java:comp/env/ds when has lookup specified", e);
+            }
+        } else {
+            try {
+                new InitialContext().lookup("java:comp/env/ds");
+                Assert.fail("lookup should fail when no lookup specified for 'java:comp/env/ds'");
+            } catch (NamingException e) {
+                Assert.assertTrue(e.getMessage().contains("env/ds"));
+            }
+        }
+        out.print("OK");
+        out.flush();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.ee.subsystem.DefaultBindingsResourceDefinition;
+import org.jboss.as.ee.subsystem.EESubsystemModel;
+import org.jboss.as.ee.subsystem.EeExtension;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.integration.jaxrs.packaging.war.WebXml;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.net.SocketPermission;
+
+
+/**
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(DefaultDataSourceRemovedTestCase.RemoveDefaultDSBindingSetupTask.class)
+public class DefaultDataSourceRemovedTestCase {
+
+    static class RemoveDefaultDSBindingSetupTask extends SnapshotRestoreSetupTask {
+        @Override
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            ModelNode undefineDatasourceFromDefaultBindings = new ModelNode();
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.ADDRESS)
+                    .set(PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM,EeExtension.SUBSYSTEM_NAME), EESubsystemModel.DEFAULT_BINDINGS_PATH).toModelNode());
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION);
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.NAME).set(DefaultBindingsResourceDefinition.DATASOURCE);
+            ModelNode response = client.getControllerClient().execute(undefineDatasourceFromDefaultBindings);
+            Assert.assertEquals(SUCCESS, response.get(OUTCOME).asString());
+        }
+    }
+
+    @Deployment(name = "with-default-ds")
+    public static WebArchive defaultDS() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds.war");
+        war.addClasses(DefaultDSServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addAsManifestResource(createPermissionsXmlAsset(
+            new RuntimePermission("modifyThread"),
+            new SocketPermission(TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort(), "connect,resolve")), "permissions.xml");
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name")
+    public static WebArchive defaultDSWithName() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name.war");
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addClasses(DefaultDSWithNameServlet.class);
+        war.addAsWebInfResource(WebXml.get("<servlet>\n" +
+                "  <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "  <servlet-class>org.jboss.as.test.integration.ee.naming.defaultbindings.datasource.DefaultDSWithNameServlet</servlet-class>" +
+                "  <load-on-startup>1</load-on-startup>\n" +
+                "</servlet>\n" +
+                "<servlet-mapping>\n" +
+                "    <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "    <url-pattern>/defaultDSWithName</url-pattern>\n" +
+                "</servlet-mapping>"), "web.xml");
+        war.addAsManifestResource(createPermissionsXmlAsset(
+            new RuntimePermission("modifyThread"),
+            new SocketPermission(TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort(), "connect,resolve")), "permissions.xml");
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name-and-lookup")
+    public static WebArchive defaultDSWithNameAndLookup() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name-and-lookup.war");
+        war.addClasses(DefaultDSWithNameServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addAsManifestResource(createPermissionsXmlAsset(
+            new RuntimePermission("modifyThread"),
+            new SocketPermission(TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort(), "connect,resolve")), "permissions.xml");
+        war.addAsWebInfResource(WebXml.get("<servlet>\n" +
+                "  <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "  <servlet-class>org.jboss.as.test.integration.ee.naming.defaultbindings.datasource.DefaultDSWithNameServlet</servlet-class>\n" +
+                "  <load-on-startup>1</load-on-startup>\n" +
+                "    <init-param>\n" +
+                "      <param-name>hasLookup</param-name>\n" +
+                "      <param-value>true</param-value>\n" +
+                "    </init-param>\n" +
+                "</servlet>\n" +
+                "<servlet-mapping>\n" +
+                "    <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "    <url-pattern>/defaultDSWithName</url-pattern>\n" +
+                "</servlet-mapping>"), "web.xml");
+        war.addAsWebInfResource(new StringAsset("<jboss-web>\n" +
+                "    <resource-ref>\n" +
+                "        <res-ref-name>ds</res-ref-name>\n" +
+                "        <res-type>javax.sql.DataSource</res-type>\n" +
+                "        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>\n" +
+                "    </resource-ref>\n" +
+                "</jboss-web>"), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name-and-ctx")
+    public static WebArchive defaultDSWithNameAndCtx() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name-and-ctx.war");
+        war.addClasses(DefaultDSWithCtxListenerServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addAsManifestResource(createPermissionsXmlAsset(
+            new RuntimePermission("modifyThread"),
+            new SocketPermission(TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort(), "connect,resolve")), "permissions.xml");
+        return war;
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds")
+    public void testDeployDefaultDS(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDS", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name")
+    public void testDeployDefaultDSWithName(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithName", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name-and-lookup")
+    public void testDeployDefaultDSWithNameAndLookup(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithName", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name-and-ctx")
+    public void testDeployDefaultDSWithNameAndCtx(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithCtxListener", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14025

This PR added some tests against the fix for WFLY-14025, which covers the following cases:

* @Resource() DataSource ds; injection without name and lookup
* @Resource(name="ds") DataSource ds; injection with name specified
* @Resource(name="ds") DataSource ds; injection with name specified, and lookup is specified in jboss-web.xml
* @Resource(name="ds") DataSource ds; simulates injection done in ServletContextListener
