### PR TITLE
WFLY-14172 Update Weld 4 for EE 9 WFLY. Also try to align Weld SE ver…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -85,12 +85,8 @@
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.0.Alpha6</version.org.hibernate.validator>
         <version.org.jboss.metadata>14.0.0.Alpha1</version.org.jboss.metadata>
-        <version.org.jboss.weld.weld>4.0.0.Beta5</version.org.jboss.weld.weld>
-        <!-- TODO in the main pom this is a different version from the rest of weld. Why? -->
-        <!-- It's just a test dep so don't override it for now
-        <version.org.jboss.weld.se.weld-se-core>${version.org.jboss.weld.weld}</version.org.jboss.weld.se.weld-se-core>
-        -->
-        <version.org.jboss.weld.weld-api>4.0.Beta1</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>4.0.0.CR1</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>4.0.CR1</version.org.jboss.weld.weld-api>
 
         <!-- TODO Glassfish uses org.glassfish:jakarta-el for this, which we use for the impl
              but we have a separate API jar -->
@@ -1008,13 +1004,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <!--<dependency>
-            <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se-core</artifactId>
-            <version>${version.org.jboss.weld.se.weld-se-core}</version>
-            <scope>test</scope>
-        </dependency>-->
 
         <!-- Misc -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,6 @@
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
         <version.org.jboss.weld.weld>3.1.5.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>3.1.SP3</version.org.jboss.weld.weld-api>
-        <version.org.jboss.weld.se.weld-se-core>3.0.5.Final</version.org.jboss.weld.se.weld-se-core>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.3.3.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.2.Final</version.org.jboss.ws.common.tools>
@@ -5854,7 +5853,7 @@
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
-                <version>${version.org.jboss.weld.se.weld-se-core}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
…sion used by tests.

JIRA issue - https://issues.redhat.com/browse/WFLY-14172

Note that apart from just bumping the version, I have noticed that WFLY uses different Weld SE version for some tests (and this isn't overriden in EE 9 setup).
I have tried aligning these version to see what happens because I don't quite see why they'd need to be different.
