### PR TITLE
[WFLY-14277] Upgrade to support MicroProfile JWT 1.2

### DIFF
--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -158,6 +158,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-jwt-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye</groupId>

--- a/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
@@ -157,6 +157,17 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-jwt-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-metrics</artifactId>
       <licenses>
         <license>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
@@ -25,6 +25,7 @@
     
     <resources>
         <artifact name="${io.smallrye:smallrye-jwt}"/>
+        <artifact name="${io.smallrye:smallrye-jwt-common}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
         <version.org.eclipse.microprofile.fault-tolerance.api>2.1.1</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.fault-tolerance.tck>${version.org.eclipse.microprofile.fault-tolerance.api}</version.org.eclipse.microprofile.fault-tolerance.tck>
         <version.org.eclipse.microprofile.health.api>3.0</version.org.eclipse.microprofile.health.api>
-        <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
+        <version.org.eclipse.microprofile.jwt.api>1.2</version.org.eclipse.microprofile.jwt.api>
         <version.org.eclipse.microprofile.metrics.api>3.0</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.openapi>2.0</version.org.eclipse.microprofile.openapi>
         <version.org.eclipse.microprofile.opentracing>2.0-RC2</version.org.eclipse.microprofile.opentracing>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <version.io.smallrye.smallrye-config>2.0.2</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>4.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.0.0</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
+        <version.io.smallrye.smallrye-jwt>3.0.0-RC1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>2.1.0</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0-RC1</version.io.smallrye.opentracing>
@@ -354,7 +354,7 @@
         <version.org.apache.ws.security>2.2.5</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
-        <version.org.bitbucket.jose4j>0.7.0</version.org.bitbucket.jose4j>
+        <version.org.bitbucket.jose4j>0.7.2</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
@@ -2153,6 +2153,11 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt</artifactId>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-jwt-common</artifactId>
                 <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>

--- a/testsuite/integration/microprofile-tck/jwt/tck-base-suite.xml
+++ b/testsuite/integration/microprofile-tck/jwt/tck-base-suite.xml
@@ -31,7 +31,7 @@
                 <include name="config" description="Validate configuration using MP-config"/>
             </define>
             <define name="excludes">
-                <include name="debug" description="Internal debugging tests" />
+                <include name="utils-extra" description="Additional utility tests" />
             </define>
             <run>
                 <include name="base-groups" />
@@ -40,6 +40,9 @@
         </groups>
         <classes>
             <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsExtraTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" />
@@ -49,6 +52,12 @@
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" />
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudArrayValidationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationBadAudTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.AudValidationMissingAudTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" />
@@ -59,10 +68,19 @@
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest" />
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationNoIssTest" />
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationBadIssTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsJWKLocationTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
+            <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14277
https://github.com/wildfly/wildfly-proposals/pull/358

This pull request is using a release candidate of SmallRye JWT so a couple more updates will be required to complete the work under WFLY-14277.

This pull request does add a new dependency, however this is just a new artefact from the SmallRye JWT project so not a true new dependency.

No community documentation is required as we do not specify the version of MicroProfile JWT supported in the documentation and the general approach has not changed with this update.

No test updates are required as this PR pulls in the latest version of the MicroProfile JWT TCK to add coverage for the latest areas required in the specification.
