### PR TITLE
[WFLY-14229] Allow MP modules to easily change its maven groupid

### DIFF
--- a/ee-feature-pack/common/src/license/feature-pack-licenses.xml
+++ b/ee-feature-pack/common/src/license/feature-pack-licenses.xml
@@ -2597,28 +2597,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>wildfly-microprofile-opentracing-extension</artifactId>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License v2.1 or later</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>wildfly-microprofile-opentracing-smallrye</artifactId>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License v2.1 or later</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-mod_cluster-extension</artifactId>
       <licenses>
         <license>

--- a/microprofile/config-smallrye/pom.xml
+++ b/microprofile/config-smallrye/pom.xml
@@ -92,7 +92,7 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
@@ -321,7 +321,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-config-smallrye</artifactId>
       <licenses>
         <license>
@@ -332,7 +332,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-fault-tolerance-smallrye-executor</artifactId>
       <licenses>
         <license>
@@ -343,7 +343,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-fault-tolerance-smallrye-extension</artifactId>
       <licenses>
         <license>
@@ -354,7 +354,18 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-health-smallrye</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-jwt-smallrye</artifactId>
       <licenses>
         <license>
@@ -365,8 +376,41 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-metrics-smallrye</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-openapi-smallrye</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-opentracing-extension</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-opentracing-smallrye</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 or later</name>

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -105,11 +105,11 @@
             <artifactId>smallrye-health</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -100,7 +100,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-config-smallrye</artifactId>
             <exclusions>
                 <exclusion>
@@ -114,7 +114,7 @@
             <artifactId>smallrye-metrics</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/opentracing-extension/pom.xml
+++ b/microprofile/opentracing-extension/pom.xml
@@ -39,7 +39,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-opentracing-smallrye</artifactId>
         </dependency>
 
@@ -73,7 +73,7 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
             <exclusions>
                 <exclusion>
@@ -84,7 +84,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-config-smallrye</artifactId>
         </dependency>
         <dependency>
@@ -99,7 +99,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>smallrye-opentracing</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
             <exclusions>
                 <exclusion>
@@ -83,7 +83,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
- The MP modules should be able to mutate its groupid. This patch reviews and corrects the uses of `ee.maven.groupId` and `full.maven.groupId` on the MP module dependencies.
- It also fixes the licences files for MP modules moving opentracing-extension variants from ee-feature-pack license files to microprofile/galleon-common and adds missing licenses for wildfly-microprofile-metrics and wildfly-microprofile-health

Jira issue: https://issues.redhat.com/browse/WFLY-14229
