### PR TITLE
WFLY-14283 Allow Infinispan to resolve exceptions containing JBoss Marshalling TraceInformation

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -42,6 +42,8 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
+        <!-- WFLY-14283 Allow Infinispan to resolve exceptions containing JBoss Marshalling TraceInformation -->
+        <module name="org.jboss.marshalling" optional="true"/>
         <module name="org.jboss.threads"/>
         <module name="org.jgroups" optional="true"/>
         <module name="org.reactivestreams"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14283