### PR TITLE
[WFLY-14226] Upgrade Mojarra to 3.0.0.SP03 in the EE9 feature pack

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -51,7 +51,7 @@
         <full.ee-9-api.license.directory>${basedir}/src/license</full.ee-9-api.license.directory>
 
 
-        <version.com.sun.faces>3.0.0.SP02</version.com.sun.faces>
+        <version.com.sun.faces>3.0.0.SP03</version.com.sun.faces>
         <version.com.sun.activation.jakarta.activation>2.0.0</version.com.sun.activation.jakarta.activation>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authentication.jakarta-authentication-api>2.0.0</version.jakarta.authentication.jakarta-authentication-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14226

This upgrade incorporates fixes from the Mojarra 2.3.14.SP branch. The complete list of fixes included in Mojarra 3.0.0.SP03 can be seen here:

https://github.com/jboss/mojarra/compare/3.0.0.SP02...3.0.0.SP03
