### PR TITLE
[WFLY-12503] Set up using a maven property to enable/disable surefire…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,15 @@
         <testsuite.ee.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.ee.galleon.pack.artifactId>
         <testsuite.ee.galleon.pack.version>${full.maven.version}</testsuite.ee.galleon.pack.version>
 
+        <!-- Properties that set the phase used for different plugin executions.
+             Profiles can override the values here to enable/disable executions.
+             A value of 'none' disables the execution; to enable set the value to the
+             normal phase for the goal.
+             This setup allows the bulk of the execution configuration to be in the
+             default build config (and thus shared in different profiles) while
+             still being easily disabled in profiles where it is not wanted. -->
+        <surefire.default-test.phase>test</surefire.default-test.phase>
+
         <!--
             *Plugin* Dependency versions. Please keep alphabetical.
 
@@ -9587,6 +9596,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Surefire runs a 'default-test' execution by default.
+                             Configure it here to use a property to set the phase for that execution.
+                             Default value of the property is the normal 'test' phase
+                             (see 'properties' declarations in this pom.)
+                             Profiles can set the property to 'none' to disable this execution -->
+                        <id>default-test</id>
+                        <phase>${surefire.default-test.phase}</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -9650,25 +9670,10 @@
                 <wildfly.web.build.output.dir>${wildfly.build.output.dir}</wildfly.web.build.output.dir>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
                 <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
+                <!-- Disable the surefire tests (at least the default ones) for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>
@@ -9678,24 +9683,11 @@
                     <name>ts.layers</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
         </profile>
 
         <profile>
@@ -9705,24 +9697,11 @@
                     <name>ts.standalone.microprofile</name>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests (at least the default ones) for all modules except for
-                             those where this profile turns them on.  This profile is meant to be an
-                             entirely alternative testsuite execution so there's no point running the normal
-                             tests, which get plenty of exercise elsewhere. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
         </profile>
 
         <profile>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -34,6 +34,8 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
+        <!-- Disable the default surefire test execution. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <dependencies>
@@ -741,14 +743,6 @@
                         <!-- Here we just have executions -->
                         <executions combine.children="append">
 
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>test</phase>
@@ -998,6 +992,7 @@
                                         </includes>
                                     </configuration>
                                 </execution>
+                                <!-- Disable the other standard executions -->
                                 <execution>
                                     <id>basic-integration-default-web.surefire</id>
                                     <phase>none</phase>
@@ -1074,10 +1069,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
@@ -2035,10 +2026,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
@@ -3295,10 +3282,6 @@
                         <executions>
                             <!-- Disable the standard test executions. -->
                             <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <phase>none</phase>
                             </execution>
@@ -3496,11 +3479,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!-- Disable the standard test executions. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>basic-integration-default-full.surefire</id>
                                 <!--<phase>none</phase>-->

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -47,6 +47,8 @@
         <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.org.infinispan.server>11.0.8.Final</version.org.infinispan.server>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>
+        <!-- Disable the default surefire test execution. All profiles use custom executions. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <dependencies>
@@ -165,33 +167,6 @@
     </dependencies>
 
     <profiles>
-        <!-- Skip the default 'test' surefire goal if using -Dts.noClustering -->
-        <profile>
-            <id>ts.clustering.integration.tests.skip.profile</id>
-            <activation>
-                <property>
-                    <name>ts.noClustering</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions combine.children="append">
-                            <!-- Disable default-test surefire execution which would fail otherwise. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <!-- Common step to prepare servers in use by all non-Galleon tests -->
         <profile>
@@ -373,14 +348,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
@@ -455,14 +422,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha-infinispan-server</id>
@@ -527,14 +486,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.fullha</id>
@@ -598,14 +549,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
                         <executions combine.children="append">
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Single node clustering tests. -->
                             <execution>
                                 <id>ts.surefire.clustering.single</id>
@@ -1343,10 +1286,6 @@
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
                             <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>
                             </execution>
@@ -1553,10 +1492,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>
@@ -1822,10 +1757,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <!-- Disable the test executions that are not compatible with this profile. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
                                 <phase>none</phase>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -554,10 +554,9 @@
                             </systemPropertyVariables>
                         </configuration>
                         <executions>
-                            <!-- Re-enable the defaut test execution but exclude tests incompatible with this configxf. -->
+                            <!-- Run the default test execution but exclude tests incompatible with this config. -->
                             <execution>
                                 <id>default-test</id>
-                                <phase>test</phase>
                                 <configuration>
                                     <excludes combine-children="append">
                                         <!-- Needs batch -->
@@ -685,13 +684,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!-- Enable the default tests (which the parent pom turns off for this profile) -->
+                            <!-- Configure the default tests -->
                             <execution>
                                 <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
                                         <install.dir>${project.build.directory}/${wildfly.instance.name}</install.dir>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -28,6 +28,8 @@
         <ts.elytron.cli>ssl-enable-elytron.cli</ts.elytron.cli>
         <wildfly>wildfly</wildfly>
         <wildfly.config.dir>${basedir}/target/${wildfly}/standalone/configuration</wildfly.config.dir>
+        <!-- Disable the default surefire test execution. All profiles use custom executions. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
     <dependencies>
         <dependency>
@@ -144,14 +146,6 @@
                         </configuration>
                         <executions combine.children="append">
 
-                            <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
                             <!-- Multi node clustering tests. -->
                             <execution>
                                 <id>tests-iiop-multi-node.surefire</id>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -167,30 +167,32 @@
                         <id>default-test</id>
                         <configuration>
                             <excludes>
+                                <!-- In this module default-test runs against standalone-microprofile.xml
+                                     Exclude tests from that execution that require functionality not in that config. -->
                                 <exclude>org/wildfly/test/integration/microprofile/jwt/ejb/JWTEJBTestCase.java</exclude>
                             </excludes>
                         </configuration>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
                     </execution>
+                    <!-- An execution analogous to default-test but separately customizable -->
                     <execution>
                         <id>layers-test</id>
+                        <!-- Disabled by default; relevant profiles enable it -->
                         <phase>none</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                     </execution>
+                    <!-- An execution analogous to default-test but uses standalone.xml -->
                     <execution>
+                        <id>standalone-enabled-microprofile-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
                         <configuration>
                             <systemPropertyVariables>
                                 <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                             </systemPropertyVariables>
                         </configuration>
-                        <id>standalone-enabled-microprofile-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -287,7 +289,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Enable the layers-test surefire execution -->
+                        <!-- Enable the layers-test surefire execution; disable others. -->
                         <executions>
                             <execution>
                                 <id>layers-test</id>
@@ -406,7 +408,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Enable the layers-test surefire execution -->
+                        <!-- Enable the layers-test surefire execution, disable others -->
                         <executions>
                             <execution>
                                 <id>layers-test</id>
@@ -490,7 +492,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <!--Re-enable the default surefire execution. -->
+                            <!--Re-enable the default surefire execution, disable others. -->
                             <execution>
                                 <id>default-test</id>
                                 <phase>test</phase>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -288,30 +288,6 @@
     <profiles>
 
         <profile>
-            <id>not.standalone.microprofile.profile</id>
-            <activation>
-                <property>
-                    <name>!ts.standalone.microprofile</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <!--Re-enable the default surefire execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
             <id>standalone.microprofile.profile</id>
             <activation>
                 <property>
@@ -534,9 +510,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
                             <!-- Tests against the install without legacy security -->
                             <!-- Reuse the microprofile.surefire execution as the valid tests are the same.

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -169,30 +169,6 @@
         </profile>
 
         <profile>
-            <id>not.standalone.microprofile.profile</id>
-            <activation>
-                <property>
-                    <name>!ts.standalone.microprofile</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <!--Re-enable the default surefire execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
             <id>standalone.microprofile.profile</id>
             <activation>
                 <property>
@@ -535,9 +511,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
 
                             <!-- Tests against the datasource-web-server without legacy security -->
@@ -993,9 +966,6 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>none</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                             </execution>
 
                             <!-- Tests against the datasource-web-server without legacy security -->

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -238,9 +238,6 @@
                             <!-- Disable default-test execution. -->
                             <execution>
                                 <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                                 <phase>none</phase>
                             </execution>
 

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -58,7 +58,8 @@
              Provisioning executions using the wildfly-test-galleon-pack are handled separately from others. -->
         <provisioning.phase>none</provisioning.phase>
         <provisioning.phase.preview.excluded>none</provisioning.phase.preview.excluded>
-        <surefire.phase>none</surefire.phase>
+        <!-- Don't run the default surefire execution unless a profile enables it -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
     </properties>
 
     <profiles>
@@ -73,7 +74,7 @@
                 <!-- Turn on normal plugin execution by changing the phase props from 'none' -->
                 <provisioning.phase>compile</provisioning.phase>
                 <provisioning.phase.preview.excluded>compile</provisioning.phase.preview.excluded>
-                <surefire.phase>test</surefire.phase>
+                <surefire.default-test.phase>test</surefire.default-test.phase>
             </properties>
         </profile>
 
@@ -2506,12 +2507,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>${surefire.phase}</phase>
-                            </execution>
-                        </executions>
                         <configuration>
                             <systemPropertyVariables>
                                 <!-- maven.local.repo is set in parent pom.xml, system property surefire.system.args -->


### PR DESCRIPTION
… default-test execution. Use that where appropriate.

In some places direct enabling/disabling of default-test is left in place. This is done in contexts where direct enabling/disabling of other surefire executions is being done so it seemed clearer to handle default-test in the same way.

JUST FOR CI; this is meant to be a foundational commit in a branch with other commits