### PR TITLE
WFLY-14133 Add call-timeout attribute to JMS core bridge

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -24,8 +24,10 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
+import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
 import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.jboss.dmr.ModelType.INT;
+import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 import static org.wildfly.extension.messaging.activemq.MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.STATIC_CONNECTORS;
@@ -173,6 +175,17 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see {@link org.apache.activemq.artemis.api.core.client.ActiveMQClient#DEFAULT_CALL_TIMEOUT}
+     */
+    public static final SimpleAttributeDefinition CALL_TIMEOUT = create("call-timeout", LONG)
+            .setDefaultValue(new ModelNode(30000L))
+            .setMeasurementUnit(MILLISECONDS)
+            .setRequired(false)
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
+
     public static final AttributeDefinition[] ATTRIBUTES = {
             QUEUE_NAME, FORWARDING_ADDRESS, CommonAttributes.HA,
             CommonAttributes.FILTER, CommonAttributes.TRANSFORMER_CLASS_NAME,
@@ -185,7 +198,8 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             PRODUCER_WINDOW_SIZE,
             CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
             USER, PASSWORD, CREDENTIAL_REFERENCE,
-            CONNECTOR_REFS, DISCOVERY_GROUP_NAME
+            CONNECTOR_REFS, DISCOVERY_GROUP_NAME,
+            CALL_TIMEOUT
     };
 
     private final boolean registerRuntimeOnly;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeRemove.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeRemove.java
@@ -79,7 +79,7 @@ public class BridgeRemove extends AbstractRemoveStepHandler {
             final String name = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
             final BridgeConfiguration bridgeConfiguration = BridgeAdd.createBridgeConfiguration(context, name, model);
             ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-            BridgeAdd.createBridge(name, bridgeConfiguration, server.getActiveMQServerControl());
+            BridgeAdd.createBridge(bridgeConfiguration, server);
         }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
@@ -512,7 +512,8 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.PASSWORD,
                                                         BridgeDefinition.CREDENTIAL_REFERENCE,
                                                         BridgeDefinition.CONNECTOR_REFS,
-                                                        BridgeDefinition.DISCOVERY_GROUP_NAME))
+                                                        BridgeDefinition.DISCOVERY_GROUP_NAME,
+                                                        BridgeDefinition.CALL_TIMEOUT))
                                 .addChild(
                                         builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
                                                 .addAttributes(

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -108,6 +108,9 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
                 ServerDefinition.CRITICAL_ANALYZER_TIMEOUT,
                 ServerDefinition.JOURNAL_MAX_ATTIC_FILES);
         server.discardOperations(PrintDataOperation.OPERATION_NAME);
+
+        ResourceTransformationDescriptionBuilder bridge = server.addChildResource(MessagingExtension.BRIDGE_PATH);
+        rejectDefinedAttributeWithDefaultValue(bridge, BridgeDefinition.CALL_TIMEOUT);
     }
 
     private static void registerTransformers_WF_22(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -872,4 +872,8 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 102, value = "HTTP Upgrade request missing Sec-JbossRemoting-Key header")
     IOException upgradeRequestMissingKey();
+
+    @Message(id = 103, value = "Broker is not started. It cannot be managed yet.")
+    IllegalStateException brokerNotStarted();
+
 }

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -43,6 +43,7 @@ address-setting.slow-consumer-threshold=The minimum rate of message consumption 
 address-setting=An address setting defines some attributes that are defined against an address wildcard rather than a specific queue.
 bindings-directory.path=The directory in which the bindings journal lives. The default is ${jboss.server.data.dir}/messagingbindings.
 bridge.add=Operation adding a bridge.
+bridge.call-timeout=Timeout for blocking calls.
 bridge.check-period=The period (in milliseconds) between client failure check.
 bridge.confirmation-window-size=The confirmation-window-size to use for the connection used to forward messages to the target node.
 bridge.connection-ttl=The maximum time (in milliseconds) for which the connections used by the bridges are considered alive (in the absence of heartbeat).

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_13_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_13_0.xsd
@@ -636,6 +636,7 @@
                     <xs:attribute name="password" type="xs:string"  use="optional" />
                     <xs:attribute name="static-connectors" type="stringList"  use="optional" />
                     <xs:attribute name="discovery-group" type="xs:string"  use="optional" />
+                    <xs:attribute name="call-timeout" type="xs:long"  use="optional" default="30000" />
                 </xs:complexType>
             </xs:element>
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/BridgeAddTestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/BridgeAddTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.messaging.activemq;
+
+import org.apache.activemq.artemis.core.config.BridgeConfiguration;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BridgeAddTestCase {
+
+    private static final String BRIDGE_NAME = "CoreBridge";
+    private static final String SOURCE_QUEUE_NAME = "SourceQueue";
+    private static final String TARGET_QUEUE_NAME = "TargetQueue";
+
+    @Test
+    public void testCreateBridgeConfiguration() throws OperationFailedException {
+        BridgeConfiguration bridgeConfiguration =
+                BridgeAdd.createBridgeConfiguration(ExpressionResolver.SIMPLE, BRIDGE_NAME, createModel());
+
+        Assert.assertEquals(BRIDGE_NAME, bridgeConfiguration.getName());
+        Assert.assertEquals(SOURCE_QUEUE_NAME, bridgeConfiguration.getQueueName());
+        Assert.assertEquals(TARGET_QUEUE_NAME, bridgeConfiguration.getForwardingAddress());
+        Assert.assertArrayEquals(new String[] {"in-vm"}, bridgeConfiguration.getStaticConnectors().toArray());
+        Assert.assertEquals(30000, bridgeConfiguration.getCallTimeout());
+    }
+
+    @Test
+    public void testCreateBridgeConfigurationCallTimeoutInModel() throws OperationFailedException {
+        ModelNode model = createModel();
+        model.get("call-timeout").set(70000);
+        BridgeConfiguration bridgeConfiguration =
+                BridgeAdd.createBridgeConfiguration(ExpressionResolver.SIMPLE, BRIDGE_NAME, model);
+
+        Assert.assertEquals(BRIDGE_NAME, bridgeConfiguration.getName());
+        Assert.assertEquals(SOURCE_QUEUE_NAME, bridgeConfiguration.getQueueName());
+        Assert.assertEquals(TARGET_QUEUE_NAME, bridgeConfiguration.getForwardingAddress());
+        Assert.assertArrayEquals(new String[] {"in-vm"}, bridgeConfiguration.getStaticConnectors().toArray());
+        Assert.assertEquals(70000, bridgeConfiguration.getCallTimeout());
+    }
+
+    @Test
+    public void testCreateBridgeConfigurationCallTimeoutSystemProperty() throws OperationFailedException {
+        try {
+            System.setProperty(BridgeAdd.CALL_TIMEOUT_PROPERTY, "80000");
+
+            BridgeConfiguration bridgeConfiguration =
+                    BridgeAdd.createBridgeConfiguration(ExpressionResolver.SIMPLE, BRIDGE_NAME, createModel());
+
+            Assert.assertEquals(BRIDGE_NAME, bridgeConfiguration.getName());
+            Assert.assertEquals(SOURCE_QUEUE_NAME, bridgeConfiguration.getQueueName());
+            Assert.assertEquals(TARGET_QUEUE_NAME, bridgeConfiguration.getForwardingAddress());
+            Assert.assertArrayEquals(new String[] {"in-vm"}, bridgeConfiguration.getStaticConnectors().toArray());
+            Assert.assertEquals(80000, bridgeConfiguration.getCallTimeout());
+        } finally {
+            System.clearProperty(BridgeAdd.CALL_TIMEOUT_PROPERTY);
+        }
+    }
+
+    private static ModelNode createModel() {
+        ModelNode model = new ModelNode();
+        model.get("queue-name").set(SOURCE_QUEUE_NAME);
+        model.get("forwarding-address").set(TARGET_QUEUE_NAME);
+        model.get("static-connectors").add("in-vm");
+        return model;
+    }
+}

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0.xml
@@ -429,7 +429,8 @@
                 producer-window-size="${producer.windows.size:5678}"
                 user="${user:Brian}"
                 password="${password:secret}"
-                static-connectors="in-vm netty" />
+                static-connectors="in-vm netty"
+                call-timeout="${call.timeout:60000}" />
         <bridge name="bridge2"
                 queue-name="coreQueueB"
                 discovery-group="groupC" />

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0_reject_transform.xml
@@ -172,7 +172,8 @@
                 forwarding-address="${forwarding.address:forwardingaddress1}"
                 producer-window-size="${producer.windows.size:5678}"
                 static-connectors="in-vm netty"
-                user="${user:Brian}">
+                user="${user:Brian}"
+                call-timeout="${call.timeout:60000}">
             <credential-reference clear-text="secret1"/>
         </bridge>
         <bridge name="bridge2"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_13_0_transform.xml
@@ -255,7 +255,8 @@
                 producer-window-size="-1"
                 user="${user:Brian}"
                 password="${password:secret}"
-                static-connectors="in-vm netty" />
+                static-connectors="in-vm netty"
+                call-timeout="30000" />
         <bridge name="bridge2"
                 queue-name="coreQueueB"
                 discovery-group="groupC" />

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/CoreBridgeCallTimeoutTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/CoreBridgeCallTimeoutTestCase.java
@@ -1,0 +1,274 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.messaging;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.byteman.agent.submit.Submit;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.Server;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.ADDRESS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test verifies that setting a call timeout on a core bridge takes an effect.
+ *
+ * @author Tomas Hofman
+ */
+@RunWith(WildflyTestRunner.class)
+@RunAsClient
+@ServerControl(manual = true)
+public class CoreBridgeCallTimeoutTestCase {
+
+    private static final Logger logger = Logger.getLogger(CoreBridgeCallTimeoutTestCase.class);
+
+    private static final String SERVER_CONFIG_NAME = "standalone-full.xml";
+    private static final String EXPORTED_PREFIX = "java:jboss/exported/";
+    private static final String REMOTE_CONNECTION_FACTORY_LOOKUP = "jms/RemoteConnectionFactory";
+    private static final String SOURCE_QUEUE_NAME = "SourceQueue";
+    private static final String SOURCE_QUEUE_LOOKUP = "jms/SourceQueue";
+    private static final String TARGET_QUEUE_NAME = "TargetQueue";
+    private static final String TARGET_QUEUE_LOOKUP = "jms/TargetQueue";
+    private static final String BRIDGE_NAME = "CoreBridge";
+    private static final String MESSAGE_TEXT = "Hello world!";
+
+    private static final String BYTEMAN_ADDRESS = System.getProperty("byteman.server.ipaddress", Submit.DEFAULT_ADDRESS);
+    private static final Integer BYTEMAN_PORT = Integer.getInteger("byteman.server.port", Submit.DEFAULT_PORT);
+    private static final Submit BYTEMAN = new Submit(BYTEMAN_ADDRESS, BYTEMAN_PORT);
+
+    private static final String ORIGINAL_JVM_ARGS = System.getProperty("jvm.args", "");
+    private static final String BASE_DIR = System.getProperty("basedir", "./");
+
+    @Inject
+    protected static ServerController container;
+
+    private JMSOperations jmsOperations;
+    private ManagementClient managementClient;
+
+    @BeforeClass
+    public static void startContainer() {
+        System.out.println("jvm.args:" + System.getProperty("jvm.args"));
+        System.out.println("basedir:" + System.getProperty("basedir"));
+        System.setProperty("jvm.args", ORIGINAL_JVM_ARGS +
+                " -Xmx512m -XX:MaxMetaspaceSize=256m " +
+                "-Dorg.jboss.byteman.verbose " +
+                "-Djboss.modules.system.pkgs=org.jboss.byteman " +
+                "-Dorg.jboss.byteman.transform.all " +
+                "-javaagent:" + BASE_DIR + "/target/lib/byteman.jar=listener:true,port:" + BYTEMAN_PORT + ",address:" + BYTEMAN_ADDRESS + ",policy:true");
+        container.start(SERVER_CONFIG_NAME, Server.StartMode.NORMAL);
+    }
+
+    @AfterClass
+    public static void stopContainer() {
+        System.setProperty("jvm.args", ORIGINAL_JVM_ARGS);
+        container.stop();
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        managementClient = createManagementClient();
+        jmsOperations = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
+
+        // create source and target queues and a bridge
+        jmsOperations.createJmsQueue(SOURCE_QUEUE_NAME, EXPORTED_PREFIX + SOURCE_QUEUE_LOOKUP);
+        removeMessagesFromQueue(SOURCE_QUEUE_NAME);
+        jmsOperations.createJmsQueue(TARGET_QUEUE_NAME, EXPORTED_PREFIX + TARGET_QUEUE_LOOKUP);
+        removeMessagesFromQueue(TARGET_QUEUE_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        // clean up
+        jmsOperations.removeJmsQueue(SOURCE_QUEUE_NAME);
+        jmsOperations.removeJmsQueue(TARGET_QUEUE_NAME);
+        if (jmsOperations != null) {
+            jmsOperations.close();
+        }
+        if (managementClient != null) {
+            managementClient.close();
+        }
+    }
+
+    /**
+     * Scenario:
+     *
+     * <ol>
+     * <li>Create a bridge without a call-timeout.</li>
+     * <li>Verify that messages are transferred.</li>
+     * </ol>
+     */
+    @Test(timeout = 150000)
+    public void testCoreBridge() throws Exception {
+        Message receivedMessage = verifyCoreBridge(null); // no call timeout
+
+        // assert that message was delivered
+        assertNotNull("Expected message was not received", receivedMessage);
+    }
+
+    /**
+     * Scenario:
+     *
+     * <ol>
+     * <li>Create a bridge with call-timeout of 500 ms, and introduce delays to bridge calls via a byteman rule.</li>
+     * <li>Verify that messages are not transferred.</li>
+     * </ol>
+     */
+    @Test(timeout = 150000)
+    public void testCallTimeoutWithFailure() throws Exception {
+        try {
+            insertBytemanRules(); // introduce 1 sec delay to bridge calls
+            Message receivedMessage = verifyCoreBridge(500L);// set call timeout to 500 ms
+
+            // assert that message was delivered
+            assertNull("No message was expected to be transferred by the bridge", receivedMessage);
+        } finally {
+            deleteBytemanRules();
+        }
+    }
+
+    private Message verifyCoreBridge(Long callTimeout) throws Exception {
+        createCoreBridge(callTimeout);
+
+        InitialContext remoteContext = createJNDIContext();
+        ConnectionFactory connectionFactory = (ConnectionFactory) remoteContext.lookup(REMOTE_CONNECTION_FACTORY_LOOKUP);
+
+        // lookup source and target queues
+        Queue sourceQueue = (Queue) remoteContext.lookup(SOURCE_QUEUE_LOOKUP);
+        Queue targetQueue = (Queue) remoteContext.lookup(TARGET_QUEUE_LOOKUP);
+
+        try (Connection connection = connectionFactory.createConnection("guest", "guest")) {
+            try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+                // send a message on the source queue
+                MessageProducer producer = session.createProducer(sourceQueue);
+                String text = MESSAGE_TEXT + " " + UUID.randomUUID().toString();
+                Message message = session.createTextMessage(text);
+                message.setJMSDeliveryMode(DeliveryMode.NON_PERSISTENT);
+                producer.send(message);
+
+                // receive a message from the target queue
+                MessageConsumer consumer = session.createConsumer(targetQueue);
+                connection.start();
+                Message receivedMessage = consumer.receive(5000);
+
+                // if some message was delivered, assert it's the same message which was sent
+                if (receivedMessage != null) {
+                    assertTrue(receivedMessage instanceof TextMessage);
+                    assertEquals(text, ((TextMessage) receivedMessage).getText());
+                }
+
+                return receivedMessage;
+            }
+        } finally {
+            jmsOperations.removeCoreBridge(BRIDGE_NAME);
+            remoteContext.close();
+        }
+    }
+
+    private void createCoreBridge(Long callTimeout) {
+        ModelNode bridgeAttributes = new ModelNode();
+        bridgeAttributes.get("queue-name").set("jms.queue." + SOURCE_QUEUE_NAME);
+        bridgeAttributes.get("forwarding-address").set("jms.queue." + TARGET_QUEUE_NAME);
+        bridgeAttributes.get("static-connectors").add("in-vm");
+        bridgeAttributes.get("use-duplicate-detection").set(false);
+        if (callTimeout != null) {
+            bridgeAttributes.get("call-timeout").set(callTimeout);
+        }
+        bridgeAttributes.get("user").set("guest");
+        bridgeAttributes.get("password").set("guest");
+        jmsOperations.addCoreBridge(BRIDGE_NAME, bridgeAttributes);
+    }
+
+    private void removeMessagesFromQueue(String queueName) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(ADDRESS).set(jmsOperations.getServerAddress().add("jms-queue", queueName));
+        operation.get(OP).set("remove-messages");
+        jmsOperations.getControllerClient().execute(operation);
+    }
+
+    private static void insertBytemanRules() throws Exception {
+        logger.info("Installing byteman rules.");
+        BYTEMAN.addRulesFromResources(Collections.singletonList(
+                CoreBridgeCallTimeoutTestCase.class.getClassLoader().getResourceAsStream("byteman/"
+                        + CoreBridgeCallTimeoutTestCase.class.getSimpleName()
+                        + ".btm")));
+    }
+
+    private static void deleteBytemanRules() throws Exception {
+        logger.info("Removing byteman rules.");
+        BYTEMAN.deleteAllRules();
+    }
+
+    private static ManagementClient createManagementClient() {
+        return new ManagementClient(
+                TestSuiteEnvironment.getModelControllerClient(),
+                TestSuiteEnvironment.formatPossibleIpv6Address(TestSuiteEnvironment.getServerAddress()),
+                TestSuiteEnvironment.getServerPort(),
+                "remote+http");
+    }
+
+    private static InitialContext createJNDIContext() throws NamingException {
+        final Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
+        env.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":8080");
+        env.put(Context.SECURITY_PRINCIPAL, "guest");
+        env.put(Context.SECURITY_CREDENTIALS, "guest");
+        return new InitialContext(env);
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/resources/byteman/CoreBridgeCallTimeoutTestCase.btm
+++ b/testsuite/integration/manualmode/src/test/resources/byteman/CoreBridgeCallTimeoutTestCase.btm
@@ -1,0 +1,9 @@
+RULE Introduce delay to blocking bridge calls
+CLASS org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl
+METHOD handlePacket
+AT ENTRY
+IF $1.getType() != 22 && $1.isResponse()
+DO
+  System.out.println("Introducing artificial delay");
+  Thread.sleep(1000);
+ENDRULE

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/ActiveMQProviderJMSOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/ActiveMQProviderJMSOperations.java
@@ -175,6 +175,20 @@ public class ActiveMQProviderJMSOperations implements JMSOperations {
     }
 
     @Override
+    public void addCoreBridge(String name, ModelNode attributes) {
+        ModelNode address = getServerAddress();
+        address.add("bridge", name);
+        executeOperation(address, ADD, attributes);
+    }
+
+    @Override
+    public void removeCoreBridge(String name) {
+        ModelNode address = getServerAddress();
+        address.add("bridge", name);
+        executeOperation(address, REMOVE_OPERATION, null);
+    }
+
+    @Override
     public void addCoreQueue(String queueName, String queueAddress, boolean durable, String routing) {
         ModelNode address = getServerAddress()
                 .add("queue", queueName);
@@ -390,4 +404,35 @@ public class ActiveMQProviderJMSOperations implements JMSOperations {
     public boolean isRemoteBroker() {
         return false;
     }
+
+    @Override
+    public void disableSecurity() {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(getServerAddress());
+        operation.get(NAME).set("security-enabled");
+        operation.get(VALUE).set(false);
+
+        try {
+            execute(client, operation);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void enableSecurity() {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(getServerAddress());
+        operation.get(NAME).set("security-enabled");
+        operation.get(VALUE).set(true);
+
+        try {
+            execute(client, operation);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
@@ -69,6 +69,10 @@ public interface JMSOperations {
 
     void removeJmsBridge(String name);
 
+    void addCoreBridge(String name, ModelNode attributes);
+
+    void removeCoreBridge(String name);
+
     void addCoreQueue(final String queueName, final String queueAddress, boolean durable, String routing);
 
     void removeCoreQueue(final String queueName);
@@ -125,4 +129,8 @@ public interface JMSOperations {
     void createSocketBinding(String name, String interfaceName, int port);
 
     boolean isRemoteBroker();
+
+    void disableSecurity();
+
+    void enableSecurity();
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/RemoteActiveMQProviderJMSOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/RemoteActiveMQProviderJMSOperations.java
@@ -192,6 +192,20 @@ public class RemoteActiveMQProviderJMSOperations implements JMSOperations {
     }
 
     @Override
+    public void addCoreBridge(String name, ModelNode attributes) {
+        ModelNode address = getServerAddress();
+        address.add("bridge", name);
+        executeOperation(address, ADD, attributes);
+    }
+
+    @Override
+    public void removeCoreBridge(String name) {
+        ModelNode address = getServerAddress();
+        address.add("bridge", name);
+        executeOperation(address, REMOVE_OPERATION, null);
+    }
+
+    @Override
     public void addCoreQueue(String queueName, String queueAddress, boolean durable, String routing) {
         ModelNode address = getServerAddress()
                 .add("queue", queueName);
@@ -501,4 +515,35 @@ public class RemoteActiveMQProviderJMSOperations implements JMSOperations {
     public boolean isRemoteBroker() {
         return true;
     }
+
+    @Override
+    public void disableSecurity() {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(getServerAddress());
+        operation.get(NAME).set("security-enabled");
+        operation.get(VALUE).set(false);
+
+        try {
+            execute(client, operation);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void enableSecurity() {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(getServerAddress());
+        operation.get(NAME).set("security-enabled");
+        operation.get(VALUE).set(true);
+
+        try {
+            execute(client, operation);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14133

The call timeout attribute is not currently configurable via the management model. This PR makes it accessible.

Work in progress.