### PR TITLE
WFLY-14142 Update Google Guava to 30.1-jre 

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -251,6 +251,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.remotingjmx</groupId>
             <artifactId>remoting-jmx</artifactId>
         </dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -197,6 +197,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/ee-feature-pack/common/src/license/feature-pack-licenses.xml
+++ b/ee-feature-pack/common/src/license/feature-pack-licenses.xml
@@ -220,6 +220,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>failureaccess</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <licenses>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/google/guava/failureaccess/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/google/guava/failureaccess/main/module.xml
@@ -22,19 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.9" name="com.google.guava">
+<module xmlns="urn:jboss:module:1.9" name="com.google.guava.failureaccess">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.guava:guava}"/>
+        <artifact name="${com.google.guava:failureaccess}"/>
     </resources>
-
-    <dependencies>
-        <module name="com.google.guava.failureaccess" export="true"/>
-        <module name="java.logging"/>
-        <module name="jdk.unsupported"/>
-    </dependencies>
 </module>

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -238,6 +238,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,8 @@
         <version.com.github.spullara.mustache>0.9.6</version.com.github.spullara.mustache>
         <version.com.github.tomakehurst.wiremock>2.20.0</version.com.github.tomakehurst.wiremock>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
-        <version.com.google.guava>25.0-jre</version.com.google.guava>
+        <version.com.google.guava>30.1-jre</version.com.google.guava>
+        <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.microsoft.azure>8.6.5</version.com.microsoft.azure>
         <version.com.nimbus.jose-jwt>8.11</version.com.nimbus.jose-jwt>
@@ -1680,22 +1681,33 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-compat-qual</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>failureaccess</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>com.google.j2objc</groupId>
                         <artifactId>j2objc-annotations</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-annotations</artifactId>
+                       <groupId>org.checkerframework</groupId>
+                       <artifactId>checker-qual</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <!-- This is a transitive dep of com.google.guava -->
+                <groupId>com.google.guava</groupId>
+                <artifactId>failureaccess</artifactId>
+                <version>${version.com.google.guava.failureaccess}</version>
             </dependency>
 
             <dependency>
@@ -2635,6 +2647,10 @@
                     <exclusion>
                         <groupId>org.jctools</groupId>
                         <artifactId>jctools-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -84,6 +84,16 @@
             <artifactId>artemis-server</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+           <groupId>com.google.guava</groupId>
+           <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+           <groupId>com.google.guava</groupId>
+           <artifactId>failureaccess</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- The following are required at for JAXB on Java 11 -->
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
Fixes [WFLY-14142](https://issues.redhat.com/browse/WFLY-14142)
This PR depends on [WFCORE-5203 PR 4406](https://github.com/wildfly/wildfly-core/pull/4406). Tests will fail as long as WFCORE model-test/pom.xml changes are missing.
