### PR TITLE
Fix the mp-4.0 GH action to build the PR branch

### DIFF
--- a/.github/workflows/mp-4.0.yml
+++ b/.github/workflows/mp-4.0.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'MP4'
-  pull_request_target:
+  pull_request:
     branches:
       - 'MP4'
 


### PR DESCRIPTION
I noticed in https://github.com/wildfly/wildfly/pull/13850 that the PR itself wasn't built as I updated the MP Health to 3.0 which has now 21 TCK tests (and run had only 16 from Health 2.2) so after some checking the current approach with `pull_request_target` (https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target) is probably not intended - "This event runs in the context of the base of the pull request, rather than in the merge commit as the pull_request event does." meaning this workflow now checkouts directly MP4 branch and not the PR branch. This change will make it check out the PR branch merged on top of MP4. 