### PR TITLE
Experiment with removal all testsuite use of PortableRemoteObject

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingInContainerDDNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingInContainerDDNameTestCase.java
@@ -5,7 +5,7 @@ import java.util.Properties;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -54,7 +54,7 @@ public class IIOPNamingInContainerDDNameTestCase {
         final Properties prope = new Properties();
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("corbaname:iiop:" + managementClient.getMgmtAddress() + ":3528#bean/custom/name/IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingInContainerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingInContainerTestCase.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import javax.ejb.RemoveException;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import java.rmi.NoSuchObjectException;
 import java.rmi.RemoteException;
@@ -46,7 +46,7 @@ public class IIOPNamingInContainerTestCase {
         final Properties prope = new Properties();
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("corbaname:iiop:" + managementClient.getMgmtAddress() + ":3528#IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -57,7 +57,7 @@ public class IIOPNamingInContainerTestCase {
         final Properties prope = new Properties();
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("corbaname:iiop:" + managementClient.getMgmtAddress() + ":3528#IIOPStatefulNamingBean");
-        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
+        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
         final IIOPStatefulRemote result = object.create(10);
         Assert.assertEquals(11, result.increment());
         Assert.assertEquals(12, result.increment());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/iiop/naming/IIOPNamingTestCase.java
@@ -8,7 +8,7 @@ import javax.ejb.RemoveException;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -59,7 +59,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::" +managementClient.getMgmtAddress() + ":3528/NameService");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;// PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -71,7 +71,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::" + managementClient.getMgmtAddress() +":3528/NameService");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("IIOPStatefulNamingBean");
-        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
+        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
         final IIOPStatefulRemote result = object.create(10);
         Assert.assertEquals(11, result.increment());
         Assert.assertEquals(12, result.increment());
@@ -91,7 +91,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::" + managementClient.getMgmtAddress() +":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("corbaname:iiop:" + managementClient.getMgmtAddress() +":3528#IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -103,7 +103,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::"  + managementClient.getMgmtAddress() + ":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("IIOPStatefulNamingBean");
-        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
+        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
         final IIOPStatefulRemote result = object.create(10);
         Assert.assertEquals(11, result.increment());
         Assert.assertEquals(12, result.increment());
@@ -123,7 +123,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "iiop://" + managementClient.getMgmtAddress() +":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -135,7 +135,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "iiop://" + managementClient.getMgmtAddress() +":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("IIOPStatefulNamingBean");
-        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
+        final IIOPStatefulNamingHome object = (IIOPStatefulNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPStatefulNamingHome.class);
         final IIOPStatefulRemote result = object.create(10);
         Assert.assertEquals(11, result.increment());
         Assert.assertEquals(12, result.increment());
@@ -164,7 +164,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::" + managementClient.getMgmtAddress() +":3528/NameService");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("bean/custom/name/IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -186,7 +186,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "corbaloc::" + managementClient.getMgmtAddress() +":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("corbaname:iiop:" + managementClient.getMgmtAddress() +":3528#bean/custom/name/IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }
@@ -208,7 +208,7 @@ public class IIOPNamingTestCase {
         prope.put(Context.PROVIDER_URL, "iiop://" + managementClient.getMgmtAddress() +":3528");
         final InitialContext context = new InitialContext(prope);
         final Object iiopObj = context.lookup("bean/custom/name/IIOPNamingBean");
-        final IIOPNamingHome object = (IIOPNamingHome) PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
+        final IIOPNamingHome object = (IIOPNamingHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPNamingHome.class);
         final IIOPRemote result = object.create();
         Assert.assertEquals("hello", result.hello());
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodUnitTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.integration.ejb.remove.method;
 import java.rmi.NoSuchObjectException;
 import javax.ejb.EJBObject;
 import javax.naming.InitialContext;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -98,7 +98,7 @@ public class RemoveMethodUnitTestCase {
     public void testExplicitExtensionEjbObjectInProxy() throws Exception {
         // Obtain stub
         Object obj = ctx.lookup("java:app/" + ANNOTATION_BASED_MODULE_NAME + "/" + Ejb21ViewBean.class.getSimpleName() + "!" + Ejb21ViewHome.class.getName());
-        Ejb21ViewHome home = (Ejb21ViewHome) PortableRemoteObject.narrow(obj, Ejb21ViewHome.class);
+        Ejb21ViewHome home = (Ejb21ViewHome) obj;//PortableRemoteObject.narrow(obj, Ejb21ViewHome.class);
         Ejb21View session = home.create();
 
         // Ensure EJBObject
@@ -132,7 +132,7 @@ public class RemoveMethodUnitTestCase {
     public void testEjbRemoveInvokedOnRemoval() throws Exception {
         // Obtain stub
         Object obj = ctx.lookup("java:app/" + DD_BASED_MODULE_NAME + "/" + Ejb21ViewDDBean.class.getSimpleName() + "!" + Ejb21ViewHome.class.getName());
-        Ejb21ViewHome home = (Ejb21ViewHome) PortableRemoteObject.narrow(obj, Ejb21ViewHome.class);
+        Ejb21ViewHome home = (Ejb21ViewHome) obj;//PortableRemoteObject.narrow(obj, Ejb21ViewHome.class);
         Ejb21View bean = home.create();
 
         // Ensure EJBObject

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/ClientEjb.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/ClientEjb.java
@@ -6,7 +6,7 @@ import javax.ejb.EJBMetaData;
 import javax.ejb.Handle;
 import javax.ejb.HomeHandle;
 import javax.ejb.Stateless;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import org.junit.Assert;
 import org.jboss.ejb.iiop.HandleImplIIOP;
@@ -27,7 +27,7 @@ public class ClientEjb {
 
     public String getRemoteViaHomeHandleMessage() throws RemoteException {
         final HomeHandle handle = home.getHomeHandle();
-        final IIOPBasicHome newHome = (IIOPBasicHome) PortableRemoteObject.narrow(handle.getEJBHome(), IIOPBasicHome.class);
+        final IIOPBasicHome newHome = (IIOPBasicHome) handle.getEJBHome();//PortableRemoteObject.narrow(handle.getEJBHome(), IIOPBasicHome.class);
         final IIOPBasicRemote object = newHome.create();
         return object.hello();
     }
@@ -37,7 +37,7 @@ public class ClientEjb {
 
         final IIOPBasicRemote object = home.create();
         final Handle handle = object.getHandle();
-        final IIOPBasicRemote newObject = (IIOPBasicRemote) PortableRemoteObject.narrow(handle.getEJBObject(), IIOPBasicRemote.class);
+        final IIOPBasicRemote newObject = (IIOPBasicRemote) handle.getEJBObject();//PortableRemoteObject.narrow(handle.getEJBObject(), IIOPBasicRemote.class);
         return newObject.hello();
     }
 
@@ -46,13 +46,13 @@ public class ClientEjb {
         final IIOPBasicRemote object = home.create();
         final Handle handle = object.wrappedHandle().getHandle();
         Assert.assertEquals(HandleImplIIOP.class, handle.getClass());
-        final IIOPBasicRemote newObject = (IIOPBasicRemote) PortableRemoteObject.narrow(handle.getEJBObject(), IIOPBasicRemote.class);
+        final IIOPBasicRemote newObject = (IIOPBasicRemote) handle.getEJBObject();//PortableRemoteObject.narrow(handle.getEJBObject(), IIOPBasicRemote.class);
         return newObject.hello();
     }
 
     public String getRemoteMessageViaEjbMetadata() throws RemoteException {
         final EJBMetaData metadata = home.getEJBMetaData();
-        final IIOPBasicHome newHome = (IIOPBasicHome) PortableRemoteObject.narrow(metadata.getEJBHome(), IIOPBasicHome.class);
+        final IIOPBasicHome newHome = (IIOPBasicHome) metadata.getEJBHome();//PortableRemoteObject.narrow(metadata.getEJBHome(), IIOPBasicHome.class);
         final IIOPBasicRemote object = newHome.create();
         Assert.assertEquals(IIOPBasicHome.class, metadata.getHomeInterfaceClass());
         Assert.assertEquals(IIOPBasicRemote.class, metadata.getRemoteInterfaceClass());

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/IIOPTransactionPropagationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/IIOPTransactionPropagationTestCase.java
@@ -30,7 +30,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 import javax.transaction.Status;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -105,7 +105,7 @@ public class IIOPTransactionPropagationTestCase {
     @Test
     public void testIIOPInvocation() throws Throwable {
         final Object iiopObj = context.lookup(IIOPTestBean.class.getSimpleName());
-        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
+        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
         final IIOPTestRemote bean = beanHome.create();
 
         try {
@@ -122,7 +122,7 @@ public class IIOPTransactionPropagationTestCase {
     @Test
     public void testIIOPNeverCallInvocation() throws Throwable {
         final Object iiopObj = context.lookup(IIOPTestBean.class.getSimpleName());
-        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
+        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
         final IIOPTestRemote bean = beanHome.create();
 
         try {
@@ -141,7 +141,7 @@ public class IIOPTransactionPropagationTestCase {
     @Test
     public void testIIOPInvocationWithRollbackOnly() throws Throwable {
         final Object iiopObj = context.lookup(IIOPTestBean.class.getSimpleName());
-        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
+        final IIOPTestBeanHome beanHome = (IIOPTestBeanHome) iiopObj;//PortableRemoteObject.narrow(iiopObj, IIOPTestBeanHome.class);
         final IIOPTestRemote bean = beanHome.create();
 
         try {

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiopssl/basic/ClientEjb.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiopssl/basic/ClientEjb.java
@@ -26,7 +26,7 @@ import org.jboss.as.network.NetworkUtils;
 import javax.ejb.Stateless;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 import java.rmi.RemoteException;
 
 /**
@@ -48,7 +48,7 @@ public class ClientEjb {
         final String hostname = NetworkUtils.formatPossibleIpv6Address(System.getProperty("node1"));
         final Object value = ctx.lookup("corbaname:iiop:"+hostname+":" + port + "#IIOPSslStatelessBean");
 
-        final Object narrow = PortableRemoteObject.narrow(value, IIOPSslStatelessHome.class);
+        final Object narrow = value;//PortableRemoteObject.narrow(value, IIOPSslStatelessHome.class);
         return ((IIOPSslStatelessHome)narrow).create().hello();
     }
 
@@ -57,7 +57,7 @@ public class ClientEjb {
         final String hostname = NetworkUtils.formatPossibleIpv6Address(System.getProperty("node1"));
         final Object value = ctx.lookup("corbaname:ssliop:1.2@"+hostname+":" + port + "#IIOPSslStatelessBean");
 
-        final Object narrow = PortableRemoteObject.narrow(value, IIOPSslStatelessHome.class);
+        final Object narrow = value;//PortableRemoteObject.narrow(value, IIOPSslStatelessHome.class);
         return ((IIOPSslStatelessHome)narrow).create().hello();
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/RemoteLookups.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/RemoteLookups.java
@@ -29,7 +29,7 @@ import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
+//import javax.rmi.PortableRemoteObject;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
@@ -85,7 +85,7 @@ public final class RemoteLookups {
         prope.put(Context.PROVIDER_URL, "corbaloc::" + serverHost +":" + iiopPort + "/JBoss/Naming/root");
         final InitialContext context = new InitialContext(prope);
         final Object ejbHome = context.lookup(beanClass.getSimpleName());
-        return homeClass.cast(PortableRemoteObject.narrow(ejbHome, homeClass));
+        return homeClass.cast(ejbHome);//PortableRemoteObject.narrow(ejbHome, homeClass));
     }
 
     private static <T> T lookupEjb(InitialContext ctx, String archiveName, Class<? extends T> beanType,

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/EJBServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/EJBServlet.java
@@ -51,7 +51,7 @@ public class EJBServlet extends HttpServlet {
             bean.noop();
 
             Object homeRef = enc.lookup("ejb/OptimizedEJB");
-            home = (StatelessSessionHome) PortableRemoteObject.narrow(homeRef, StatelessSessionHome.class);
+            home = (StatelessSessionHome) homeRef;//PortableRemoteObject.narrow(homeRef, StatelessSessionHome.class);
             bean = home.create();
             bean.noop();
             bean.getData();


### PR DESCRIPTION
Just an experiment to confirm the testsuite runs fine with all *testsuite* use of PortableRemoteObject.narrow removed.

See https://www.eclipse.org/lists/ejb-dev/msg00162.html for context.

Note if if this works fine there may be good reasons not to do this in some cases; i.e. to prove that PortableRemoteObject.narrow works. However, PortableRemoteObject.narrow works by first seeing if the object is assignable to the target class before doing the org.omg.CORBA stuff, so if a cast would work then PortableRemoteObject.narrow would too.