### PR TITLE
[WFLY-14264] Update the default Elytron KeyStore type to JKS in the Elytron subsystem documentation

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -632,7 +632,7 @@ and openssl provider loaders.
                 "required" => false,
                 "provider-name" => undefined,
                 "providers" => undefined,
-                "type" => "PKCS12"
+                "type" => "JKS"
             }
         },
         "key-store-realm" => undefined,


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14264

https://github.com/wildfly/wildfly-core/pull/4443 updates the default Elytron KeyStore type to JKS. This PR simply updates the documentation accordingly.