### PR TITLE
[WFLY-14271] timed object id throws null when tried to be restored

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3229,4 +3229,11 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 522, value = "The default pool name %s could not be resolved from its value: %s")
     void defaultPoolExpressionCouldNotBeResolved(String defaultPoolName, String defaultPoolValue);
+
+    @LogMessage(level = WARN)
+    @Message(id = 523, value = "Timer %s has not been deployed")
+    void timerNotDeployed(String timer);
+
+    @Message(id = 524, value = "Timer %s cannot be added")
+    RuntimeException timerCannotBeAdded(TimerImpl timer);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -197,6 +197,7 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         }
 
         started = true;
+        timerPersistence.getValue().timerDeployed(timedObjectInvoker.getValue().getTimedObjectId());
         // register ourselves to the TimerServiceRegistry (if any)
         if (timerServiceRegistry != null) {
             timerServiceRegistry.registerTimerService(this);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
@@ -60,6 +60,12 @@ public interface TimerPersistence {
     boolean shouldRun(TimerImpl timer, @Deprecated TransactionManager txManager);
 
     /**
+     * Signals that the timer is being deployed and any internal structured required should be added.
+     * @param timedObjectId
+     */
+    default void timerDeployed(String timedObjectId) {};
+
+    /**
      * Signals that a timer is being undeployed, and all cached data relating to this object should
      * be dropped to prevent a class loader leak
      *


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14271
Upon activation of the timer service the creation of the hash set related to a timer object id can be null if there is a problem with database connection. This causes the map not to be filled and therfore any further registration of the timers fail to NullPointerException.
Added a new timerDeployed event in the persistence to signal before the load so always this is filled.