### PR TITLE
[WFLY-14243] New JAXB tests in WFLY-13968 fails on ee9 profile

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropCustomTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropCustomTestCase.java
@@ -46,7 +46,8 @@ public class JAXBContextSystemPropCustomTestCase extends JAXBContextTestBase {
         @Override
         protected SystemProperty[] getSystemProperties() {
             return new SystemProperty[] {
-                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, CUSTOM_JAXB_FACTORY_CLASS)
+                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, CUSTOM_JAXB_FACTORY_CLASS),
+                new DefaultSystemProperty(JAKARTA_FACTORY_PROP_NAME, CUSTOM_JAXB_FACTORY_CLASS)
             };
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropInternalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropInternalTestCase.java
@@ -46,7 +46,8 @@ public class JAXBContextSystemPropInternalTestCase extends JAXBContextTestBase {
         @Override
         protected SystemProperty[] getSystemProperties() {
             return new SystemProperty[] {
-                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, DEFAULT_JAXB_FACTORY_CLASS)
+                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, DEFAULT_JAXB_FACTORY_CLASS),
+                new DefaultSystemProperty(JAKARTA_FACTORY_PROP_NAME, DEFAULT_JAXB_FACTORY_CLASS)
             };
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
@@ -53,6 +53,7 @@ public abstract class JAXBContextTestBase {
     protected static final String WEB_APP_CUSTOM_CONTEXT = "jaxb-custom-webapp";
 
     protected static final String JAXB_FACTORY_PROP_NAME = JAXBContextFactory.class.getName();
+    protected static final String JAKARTA_FACTORY_PROP_NAME = JAXBContextFactory.class.getName().replaceFirst("javax.", "jakarta.");
     protected static final String DEFAULT_JAXB_FACTORY_CLASS = "com.sun.xml.bind.v2.JAXBContextFactory";
     protected static final String CUSTOM_JAXB_FACTORY_CLASS = FakeJAXBContextFactory.class.getName();
     protected static final String JAXB_PROPERTIES_FILE = "WEB-INF/classes/org/jboss/as/test/integration/jaxb/bindings/jaxb.properties";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java
@@ -39,14 +39,22 @@ public class JAXBContextUsingPropertiesTestCase extends JAXBContextTestBase {
     @Deployment(name = "app-internal", testable = false)
     public static WebArchive createInternalDeployment() {
         final WebArchive war = JAXBContextTestBase.createInternalDeployment();
-        war.add(new StringAsset(JAXB_FACTORY_PROP_NAME + "=" + DEFAULT_JAXB_FACTORY_CLASS), JAXB_PROPERTIES_FILE);
+        String nl = System.getProperty("line.separator");
+        war.add(new StringAsset(
+                JAXB_FACTORY_PROP_NAME + "=" + DEFAULT_JAXB_FACTORY_CLASS + nl
+                + JAKARTA_FACTORY_PROP_NAME + "=" + DEFAULT_JAXB_FACTORY_CLASS),
+                JAXB_PROPERTIES_FILE);
         return war;
     }
 
     @Deployment(name = "app-custom", testable = false)
     public static WebArchive createCustomDeployment() {
         final WebArchive war = JAXBContextTestBase.createCustomDeployment();
-        war.add(new StringAsset(JAXB_FACTORY_PROP_NAME + "=" + CUSTOM_JAXB_FACTORY_CLASS), JAXB_PROPERTIES_FILE);
+        String nl = System.getProperty("line.separator");
+        war.add(new StringAsset(
+                JAXB_FACTORY_PROP_NAME + "=" + CUSTOM_JAXB_FACTORY_CLASS + nl
+                + JAKARTA_FACTORY_PROP_NAME + "=" + CUSTOM_JAXB_FACTORY_CLASS),
+                JAXB_PROPERTIES_FILE);
         return war;
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14243

Fix for the JAXB tests when using the ee9 profile requested by @bstansberry. Just adding the two possible system properties or keys inside the `jaxb.properties` file.

Thanks!
