### PR TITLE
[WFLY-14219] Upgrade module descriptors to 1.9.

### DIFF
--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/activation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/activation/api/main/module.xml
@@ -22,8 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.activation.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.activation.api">
+
+    <resources>
+        <artifact name="${com.sun.activation:jakarta.activation}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.logging" />
         <module name="javax.api" />
         <module name="javax.mail.api" optional="true">
             <imports><include path="META-INF"/></imports>
@@ -32,8 +38,4 @@
         <module name="org.jboss.ws.native.jbossws-native-core" optional="true"/>
         <module name="org.apache.cxf" optional="true"/>
     </dependencies>
-
-    <resources>
-        <artifact name="${com.sun.activation:jakarta.activation}"/>
-    </resources>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/annotation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/annotation/api/main/module.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.annotation.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.annotation.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec}"/>-->
         <artifact name="${jakarta.annotation:jakarta.annotation-api}"/>
     </resources>
-
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/batch/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/batch/api/main/module.xml
@@ -22,13 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.batch.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.batch.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.batch:jboss-batch-api_1.0_spec}"/>-->
         <artifact name="${jakarta.batch:jakarta.batch-api}"/>
     </resources>
+
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
     </dependencies>    
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/ejb/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/ejb/api/main/module.xml
@@ -22,15 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.ejb.api">
-    <dependencies>
-        <!-- This dep is for javax.naming -->
-        <module name="javax.api" />
-        <module name="javax.transaction.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.ejb.api">
 
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec}"/>-->
         <artifact name="${jakarta.ejb:jakarta.ejb-api}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <!-- This dep is for javax.naming -->
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.transaction.api"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/el/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/el/api/main/module.xml
@@ -22,8 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.el.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.el.api">
+
     <resources>
         <artifact name="${org.jboss.spec.jakarta.el:jboss-el-api_4.0_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+    </dependencies>    
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
@@ -22,7 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="jakarta.enterprise.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.enterprise.api">
+
+    <resources>
+        <artifact name="${jakarta.enterprise:jakarta.enterprise.cdi-api}"/>
+    </resources>
+
     <dependencies>
         <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.inject.api" export="true"/>
@@ -32,9 +37,4 @@
         <module name="org.jboss.as.weld" services="import" optional="true"/>
         <module name="org.jboss.weld.core" optional="true"/>
     </dependencies>
-
-    <resources>
-        <artifact name="${jakarta.enterprise:jakarta.enterprise.cdi-api}"/>
-    </resources>
-
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/concurrent/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/concurrent/api/main/module.xml
@@ -22,14 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.enterprise.concurrent.api">
-    
-    <dependencies>
-    </dependencies>
-    
+<module xmlns="urn:jboss:module:1.9" name="jakarta.enterprise.concurrent.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec}"/>-->
         <artifact name="${jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api}"/>
     </resources>
-    
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/faces/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/faces/api/main/module.xml
@@ -22,8 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="jakarta.faces.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.faces.api">
+
+    <resources>
+        <!--<artifact name="${org.jboss.spec.javax.faces:jboss-jsf-api_2.3_spec}"/>-->
+        <artifact name="${jakarta.faces:jakarta.faces-api}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
         <module name="com.sun.jsf-impl"/>
         <module name="javax.enterprise.api" export="true"/>
         <module name="javax.servlet.api" export="true"/>
@@ -31,12 +41,7 @@
         <module name="javax.servlet.jstl.api" export="true"/>
         <module name="javax.validation.api" export="true"/>
         <module name="org.glassfish.jakarta.el" export="true"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.websocket.api"/>
     </dependencies>
-
-    <resources>
-        <!--<artifact name="${org.jboss.spec.javax.faces:jboss-jsf-api_2.3_spec}"/>-->
-        <artifact name="${jakarta.faces:jakarta.faces-api}"/>
-    </resources>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/inject/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/inject/api/main/module.xml
@@ -22,6 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="jakarta.inject.api">
+
     <resources>
         <artifact name="${jakarta.inject:jakarta.inject-api}"/>
     </resources>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/interceptor/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/interceptor/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="jakarta.interceptor.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.interceptor.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec}"/>-->
         <artifact name="${jakarta.interceptor:jakarta.interceptor-api}"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/jms/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/jms/api/main/module.xml
@@ -22,13 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.jms.api">
-    <dependencies>
-        <module name="javax.transaction.api" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.jms.api">
 
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec}"/>-->
         <artifact name="${jakarta.jms:jakarta.jms-api}"/>
     </resources>
+
+    <dependencies>
+        <module name="javax.transaction.api" export="true"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
@@ -31,6 +31,7 @@
     <resources>
         <artifact name="${jakarta.json:jakarta.json-api}"/>
     </resources>
+
     <dependencies>
         <!--
             This is required as a circular dependency because the RI does not include a META-INF/services provider file.

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/json/bind/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/json/bind/api/main/module.xml
@@ -17,12 +17,15 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="jakarta.json.bind.api">
+
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>
+
     <resources>
         <artifact name="${jakarta.json.bind:jakarta.json.bind-api}"/>
     </resources>
+
     <dependencies>
         <module name="javax.json.api"/>
     </dependencies>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/jws/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/jws/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.jws.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.jws.api">
+
     <resources>
         <artifact name="${javax.jws:jsr181-api}"/>
     </resources>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/mail/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/mail/api/main/module.xml
@@ -22,13 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.mail.api">
-    <dependencies>
-        <module name="javax.activation.api" />
-        <module name="javax.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.mail.api">
 
     <resources>
         <artifact name="${com.sun.mail:jakarta.mail}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.security.sasl"/>
+        <module name="javax.activation.api" />
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/persistence/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/persistence/api/main/module.xml
@@ -22,13 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.persistence.api">
-    <dependencies>
-        <!-- PersistenceUnitInfo needs javax.sql.DataSource -->
-        <module name="javax.api" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.persistence.api">
 
     <resources>
         <artifact name="${jakarta.persistence:jakarta.persistence-api}"/>
     </resources>
+
+    <dependencies>
+        <!-- java.instrument export due to jdeps result -->
+        <module name="java.instrument" export="true"/>
+        <module name="java.logging"/>
+        <!-- PersistenceUnitInfo needs javax.sql.DataSource -->
+        <module name="java.sql" export="true"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/resource/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/resource/api/main/module.xml
@@ -22,8 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.resource.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.resource.api">
+
+    <resources>
+        <!--<artifact name="${org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec}"/>-->
+        <artifact name="${jakarta.resource:jakarta.resource-api}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="javax.transaction.api" export="true"/>
         <module name="javax.api" export="false">
             <exports>
@@ -31,9 +40,4 @@
             </exports>
         </module>
     </dependencies>
-
-    <resources>
-        <!--<artifact name="${org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec}"/>-->
-        <artifact name="${jakarta.resource:jakarta.resource-api}"/>
-    </resources>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
@@ -22,15 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.security.auth.message.api">
-
-    <dependencies>
-        <!-- Needed for javax.security.auth -->
-        <module name="javax.api" export="false"/>
-     </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.security.auth.message.api">
 
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec}"/>-->
         <artifact name="${jakarta.authentication:jakarta.authentication-api}"/>
     </resources>
+
+    <dependencies>
+        <!-- Needed for javax.security.auth -->
+        <module name="javax.api" export="false"/>
+     </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.security.enterprise.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.security.enterprise.api">
+
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/jacc/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/jacc/api/main/module.xml
@@ -22,13 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="jakarta.security.jacc.api">
-    <dependencies>
-        <module name="javax.servlet.api" optional="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.security.jacc.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec}"/>
         <!--<artifact name="${jakarta.authorization:jakarta.authorization-api}"/>-->
     </resources>
+
+    <dependencies>
+        <module name="javax.servlet.api" optional="true"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.servlet.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.servlet.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec}"/>-->
         <artifact name="${jakarta.servlet:jakarta.servlet-api}"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/jsp/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/jsp/api/main/module.xml
@@ -22,14 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.servlet.jsp.api">
-    <dependencies>
-        <module name="javax.servlet.api" export="true"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.servlet.jsp.api">
 
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.servlet.jsp:jboss-jsp-api_2.3_spec}"/>-->
         <artifact name="${jakarta.servlet.jsp:jakarta.servlet.jsp-api}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/jstl/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/servlet/jstl/api/main/module.xml
@@ -22,18 +22,24 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.servlet.jstl.api">
-    <dependencies>
-        <!-- org.xml.sax -->
-        <module name="javax.api" export="false"/>
-        <module name="javax.servlet.api" export="false"/>
-        <module name="javax.servlet.jsp.api" export="false"/>
-        <module name="org.apache.xalan" export="false"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.servlet.jstl.api">
 
     <resources>
         <artifact name="${org.apache.taglibs:taglibs-standard-spec}"/>
         <artifact name="${org.apache.taglibs:taglibs-standard-impl}"/>
         <artifact name="${org.apache.taglibs:taglibs-standard-compat}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <!-- org.xml.sax -->
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="org.apache.xalan"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/validation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/validation/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.validation.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.validation.api">
+
     <resources>
         <artifact name="${jakarta.validation:jakarta.validation-api}"/>
     </resources>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/websocket/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/websocket/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.websocket.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.websocket.api">
+
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec}"/>-->
         <artifact name="${jakarta.websocket:jakarta.websocket-api}"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/ws/rs/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/ws/rs/api/main/module.xml
@@ -22,15 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.ws.rs.api">
+<module xmlns="urn:jboss:module:1.9" name="jakarta.ws.rs.api">
+
     <resources>
         <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}"/>
         <!--<artifact name="${jakarta.ws.rs:jakarta.ws.rs-api}"/>-->
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="javax.xml.bind.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/bind/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/bind/api/main/module.xml
@@ -22,18 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.xml.bind.api">
-
-
-    <dependencies>
-        <module name="javax.activation.api" export="true"/>
-        <module name="javax.xml.stream.api"/>
-        <module name="com.sun.xml.bind" services="import"/>
-        <module name="javax.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.xml.bind.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec}"/>
         <!--<artifact name="${jakarta.xml.bind:jakarta.xml.bind-api}"/>-->
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="javax.activation.api" export="true"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="com.sun.xml.bind" services="import"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/soap/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/soap/api/main/module.xml
@@ -22,14 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="jakarta.xml.soap.api">
-    <dependencies>
-        <module name="javax.activation.api" export="true"/>
-        <module name="javax.api"/>
-        <module name="org.jboss.modules"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.xml.soap.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.soap:jboss-saaj-api_1.4_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="javax.activation.api" export="true"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/ws/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/xml/ws/api/main/module.xml
@@ -22,15 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="jakarta.xml.ws.api">
-    <dependencies>
-        <module name="javax.xml.bind.api" export="true"/>
-        <module name="javax.xml.soap.api" export="true"/>
-        <module name="javax.api"/>
-        <module name="org.jboss.modules"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="jakarta.xml.ws.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.ws:jboss-jaxws-api_2.3_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="javax.xml.bind.api" export="true"/>
+        <module name="javax.xml.soap.api" export="true"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.activation.api" target-name="jakarta.activation.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.activation.api" target-name="jakarta.activation.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.annotation.api" target-name="jakarta.annotation.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.annotation.api" target-name="jakarta.annotation.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.batch.api" target-name="jakarta.batch.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.batch.api" target-name="jakarta.batch.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.ejb.api" target-name="jakarta.ejb.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.ejb.api" target-name="jakarta.ejb.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.el.api" target-name="jakarta.el.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.el.api" target-name="jakarta.el.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.enterprise.api" target-name="jakarta.enterprise.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.enterprise.api" target-name="jakarta.enterprise.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.enterprise.concurrent.api" target-name="jakarta.enterprise.concurrent.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.enterprise.concurrent.api" target-name="jakarta.enterprise.concurrent.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.faces.api" target-name="jakarta.faces.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.faces.api" target-name="jakarta.faces.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.inject.api" target-name="jakarta.inject.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.inject.api" target-name="jakarta.inject.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.interceptor.api" target-name="jakarta.interceptor.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.interceptor.api" target-name="jakarta.interceptor.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.jms.api" target-name="jakarta.jms.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.jms.api" target-name="jakarta.jms.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.json.api" target-name="jakarta.json.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.json.api" target-name="jakarta.json.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.json.bind.api" target-name="jakarta.json.bind.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.json.bind.api" target-name="jakarta.json.bind.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.jws.api" target-name="jakarta.jws.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.jws.api" target-name="jakarta.jws.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.mail.api" target-name="jakarta.mail.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.mail.api" target-name="jakarta.mail.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.persistence.api" target-name="jakarta.persistence.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.persistence.api" target-name="jakarta.persistence.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.resource.api" target-name="jakarta.resource.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.resource.api" target-name="jakarta.resource.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/auth/message/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/auth/message/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.security.auth.message.api" target-name="jakarta.security.auth.message.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.security.auth.message.api" target-name="jakarta.security.auth.message.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.security.enterprise.api" target-name="jakarta.security.enterprise.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.security.enterprise.api" target-name="jakarta.security.enterprise.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.security.jacc.api" target-name="jakarta.security.jacc.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.security.jacc.api" target-name="jakarta.security.jacc.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.servlet.api" target-name="jakarta.servlet.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.servlet.api" target-name="jakarta.servlet.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.servlet.jsp.api" target-name="jakarta.servlet.jsp.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.servlet.jsp.api" target-name="jakarta.servlet.jsp.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.servlet.jstl.api" target-name="jakarta.servlet.jstl.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.servlet.jstl.api" target-name="jakarta.servlet.jstl.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/transaction/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/transaction/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.transaction.api" target-name="jakarta.transaction.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.transaction.api" target-name="jakarta.transaction.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.validation.api" target-name="jakarta.validation.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.validation.api" target-name="jakarta.validation.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.websocket.api" target-name="jakarta.websocket.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.websocket.api" target-name="jakarta.websocket.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.ws.rs.api" target-name="jakarta.ws.rs.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.ws.rs.api" target-name="jakarta.ws.rs.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.xml.bind.api" target-name="jakarta.xml.bind.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.xml.bind.api" target-name="jakarta.xml.bind.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/internal/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/internal/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.xml.rpc.api.internal">
+<module xmlns="urn:jboss:module:1.9" name="javax.xml.rpc.api.internal">
     <!--
       This module providing the JAX-RPC API classes is meant only for internal use
       by WildFly modules that have a compile time dependency on JAX-RPC classes.
@@ -46,4 +46,8 @@
         <artifact name="${org.jboss.spec.javax.xml.rpc:jboss-jaxrpc-api_1.1_spec}"/>
     </resources>
 
+    <dependencies>
+        <module name="java.rmi"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.xml.soap.api" target-name="jakarta.xml.soap.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.xml.soap.api" target-name="jakarta.xml.soap.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
@@ -16,4 +16,4 @@
   ~ limitations under the License.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="javax.xml.ws.api" target-name="jakarta.xml.ws.api"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="javax.xml.ws.api" target-name="jakarta.xml.ws.api"/>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/json/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/json/main/module.xml
@@ -27,9 +27,6 @@
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <dependencies>
-        <module name="javax.json.api" />
-    </dependencies>
     <resources>
         <artifact name="${org.glassfish:jakarta.json}">
             <filter>
@@ -43,4 +40,8 @@
             </filter>
         </artifact>
     </resources>
+
+    <dependencies>
+        <module name="javax.json.api" />
+    </dependencies>
 </module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/deployment/transformation/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/deployment/transformation/main/module.xml
@@ -22,14 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.deployment.transformation">
-    <dependencies>
-        <module name="org.jboss.as.server"/>
-        <module name="org.jboss.logging"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.deployment.transformation">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-ee-9-deployment-transformer}"/>
         <artifact name="${org.wildfly.galleon-plugins:transformer}"/>
     </resources>
+
+    <dependencies>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="asm.asm">
+<module xmlns="urn:jboss:module:1.9" name="asm.asm">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,7 +32,4 @@
         <artifact name="${org.ow2.asm:asm}"/>
         <artifact name="${org.ow2.asm:asm-util}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
@@ -22,7 +22,7 @@
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.classmate">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.classmate">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
@@ -21,12 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.core.jackson-annotations">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.core.jackson-annotations">
      <resources>
         <artifact name="${com.fasterxml.jackson.core:jackson-annotations}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
@@ -21,12 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.core.jackson-core">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.core.jackson-core">
      <resources>
         <artifact name="${com.fasterxml.jackson.core:jackson-core}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
@@ -21,13 +21,17 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.core.jackson-databind">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.core.jackson-databind">
+
      <resources>
         <artifact name="${com.fasterxml.jackson.core:jackson-databind}"/>
     </resources>
-
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
         <module name="com.fasterxml.jackson.core.jackson-core"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8">
      <resources>
         <artifact name="${com.fasterxml.jackson.datatype:jackson-datatype-jdk8}"/>
     </resources>
@@ -30,6 +30,6 @@
         <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310">
      <resources>
         <artifact name="${com.fasterxml.jackson.datatype:jackson-datatype-jsr310}"/>
     </resources>
@@ -30,6 +30,6 @@
         <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
      <resources>
         <artifact name="${com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider}"/>
         <artifact name="${com.fasterxml.jackson.jaxrs:jackson-jaxrs-base}"/>
@@ -29,7 +29,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ws.rs.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/ben-manes/caffeine/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/ben-manes/caffeine/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 
-<module xmlns="urn:jboss:module:1.5" name="com.github.ben-manes.caffeine">
+<module xmlns="urn:jboss:module:1.9" name="com.github.ben-manes.caffeine">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,6 +33,8 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
         <module name="sun.jdk"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/btf/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/btf/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.btf">
+<module xmlns="urn:jboss:module:1.9" name="com.github.fge.btf">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -31,5 +31,4 @@
     <resources>
         <artifact name="${com.github.fge:btf}"/>
     </resources>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/jackson-coreutils/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/jackson-coreutils/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.jackson-coreutils">
+<module xmlns="urn:jboss:module:1.9" name="com.github.fge.jackson-coreutils">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/json-patch/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/json-patch/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.json-patch">
+<module xmlns="urn:jboss:module:1.9" name="com.github.fge.json-patch">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/msg-simple/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/fge/msg-simple/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.msg-simple">
+<module xmlns="urn:jboss:module:1.9" name="com.github.fge.msg-simple">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/spullara/mustache/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/github/spullara/mustache/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.github.spullara.mustache">
+<module xmlns="urn:jboss:module:1.9" name="com.github.spullara.mustache">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging" />
         <module name="com.google.guava" />
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.9" name="com.google.code.gson">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -24,6 +25,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.sql"/>
         <module name="javax.sql.api"/>
         <module name="sun.jdk"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/h2database/h2/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/h2database/h2/main/module.xml
@@ -22,13 +22,22 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.h2database.h2">
+<module xmlns="urn:jboss:module:1.9" name="com.h2database.h2">
 
     <resources>
         <artifact name="${com.h2database:h2}"/>
     </resources>
+
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.compiler"/>
+        <module name="java.desktop"/>
+        <module name="java.instrument"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.scripting"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.servlet.api" optional="true"/>
         <module name="org.slf4j"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/microsoft/azure/storage/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/microsoft/azure/storage/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.microsoft.azure.storage">
+<module xmlns="urn:jboss:module:1.9" name="com.microsoft.azure.storage">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,10 +33,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.xml"/>
         <module name="com.fasterxml.jackson.core.jackson-core"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <!-- <module name="org.apache.commons.lang"/> -->
         <module name="org.slf4j"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="com.squareup.okhttp3">
+<module xmlns="urn:jboss:module:1.9" name="com.squareup.okhttp3">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -22,12 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="com.sun.jsf-impl">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.jsf-impl">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="javax.faces.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.servlet.api"/>
@@ -38,12 +43,13 @@
         <module name="javax.ejb.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="org.glassfish.jakarta.el"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
+        <module name="java.xml"/>
     </dependencies>
 
     <resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
@@ -21,8 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.5" name="com.sun.xml.bind">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.xml.bind">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -41,9 +40,11 @@
     </resources>
 
     <dependencies>
-        <module name="javax.activation.api" />
-        <module name="javax.api" />
-        <module name="javax.xml.bind.api" />
-        <module name="javax.xml.stream.api" />
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="javax.activation.api"/>
+        <module name="javax.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="javax.xml.stream.api"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/fastinfoset/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/fastinfoset/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.sun.xml.fastinfoset">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.xml.fastinfoset">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
-        <module name="javax.xml.stream.api" />
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.xml.stream.api"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.sun.xml.messaging.saaj">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.xml.messaging.saaj">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,11 +33,14 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
-        <module name="javax.xml.soap.api" />
+        <module name="java.datatransfer"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.xml.soap.api"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.activation.api"/>
         <module name="org.apache.xerces" services="import" />
+        <module name="java.xml"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/gnu/getopt/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/gnu/getopt/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="gnu.getopt">
+<module xmlns="urn:jboss:module:1.9" name="gnu.getopt">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,5 +31,4 @@
     <resources>
         <artifact name="${gnu.getopt:java-getopt}"/>
     </resources>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.netty">
+<module xmlns="urn:jboss:module:1.9" name="io.netty">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +32,13 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="sun.jdk"/>
         <module name="org.javassist" optional="true"/>
+        <module name="jdk.sctp"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/reactivex/rxjava2/rxjava/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/reactivex/rxjava2/rxjava/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.reactivex.rxjava2.rxjava">
+<module xmlns="urn:jboss:module:1.9" name="io.reactivex.rxjava2.rxjava">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.reactivestreams"/>
         <module name="sun.jdk"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/reactivex/rxjava3/rxjava/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/reactivex/rxjava3/rxjava/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="io.reactivex.rxjava3.rxjava">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.reactivestreams"/>
         <module name="sun.jdk"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
@@ -22,14 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.undertow.js">
+<module xmlns="urn:jboss:module:1.9" name="io.undertow.js">
 
     <resources>
         <artifact name="${io.undertow.js:undertow-js}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.scripting"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api"/>
         <module name="javax.enterprise.api" />
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/rmi/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/rmi/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.rmi.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.rmi.api">
     <dependencies>
         <module name="javax.orb.api" export="false">
             <exports>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/wsdl4j/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/wsdl4j/api/main/module.xml
@@ -22,12 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.wsdl4j.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.wsdl4j.api">
     <resources>
         <artifact name="${wsdl4j:wsdl4j}"/>
     </resources>
 
     <dependencies>
-      <module name="javax.api" />
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+      <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/net/bytebuddy/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/net/bytebuddy/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="net.bytebuddy">
+<module xmlns="urn:jboss:module:1.9" name="net.bytebuddy">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,8 @@
     </resources>
 
     <dependencies>
+        <module name="java.instrument"/>
         <module name="sun.jdk"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/net/jcip/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/net/jcip/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="net.jcip">
+<module xmlns="urn:jboss:module:1.9" name="net.jcip">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,4 @@
     <resources>
         <artifact name="${net.jcip:jcip-annotations}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/nu/xom/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/nu/xom/main/module.xml
@@ -20,7 +20,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="nu.xom">
+<module xmlns="urn:jboss:module:1.9" name="nu.xom">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -28,7 +29,8 @@
     <dependencies>
         <module name="org.jaxen"/>
         <module name="org.apache.xerces"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 
     <resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/antlr/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/antlr/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.antlr">
+<module xmlns="urn:jboss:module:1.9" name="org.antlr">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,5 +33,6 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.apache.activemq.artemis.journal">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.journal">
+
     <resources>
         <resource-root path="lib"/>
         <artifact name="${org.apache.activemq:artemis-commons}"/>
@@ -31,9 +32,12 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
         <!-- required for ARTEMIS-298 -->
         <module name="com.google.guava"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.json.api"/>
         <module name="org.apache.commons.beanutils" />
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.activemq.artemis">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis">
+
     <resources>
         <artifact name="${org.apache.activemq:artemis-core-client}"/>
         <artifact name="${org.apache.activemq:artemis-selector}"/>
@@ -35,12 +36,18 @@
         <artifact name="${org.apache.activemq:artemis-jms-server}"/>
         <artifact name="${org.apache.activemq:artemis-service-extensions}"/>
         <artifact name="${org.apache.activemq:artemis-tools}"/>
-
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
+        <module name="java.management.rmi"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="java.sql"/>
+        <module name="java.security.jgss"/>
+        <module name="javax.transaction.api"/>
         <module name="com.google.guava"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.jms.api" />
         <module name="javax.json.api"/>
         <module name="org.apache.commons.beanutils" />
@@ -69,5 +76,6 @@
         <module name="org.apache.activemq.artemis.protocol.amqp" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.hornetq" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.stomp" services="import" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
@@ -22,12 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.activemq.artemis.protocol.amqp">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.protocol.amqp">
+
     <resources>
         <artifact name="${org.apache.activemq:artemis-amqp-protocol}"/>
     </resources>
 
     <dependencies>
+        <module name="java.security.jgss"/>
+        <module name="java.security.sasl"/>
+        <module name="javax.transaction.api"/>
         <module name="javax.jms.api"/>
         <module name="org.apache.qpid.proton"/>
         <module name="io.netty"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/hornetq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/hornetq/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.activemq.artemis.protocol.hornetq">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.protocol.hornetq">
     <resources>
         <artifact name="${org.apache.activemq:artemis-hornetq-protocol}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/stomp/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/stomp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.activemq.artemis.protocol.stomp">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.protocol.stomp">
     <resources>
         <artifact name="${org.apache.activemq:artemis-stomp-protocol}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.activemq.artemis.ra">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.ra">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +33,12 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="javax.transaction.api"/>
         <module name="io.netty"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.jms.api" />
         <module name="javax.resource.api"/>
         <module name="org.apache.activemq.artemis"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/avro/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/avro/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.avro">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.avro">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,5 +34,6 @@
     <dependencies>
         <module name="org.codehaus.jackson.jackson-core-asl"/>
         <module name="org.codehaus.jackson.jackson-mapper-asl"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.beanutils">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.beanutils">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,8 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.sql"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.commons.collections"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/cli/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/cli/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.cli">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.cli">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,4 @@
     <resources>
         <artifact name="${commons-cli:commons-cli}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.codec">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.codec">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,4 @@
     <resources>
         <artifact name="${commons-codec:commons-codec}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/collections/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/collections/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.collections">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.collections">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,5 +33,6 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/io/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/io/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.io">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.io">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,4 @@
     <resources>
         <artifact name="${commons-io:commons-io}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/lang/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/lang/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.lang">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.lang">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,5 +33,6 @@
     </resources>
 
     <dependencies>
+        <module name="java.sql"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/lang3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/commons/lang3/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.lang3">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.lang3">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,5 +33,6 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.cxf.impl">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.cxf.impl">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -64,32 +64,40 @@
     </resources>
 
     <dependencies>
-        <module name="asm.asm" />
-        <module name="javax.api" />
-        <module name="javax.annotation.api" />
-        <module name="javax.jms.api" />
-        <module name="javax.jws.api" />
-        <module name="javax.mail.api" />
-        <module name="javax.resource.api" />
-        <module name="javax.servlet.api" />
-        <module name="javax.wsdl4j.api" />
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.sql"/>
+        <module name="java.management"/>
+        <module name="java.management.rmi"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="java.security.jgss"/>
+        <module name="asm.asm"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.annotation.api"/>
+        <module name="javax.jms.api"/>
+        <module name="javax.jws.api"/>
+        <module name="javax.mail.api"/>
+        <module name="javax.resource.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.wsdl4j.api"/>
         <module name="javax.xml.bind.api" services="import"/>
         <module name="com.sun.xml.bind" services="import"/>
-        <module name="javax.xml.soap.api" />
-        <module name="javax.xml.stream.api" />
-        <module name="javax.xml.ws.api" />
-        <module name="org.apache.commons.lang3" />
+        <module name="javax.xml.soap.api"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="javax.xml.ws.api"/>
+        <module name="org.apache.commons.lang3"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.httpcomponents"/>
-        <module name="org.apache.neethi" />
-        <module name="org.apache.velocity" />
-        <module name="org.apache.xml-resolver" />
-        <module name="org.apache.ws.xmlschema" />
-        <module name="org.apache.ws.security" />
-        <module name="org.apache.santuario.xmlsec" />
-        <module name="org.codehaus.woodstox" />
-        <module name="org.joda.time" />
-        <module name="org.opensaml" />
+        <module name="org.apache.neethi"/>
+        <module name="org.apache.velocity"/>
+        <module name="org.apache.xml-resolver"/>
+        <module name="org.apache.ws.xmlschema"/>
+        <module name="org.apache.ws.security"/>
+        <module name="org.apache.santuario.xmlsec"/>
+        <module name="org.codehaus.woodstox"/>
+        <module name="org.joda.time"/>
+        <module name="org.opensaml"/>
         <module name="org.apache.cxf" export="true">
           <imports>
             <include path="META-INF/cxf"/>
@@ -125,5 +133,6 @@
                 <include path="META-INF"/>
             </imports>
         </module>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.cxf">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.cxf">
 
     <resources>
         <artifact name="${org.apache.cxf:cxf-core}"/>
@@ -30,6 +30,13 @@
     </resources>
 
     <dependencies>
+        <module name="java.compiler"/>
+        <module name="java.datatransfer"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="org.apache.cxf.impl" services="import">
             <imports>
                 <include path="META-INF/cxf"/> <!-- required to also pull in the bus extensions from META-INF -->
@@ -61,5 +68,6 @@
                 <include path="META-INF"/>
             </imports>
         </module>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/services-sts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/services-sts/main/module.xml
@@ -22,13 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.cxf.services-sts">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.cxf.services-sts">
 
     <resources>
         <artifact name="${org.apache.cxf.services.sts:cxf-services-sts-core}"/>
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
         <module name="org.apache.cxf.ws-security" services="import">
           <imports>
             <include path="META-INF/cxf"/>
@@ -70,6 +74,7 @@
         <module name="org.codehaus.woodstox" />
         <module name="org.joda.time" />
         <module name="org.opensaml" />
+        <module name="java.xml"/>
+        <module name="java.xml.crypto"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/ws-security/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/cxf/ws-security/main/module.xml
@@ -22,13 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.cxf.ws-security">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.cxf.ws-security">
 
     <resources>
         <artifact name="${org.apache.cxf:cxf-rt-ws-security}"/>
     </resources>
 
     <dependencies>
+        <module name="java.logging" />
+        <module name="java.security.jgss" />
         <module name="asm.asm" />
         <module name="javax.api" />
         <module name="javax.annotation.api" />
@@ -60,6 +62,7 @@
             <include path="META-INF"/>
           </imports>
         </module>
+        <module name="java.xml" />
     </dependencies>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.httpcomponents">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.httpcomponents">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +35,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.commons.codec"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.james.mime4j"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.james.mime4j">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.james.mime4j">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.commons.logging"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/lucene/internal/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/lucene/internal/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.lucene.internal">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.lucene.internal">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.lucene"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.apache.lucene">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.lucene">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.lucene.internal" optional="true" services="import"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/neethi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/neethi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.neethi">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.neethi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,8 @@
     </resources>
 
     <dependencies>
-      <module name="javax.api"/>
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
       <module name="javax.xml.stream.api" />
+      <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
@@ -22,12 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.qpid.proton">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.qpid.proton">
     <resources>
         <artifact name="${org.apache.qpid:proton-j}"/>
     </resources>
 
     <dependencies>
+        <module name="java.logging" />
         <module name="javax.jms.api" />
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.santuario.xmlsec">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.santuario.xmlsec">
 
     <exports>
         <exclude path="javax/**"/>
@@ -31,18 +31,19 @@
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
-
     <resources>
         <artifact name="${org.apache.santuario:xmlsec}"/>
     </resources>
 
     <dependencies>
-      <module name="javax.api" />
-      <module name="org.apache.commons.logging" />
-      <module name="org.apache.commons.codec" />
-      <module name="org.apache.xalan" />
-      <module name="org.slf4j" />
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+      <module name="org.apache.commons.logging"/>
+      <module name="org.apache.commons.codec"/>
+      <module name="org.apache.xalan"/>
+      <module name="org.slf4j"/>
       <module name="javax.xml.bind.api" services="import"/>
       <module name="com.sun.xml.bind" services="import"/>
+      <module name="java.xml"/>
+      <module name="java.xml.crypto"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/thrift/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/thrift/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.apache.thrift">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.thrift">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.security.sasl"/>
         <module name="org.slf4j"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/velocity/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/velocity/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.velocity">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.velocity">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,10 +33,11 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="org.apache.commons.collections"/>
         <module name="org.apache.commons.lang3"/>
         <module name="org.slf4j"/>
     </dependencies>
-
 </module>
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.ws.security">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.ws.security">
+
     <resources>
         <artifact name="${org.apache.wss4j:wss4j-bindings}"/>
         <artifact name="${org.apache.wss4j:wss4j-policy}"/>
@@ -34,17 +35,20 @@
     </resources>
 
     <dependencies>
-      <module name="javax.api" />
+      <module name="java.security.jgss"/>
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
       <module name="javax.xml.bind.api" services="import"/>
       <module name="com.sun.xml.bind" services="import"/>
       <module name="com.sun.xml.messaging.saaj" export="true" services="export"/>
-      <module name="org.apache.commons.codec" />
-      <module name="org.apache.commons.logging" />
-      <module name="org.apache.neethi" />
-      <module name="org.apache.santuario.xmlsec" />
-      <module name="org.apache.xalan" />
-      <module name="org.joda.time" />
-      <module name="org.opensaml" />
-      <module name="org.slf4j" />
+      <module name="org.apache.commons.codec"/>
+      <module name="org.apache.commons.logging"/>
+      <module name="org.apache.neethi"/>
+      <module name="org.apache.santuario.xmlsec"/>
+      <module name="org.apache.xalan"/>
+      <module name="org.joda.time"/>
+      <module name="org.opensaml"/>
+      <module name="org.slf4j"/>
+      <module name="java.xml"/>
+      <module name="java.xml.crypto"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/ws/xmlschema/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/ws/xmlschema/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.ws.xmlschema">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.ws.xmlschema">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,7 @@
     </resources>
 
     <dependencies>
-      <module name="javax.api" />
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+      <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.apache.xml-resolver">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.xml-resolver">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,6 +31,7 @@
     <resources>
         <artifact name="${xml-resolver:xml-resolver}"/>
     </resources>
+
     <dependencies>
         <module name="java.xml" />
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.bouncycastle.bcmail">
+<module xmlns="urn:jboss:module:1.9" name="org.bouncycastle.bcmail">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -31,8 +31,9 @@
     <resources>
         <artifact name="${org.bouncycastle:bcmail-jdk15on}"/>
     </resources>
+
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.mail.api" optional="true"/>
         <module name="javax.activation.api" optional="true"/>
         <module name="org.bouncycastle.bcpkix"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.bouncycastle">
+<module xmlns="urn:jboss:module:1.9" name="org.bouncycastle">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.jackson.jackson-core-asl">
+<module xmlns="urn:jboss:module:1.9" name="org.codehaus.jackson.jackson-core-asl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,6 +31,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.jackson.jackson-jaxrs">
+<module xmlns="urn:jboss:module:1.9" name="org.codehaus.jackson.jackson-jaxrs">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +34,7 @@
         <module name="org.codehaus.jackson.jackson-core-asl"/>
         <module name="org.codehaus.jackson.jackson-mapper-asl"/>
         <module name="org.codehaus.jackson.jackson-xc"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ws.rs.api"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.jackson.jackson-mapper-asl">
+<module xmlns="urn:jboss:module:1.9" name="org.codehaus.jackson.jackson-mapper-asl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,8 +31,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.sql"/>
         <module name="org.codehaus.jackson.jackson-core-asl"/>
         <module name="org.joda.time"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.jackson.jackson-xc">
+<module xmlns="urn:jboss:module:1.9" name="org.codehaus.jackson.jackson-xc">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,10 +31,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.activation.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="org.codehaus.jackson.jackson-mapper-asl"/>
         <module name="org.codehaus.jackson.jackson-core-asl"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jettison/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/codehaus/jettison/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.jettison">
+<module xmlns="urn:jboss:module:1.9" name="org.codehaus.jettison">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,6 +31,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/dom4j/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/dom4j/main/module.xml
@@ -22,15 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.dom4j">
+<module xmlns="urn:jboss:module:1.9" name="org.dom4j">
+
   <resources>
     <artifact name="${org.dom4j:dom4j}"/>
   </resources>
 
   <dependencies>
-      <module name="javax.api"/>
+      <module name="java.desktop"/>
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
       <module name="com.sun.xml.bind"/>
       <module name="javax.xml.bind.api"/>
       <module name="org.jaxen"/>
+      <module name="java.xml"/>
   </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/soteria/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/soteria/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.glassfish.soteria">
+<module xmlns="urn:jboss:module:1.9" name="org.glassfish.soteria">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging" />
+        <module name="java.naming" />
+        <module name="java.sql" />
         <module name="javax.security.enterprise.api" />
         <module name="javax.servlet.api"/>
         <module name="javax.enterprise.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/5.3/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/5.3/module.xml
@@ -23,5 +23,5 @@
   -->
 
 <!-- Represents the Hibernate 5.3.x module-->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.hibernate" slot="5.3"  target-name="org.hibernate"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate:5.3" target-name="org.hibernate"/>
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/bytecodetransformer/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/bytecodetransformer/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate.bytecodetransformer">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.bytecodetransformer">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.instrument"/>
         <module name="asm.asm"/>
         <module name="javax.annotation.api"/>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/commons-annotations/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/commons-annotations/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.0.x module-->
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate.commons-annotations">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.commons-annotations">
     <resources>
         <artifact name="${org.hibernate.common:hibernate-commons-annotations}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="org.hibernate.envers" target-name="org.hibernate"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate.envers" target-name="org.hibernate"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="org.hibernate.infinispan" target-name="org.infinispan.hibernate-cache"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate.infinispan" target-name="org.infinispan.hibernate-cache"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate5-3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate5-3/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate.jipijapa-hibernate5-3">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate5-3">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,7 @@
 
     <dependencies>
         <module name="org.hibernate"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -23,15 +23,21 @@
   -->
 
 <!-- Represents Hibernate 5.1.x, will later become 5.3.x for WF 14  -->
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate">
+
     <resources>
         <artifact name="${org.hibernate:hibernate-core}"/>
         <artifact name="${org.hibernate:hibernate-envers}"/> 
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.instrument"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="com.fasterxml.classmate"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>
@@ -49,5 +55,6 @@
         <module name="org.hibernate.jipijapa-hibernate5-3" services="import"/>
         <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
         <module name="net.bytebuddy"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jms/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jms/main/module.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate.search.backend-jms">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.backend-jms">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,6 +33,6 @@
         <module name="org.jboss.logging"/>
         <module name="javax.jms.api"/>
         <module name="org.jboss.as.naming"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -25,7 +25,8 @@
 <!-- Hibernate Search Engine: the fulltext indexing and query capabilities
      without the ORM integration bits. This is reused by several other project
      outside of the Hibernate group. -->
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.engine">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,6 +35,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.management"/>
+        <module name="java.sql"/>
         <module name="javax.transaction.api"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.apache.lucene" export="true"/>
@@ -61,5 +65,7 @@
         <!-- For naming -->
         <module name="javax.api" />
         <module name="org.jboss.as.naming" />
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
@@ -24,12 +24,14 @@
 <!-- Hibernate Search ORM: integrates org.hibernate.search.engine with
      Hibernate ORM to provide Hibernate Search functionality to
      JPA Applications -->
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate.search.orm">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.orm">
+
     <resources>
         <artifact name="${org.hibernate:hibernate-search-orm}"/>
     </resources>
 
     <dependencies>
+        <module name="java.sql" />
         <module name="javax.transaction.api" />
         <module name="org.hibernate" />
         <module name="org.hibernate.commons-annotations" />

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/serialization-avro/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/serialization-avro/main/module.xml
@@ -21,13 +21,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate.search.serialization-avro">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.serialization-avro">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
+
     <resources>
         <artifact name="${org.hibernate:hibernate-search-serialization-avro}"/>
     </resources>
+
     <dependencies>
         <module name="org.hibernate.search.engine"/>
         <module name="org.apache.lucene"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
@@ -22,7 +22,7 @@
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate.validator.cdi">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.validator.cdi">
 
   <resources>
     <artifact name="${org.hibernate.validator:hibernate-validator-cdi}"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -22,13 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.hibernate.validator">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.validator">
 
   <resources>
     <artifact name="${org.hibernate.validator:hibernate-validator}"/>
   </resources>
 
   <dependencies>
+    <module name="java.desktop"/>
+    <module name="java.scripting"/>
     <module name="com.fasterxml.classmate"/>
     <module name="javax.persistence.api"/>
     <module name="javax.validation.api"/>
@@ -41,5 +43,6 @@
     <module name="org.jsoup"/>
     <module name="org.apache.xerces" services="import"/>
     <module name="sun.jdk" services="import"/>
+    <module name="java.xml"/>
   </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hornetq/client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hornetq/client/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.hornetq.client">
+<module xmlns="urn:jboss:module:1.9" name="org.hornetq.client">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,12 +35,16 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="javax.transaction.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.jms.api" />
         <module name="javax.resource.api"/>
         <module name="io.netty"/>
         <module name="org.jboss.logging"/>
         <module name="org.jgroups"/>
         <module name="org.wildfly.naming-client" services="import" />
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
@@ -21,6 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.client.hotrod">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.security.sasl"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
 
         <module name="com.github.ben-manes.caffeine"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/commons/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/commons/main/module.xml
@@ -21,6 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.commons">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,11 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.security.sasl"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
 
         <module name="com.github.ben-manes.caffeine"/>
@@ -39,5 +44,6 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.logging"/>
         <module name="org.reactivestreams"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/component/annotations/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/component/annotations/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.component.annotations">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
@@ -36,8 +36,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="org.hibernate"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="org.hibernate.jipijapa-hibernate5-3" services="import"/>
         <module name="org.infinispan" services="import"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -21,6 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="com.github.ben-manes.caffeine"/>
         <module name="io.reactivex.rxjava3.rxjava"/>
@@ -48,5 +52,6 @@
         <module name="org.jgroups" optional="true"/>
         <module name="org.reactivestreams"/>
         <module name="sun.jdk" optional="true"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/persistence/jdbc/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/persistence/jdbc/main/module.xml
@@ -21,6 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.persistence.jdbc">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="io.reactivex.rxjava3.rxjava"/>
         <module name="org.infinispan"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/persistence/remote/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/persistence/remote/main/module.xml
@@ -21,6 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.persistence.remote">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="io.reactivex.rxjava3.rxjava"/>
         <module name="org.infinispan"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.infinispan.protostream">
+<module xmlns="urn:jboss:module:1.9" name="org.infinispan.protostream">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +33,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.sql.api"/>
+        <module name="java.compiler"/>
+        <module name="java.logging"/>
+        <module name="java.sql"/>
         <module name="org.jboss.logging"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/javassist/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/javassist/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.javassist">
+<module xmlns="urn:jboss:module:1.9" name="org.javassist">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,5 +34,7 @@
 
     <dependencies>
         <module name="sun.jdk"/>
+        <module name="jdk.attach"/>
+        <module name="jdk.jdi"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
@@ -20,7 +20,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jaxen">
+<module xmlns="urn:jboss:module:1.9" name="org.jaxen">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -28,7 +29,8 @@
     <dependencies>
         <module name="nu.xom"/>
         <module name="org.dom4j"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 
     <resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jberet.jberet-core">
+<module xmlns="urn:jboss:module:1.9" name="org.jberet.jberet-core">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.scripting"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.batch.api"/>
         <module name="javax.inject.api"/>
         <module name="javax.enterprise.api"/>
@@ -43,5 +49,6 @@
         <module name="org.wildfly.security.elytron-private"/>
         <module name="com.google.guava"/>
         <module name="com.h2database.h2" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.appclient">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.appclient">
+
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.7"/>
@@ -39,7 +40,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.xalan" services="import"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.codehaus.woodstox" services="import"/>
@@ -75,6 +77,7 @@
         <module name="org.picketbox"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.appclient"/>
-        <module name="org.wildfly.common" />
+        <module name="org.wildfly.common"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.jboss.as.clustering.ejb3.infinispan" target-name="org.wildfly.clustering.ejb.infinispan"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.ejb3.infinispan" target-name="org.wildfly.clustering.ejb.infinispan"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.infinispan">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <!-- The io.netty module is only require to initialize Netty's InternalLoggingFactory -->
         <module name="io.netty"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.clustering.jgroups">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.jgroups">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
@@ -54,5 +57,6 @@
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.jboss.as.clustering.web.infinispan" target-name="org.wildfly.clustering.web.infinispan"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.web.infinispan" target-name="org.wildfly.clustering.web.infinispan"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.connector">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.connector">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -37,9 +38,13 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
+        <module name="java.sql"/>
         <module name="javax.security.auth.message.api" />
         <module name="sun.jdk"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.annotation.api"/>
@@ -75,6 +80,7 @@
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.common"/>
         <module name="org.glassfish.jakarta.el"/>
+        <module name="java.xml"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/console/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/console/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.console">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.console">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.ejb3">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.ejb3">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,9 +31,15 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="java.sql"/>
+        <module name="javax.transaction.api"/>
         <module name="org.wildfly.http-client.ejb" services="import"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api"/>
         <module name="javax.interceptor.api"/>
         <module name="javax.jms.api"/>
@@ -117,5 +123,7 @@
         <module name="org.jboss.as.weld.common" optional="true"/>
         <module name="org.hibernate.validator" optional="true"/>
         <module name="org.hibernate.validator.cdi" optional="true"/>
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jaxrs">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jaxrs">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.ws.rs.api"/>
         <module name="javax.servlet.api"/>
@@ -71,5 +73,6 @@
         <module name="org.jboss.resteasy.resteasy-yaml-provider" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jdr">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jdr">
+
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.7"/>
@@ -40,7 +41,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.apache.commons.cli"/>
         <module name="org.apache.commons.io"/>
         <module name="org.apache.xalan" services="import"/>
@@ -56,5 +58,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.vfs"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jpa">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jpa">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.instrument"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>
@@ -70,5 +73,7 @@
         <module name="org.wildfly.clustering.infinispan.spi"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="org.hibernate.bytecodetransformer"/>
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jpa.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jpa.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.sql"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
         <module name="org.jboss.jandex"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.jsf-injection">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.jsf">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,7 @@
 
     <dependencies>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.faces.api" />
         <module name="javax.enterprise.api"/>
         <module name="com.sun.jsf-impl"/>
@@ -55,5 +56,7 @@
         <module name="org.jboss.metadata.web"/>
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.weld.spi"/>
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.mail">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.mail">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.mail.api">
             <imports>
                 <include path="META-INF"/>
@@ -49,8 +50,8 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.logging"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.jboss.as.modcluster" target-name="org.wildfly.extension.mod_cluster"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.modcluster" target-name="org.wildfly.extension.mod_cluster"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.pojo">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.pojo">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
@@ -46,5 +48,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.sar">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.sar">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.common-beans" services="import"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
@@ -50,5 +53,6 @@
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.as.naming"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.security-api">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.security-api">
 
     <properties>
         <property name="jboss.api" value="deprecated"/>
@@ -33,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.picketbox"/>
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.as.security"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/system-jmx/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/system-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.system-jmx">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.system-jmx">
 
     <exports>
         <exclude path="org/jboss/system/logging"/>
@@ -33,7 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.transactions">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.transactions">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.enterprise.concurrent.api"/>
@@ -71,5 +73,7 @@
         <!-- Only used if the org.jboss.remoting.endpoint capability is present,
              in which case this module will also be present. -->
         <module name="org.jboss.remoting" optional="true"/>
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.webservices">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.webservices">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -37,8 +38,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api"/>
         <module name="javax.jws.api"/>
         <module name="javax.servlet.api"/>
@@ -74,5 +76,6 @@
         <module name="javax.transaction.api"/>
         <!-- Only used if capability org.wildfly.weld is available-->
         <module name="org.jboss.as.weld.common" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -22,13 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.webservices.server.integration">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.webservices.server.integration">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
-
-    <resources>
-    </resources>
 
     <dependencies>
         <module name="asm.asm" export="true"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.beanvalidation">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.beanvalidation">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.common">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.ejb">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.ejb">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -55,5 +55,4 @@
         <module name="org.jboss.ejb3"/>
         <module name="org.jboss.ejb-client"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.jpa">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.jpa">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.transactions">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.transactions">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -44,5 +44,4 @@
         <module name="org.wildfly.transaction.client"/>
         <module name="javax.transaction.api"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.webservices">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.weld.webservices">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.xts">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.xts">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.jboss.as.ee"/>
@@ -63,5 +64,6 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.narayana.compensations" />
         <module name="org.wildfly.transaction.client" />
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/deployers/jboss-service-deployer/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/deployers/jboss-service-deployer/main/module.xml
@@ -22,16 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.deployers.jboss-service-deployer">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.deployers.jboss-service-deployer">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <resources>
-    </resources>
-
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -20,14 +20,17 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ejb-client">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ejb-client">
 
     <resources>
         <artifact name="${org.jboss:jboss-ejb-client}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="javax.transaction.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api"/>
         <module name="javax.interceptor.api"/>
         <module name="org.wildfly.client.config"/>
@@ -42,7 +45,7 @@
         <module name="org.jboss.marshalling.river"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="javax.transaction.api"/>
-
         <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb/remote/protocol/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb/remote/protocol/main/module.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
@@ -20,13 +21,11 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ejb.remote.protocol">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ejb.remote.protocol">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
-
-    <resources>
-    </resources>
 
     <dependencies>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
@@ -20,10 +20,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ejb3">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ejb3">
 
     <resources>
         <artifact name="${org.jboss.ejb3:jboss-ejb3-ext-api}"/>
     </resources>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
@@ -20,23 +20,27 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.genericjms">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.genericjms">
+
     <resources>
        <resource-root path="."/>
         <artifact name="${org.jboss.genericjms:generic-jms-ra-jar}"/>
     </resources>
+
     <dependencies>
-        <module name="javax.api" slot="main"/>
+        <module name="java.naming"/>
+        <module name="javax.transaction.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <!-- WFLY-4656 export the JMS API module,  otherwise MDB using this RA will not found JMS classes -->
-        <module name="javax.jms.api" slot="main" export="true"/>
-        <module name="javax.resource.api" slot="main"/>
-        <module name="org.jboss.logging" slot="main"/>
+        <module name="javax.jms.api" export="true"/>
+        <module name="javax.resource.api"/>
+        <module name="org.jboss.logging"/>
 
         <!--
              This module is used to provide the provider-specific classes
              containing the JMS implementation (and any of their dependencies)
              used by the generic JMS resource adapter
         -->
-        <module name="org.jboss.genericjms.provider" slot="main" optional="true"/>
+        <module name="org.jboss.genericjms.provider" optional="true"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
@@ -20,7 +20,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.iiop-client">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.iiop-client">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api"/>
         <module name="org.omg.api"/>
         <module name="javax.rmi.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/integration/ext-content/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/integration/ext-content/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.integration.ext-content">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.integration.ext-content">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -30,7 +31,4 @@
     <resources>
         <resource-root path="bundled"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ironjacamar.api">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ironjacamar.api">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -35,8 +35,9 @@
 
     <dependencies>
         <module name="javax.resource.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ironjacamar.impl">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ironjacamar.impl">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -35,9 +36,12 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="javax.transaction.api"/>
         <module name="sun.jdk"/>
         <!-- javax.security.auth.callback -->
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.resource.api"/>
         <module name="javax.security.auth.message.api"/>
         <module name="javax.validation.api"/>
@@ -51,5 +55,6 @@
         <module name="org.picketbox"/>
         <module name="javax.xml.stream.api"/>
         <module name="org.wildfly.transaction.client"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ironjacamar.jdbcadapters">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ironjacamar.jdbcadapters">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
+        <module name="java.sql"/>
+        <module name="javax.transaction.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
@@ -44,6 +50,5 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
         <module name="javax.xml.stream.api"/>
-
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.jaxbintros">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.jaxbintros">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,10 +33,11 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.xml.bind.api"/>
         <module name="com.sun.xml.bind" services="import"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.commons.beanutils"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jboss-transaction-spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jboss-transaction-spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.jboss-transaction-spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.jboss-transaction-spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
         <module name="org.jboss.logging"/>
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.jts.integration">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.jts.integration">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,11 +33,12 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming" />
         <module name="org.omg.api" />
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
         <module name="org.jboss.as.transactions">

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.jts">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.jts">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,12 +33,18 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="javax.transaction.api"/>
         <module name="sun.jdk"/>
         <module name="org.omg.api" />
         <module name="org.jboss.logging"/>
         <module name="org.jboss.jts.integration"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
         <module name="org.apache.activemq.artemis.journal"/>
@@ -55,5 +62,7 @@
 
         <!-- For the ContextPropagationAsyncHandler used with the context propagation feature pack -->
         <module name="org.wildfly.reactive.dep.jts" services="import" optional="true"/>
+        <module name="java.xml"/>
+        <module name="jdk.jconsole"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata.appclient">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.metadata.appclient">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata.ejb">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.metadata.ejb">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,8 +33,9 @@
 
     <dependencies>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.ejb.api" optional="true"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/container/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/container/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.mod_cluster.container.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.mod_cluster.container.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/core/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/core/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.mod_cluster.core">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.mod_cluster.core">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.mod_cluster.container.spi"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/load/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/load/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.mod_cluster.load.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.mod_cluster.load.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.narayana.compensations">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.narayana.compensations">
 
     <properties>
         <property name="jboss.api" value="deprecated"/>
@@ -44,5 +44,6 @@
         <module name="javax.servlet.api" />
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api"  export="true" />
+        <module name="java.xml" />
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.narayana.rts">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.narayana.rts">
     <resources>
         <artifact name="${org.jboss.narayana.rts:restat-api}"/>
         <artifact name="${org.jboss.narayana.rts:restat-util}"/>
@@ -34,7 +34,7 @@
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
         <module name="javax.ws.rs.api" services="export"/>
@@ -53,5 +53,6 @@
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->
         <module name="javax.rmi.api"/>
         <module name="org.omg.api"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -22,8 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.narayana.txframework">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.narayana.txframework">
     <!-- This module is deprecated and subject to being removed in a subsequent release. -->
+
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>
@@ -33,12 +34,13 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.xts" />
         <module name="org.jboss.resteasy.resteasy-jaxrs" />
         <module name="org.jboss.weld.core" />
         <module name="javax.servlet.api" />
         <module name="javax.interceptor.api"  export="true" />
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
@@ -22,14 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.remoting3">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.remoting3">
     <!-- This module is deprecated and subject to being removed in a subsequent release.      -->
 
     <!-- Any use of the Remoting library should now reference the org.jboss.remoting          -->
     <!-- module instead.                                                                      -->
-
-    <resources>
-    </resources>
 
     <dependencies>
         <module name="org.jboss.remoting" export="true" />

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remoting3/remoting-jmx/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remoting3/remoting-jmx/main/module.xml
@@ -22,15 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.remoting3.remoting-jmx">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.remoting3.remoting-jmx">
     <!-- This module is deprecated and subject to being removed in a subsequent release.      -->
     
     <!-- Any use of the Remoting JMX library should now reference the org.jboss.remoting-jmx  -->
     <!-- module instead.                                                                      -->
     
-    <resources>
-    </resources>
-
     <dependencies>
         <module name="org.jboss.remoting-jmx" export="true" />
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.jose-jwt">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.jose-jwt">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -34,7 +34,7 @@
 
     <dependencies>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
@@ -47,5 +47,5 @@
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
         <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8"/>
         <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310"/>
-</dependencies>
+    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-atom-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-atom-provider">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-atom-provider}"/>
@@ -31,12 +31,13 @@
     <dependencies>
         <module name="com.sun.xml.bind"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-cdi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-cdi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-crypto">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-crypto">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.activation.api"/>
         <module name="javax.mail.api"/>
         <module name="org.apache.james.mime4j"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jackson-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jackson-provider">
+
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>
@@ -37,7 +38,7 @@
         <module name="org.codehaus.jackson.jackson-mapper-asl" export="true"/>
         <module name="org.codehaus.jackson.jackson-xc" export="true"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jackson2-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jackson2-provider">
+
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jackson2-provider}"/>
     </resources>
@@ -36,11 +37,12 @@
         <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310"/>
         <module name="com.github.fge.json-patch"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jaxb-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jaxb-provider">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jaxb-provider}"/>
@@ -31,11 +31,12 @@
     <dependencies>
         <module name="com.sun.xml.bind"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.jboss.resteasy.resteasy-jaxrs">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jaxrs">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jaxrs}" />
@@ -30,7 +30,11 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.activation.api"/>
         <module name="javax.validation.api"/>
@@ -48,5 +52,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.reactivestreams"/>
         <module name="org.eclipse.microprofile.config.api" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
@@ -22,12 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jettison-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jettison-provider">
     <!-- This module is deprecated and subject to being removed in a subsequent release. -->
+
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>
-
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jettison-provider}"/>
@@ -36,12 +36,13 @@
     <dependencies>
         <module name="org.codehaus.jettison"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jsapi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jsapi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jsapi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-jsapi">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jsapi}"/>
@@ -30,7 +30,7 @@
 
     <dependencies>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-json-binding-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-json-binding-provider">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -36,7 +36,7 @@
         <module name="org.glassfish.jakarta.json"/>
         <module name="javax.json.bind.api" export="true"/>
         <module name="org.eclipse.yasson"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.json.api"/>
         <module name="javax.enterprise.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-p-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-p-provider/main/module.xml
@@ -22,14 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-json-p-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-json-p-provider">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-json-p-provider}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.json.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.ws.rs.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-multipart-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-multipart-provider/main/module.xml
@@ -22,15 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-multipart-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-multipart-provider">
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-multipart-provider}"/>
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.mail.api"/>
         <module name="javax.servlet.api"/>
@@ -39,5 +40,6 @@
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-rxjava2/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-rxjava2/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.jboss.resteasy.resteasy-rxjava2">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-rxjava2">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-spring">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-spring">
 
     <resources>
         <!-- This module just contains the jar as a resource root. It cannot be depended on to get
@@ -31,5 +31,6 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-validator-provider-11" target-name="org.jboss.resteasy.resteasy-validator-provider"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-validator-provider-11" target-name="org.jboss.resteasy.resteasy-validator-provider"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider/main/module.xml
@@ -22,12 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-validator-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-validator-provider">
+
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-validator-provider}"/>
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="javax.validation.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-yaml-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-yaml-provider/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-yaml-provider">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-yaml-provider">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +35,7 @@
     <dependencies>
         <module name="com.sun.xml.bind"/>
         <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/security/xacml/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/security/xacml/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.security.xacml">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.security.xacml">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +33,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="sun.jdk"/>
         <module name="javax.xml.bind.api"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.api">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.weld.api">
 
     <resources>
         <artifact name="${org.jboss.weld:weld-api}"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.core">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.weld.core">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.probe">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.weld.probe">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.weld.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/api/main/module.xml
@@ -22,19 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.api">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.api">
 
     <resources>
         <artifact name="${org.jboss.ws:jbossws-api}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.xml.soap.api"/>
         <module name="javax.xml.ws.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.ws.jaxws-client" services="import"/>
+        <module name="java.xml"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.common">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,7 +33,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.jws.api"/>
@@ -47,5 +49,6 @@
         <module name="org.jboss.jaxbintros"/>
         <!-- Not supported and the API is not provided in an EE 9 server -->
         <module name="javax.xml.rpc.api" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
@@ -22,10 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.jbossws-cxf-client">
-
-    <resources>
-    </resources>
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.jbossws-cxf-client">
 
     <dependencies>
         <!-- JAXB API + REF IMPL -->

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-factories/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-factories/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.jbossws-cxf-factories">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.jbossws-cxf-factories">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.jbossws-cxf-server">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.jbossws-cxf-server">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,7 +33,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.security.auth.message.api"/>
         <module name="javax.servlet.api" />
         <module name="javax.jws.api" />
@@ -68,5 +70,6 @@
         <module name="org.jboss.logging" />
         <module name="org.apache.ws.security" />
         <module name="org.picketbox" />
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-udp/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-udp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.jbossws-cxf-transports-udp">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.jbossws-cxf-transports-udp">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,9 +33,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.annotation.api" />
-        <module name="org.jboss.logging" />
-        <module name="javax.xml.ws.api" />
+        <module name="java.logging"/>
+        <module name="javax.annotation.api"/>
+        <module name="org.jboss.logging"/>
+        <module name="javax.xml.ws.api"/>
         <module name="org.apache.cxf.impl" services="import">
           <imports>
             <include path="META-INF/cxf"/> <!-- required to also pull in the bus extensions from META-INF -->

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-undertow/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-undertow/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.jbossws-cxf-transports-undertow">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.jbossws-cxf-transports-undertow">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,12 +33,13 @@
     </resources>
 
     <dependencies>
-        <module name="org.jboss.ws.spi" />
-        <module name="org.jboss.ws.common" />
-        <module name="org.jboss.logging" />
-        <module name="javax.annotation.api" />
-        <module name="javax.xml.ws.api" />
-        <module name="org.jboss.ws.jaxws-undertow-httpspi" />
+        <module name="java.logging"/>
+        <module name="org.jboss.ws.spi"/>
+        <module name="org.jboss.ws.common"/>
+        <module name="org.jboss.logging"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.xml.ws.api"/>
+        <module name="org.jboss.ws.jaxws-undertow-httpspi"/>
         <module name="org.apache.cxf.impl" services="import">
           <imports>
             <include path="META-INF/cxf"/> <!-- required to also pull in the bus extensions from META-INF -->

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/sts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/sts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.cxf.sts">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.cxf.sts">
     
     <resources/>
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.jaxws-client">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.jaxws-client">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -34,7 +34,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
+        <module name="java.compiler"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api" />
         <module name="javax.xml.bind.api" />
         <module name="javax.security.auth.message.api"/>
@@ -74,5 +77,6 @@
         <module name="org.bouncycastle.bcpkix"/>
         <module name="org.bouncycastle.bcprov"/>
         <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-undertow-httpspi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-undertow-httpspi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.jaxws-undertow-httpspi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.jaxws-undertow-httpspi">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.xml.ws.api" />
+        <module name="javax.xml.ws.api"/>
         <module name="io.undertow.core"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/saaj-impl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/saaj-impl/main/module.xml
@@ -22,18 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.saaj-impl">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.saaj-impl">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <resources>
-    </resources>
-
     <dependencies>
         <module name="org.jboss.ws.jaxws-client" services="import"/> <!-- to pull the jbossws-cxf SOAPConnection impl -->
         <module name="com.sun.xml.messaging.saaj" services="import"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,12 +33,14 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.xml.ws.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.ws.api"/>
         <module name="org.jboss.as.webservices"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/common/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.tools.common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.tools.common">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -42,5 +42,4 @@
           </imports>
         </module>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsconsume/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsconsume/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.tools.wsconsume">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.tools.wsconsume">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -36,5 +36,4 @@
         <module name="org.jboss.ws.tools.common"/>
         <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsprovide/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsprovide/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ws.tools.wsprovide">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ws.tools.wsprovide">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -36,5 +36,4 @@
         <module name="org.jboss.ws.tools.common"/>
         <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.xnio.netty.netty-xnio-transport">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.xnio.netty.netty-xnio-transport">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.xts">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.xts">
 
     <properties>
         <property name="jboss.api" value="deprecated"/>
@@ -34,6 +34,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
+        <module name="java.rmi"/>
+
         <module name="org.jboss.jts"/>
 
         <module name="javax.transaction.api"/>
@@ -48,7 +51,7 @@
         <module name="javax.xml.stream.api"/>
 
         <!-- this is needed to get javax.xml.namespace.QName but it would be better if it were exposed on its own -->
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <!-- this is needed because our endpoints are not in a normal deployment and we need to be able
             to resolve the javax.jws.WebService annotation attached to them. presumably an endpoint
             found in a deployment gets this package auto-added to its module loader
@@ -76,6 +79,6 @@
             <include path="org.jboss.as.xts.txnclient"/>
           </imports>
         </module>
-
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jctools/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jctools/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.jctools">
+<module xmlns="urn:jboss:module:1.9" name="org.jctools">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,5 +35,6 @@
 
     <dependencies>
         <module name="sun.jdk"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/azure/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/azure/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jgroups.azure">
+<module xmlns="urn:jboss:module:1.9" name="org.jgroups.azure">
 
     <resources>
         <artifact name="${org.jgroups.azure:jgroups-azure}"/>
@@ -30,7 +30,7 @@
 
     <dependencies>
         <module name="com.microsoft.azure.storage"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jgroups"/>
     </dependencies>
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/main/module.xml
@@ -22,15 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.jgroups.kubernetes">
+<module xmlns="urn:jboss:module:1.9" name="org.jgroups.kubernetes">
 
     <resources>
         <artifact name="${org.jgroups.kubernetes:jgroups-kubernetes}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jgroups"/>
     </dependencies>
-
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jgroups/main/module.xml
@@ -22,16 +22,25 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.jgroups">
+<module xmlns="urn:jboss:module:1.9" name="org.jgroups">
 
     <resources>
         <artifact name="${org.jgroups:jgroups}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.scripting"/>
+        <module name="java.security.jgss"/>
+        <module name="java.security.sasl"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jgroups.azure"/>
         <module name="org.jgroups.kubernetes"/>
+        <module name="java.xml"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/joda/time/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/joda/time/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.joda.time">
+<module xmlns="urn:jboss:module:1.9" name="org.joda.time">
 
     <resources>
         <artifact name="${joda-time:joda-time}"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jsoup/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jsoup/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jsoup">
+<module xmlns="urn:jboss:module:1.9" name="org.jsoup">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/omg/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/omg/api/main/module.xml
@@ -21,7 +21,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.omg.api">
+<module xmlns="urn:jboss:module:1.9" name="org.omg.api">
+
     <dependencies>
         <module name="javax.orb.api" export="false">
             <exports>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.opensaml">
+<module xmlns="urn:jboss:module:1.9" name="org.opensaml">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -47,15 +47,17 @@
     </resources>
 
     <dependencies>
-      <module name="javax.api"/>
+      <module name="java.scripting"/>
+      <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
       <module name="org.slf4j"/>
       <module name="org.apache.santuario.xmlsec"/>
       <module name="org.apache.ws.security" />
       <module name="org.joda.time"/>
       <module name="com.google.guava"/>
-        <module name="org.bouncycastle.bcmail"/>
-        <module name="org.bouncycastle.bcpkix"/>
-        <module name="org.bouncycastle.bcprov"/>
+      <module name="org.bouncycastle.bcmail"/>
+      <module name="org.bouncycastle.bcpkix"/>
+      <module name="org.bouncycastle.bcprov"/>
       <module name="org.apache.commons.codec"/>
+      <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/reactivestreams/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/reactivestreams/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.reactivestreams">
+<module xmlns="urn:jboss:module:1.9" name="org.reactivestreams">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/api/main/module.xml
@@ -22,12 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.api">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.api">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-api}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/cache/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/cache/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ee.cache">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ee.cache">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -43,5 +44,6 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/hotrod/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/hotrod/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ee.hotrod">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ee.hotrod">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/infinispan/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ee.infinispan">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ee.infinispan">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ee/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ee.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ee.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ejb.infinispan">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ejb.infinispan">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.ejb.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.ejb.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.infinispan.client">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.infinispan.client">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,6 @@
 
     <dependencies>
         <module name="javax.transaction.api"/>
-
         <module name="com.github.ben-manes.caffeine"/>
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/marshalling/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/marshalling/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.infinispan.marshalling">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.infinispan.marshalling">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.infinispan.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/jgroups/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/jgroups/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.jgroups.api">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.jgroups.api">
+
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-jgroups-api}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/jgroups/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/jgroups/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.jgroups.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.jgroups.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/api/main/module.xml
@@ -22,12 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.marshalling.api">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.marshalling.api">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-marshalling-api}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/jboss/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/jboss/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.marshalling.jboss">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.marshalling.jboss">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/protostream/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/protostream/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.marshalling.protostream">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.marshalling.protostream">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.marshalling.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.marshalling.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +33,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.sql"/>
         <module name="org.jboss.logging"/>
         <module name="org.wildfly.clustering.marshalling.api"/>
         <module name="org.wildfly.security.elytron-private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.server">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.server">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,6 +37,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.singleton">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.singleton">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-singleton-api}"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/api/main/module.xml
@@ -22,12 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.api">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.api">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-web-api}"/>
     </resources>
-
-    <dependencies>
-    </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/cache/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/cache/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.cache">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.cache">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.hotrod">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.hotrod">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -37,7 +38,6 @@
 
     <dependencies>
         <module name="javax.transaction.api"/>
-
         <module name="com.github.ben-manes.caffeine"/>
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.infinispan">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.infinispan">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -37,7 +38,6 @@
 
     <dependencies>
         <module name="javax.transaction.api"/>
-
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.spi">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.spi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.web.undertow">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.undertow">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,6 @@
 
     <dependencies>
         <module name="javax.servlet.api"/>
-
         <module name="io.undertow.core"/>
         <module name="io.undertow.servlet"/>
         <module name="org.infinispan.commons"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.batch.jberet">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.batch.jberet">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.batch.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.transaction.api"/>
@@ -62,5 +64,6 @@
         <module name="org.wildfly.extension.request-controller"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.transaction.client"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/bean-validation/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/bean-validation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.bean-validation">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.bean-validation">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -37,20 +37,21 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.interceptor.api"/>
         <module name="javax.validation.api"/>
         <module name="org.hibernate.validator" optional="true" services="import"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.naming" />
+        <module name="org.jboss.as.naming"/>
         <!-- Only used if capability org.wildfly.weld is available -->
         <module name="org.jboss.as.weld.common" optional="true"/>
         <module name="org.wildfly.security.elytron-private"/>
-        <module name="org.jboss.as.server" />
+        <module name="org.jboss.as.server"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/singleton/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/singleton/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.clustering.singleton">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.clustering.singleton">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
@@ -48,5 +49,6 @@
         <module name="org.wildfly.clustering.singleton"/>
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.common"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/web/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/web/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.clustering.web">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.clustering.web">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
 
         <module name="org.infinispan"/>
         <module name="org.jboss.as.clustering.common"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.ee-security">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.ee-security">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -37,7 +37,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/health/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/health/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.health">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.health">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,7 @@
 
     <dependencies>
         <module name="io.undertow.core"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.core-security"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.messaging-activemq">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.messaging-activemq">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,16 +35,21 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+
         <!-- io.undertow.core is required only if http-acceptor are used -->
         <module name="io.undertow.core" optional="true" />
-        <module name="io.netty" />
-        <module name="javax.api"/>
+        <module name="io.netty"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.jms.api"/>
         <module name="javax.json.api"/>
-        <module name="javax.resource.api" />
+        <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>
-        <module name="org.apache.activemq.artemis" services="import" />
+        <module name="org.apache.activemq.artemis" services="import"/>
         <module name="org.apache.activemq.artemis.ra"/>
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>
@@ -65,7 +71,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.ironjacamar.impl"/>
         <module name="org.jboss.ironjacamar.api"/>
-        <module name="org.jboss.as.connector" />
+        <module name="org.jboss.as.connector"/>
         <!-- Use of legacy security domain ends up using this module's class loader. -->
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.as.security-plugins"/>
@@ -73,13 +79,13 @@
         <module name="org.jboss.jts"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.wildfly.naming-client" services="import" />
+        <module name="org.wildfly.naming-client" services="import"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.weld.core"/>
         <!-- org.jboss.xnio is required only if http-acceptor are used -->
-        <module name="org.jboss.xnio" optional="true" />
+        <module name="org.jboss.xnio" optional="true"/>
         <!-- org.jboss.xnio.netty.netty-xnio-transport is required only if http-acceptor are used -->
-        <module name="org.jboss.xnio.netty.netty-xnio-transport" optional="true" />
+        <module name="org.jboss.xnio.netty.netty-xnio-transport" optional="true"/>
         <module name="org.wildfly.clustering.api"/>
         <module name="org.wildfly.clustering.marshalling.jboss"/>
         <module name="org.wildfly.clustering.service"/>
@@ -87,5 +93,7 @@
         <module name="org.wildfly.transaction.client"/>
         <!-- Use the HornetQ client module to create the legacy connection factory and destination resources -->
         <module name="org.hornetq.client" />
+
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/metrics/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/metrics/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.metrics">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.metrics">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +33,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.management"/>
         <module name="io.undertow.core"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.core-security"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.mod_cluster">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.mod_cluster">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>
@@ -48,5 +49,6 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.mod_cluster.undertow" services="import" optional="true"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.rts">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.rts">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +37,7 @@
     </exports>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.jboss.staxmapper"/>
@@ -60,5 +61,6 @@
         <module name="org.hibernate.validator" services="export"/>
         <module name="org.jboss.narayana.rts"/>
         <module name="org.wildfly.transaction.client"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/ejb/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/ejb/main/module.xml
@@ -22,13 +22,14 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.http-client.ejb">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.http-client.ejb">
 
     <resources>
         <artifact name="${org.wildfly.wildfly-http-client:wildfly-http-ejb-client}"/>
     </resources>
 
     <dependencies>
+        <module name="java.rmi"/>
         <module name="javax.ejb.api"/>
         <module name="javax.transaction.api"/>
         <module name="org.wildfly.http-client.common"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/transaction/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/transaction/main/module.xml
@@ -22,13 +22,14 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.http-client.transaction">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.http-client.transaction">
 
     <resources>
         <artifact name="${org.wildfly.wildfly-http-client:wildfly-http-transaction-client}"/>
     </resources>
 
     <dependencies>
+        <module name="java.rmi"/>
         <module name="javax.transaction.api"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="org.wildfly.http-client.common"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.iiop-openjdk">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.iiop-openjdk">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="java.security.jgss"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.orb.api"/>
         <module name="org.jboss.as.controller"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.mod_cluster.undertow">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.mod_cluster.undertow">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.transaction.client">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.transaction.client">
+
     <exports>
         <exclude path="org/wildfly/transaction/client/_private" />
     </exports>
@@ -33,6 +34,7 @@
 
     <dependencies>
         <!-- Sorted alphabetically -->
+        <module name="java.naming"/>
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>
 
@@ -52,6 +54,7 @@
         <module name="org.wildfly.naming-client"/>
         <module name="org.wildfly.security.elytron"/>
     </dependencies>
+
     <provides>
         <service name="org.wildfly.transaction.client.spi.RemoteTransactionProvider">
             <with-class name="org.wildfly.httpclient.transaction.HttpRemoteTransactionProvider"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/yaml/snakeyaml/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/yaml/snakeyaml/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.yaml.snakeyaml">
+<module xmlns="urn:jboss:module:1.9" name="org.yaml.snakeyaml">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,6 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
@@ -22,12 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.batch.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.batch.api">
+
     <resources>
         <artifact name="${org.jboss.spec.javax.batch:jboss-batch-api_1.0_spec}"/>
     </resources>
+
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
     </dependencies>    
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -22,15 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.ejb.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.ejb.api">
+
+    <resources>
+        <artifact name="${org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.naming" />
+        <module name="java.rmi" />
         <!-- This dep is for javax.naming -->
         <module name="javax.api" />
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api.internal"/>
     </dependencies>
-
-    <resources>
-        <artifact name="${org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec}"/>
-    </resources>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
@@ -22,8 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="javax.faces.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.faces.api">
+
+    <resources>
+        <artifact name="${org.jboss.spec.javax.faces:jboss-jsf-api_2.3_spec}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
         <module name="com.sun.jsf-impl"/>
         <module name="javax.enterprise.api" export="true"/>
         <module name="javax.servlet.api" export="true"/>
@@ -31,11 +40,7 @@
         <module name="javax.servlet.jstl.api" export="true"/>
         <module name="javax.validation.api" export="true"/>
         <module name="org.glassfish.jakarta.el" export="true"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.websocket.api"/>
     </dependencies>
-
-    <resources>
-        <artifact name="${org.jboss.spec.javax.faces:jboss-jsf-api_2.3_spec}"/>
-    </resources>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
@@ -22,12 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.jms.api">
-    <dependencies>
-        <module name="javax.transaction.api" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.jms.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="javax.transaction.api" export="true"/>
+    </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.jws.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.jws.api">
+
     <resources>
         <artifact name="${javax.jws:jsr181-api}"/>
     </resources>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
@@ -22,13 +22,19 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.mail.api">
-    <dependencies>
-        <module name="javax.activation.api" />
-        <module name="javax.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.mail.api">
 
     <resources>
         <artifact name="${com.sun.mail:jakarta.mail}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.datatransfer"/>
+        <module name="java.logging"/>
+        <module name="java.security.sasl"/>
+        <module name="javax.activation.api" />
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
@@ -22,13 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.persistence.api">
-    <dependencies>
-        <!-- PersistenceUnitInfo needs javax.sql.DataSource -->
-        <module name="javax.api" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.persistence.api">
 
     <resources>
         <artifact name="${jakarta.persistence:jakarta.persistence-api}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.instrument" export="true"/>
+        <module name="java.logging"/>
+        <!-- PersistenceUnitInfo needs javax.sql.DataSource -->
+        <module name="java.sql" export="true"/>
+        <module name="javax.api" />
+    </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
@@ -22,8 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.resource.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.resource.api">
+
+    <resources>
+        <artifact name="${org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec}"/>
+    </resources>
+
     <dependencies>
+        <module name="java.desktop"/>
+        <!-- Revisit when checking already deprecated javax.api removal  <module name="java.naming"/> -->
+        <module name="java.sql"/>
         <module name="javax.transaction.api" export="true"/>
         <module name="javax.api" export="false">
             <exports>
@@ -31,8 +39,4 @@
             </exports>
         </module>
     </dependencies>
-
-    <resources>
-        <artifact name="${org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec}"/>
-    </resources>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.security.enterprise.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.security.enterprise.api">
+
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
@@ -22,14 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.ws.rs.api">
+
     <resources>
         <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}"/>
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="javax.xml.bind.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
@@ -22,17 +22,19 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.xml.bind.api">
-
-
-    <dependencies>
-        <module name="javax.activation.api" export="true"/>
-        <module name="javax.xml.stream.api"/>
-        <module name="com.sun.xml.bind" services="import"/>
-        <module name="javax.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.xml.bind.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="javax.activation.api" export="true"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="com.sun.xml.bind" services="import"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+    </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
@@ -22,14 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.xml.soap.api">
-    <dependencies>
-        <module name="javax.activation.api" export="true"/>
-        <module name="javax.api"/>
-        <module name="org.jboss.modules"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.xml.soap.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.soap:jboss-saaj-api_1.4_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="javax.activation.api" export="true"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
@@ -22,15 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.xml.ws.api">
-    <dependencies>
-        <module name="javax.xml.bind.api" export="true"/>
-        <module name="javax.xml.soap.api" export="true"/>
-        <module name="javax.api"/>
-        <module name="org.jboss.modules"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.xml.ws.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.xml.ws:jboss-jaxws-api_2.3_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+        <module name="javax.xml.bind.api" export="true"/>
+        <module name="javax.xml.soap.api" export="true"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="org.jboss.modules"/>
+        <module name="java.xml"/>
+    </dependencies>
 </module>

--- a/ee-feature-pack/galleon-common/src/main/resources/packages/product.conf/content/modules/system/layers/base/org/jboss/as/product/main/module.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/packages/product.conf/content/modules/system/layers/base/org/jboss/as/product/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.product" slot="main">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.product">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/main/module.xml
@@ -21,7 +21,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="com.fasterxml.jackson.dataformat.jackson-dataformat-yaml">
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.dataformat.jackson-dataformat-yaml">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="org.yaml.snakeyaml"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.jaegertracing.jaeger">
+<module xmlns="urn:jboss:module:1.9" name="io.jaegertracing.jaeger">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-concurrent/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-concurrent/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-concurrent">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.contrib.opentracing-concurrent">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-interceptors/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-interceptors/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-interceptors">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.contrib.opentracing-interceptors">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-jaxrs2">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.contrib.opentracing-jaxrs2">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-tracerresolver/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-tracerresolver/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-tracerresolver">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.contrib.opentracing-tracerresolver">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-web-servlet-filter/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-web-servlet-filter/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-web-servlet-filter">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.contrib.opentracing-web-servlet-filter">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-api/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-api">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.opentracing-api">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -22,6 +23,7 @@
     <resources>
         <artifact name="${io.opentracing:opentracing-api}"/>
     </resources>
+
     <dependencies>
         <module name="java.logging"/>
     </dependencies>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-noop/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-noop/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-noop">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.opentracing-noop">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-util/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-util/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-util">
+<module xmlns="urn:jboss:module:1.9" name="io.opentracing.opentracing-util">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.config">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.config">
+
     <resources>
         <artifact name="${io.smallrye.config:smallrye-config}"/>
         <artifact name="${io.smallrye.config:smallrye-config-common}"/>
@@ -30,7 +31,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.jboss.logging" />
         <module name="javax.enterprise.api" />

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/fault-tolerance/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/fault-tolerance/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="io.smallrye.fault-tolerance">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -37,7 +38,7 @@
         <module name="io.smallrye.config"/>
         <module name="io.smallrye.metrics"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.enterprise.concurrent.api"/>
         <module name="org.eclipse.microprofile.config.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.health">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.health">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.eclipse.microprofile.config.api" />
         <module name="org.eclipse.microprofile.health.api"/>
         <module name="javax.enterprise.api" />

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
@@ -18,7 +18,8 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.jwt">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.jwt">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -28,7 +29,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.security.enterprise.api" />
         <module name="javax.servlet.api"/>
         <module name="org.bitbucket.jose4j"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.metrics">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.metrics">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,8 +34,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.json.api"/>
         <module name="org.eclipse.microprofile.config.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.openapi">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.openapi">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.json.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/opentracing/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/opentracing/main/module.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.opentracing">
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.opentracing">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/bitbucket/jose4j/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/bitbucket/jose4j/main/module.xml
@@ -18,7 +18,8 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.bitbucket.jose4j">
+<module xmlns="urn:jboss:module:1.9" name="org.bitbucket.jose4j">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/config/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/config/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.config.api">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.config.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.config:microprofile-config-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/fault-tolerance/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/fault-tolerance/api/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.fault-tolerance.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/health/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/health/api/main/module.xml
@@ -22,13 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.health.api">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.health.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.health:microprofile-health-api}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api" />
     </dependencies>
 </module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/jwt/auth/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/jwt/auth/api/main/module.xml
@@ -18,7 +18,8 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.jwt.auth.api">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.jwt.auth.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.jwt:microprofile-jwt-auth-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/metrics/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/metrics/api/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.metrics.api">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.metrics.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.metrics:microprofile-metrics-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/openapi/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/openapi/api/main/module.xml
@@ -22,12 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.openapi.api">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.openapi.api">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.openapi:microprofile-openapi-api}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 </module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/opentracing/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/opentracing/main/module.xml
@@ -15,7 +15,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.opentracing">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.opentracing">
+
     <resources>
         <artifact name="${org.eclipse.microprofile.opentracing:microprofile-opentracing-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/restclient/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/restclient/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.eclipse.microprofile.restclient">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.restclient">
 
   <properties>
     <property name="jboss.api" value="private"/>
@@ -33,7 +33,8 @@
   </resources>
 
   <dependencies>
-    <module name="javax.api"/>
+    <module name="java.logging"/>
+    <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     <module name="javax.annotation.api"/>
     <module name="javax.enterprise.api"/>
     <module name="javax.xml.bind.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.jboss.resteasy.resteasy-client-microprofile">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.resteasy.resteasy-client-microprofile">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -32,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.ws.rs.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config-smallrye/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.config-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.config-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +34,7 @@
 
     <dependencies>
         <module name="io.smallrye.config" export="true"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/fault-tolerance-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/fault-tolerance-smallrye/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.fault-tolerance-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.health-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.health-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +35,7 @@
     <dependencies>
         <module name="io.smallrye.health" />
         <module name="io.undertow.core"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
@@ -18,7 +18,8 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.jwt-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.jwt-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -29,7 +30,7 @@
 
     <dependencies>
         <module name="io.smallrye.config" export="true"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/metrics-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/metrics-smallrye/main/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.metrics-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.metrics-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +35,7 @@
     <dependencies>
         <module name="io.smallrye.metrics" export="true"/>
         <module name="io.undertow.core"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.eclipse.microprofile.metrics.api" />
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
@@ -21,7 +21,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.openapi-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.openapi-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
@@ -15,7 +15,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.opentracing-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.microprofile.opentracing-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/fault-tolerance-smallrye/executor/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/fault-tolerance-smallrye/executor/main/module.xml
@@ -23,6 +23,7 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.microprofile.fault-tolerance-smallrye.executor">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +33,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
         <module name="io.smallrye.fault-tolerance"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.concurrent.api"/>
     </dependencies>
 </module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
@@ -15,7 +15,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.microprofile.opentracing-smallrye">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.microprofile.opentracing-smallrye">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -25,7 +26,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/> <!-- for javax.naming -->
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> --> <!-- for javax.naming -->
 
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-jwt/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-jwt/main/module.xml
@@ -18,7 +18,8 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.security.elytron-jwt">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-jwt">
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/jsp/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/jsp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.undertow.jsp">
+<module xmlns="urn:jboss:module:1.9" name="io.undertow.jsp">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="sun.jdk"/>
         <module name="javax.servlet.api"/>
         <module name="javax.servlet.jsp.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
@@ -22,13 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.undertow.servlet">
+<module xmlns="urn:jboss:module:1.9" name="io.undertow.servlet">
     <resources>
         <artifact name="${io.undertow:undertow-servlet}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.annotation.api"/>
         <module name="sun.jdk"/>
         <module name="javax.servlet.api"/>
@@ -37,5 +37,6 @@
         <module name="org.jboss.logging"/>
         <module name="io.undertow.core" />
         <module name="org.jboss.xnio"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/websocket/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/io/undertow/websocket/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="io.undertow.websocket">
+<module xmlns="urn:jboss:module:1.9" name="io.undertow.websocket">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api"/>
         <module name="javax.websocket.api"/>
         <module name="org.jboss.logging"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/xalan/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/xalan/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.xalan">
+<module xmlns="urn:jboss:module:1.9" name="org.apache.xalan">
 
     <resources>
         <artifact name="${xalan:serializer}"/>
@@ -30,7 +30,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <module name="jdk.xml.dom"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 
 </module>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.eclipse.jdt.ecj">
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.jdt.ecj">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -31,4 +31,7 @@
         <artifact name="${org.eclipse.jdt.core.compiler:ecj}"/>
     </resources>
 
+    <dependencies>
+        <module name="java.compiler"/>
+    </dependencies>
 </module>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -23,7 +23,7 @@
     </properties>
 
     <dependencies>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.api"/>
         <module name="javax.json.api"/>
         <module name="javax.json.bind.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/el/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/el/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.glassfish.jakarta.el">
+<module xmlns="urn:jboss:module:1.9" name="org.glassfish.jakarta.el">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -39,7 +39,8 @@
         </artifact>
     </resources>
     <dependencies>
-            <module name="javax.api"/>
+            <module name="java.desktop"/>
+            <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
             <module name="javax.el.api" services="import" export="true"/>
     </dependencies>
 </module>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.el" target-name="org.glassfish.jakarta.el"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.glassfish.javax.el" target-name="org.glassfish.jakarta.el"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/javax/enterprise/concurrent/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/glassfish/javax/enterprise/concurrent/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.enterprise.concurrent">
+<module xmlns="urn:jboss:module:1.9" name="org.glassfish.javax.enterprise.concurrent">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,8 @@
     </resources>
 
     <dependencies>
+        <module name="java.logging"/>
+        <module name="java.management"/>
         <module name="javax.enterprise.concurrent.api"/>
     </dependencies>
 

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.clustering.common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.ee">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.ee">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,8 +36,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.enterprise.concurrent.api"/>
         <module name="javax.el.api"/>
         <module name="javax.interceptor.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.naming">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.naming">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.wildfly.http-client.naming"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.staxmapper"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-integration/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-integration/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.security-integration">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.security-integration">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-plugins/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security-plugins/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.security-plugins">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.security-plugins">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
         <module name="javax.security.jacc.api"/>
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.logging"/>
@@ -42,5 +43,6 @@
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="sun.jdk"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.security">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.security">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,7 +36,10 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.security.sasl"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.security.jacc.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.transaction.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.web-common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.web-common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,6 +32,8 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
         <module name="javax.security.auth.message.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.servlet.jsp.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
@@ -22,13 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.common-beans">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.common-beans">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
     
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
     </dependencies>
 
     <resources>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata.common">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.metadata.common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,8 +32,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.xml"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ear/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ear/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata.ear">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.metadata.ear">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,9 +32,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.xml"/>
         <module name="org.jboss.metadata.common"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/web/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/web/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata.web">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.metadata.web">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,9 +32,10 @@
     </resources>
 
     <dependencies>
+        <module name="java.xml"/>
         <module name="org.jboss.metadata.common"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api" optional="true"/>
         <module name="javax.servlet.jsp.api" optional="true"/>
         <module name="org.jboss.staxmapper"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
@@ -20,4 +20,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.5" name="org.jboss.remote-naming" target-name="org.wildfly.naming-client"/>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.remote-naming" target-name="org.wildfly.naming-client"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/security/negotiation/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/security/negotiation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.security.negotiation">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.security.negotiation">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -35,8 +35,11 @@
     </resources>
 
     <dependencies>
+        <module name="java.management" />
+        <module name="java.naming" />
+        <module name="java.security.jgss" />
         <module name="io.undertow.core" />
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.servlet.api"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.logging"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/picketbox/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/picketbox/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.picketbox">
+<module xmlns="urn:jboss:module:1.9" name="org.picketbox">
     <!-- This module is deprecated and subject to being removed in a subsequent release. -->
     <properties>
       <property name="jboss.api" value="deprecated"/>
@@ -35,7 +35,12 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.persistence.api" optional="true"/>
         <module name="javax.resource.api" optional="true"/>
         <module name="javax.security.auth.message.api" optional="true"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.clustering.service">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.service">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/container/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/container/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.clustering.web.container">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.web.container">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.undertow">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.undertow">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -36,13 +36,17 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
         <module name="io.undertow.core" services="import"/>
         <module name="io.undertow.servlet" services="import"/>
         <module name="io.undertow.jsp"/>
         <module name="io.undertow.websocket"/>
         <module name="sun.jdk"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.security.auth.message.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.servlet.jsp.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/common/main/module.xml
@@ -22,14 +22,16 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.http-client.common">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.http-client.common">
 
     <resources>
         <artifact name="${org.wildfly.wildfly-http-client:wildfly-http-client-common}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.xnio" />
         <module name="org.wildfly.client.config"/>
         <module name="javax.transaction.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/naming/main/module.xml
@@ -22,14 +22,15 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.http-client.naming">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.http-client.naming">
 
     <resources>
         <artifact name="${org.wildfly.wildfly-http-client:wildfly-http-naming-client}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.wildfly.http-client.common"/>
         <module name="org.wildfly.client.config"/>
         <module name="javax.transaction.api"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/naming-client/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/naming-client/main/module.xml
@@ -22,14 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.wildfly.naming-client">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.naming-client">
 
     <resources>
         <artifact name="${org.wildfly:wildfly-naming-client}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.security.jgss"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.logging"/>
         <module name="org.jboss.remoting"/>
         <module name="org.wildfly.common"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/naming/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.naming">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.naming">
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server-servlet/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server-servlet/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-web.undertow-server-servlet" version="${org.wildfly.security.elytron-web:undertow-server-servlet}">
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-web.undertow-server-servlet" version="${org.wildfly.security.elytron-web:undertow-server-servlet}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
@@ -22,9 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.activation.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.activation.api">
     <dependencies>
-        <module name="javax.api" />
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.datatransfer"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.mail.api" optional="true">
             <imports><include path="META-INF"/></imports>
         </module>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.annotation.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.annotation.api">
     <resources>
         <artifact name="${org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec}"/>
     </resources>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
@@ -22,8 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.el.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.el.api">
     <resources>
         <artifact name="${org.jboss.spec.javax.el:jboss-el-api_3.0_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+    </dependencies>
 </module>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="javax.enterprise.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.enterprise.api">
     <dependencies>
         <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.inject.api" export="true"/>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
@@ -22,13 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.enterprise.concurrent.api">
-    
-    <dependencies>
-    </dependencies>
-    
+<module xmlns="urn:jboss:module:1.9" name="javax.enterprise.concurrent.api">
+
     <resources>
         <artifact name="${org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec}"/>
     </resources>
-    
 </module>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
@@ -22,6 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.9" name="javax.inject.api">
+
     <resources>
         <artifact name="${jakarta.inject:jakarta.inject-api}"/>
     </resources>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -17,13 +17,17 @@
   -->
 
 <module xmlns="urn:jboss:module:1.9" name="javax.json.bind.api">
+
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>
+
     <resources>
         <artifact name="${jakarta.json.bind:jakarta.json.bind-api}"/>
     </resources>
+
     <dependencies>
+        <module name="java.logging"/>
         <module name="javax.json.api"/>
     </dependencies>
 </module>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.servlet.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.servlet.api">
     <resources>
         <artifact name="${org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec}"/>
     </resources>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
@@ -22,13 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.servlet.jsp.api">
-    <dependencies>
-        <module name="javax.servlet.api" export="true"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.9" name="javax.servlet.jsp.api">
 
     <resources>
         <artifact name="${org.jboss.spec.javax.servlet.jsp:jboss-jsp-api_2.3_spec}"/>
     </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
+    </dependencies>
 </module>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
@@ -22,13 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.servlet.jstl.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.servlet.jstl.api">
     <dependencies>
         <!-- org.xml.sax -->
-        <module name="javax.api" export="false"/>
-        <module name="javax.servlet.api" export="false"/>
-        <module name="javax.servlet.jsp.api" export="false"/>
-        <module name="org.apache.xalan" export="false"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="org.apache.xalan"/>
+        <module name="java.xml"/>
     </dependencies>
 
     <resources>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.validation.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.validation.api">
     <resources>
         <artifact name="${jakarta.validation:jakarta.validation-api}"/>
     </resources>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.websocket.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.websocket.api">
     <resources>
         <artifact name="${org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec}"/>
     </resources>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/packages/product.conf/content/modules/system/layers/base/org/jboss/as/product/wildfly-web/module.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/packages/product.conf/content/modules/system/layers/base/org/jboss/as/product/wildfly-web/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.product" slot="wildfly-web">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.product:wildfly-web">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -76,7 +76,7 @@ public class LayersTestCase {
         // tooling
         "org.jboss.as.domain-add-user",
         // Brought by galleon FP config
-        "org.jboss.as.product",
+        "org.jboss.as.product:wildfly-web",
         // Brought by galleon FP config
         "org.jboss.as.standalone",
         // injected by ee


### PR DESCRIPTION
Fixes [WFLY-14219](https://issues.redhat.com/browse/WFLY-14219)
Upgrade module descriptor to 1.9:
Exceptions: 1) System property is in use 2) jdeps error.

Please find jdeps results as attachment in JIRA.
