### PR TITLE
[WFLY-14262] Avoid running microprofile TCK related plugin executions…

### DIFF
--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -47,7 +47,6 @@
         <extension module="org.wildfly.extension.ee-security"/>
         <extension module="org.wildfly.extension.io"/>
         <extension module="org.wildfly.extension.messaging-activemq"/>
-        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
         <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.security.manager"/>
         <extension module="org.wildfly.extension.undertow"/>
@@ -246,7 +245,6 @@
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>
                 </mail-session>
             </subsystem>
-            <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
             <subsystem xmlns="urn:jboss:domain:naming:1.0"/>
             <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
                 <deployment-permissions>
@@ -459,7 +457,6 @@
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>
                 </mail-session>
             </subsystem>
-            <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
             <subsystem xmlns="urn:jboss:domain:naming:1.0"/>
             <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
                 <deployment-permissions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -44,7 +44,6 @@
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.wildfly.extension.io"/>
         <extension module="org.wildfly.extension.messaging-activemq"/>
-        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
         <extension module="org.wildfly.extension.security.manager"/>
         <extension module="org.wildfly.extension.undertow"/>
     </extensions>
@@ -250,7 +249,6 @@
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>
                 </mail-session>
             </subsystem>
-            <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
             <subsystem xmlns="urn:jboss:domain:naming:1.0"/>
             <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
                 <deployment-permissions>
@@ -521,7 +519,6 @@
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>
                 </mail-session>
             </subsystem>
-            <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0"/>
             <subsystem xmlns="urn:jboss:domain:naming:1.0"/>
             <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
                 <deployment-permissions>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.as.test.shared.ModelParserUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -95,6 +96,8 @@ public class ParseAndMarshalModelsTestCase {
     private static final Version[] AS_VERSIONS = {Version.AS_7_1_3, Version.AS_7_2_0};
 
     private static final File JBOSS_HOME = Paths.get("target" ,"jbossas-parse-marshal").toFile();
+
+    private static final boolean altDistTest = "ee-".equals(System.getProperty("testsuite.default.build.project.prefix"));
 
     @Test
     public void testStandaloneXml() throws Exception {
@@ -200,6 +203,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneFullHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version, "full-ha"));
             validateWebSubsystem(model, version);
@@ -211,6 +217,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneFullXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version, "full"));
             validateWebSubsystem(model, version);
@@ -222,6 +231,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version, null));
             validateWebSubsystem(model, version);
@@ -246,6 +258,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneJtsXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version, "jts"));
             validateWebSubsystem(model, version);
@@ -264,6 +279,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandalonePicketLinkXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // Did not exist until 6.3, where the tech preview was abandoned and redone
@@ -275,6 +293,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneXtsXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version, "xts"));
             validateCmpSubsystem(model, version);
@@ -288,6 +309,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneAzureFullHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -299,6 +323,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneAzureHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -310,6 +337,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneEc2FullHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -321,6 +351,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneEc2HaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -332,6 +365,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneGenericJmsXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -343,6 +379,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneGossipFullHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -354,6 +393,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneGossipHaXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -376,6 +418,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPStandaloneRtsXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             if (version.is6x()) {
                 // didn't exist yet
@@ -427,6 +472,9 @@ public class ParseAndMarshalModelsTestCase {
 
     @Test
     public void testEAPDomainXml() throws Exception {
+
+        Assume.assumeFalse(altDistTest);
+
         for (Version version : EAP_VERSIONS) {
             ModelNode model = domainXmlTest(getLegacyConfigFile("domain", version, null));
             validateProfiles(model, version);

--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -43,11 +43,7 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <ts.elytron.cli>${jbossas.ts.dir}/shared/enable-elytron.cli</ts.elytron.cli>
-        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
-        <!-- These properties control what feature packs are used and what layers are provisioned if galleon provision occurs -->
-        <ts.microprofile-tck-provisioning.fp.groupId>${full.maven.groupId}</ts.microprofile-tck-provisioning.fp.groupId>
-        <ts.microprofile-tck-provisioning.fp.artifactId>wildfly-galleon-pack</ts.microprofile-tck-provisioning.fp.artifactId>
-        <ts.microprofile-tck-provisioning.fp.version>${full.maven.version}</ts.microprofile-tck-provisioning.fp.version>
+        <!-- These properties control what layers are provisioned if galleon provision occurs -->
         <ts.microprofile-tck-provisioning.base.layer>cloud-server</ts.microprofile-tck-provisioning.base.layer>
         <ts.microprofile-tck-provisioning.decorator.layer>microprofile-fault-tolerance</ts.microprofile-tck-provisioning.decorator.layer>
     </properties>

--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -39,12 +39,8 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <ts.elytron.cli>${jbossas.ts.dir}/shared/enable-elytron.cli</ts.elytron.cli>
-        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
 
-        <!-- These properties control what feature packs are used and what layers are provisioned if galleon provision occurs -->
-        <ts.microprofile-tck-provisioning.fp.groupId>${full.maven.groupId}</ts.microprofile-tck-provisioning.fp.groupId>
-        <ts.microprofile-tck-provisioning.fp.artifactId>wildfly-galleon-pack</ts.microprofile-tck-provisioning.fp.artifactId>
-        <ts.microprofile-tck-provisioning.fp.version>${full.maven.version}</ts.microprofile-tck-provisioning.fp.version>
+        <!-- These properties control what layers are provisioned if galleon provision occurs -->
         <ts.microprofile-tck-provisioning.base.layer>cloud-server</ts.microprofile-tck-provisioning.base.layer>
         <ts.microprofile-tck-provisioning.decorator.layer>microprofile-jwt</ts.microprofile-tck-provisioning.decorator.layer>
     </properties>

--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -42,11 +42,7 @@
         <jbossas.ts.integ.dir>${basedir}/../..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
-        <!-- These properties control what feature packs are used and what layers are provisioned if galleon provision occurs -->
-        <ts.microprofile-tck-provisioning.fp.groupId>${full.maven.groupId}</ts.microprofile-tck-provisioning.fp.groupId>
-        <ts.microprofile-tck-provisioning.fp.artifactId>wildfly-galleon-pack</ts.microprofile-tck-provisioning.fp.artifactId>
-        <ts.microprofile-tck-provisioning.fp.version>${full.maven.version}</ts.microprofile-tck-provisioning.fp.version>
+        <!-- These properties control what layers are provisioned if galleon provision occurs -->
         <ts.microprofile-tck-provisioning.base.layer>cloud-server</ts.microprofile-tck-provisioning.base.layer>
         <ts.microprofile-tck-provisioning.decorator.layer>microprofile-openapi</ts.microprofile-tck-provisioning.decorator.layer>
     </properties>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -40,6 +40,7 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
         <maven.repo.local>${settings.localRepository}</maven.repo.local>
         <microprofile.jvm.args>-server -Xms64m -Xmx512m ${modular.jdk.args} -Dmaven.repo.local=${maven.repo.local}</microprofile.jvm.args>
         <!-- Properties that set the phase used for different plugin executions.
@@ -54,9 +55,9 @@
         <ts.bootable-jar-microprofile-tck-packaging.phase>none</ts.bootable-jar-microprofile-tck-packaging.phase>
         <!-- Child modules override these properties to control what feature packs are used
              and what layers are provisioned if galleon provision occurs -->
-        <ts.microprofile-tck-provisioning.fp.groupId>${testsuite.ee.galleon.pack.groupId}</ts.microprofile-tck-provisioning.fp.groupId>
-        <ts.microprofile-tck-provisioning.fp.artifactId>${testsuite.ee.galleon.pack.artifactId}</ts.microprofile-tck-provisioning.fp.artifactId>
-        <ts.microprofile-tck-provisioning.fp.version>${testsuite.ee.galleon.pack.version}</ts.microprofile-tck-provisioning.fp.version>
+        <ts.microprofile-tck-provisioning.fp.groupId>${full.maven.groupId}</ts.microprofile-tck-provisioning.fp.groupId>
+        <ts.microprofile-tck-provisioning.fp.artifactId>wildfly-galleon-pack</ts.microprofile-tck-provisioning.fp.artifactId>
+        <ts.microprofile-tck-provisioning.fp.version>${full.maven.version}</ts.microprofile-tck-provisioning.fp.version>
         <ts.microprofile-tck-provisioning.base.layer>FIXME-must-override</ts.microprofile-tck-provisioning.base.layer>
         <ts.microprofile-tck-provisioning.decorator.layer>FIXME-must-override</ts.microprofile-tck-provisioning.decorator.layer>
 
@@ -291,29 +292,53 @@
             </build>
         </profile>
 
-        <!--
-            By default the arquillian.xml files in the TCK modules use standalone-microprofile.xml for the config.
-            For those modules that support it, switch back to using standalone.xml as the server config
-            if we are testing against a non-MP build
-        -->
+        <!-- Profile to turn off execution of various plugins if the testsuite is being run
+             against an external dist (i.e. by using the jboss.dist property to point to one)
+             and that dist does not include the full set of MP functionality. -->
         <profile>
-            <id>alt.dist.profile</id>
+            <id>disable.microprofile.profile</id>
             <activation>
                 <property>
-                    <name>testsuite.default.build.project.prefix</name>
-                    <value>ee-</value>
+                    <name>disable.microprofile.tests</name>
                 </property>
             </activation>
+            <properties>
+                <!-- Disable the standard copy-based provisioning -->
+                <ts.copy-wildfly.phase>none</ts.copy-wildfly.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables combine.children="append">
-                                <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
-                            </systemPropertyVariables>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Provision a server slimmed to only what we want for a particular TCK. -->
+                            <execution>
+                                <id>microprofile-tck-provisioning</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>bootable-jar-microprofile-tck-packaging</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -37,7 +37,6 @@
         <jbossas.ts.integ.dir>${basedir}/../..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <!-- These properties control what layers are provisioned if galleon slimmed provisioning occurs -->
         <ts.microprofile-tck-provisioning.base.layer>jaxrs-server</ts.microprofile-tck-provisioning.base.layer>
@@ -260,9 +259,9 @@
                         <configuration>
                             <feature-packs>
                                 <feature-pack>
-                                    <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
-                                    <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
-                                    <version>${testsuite.ee.galleon.pack.version}</version>
+                                    <groupId>${ts.microprofile-tck-provisioning.fp.groupId}</groupId>
+                                    <artifactId>${ts.microprofile-tck-provisioning.fp.artifactId}</artifactId>
+                                    <version>${ts.microprofile-tck-provisioning.fp.version}</version>
                                     <inherit-configs>false</inherit-configs>
                                     <inherit-packages>false</inherit-packages>
                                     <!-- The wiremock module we add as part of the test fixture needs Apache Commons Lang

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -1980,9 +1980,9 @@
                                     <install-dir>${layers.install.dir}/microprofile-config</install-dir>
                                     <feature-packs>
                                         <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
@@ -2008,9 +2008,9 @@
                                     <install-dir>${layers.install.dir}/microprofile-health</install-dir>
                                     <feature-packs>
                                         <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
@@ -2036,9 +2036,9 @@
                                     <install-dir>${layers.install.dir}/microprofile-metrics</install-dir>
                                     <feature-packs>
                                         <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
@@ -2221,9 +2221,9 @@
                                     <install-dir>${layers.install.dir}/open-tracing</install-dir>
                                     <feature-packs>
                                         <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>


### PR DESCRIPTION
… when the test job is testing ee-build or ee-dist

The ee-build/ee-dist or a dist provisioned using the wildfly-ee feature pack will not work for MP TCKs so don't try to use those.

Make it easier to disable various MP TCK related plugin executions (not just surefire) by setting -Ddisable.microprofile.tests

https://issues.redhat.com/browse/WFLY-14262