### PR TITLE
WFLY-14061 Replace Java EE references in java doc with corresponding …

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JSF.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JSF.adoc
@@ -1,26 +1,26 @@
-[[JSF]]
-= JSF Configuration
+[[Jakarta_Server_Faces]]
+= Jakarta Server Faces Configuration
 
 [abstract]
 
-JSF configuration is handled by the JSF subsystem. The JSF subsystem
-allows multiple JSF implementations to be installed on the same WildFly
+Jakarta Server Faces configuration is handled by the Jakarta Server Faces subsystem. The Jakarta Server Faces subsystem
+allows multiple Jakarta Server Faces implementations to be installed on the same WildFly
 server. In particular, any version of Mojarra or MyFaces that implements
-spec level 2.1 or higher can be installed. For each JSF implementation,
+spec level 2.1 or higher can be installed. For each Jakarta Server Faces implementation,
 a new slot needs to be created under `com.sun.jsf-impl`,
-`javax.faces.api`, and `org.jboss.as.jsf-injection`. When the JSF
-subsystem starts up, it scans the module path to find all of the JSF
-implementations that have been installed. The default JSF implementation
+`javax.faces.api`, and `org.jboss.as.jsf-injection`. When the Jakarta Server Faces
+subsystem starts up, it scans the module path to find all of the Jakarta Server Faces
+implementations that have been installed. The default Jakarta Server Faces implementation
 that WildFly should use is defined by the `default-jsf-impl-slot`
 attribute.
 
 [[installing-a-new-jsf-implementation-manually]]
-== Installing a new JSF implementation manually
+== Installing a new Jakarta Server Faces implementation manually
 
-A new JSF implementation can be manually installed as follows:
+A new Jakarta Server Faces implementation can be manually installed as follows:
 
 [[add-a-module-slot-for-the-new-jsf-implementation-jar]]
-=== Add a module slot for the new JSF implementation JAR
+=== Add a module slot for the new Jakarta Server Faces implementation JAR
 
 * Create the following directory structure under the
 WILDFLY_HOME/modules directory: +
@@ -29,18 +29,18 @@ WILDFLY_HOME/modules/com/sun/jsf-impl/<JSF_IMPL_NAME>-<JSF_VERSION> +
 For example, for Mojarra 2.2.11, the above path would resolve to: +
 WILDFLY_HOME/modules/com/sun/jsf-impl/mojarra-2.2.11
 
-* Place the JSF implementation JAR in the <JSF_IMPL_NAME>-<JSF_VERSION>
+* Place the Jakarta Server Faces implementation JAR in the <JSF_IMPL_NAME>-<JSF_VERSION>
 subdirectory. In the same subdirectory, add a `module.xml` file similar
 to the
 https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml[Mojarra]
 or
 https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml[MyFaces]
 template examples. Change the `resource-root-path` to the name of your
-JSF implementation JAR and fill in appropriate values for $\{
+Jakarta Server Faces implementation JAR and fill in appropriate values for $\{
 `jsf-impl-name`} and $\{ `jsf-version`}.
 
 [[add-a-module-slot-for-the-new-jsf-api-jar]]
-=== Add a module slot for the new JSF API JAR
+=== Add a module slot for the new Jakarta Server Faces API JAR
 
 * Create the following directory structure under the
 WILDFLY_HOME/modules directory: +
@@ -53,11 +53,11 @@ https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/
 or
 https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml[MyFaces]
 template examples. Change the `resource-root-path` to the name of your
-JSF API JAR and fill in appropriate values for $\{ `jsf-impl-name`} and
+Jakarta Server Faces API JAR and fill in appropriate values for $\{ `jsf-impl-name`} and
 $\{ `jsf-version`}.
 
 [[add-a-module-slot-for-the-jsf-injection-jar]]
-=== Add a module slot for the JSF injection JAR
+=== Add a module slot for the Jakarta Server Faces injection JAR
 
 * Create the following directory structure under the
 WILDFLY_HOME/modules directory: +
@@ -96,8 +96,8 @@ Fill in the appropriate value for $\{ `version.commons-digester`}.
 === Start the server
 
 After starting the server, the following CLI command can be used to
-verify that your new JSF implementation has been installed successfully.
-The new JSF implementation should appear in the output of this command.
+verify that your new Jakarta Server Faces implementation has been installed successfully.
+The new Jakarta Server Faces implementation should appear in the output of this command.
 
 [source,options="nowrap"]
 ----
@@ -105,10 +105,10 @@ The new JSF implementation should appear in the output of this command.
 ----
 
 [[changing-the-default-jsf-implementation]]
-== Changing the default JSF implementation
+== Changing the default Jakarta Server Faces implementation
 
-The following CLI command can be used to make a newly installed JSF
-implementation the default JSF implementation used by WildFly:
+The following CLI command can be used to make a newly installed Jakarta Server Faces
+implementation the default Jakarta Server Faces implementation used by WildFly:
 
 [source,options="nowrap"]
 ----
@@ -118,12 +118,12 @@ implementation the default JSF implementation used by WildFly:
 A server restart will be required for this change to take effect.
 
 [[configuring-a-jsf-app-to-use-a-non-default-jsf-implementation]]
-== Configuring a JSF app to use a non-default JSF implementation
+== Configuring a Jakarta Server Faces app to use a non-default Jakarta Server Faces implementation
 
-A JSF app can be configured to use an installed JSF implementation
+A Jakarta Server Faces app can be configured to use an installed Jakarta Server Faces implementation
 that's not the default implementation by adding a
 `org.jboss.jbossfaces.JSF_CONFIG_NAME` context parameter to its
-`web.xml` file. For example, to indicate that a JSF app should use
+`web.xml` file. For example, to indicate that a Jakarta Server Faces app should use
 MyFaces 2.2.12 (assuming MyFaces 2.2.12 has been installed on the
 server), the following context parameter would need to be added:
 
@@ -135,14 +135,14 @@ server), the following context parameter would need to be added:
 </context-param>
 ----
 
-If a JSF app does not specify this context parameter, the default JSF
+If a Jakarta Server Faces app does not specify this context parameter, the default Jakarta Server Faces
 implementation will be used for that app.
 
 [[disallowing-doctype-declarations]]
 == Disallowing DOCTYPE declarations
 
 The following CLI commands can be used to disallow DOCTYPE declarations
-in JSF deployments:
+in Jakarta Server Faces deployments:
 
 [source,options="nowrap"]
 ----
@@ -150,7 +150,7 @@ in JSF deployments:
 reload
 ----
 
-This setting can be overridden for a particular JSF deployment by
+This setting can be overridden for a particular Jakarta Server Faces deployment by
 adding the `com.sun.faces.disallowDoctypeDecl` context parameter
 to the deployment's `web.xml` file:
 

--- a/docs/src/main/asciidoc/_developer-guide/EJB3_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/EJB3_Reference_Guide.adoc
@@ -186,8 +186,8 @@ The timer is will be started once at the specified time.
 
 In case of a server restart the timeout method of a persistent timer
 will only be called directly if the specified time is elapsed. +
-If the timer is not persistent (since EJB3.1 see 18.2.3) it will be not
-longer available if JBoss is restarted or the application is redeployed.
+If the timer is not persistent, it will no longer be available 
+if JBoss is restarted or the application is redeployed.
 
 [[recurring-timer]]
 === Recurring timer
@@ -201,9 +201,8 @@ execution.
 In case of server downtime for a persistent timer, the timeout method
 will be called only once if one, or more than one, interval is
 elapsed. +
-If the timer is not persistent (since EJB3.1 see 18.2.3) it will not
-longer be active after the server is restarted or the application is
-redeployed.
+If the timer is not persistent, it will no longer be active 
+after the server is restarted or the application is redeployed.
 
 [[calendar-timer]]
 === Calendar timer

--- a/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
@@ -13,7 +13,7 @@ when and which modules are added as implicit dependencies.
 == What's an implicit module dependency?
 
 Consider an application deployment which contains EJBs. EJBs typically
-need access to classes from the javax.ejb.* package and other Java EE
+need access to classes from the javax.ejb.* package and other Jakarta EE
 API packages. The jars containing these packages are already shipped in
 WildFly and are available as "modules". The module which contains the
 javax.ejb.* classes has a specific name and so does the module which

--- a/docs/src/main/asciidoc/_developer-guide/Remote_EJB_invocations_via_JNDI_-_EJB_client_API_or_remote-naming_project.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Remote_EJB_invocations_via_JNDI_-_EJB_client_API_or_remote-naming_project.adoc
@@ -342,7 +342,7 @@ public class FooBean implements Foo {
 
 Then the " `Foo`" remote view is exposed under the
 `java:jboss/exported/` namespace under the following JNDI name scheme
-(which is similar to that mandated by EJB3.1 spec for `java:global/`
+(which is similar to that mandated by Jakarta Enterprise Beans 3.2 spec for `java:global/`
 namespace):
 link:/pages/createpage.action?spaceKey=WFLY&title=app-name&linkCreation=true&fromPageId=557285[app-name]
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
@@ -6,7 +6,7 @@
 JBoss AS versions prior to WildFly8 allowed a JBoss specific way to
 plug-in user application specific interceptors on the server side so
 that those interceptors get invoked during an EJB invocation. Such
-interceptors differed from the typical (portable) spec provided Java EE
+interceptors differed from the typical (portable) spec provided Jakarta EE
 interceptors. The Jakarta EE interceptors are expected to run after the
 container has done necessary invocation processing which involves
 security context propagation, transaction management and other such
@@ -171,7 +171,7 @@ user application specific container interceptors to setup any relevant
 context data before the invocation proceeds.
 
 [[semantic-difference-between-container-interceptors-and-java-ee-interceptors-api]]
-== Semantic difference between container interceptor(s) and Java EE
+== Semantic difference between container interceptor(s) and Jakarta EE
 interceptor(s) API
 
 Although the container interceptors are modeled to be similar to the

--- a/docs/src/main/asciidoc/_extras/Developing_JSF_Project_Using,_Maven_and_IntelliJ.adoc
+++ b/docs/src/main/asciidoc/_extras/Developing_JSF_Project_Using,_Maven_and_IntelliJ.adoc
@@ -1,21 +1,21 @@
-[[Developing_JSF_Project_Using,_Maven_and_IntelliJ]]
-= Developing JSF Project Using JBoss AS7, Maven and IntelliJ
+[[Developing_Jakarta_Server_Faces_Project_Using,_Maven_and_IntelliJ]]
+= Developing Jakarta Server Faces Project Using JBoss AS7, Maven and IntelliJ
 ifdef::env-github[:imagesdir: ../images/]
 
 JBoss AS7 is a very 'modern' application server that has very fast
-startup speed. So it's an excellent container to test your JSF project.
+startup speed. So it's an excellent container to test your Jakarta Server Faces project.
 In this article, I'd like to show you how to use AS7, maven and IntelliJ
-together to develop your JSF project.
+together to develop your Jakarta Server Faces project.
 
 In this article I'd like to introduce the following things:
 
 * Create a project using Maven
-* Add JSF into project
+* Add Jakarta Server Faces into project
 * Writing Code
 * Add JBoss AS 7 deploy plugin into project
 * Deploy project to JBoss AS 7
 * Import project into IntelliJ
-* Add IntelliJ JSF support to project
+* Add IntelliJ Jakarta Server Faces support to project
 * Add JBoss AS7 to IntelliJ
 * Debugging project with IntelliJ and AS7
 
@@ -80,9 +80,9 @@ image:jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg[images/jsf/8108c4f111aab2
 The contents of the project is shown as above.
 
 [[add-jsf-into-project]]
-== Add JSF into project
+== Add Jakarta Server Faces into project
 
-The JSF library is now included in maven repo, so we can let maven to
+The Jakarta Server Faces library is now included in maven repo, so we can let maven to
 manage the download for us. First is to add repository into our pom.xml:
 
 [source,java,options="nowrap"]
@@ -94,7 +94,7 @@ manage the download for us. First is to add repository into our pom.xml:
 </repository>
 ----
 
-Then we add JSF dependency into pom.xml:
+Then we add Jakarta Server Faces dependency into pom.xml:
 
 [source,xml,options="nowrap"]
 ----
@@ -116,7 +116,7 @@ jsf-api for us automatically.
 [[writing-code]]
 == Writing Code
 
-Writing JSF code in this article is trivial, so I've put written a
+Writing Jakarta Server Faces code in this article is trivial, so I've put written a
 project called 'jsfdemo' onto github:
 
 https://github.com/liweinan/jsfdemo
@@ -222,7 +222,7 @@ deployed:
 
 image:jsf/2._java.jpg[images/jsf/2._java.jpg]
 
-Now we have learnt how to create a JSF project and deploy it to AS7
+Now we have learnt how to create a Jakarta Server Faces project and deploy it to AS7
 without any help from graphical tools. Next let's see how to use
 IntelliJ IDEA to go on developing/debugging our project.
 
@@ -259,15 +259,15 @@ image:jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg[images/jsf/91e40cd0b1545c
 Hooray! We've imported the project into IntelliJ now icon:smile-o[role="yellow"]
 
 [[adding-intellij-jsf-support-to-project]]
-== Adding IntelliJ JSF support to project
+== Adding IntelliJ Jakarta Server Faces support to project
 
 Let's see how to use IntelliJ and AS7 to debug the project. First we
-need to add 'JSF' facet into project. Open project setting:
+need to add 'Jakarta Server Faces' facet into project. Open project setting:
 
 image:jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg[images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg]
 
 Click on 'Facets' section on left; Select 'Web' facet that we already
-have, and click the '+' on top, choose 'JSF':
+have, and click the '+' on top, choose 'Jakarta Server Faces':
 
 image:jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg[images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg]
 
@@ -279,7 +279,7 @@ Click 'Ok':
 
 image:jsf/9988c572bad281146f405e9287f645a3da201885.jpg[images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg]
 
-Now we have enabled IntelliJ's JSF support for project.
+Now we have enabled IntelliJ's Jakarta Server Faces support for project.
 
 [[add-jboss-as7-to-intellij]]
 == Add JBoss AS7 to IntelliJ
@@ -408,7 +408,7 @@ And we could inspect our project now.
 == Conclusion
 
 In this article I've shown to you how to use maven to create a project
-using JSF and deploy it in JBoss AS7, and I've also talked about the
+using Jakarta Server Faces and deploy it in JBoss AS7, and I've also talked about the
 usage of IntelliJ during project development phase. Hope the contents
 are practical and helpful to you icon:smile-o[role="yellow"]
 

--- a/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
+++ b/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
@@ -286,8 +286,8 @@ bean, CDI will inject that bean
 [[introduction-2]]
 === Introduction
 
-This quickstart adds in a "complete" view layer into the mix. Java EE
-ships with a JSF. JSF is a server side rendering, component orientated
+This quickstart adds in a "complete" view layer into the mix. Jakarta EE
+ships with a Jakarta Server Faces. Jakarta Server Faces is a server side rendering, component orientated
 framework, where you write markup using an HTML like language, adding in
 dynamic behavior by binding components to beans in the back end. The
 quickstart also makes more use of CDI to wire the application together.
@@ -313,10 +313,10 @@ No need to open any of them, just point them out
 .  `web.xml` - don't need it!
 .  `beans.xml` - as before, marker file
 .  `faces-config.xml` - nice feature from AS7 - we can just put
-`faces-config.xml` into the WEB-INF and it enables JSF (inspiration from
+`faces-config.xml` into the WEB-INF and it enables Jakarta Server Faces (inspiration from
 CDI)
 .  `pom.xml` we saw this before, this time it's the same but adds in
-JSF API
+Jakarta Server Faces API
 
 [[views]]
 === Views
@@ -340,7 +340,7 @@ calls a method on the game bean
 persistence etc.
 ..  `@Named` – As we discussed CDI is typesafe, (beans are injected by
 type) but sometimes need to access in a non-typesafe fashion. @Named
-exposes the Bean in EL - and allows us to access it from JSF
+exposes the Bean in EL - and allows us to access it from Jakarta Server Faces
 ..  `@SessionScoped` – really simple app, we keep the game data in the
 session - to play two concurrent games, need two sessions. This is not a
 limitation of CDI, but simply keeps this demo very simple. CDI will
@@ -373,7 +373,7 @@ instance at runtime
 [[introduction-3]]
 === Introduction
 
-The login quickstart builds on the knowledge of CDI and JSF we have got
+The login quickstart builds on the knowledge of CDI and Jakarta Server Faces we have got
 from numberguess. New stuff we will learn about is how to use JPA to
 store data in a database, how to use JTA to control transactions, and
 how to use EJB for declarative TX control.
@@ -408,7 +408,7 @@ JTA and EJB
 [[views-1]]
 === Views
 
-.  `template.xhtml` One of the updates added to JSF 2.0 was templating
+.  `template.xhtml` One of the updates added to Jakarta Server Faces was templating
 ability. We take advantage of that in this app, as we have multiple
 views
 ..  Actually nothing too major here, we define the app "title" and we
@@ -434,14 +434,14 @@ logout, link to add users.
 
 .  `Credentials.java` Backing bean for the login form field, pretty
 trivial. It's request scoped (natural for a login field) and named so we
-can get it from JSF.
+can get it from Jakarta Server Faces.
 .  `Login.java`
 ..  Is session scoped (a user is logged in for the length of their
 session or until they log out}}
 ..  Is accessible from EL
 ..  Injects the current credentials
 ..  Uses the userManager service to load the user, and sends any
-messages to JSF as needed
+messages to Jakarta Server Faces as needed
 ..  Uses a producer method to expose the @LoggedIn user (producer
 methods used as we don't know which user at development time)
 .  `User.java` Is a pretty straightforward JPA entity. Mapped with
@@ -483,7 +483,7 @@ The kitchensink quickstart is generated from an archetype available for
 JBoss AS (tell people to check the
 link:/pages/createpage.action?spaceKey=WFLY&title=Getting+Started+Developing+Applications&linkCreation=true&fromPageId=557131[Getting
 Started Developing Applications] Guide for details). It demonstrates
-CDI, JSF, EJB, JPA (which we've seen before) and JAX-RS and Bean
+CDI, Jakarta Server Faces, Jakarta Enterprise Beans, JPA (which we've seen before) and JAX-RS and Bean
 Validation as well. We add in Arquillian for testing.
 
 [[run-the-app-2]]

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -64,7 +64,7 @@ and failover.
 Started Developing Applications Guide] shows you how to build Jakarta EE
 applications and deploy them to WildFly. The guide starts by showing you
 the simplest _helloworld_ application using just Servlet and CDI, and
-then adds in JSF, persistence and transactions, EJB, Bean Validation,
+then adds in Jakarta Server Faces, persistence and transactions, EJB, Bean Validation,
 RESTful web services and more. Finally, you'll get the opportunity to create
 your own skeleton project. Each tutorial is accompanied by a quickstart,
 which contains the source code, deployment descriptors and a Maven based

--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2010, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -38,7 +38,7 @@ import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.filter.PathFilters;
 
 /**
- * Deployment processor which adds the java EE APIs to EE deployments
+ * Deployment processor which adds the Jakarta EE APIs to EE deployments
  * <p/>
  *
  * @author John E. Bailey

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFComponentProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFComponentProcessor.java
@@ -247,7 +247,7 @@ public class JSFComponentProcessor implements DeploymentUnitProcessor {
     /**
      * According to JSF specification there is a table of eligible components
      * for CDI injection (TABLE 5-3 JSF Artifacts Eligible for Injection in chapter
-     * 5.4.1 JSF Managed Classes and Java EE Annotations). This method parses
+     * 5.4.1 JSF Managed Classes and Jakarta EE Annotations). This method parses
      * the faces-config configuration files and registers the classes.
      * The parser is quite simplistic. The tags are saved into a queue and
      * using the facesConfigElement tree it is known when a tag is one of the

--- a/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
+++ b/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -141,7 +141,7 @@ import javax.xml.ws.wsaddressing.*;
 
 /**
  * This class checks the dependencies as exported by the
- * "spec-api" module to ensure that compilation of all Java EE
+ * "spec-api" module to ensure that compilation of all Jakarta EE
  * 7 Specification Platform APIs are reachable.  As such, no runtime
  * assertions are required here, only references.  If this class compiles, 
  * all noted references are reachable within the spec-api dependency chain. 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/logging/WSLogger.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/logging/WSLogger.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -128,7 +128,7 @@ public interface WSLogger extends BasicLogger {
     @Message(id = 17, value = "Invalid handler chain file: %s")
     void invalidHandlerChainFile(String fileName);
 
-    String WS_SPEC_REF_5_3_2_4_2 = ". See section 5.3.2.4.2 of \"Web Services for Java EE, Version 1.4\".";
+    String WS_SPEC_REF_5_3_2_4_2 = ". See section 5.3.2.4.2 of \"Jakarta Enterprise Web Services 2.0\".";
 
     @LogMessage(level = ERROR)
     @Message(id = 18, value = "Web service method %s must not be static or final" + WS_SPEC_REF_5_3_2_4_2)

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/services/ModuleGroupSingletonProvider.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/services/ModuleGroupSingletonProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -124,7 +124,7 @@ public class ModuleGroupSingletonProvider extends SingletonProvider {
          * Default implementation of the Weld 1.2 API
          *
          * This provides forward binary compatibility with Weld 1.2 (OSGi integration).
-         * It is OK to ignore the id parameter as TCCL is still used to identify the singleton in Java EE.
+         * It is OK to ignore the id parameter as TCCL is still used to identify the singleton in Jakarta EE.
          */
         public T get(String id) {
             T val = contextIdStore.get(id);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14061

Description: Remove Java EE usage in java doc

As a part of the migration from JavaEE to Jakarta, we need to clean up JavaEE references in the sources (javadoc, documentation tags of xsd schemas, comments, etc.), replacing them with JakartaEE corresponding one when possible. Special care needed in avoiding any claim about JavaEE certification/compliance.