### PR TITLE
[WFLY-14210] Bump the jaxrs subsystems model version. Reject attribut…

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.Servlet;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -90,7 +91,7 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
                 .setReadOnly()
                 .setRuntimeOnly()
                 .setReplyType(ModelType.LIST)
-                .setDeprecated(JaxrsExtension.MODEL_VERSION_2_0_0)
+                .setDeprecated(ModelVersion.create(2, 0, 0))
                 .setReplyParameters(JAXRS_RESOURCE).build();
 
 

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsExtension.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsExtension.java
@@ -46,13 +46,8 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 public class JaxrsExtension implements Extension {
 
     public static final String SUBSYSTEM_NAME = "jaxrs";
-    public static final String NAMESPACE_1_0 = "urn:jboss:domain:jaxrs:1.0";
-    public static final String NAMESPACE_2_0 = "urn:jboss:domain:jaxrs:2.0";
 
-    public static final ModelVersion MODEL_VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
-    public static final ModelVersion MODEL_VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
-
-    private static final ModelVersion CURRENT_MODEL_VERSION = MODEL_VERSION_2_0_0;
+    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(3, 0, 0);
 
     private static final String RESOURCE_NAME = JaxrsExtension.class.getPackage().getName() + ".LocalDescriptions";
     static PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemParser_1_0.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemParser_1_0.java
@@ -25,37 +25,25 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 
 import java.util.List;
-
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
-public class JaxrsSubsystemParser_1_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+public class JaxrsSubsystemParser_1_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>> {
 
-      /**
-       * {@inheritDoc}
-       */
-      @Override
-      public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> list) throws XMLStreamException {
-          // Require no attributes or content
-          requireNoAttributes(reader);
-          requireNoContent(reader);
-          list.add(Util.createAddOperation(PathAddress.pathAddress(JaxrsExtension.SUBSYSTEM_PATH)));
-      }
-
-      /**
-       * {@inheritDoc}
-       */
-      @Override
-      public void writeContent(final XMLExtendedStreamWriter streamWriter, final SubsystemMarshallingContext context) throws XMLStreamException {
-          context.startSubsystemElement(JaxrsExtension.NAMESPACE_1_0, true);
-      }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> list) throws XMLStreamException {
+        // Require no attributes or content
+        requireNoAttributes(reader);
+        requireNoContent(reader);
+        list.add(Util.createAddOperation(PathAddress.pathAddress(JaxrsExtension.SUBSYSTEM_PATH)));
+    }
 }

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemParser_2_0.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemParser_2_0.java
@@ -49,7 +49,7 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public class JaxrsSubsystemParser_2_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
 
-    static final PathAddress PATH_ADDRESS = PathAddress.pathAddress(JaxrsExtension.SUBSYSTEM_PATH);
+    private static final String NAMESPACE = "urn:jboss:domain:jaxrs:2.0";
 
     @Override
     public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> list) throws XMLStreamException {
@@ -158,7 +158,7 @@ public class JaxrsSubsystemParser_2_0 implements XMLStreamConstants, XMLElementR
      */
     @Override
     public void writeContent(final XMLExtendedStreamWriter streamWriter, final SubsystemMarshallingContext context) throws XMLStreamException {
-        context.startSubsystemElement(JaxrsExtension.NAMESPACE_2_0, false);
+        context.startSubsystemElement(NAMESPACE, false);
         ModelNode subsystem = context.getModelNode();
         for (AttributeDefinition attr : JaxrsAttribute.ATTRIBUTES) {
             attr.marshallAsElement(subsystem, true, streamWriter);

--- a/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsTransformersTestCase.java
+++ b/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsTransformersTestCase.java
@@ -24,8 +24,8 @@ package org.jboss.as.jaxrs;
 import java.io.IOException;
 import java.util.List;
 
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.RunningMode;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -42,6 +42,7 @@ import org.junit.Test;
  * @author <a href="mailto:ema@rehdat.com>Jim Ma</a>
  * @author <a href="mailto:alessio.soldano@jboss.com>Alessio Soldano</a>
  * @author <a href="rsigal@redhat.com>Ron Sigal</a>
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class JaxrsTransformersTestCase extends AbstractSubsystemBaseTest {
 
@@ -55,59 +56,87 @@ public class JaxrsTransformersTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformers720() throws Exception {
-        testTransformers_2_0_to_1_0(ModelTestControllerVersion.EAP_7_2_0);
+    public void testTransformers700() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_0_0, "jaxrs-1.0.xml");
     }
 
     @Test
-    public void testRejections_1_0_0() throws Exception {
-        testRejections_2_0_0(ModelTestControllerVersion.EAP_7_2_0);
+    public void testTransformers710() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_1_0, "jaxrs-1.0.xml");
     }
 
-    /**
-     * Tests transformation of model from version 2.0 to version 1.0.
-     */
-    private void testTransformers_2_0_to_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+    @Test
+    public void testTransformers720() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_2_0, "jaxrs-1.0.xml");
+    }
+
+    @Test
+    public void testTransformers730() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_3_0, "jaxrs-1.0.xml");
+    }
+
+    @Test
+    public void testRejections700() throws Exception {
+        testRejections(ModelTestControllerVersion.EAP_7_0_0, "jaxrs-2.0.xml", getFailedTransformationConfig());
+    }
+
+    @Test
+    public void testRejections710() throws Exception {
+        testRejections(ModelTestControllerVersion.EAP_7_1_0, "jaxrs-2.0.xml", getFailedTransformationConfig());
+    }
+
+    @Test
+    public void testRejections720() throws Exception {
+        testRejections(ModelTestControllerVersion.EAP_7_2_0, "jaxrs-2.0.xml", getFailedTransformationConfig());
+    }
+
+    @Test
+    public void testRejections730() throws Exception {
+        testRejections(ModelTestControllerVersion.EAP_7_3_0, "jaxrs-2.0.xml", getFailedTransformationConfig());
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void testTransformers(final ModelTestControllerVersion controllerVersion, final String xmlFileName) throws Exception {
+        final ModelVersion version = controllerVersion.getSubsystemModelVersion(getMainSubsystemName());
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXmlResource("jaxrs-1.0.xml");
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXmlResource(xmlFileName);
 
         // create builder for legacy subsystem version
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, JaxrsExtension.MODEL_VERSION_1_0_0)
-        .addMavenResourceURL("org.jboss.eap:wildfly-jaxrs:" + controllerVersion.getMavenGavVersion())
-        .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null);
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version)
+                .addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-jaxrs:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null);
 
         KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(JaxrsExtension.MODEL_VERSION_1_0_0);
+        KernelServices legacyServices = mainServices.getLegacyServices(version);
 
         Assert.assertNotNull(legacyServices);
         Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
-        checkSubsystemModelTransformation(mainServices, JaxrsExtension.MODEL_VERSION_1_0_0);
+        checkSubsystemModelTransformation(mainServices, version);
     }
 
-    /**
-     * Tests rejections of attributes introduced in model version 2.0.
-     */
-    private void testRejections_2_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+    @SuppressWarnings("SameParameterValue")
+    private void testRejections(final ModelTestControllerVersion controllerVersion, final String xmlFileName, final FailedOperationTransformationConfig config) throws Exception {
+        final ModelVersion version = controllerVersion.getSubsystemModelVersion(getMainSubsystemName());
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
         // create builder for legacy subsystem version
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, JaxrsExtension.MODEL_VERSION_1_0_0)
-        .addMavenResourceURL("org.jboss.eap:wildfly-jaxrs:" + controllerVersion.getMavenGavVersion())
-        .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null)
-        .dontPersistXml();
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version)
+                .addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-jaxrs:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null)
+                .dontPersistXml();
 
         KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(JaxrsExtension.MODEL_VERSION_1_0_0);
+        KernelServices legacyServices = mainServices.getLegacyServices(version);
 
         Assert.assertNotNull(legacyServices);
         Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
-        List<ModelNode> xmlOps = builder.parseXmlResource("jaxrs-2.0.xml");
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, JaxrsExtension.MODEL_VERSION_1_0_0, xmlOps, getFailedTransformationConfig());
+        List<ModelNode> xmlOps = builder.parseXmlResource(xmlFileName);
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version, xmlOps, config);
     }
 
     private FailedOperationTransformationConfig getFailedTransformationConfig() {
@@ -136,16 +165,7 @@ public class JaxrsTransformersTestCase extends AbstractSubsystemBaseTest {
                                 JaxrsAttribute.RESTEASY_USE_BUILTIN_PROVIDERS,
                                 JaxrsAttribute.RESTEASY_USE_CONTAINER_FORM_PARAMS,
                                 JaxrsAttribute.RESTEASY_WIDER_REQUEST_MATCHING
-                                ));
-    }
-
-    protected AdditionalInitialization createAdditionalInitialization() {
-        return new AdditionalInitialization() {
-            @Override
-            protected RunningMode getRunningMode() {
-                return RunningMode.ADMIN_ONLY;
-            }
-        };
+                        ));
     }
 
 }


### PR DESCRIPTION
…es against the 1.0.0 and 2.0.0 model versions. Model version 2.0.0 was incorrectly used in WildFly 19, 20 and 21. An added system property was added to allow the transformers to be bypassed.

https://issues.redhat.com/browse/WFLY-14210
