### PR TITLE
[WFLY-14238] FaceletsResourceResolver annotation is not taken into account

### DIFF
--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/AnnotationMap.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/AnnotationMap.java
@@ -70,7 +70,10 @@ public class AnnotationMap {
             stringToAnnoMap.put(FacesBehavior.class.getName(), FacesBehavior.class);
             stringToAnnoMap.put(FacesBehaviorRenderer.class.getName(), FacesBehaviorRenderer.class);
 
-            // Put JSF 2.2 annotations below this line if any new ones are to be scanned.  So far none.
+            // Put JSF 2.2+ annotations below this line if any new ones are to be scanned.
+            // Load the class to avoid a NoClassDefFoundError if it is not present in the impl
+            ClassLoader loader = AnnotationMap.class.getClassLoader();
+            addAnnotationIfPresent(loader, "javax.faces.view.facelets.FaceletsResourceResolver");
         } catch (Exception e) {
             // Ignore.  Whatever classes are available have been loaded into the map.
         }
@@ -78,6 +81,17 @@ public class AnnotationMap {
 
     // don't allow instance
     private AnnotationMap() {}
+
+    private static void addAnnotationIfPresent(ClassLoader loader, String name) {
+        try {
+            Class clazz = loader.loadClass(name);
+            if (Annotation.class.isAssignableFrom(clazz)) {
+                stringToAnnoMap.put(name, clazz);
+            }
+        } catch(ClassNotFoundException e) {
+            // ignore, annotation not found in the used JSF version
+        }
+    }
 
     public static Map<Class<? extends Annotation>, Set<Class<?>>> get(final ExternalContext extContext) {
         Map<String, Object> appMap = extContext.getApplicationMap();

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFAnnotationProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFAnnotationProcessor.java
@@ -45,6 +45,7 @@ import javax.faces.event.NamedEvent;
 import javax.faces.render.FacesBehaviorRenderer;
 import javax.faces.render.FacesRenderer;
 import javax.faces.validator.FacesValidator;
+import javax.faces.view.facelets.FaceletsResourceResolver;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,7 +72,8 @@ public class JSFAnnotationProcessor implements DeploymentUnitProcessor {
         MANAGED_BEAN(ManagedBean.class),
         NAMED_EVENT(NamedEvent.class),
         FACES_BEHAVIOR(FacesBehavior.class),
-        FACES_BEHAVIOR_RENDERER(FacesBehaviorRenderer.class);
+        FACES_BEHAVIOR_RENDERER(FacesBehaviorRenderer.class),
+        FACELETS_RESOURCE_RESOLVER(FaceletsResourceResolver.class);
 
         private final Class<? extends Annotation> annotationClass;
         private final DotName indexName;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/CustomResourceResolver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/CustomResourceResolver.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.resourceResolver;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import javax.faces.FacesException;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.faces.view.facelets.FaceletsResourceResolver;
+import javax.faces.view.facelets.ResourceResolver;
+
+/**
+ * <p>Custom Resource Resolver that just uses the ExternalContext to locate
+ * the files inside the application. It also adds a message in the application
+ * map to register it was used.</p>
+ *
+ * @author rmartinc
+ */
+@FaceletsResourceResolver
+public class CustomResourceResolver extends ResourceResolver {
+
+    public CustomResourceResolver() {
+    }
+
+    @Override
+    public URL resolveUrl(String path) {
+       final ExternalContext externalContext = FacesContext.getCurrentInstance().getExternalContext();
+        if (!"/".equals(path)) {
+            // add the message inside the application map
+            Map<String, Object> appMap = externalContext.getApplicationMap();
+            appMap.put("message", this.getClass().getName());
+        }
+        try {
+            // locate the path using the external/servlet context
+            return externalContext.getResource(path);
+        } catch (MalformedURLException e) {
+            throw new FacesException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/FaceletsResourceResolverTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/FaceletsResourceResolverTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jsf.resourceResolver;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Test to check that annotation FaceletsResourceResolverTest is correctly
+ * managed by the JSF subsystem.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class FaceletsResourceResolverTestCase {
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, FaceletsResourceResolverTestCase.class.getSimpleName() + ".war")
+                .addClasses(CustomResourceResolver.class)
+                .addAsWebResource(FaceletsResourceResolverTestCase.class.getPackage(), "index.xhtml", "index.xhtml")
+                .addAsWebInfResource(
+                        new StringAsset("<web-app><welcome-file-list><welcome-file>index.xhtml</welcome-file></welcome-file-list></web-app>"),
+                        "web.xml");
+    }
+
+    @Test
+    public void test() throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpUriRequest request = new HttpGet(url.toExternalForm());
+            try (CloseableHttpResponse reponse = client.execute(request)) {
+                MatcherAssert.assertThat("Request success", reponse.getStatusLine().getStatusCode(), CoreMatchers.equalTo(HttpURLConnection.HTTP_OK));
+                MatcherAssert.assertThat("Contains the resource-resolver message", EntityUtils.toString(reponse.getEntity()),
+                        CoreMatchers.containsString("|message: " + CustomResourceResolver.class.getName() + "|"));
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/index.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/index.xhtml
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+   JBoss, Home of Professional Open Source.
+   Copyright 2020 Red Hat, Inc., and individual contributors
+   as indicated by the @author tags.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://java.sun.com/jsf/html">
+    <h:head>
+        <title>Verify that ResourceResolver works.</title>
+    </h:head>
+    <h:body>
+        <p>|message: #{message}|</p>
+    </h:body>
+</html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14238

The fix just adds the missing annotation (`javax.faces.view.facelets.FaceletsResourceResolver`) included in JSF 2.2+ to wildfly. Previously it was not there and the Jandex Annotation Provider does not return classes with this annotation inside a JSF app. The class is loaded programmatically (`loadClass`) because if not done this way there is a `NoClassDefFoundError` in the Jandex provider and the implementation defaults to the default JSF one. Test included.

@fjuma take a look when you have time.