### PR TITLE
[WFLY-14217] Upgrade WildFly Core 14.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>14.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>14.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14217

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/14.0.0.Beta4
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/14.0.0.Beta3...14.0.0.Beta4

---



## Release Notes - WildFly Core - Version 14.0.0.Beta4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5173'>WFCORE-5173</a>] -         Upgrade Undertow to 2.2.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5202'>WFCORE-5202</a>] -         Update bouncycastle to 1.67
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5218'>WFCORE-5218</a>] -         Upgrade JBoss Remoting to 5.0.20.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5206'>WFCORE-5206</a>] -         Remove workaround to access ModuleLoader.installMBeanServer
</li>
</ul>
                                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4135'>WFCORE-4135</a>] -         Support for read only server configuration directory
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4994'>WFCORE-4994</a>] -         Add the ability to adjust the case of a user name using an Elytron principal transformer
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5198'>WFCORE-5198</a>] -         Ignore Eclipse Transformer transformation failures caused by duplicate class files in input archive
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4967'>WFCORE-4967</a>] -         RequestController drops queued tasks randomly during server start.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5220'>WFCORE-5220</a>] -         IBM JDK jsse2 classes missing in ibm.jdk
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5013'>WFCORE-5013</a>] -         Remove the wildfly-openssl i386 and Solaris@x86_64 bindings
</li>
</ul>
                                                        