### PR TITLE
[WFLY-14310] Use standard idioms for handling attribute resolution in…

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/jpa.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/jpa.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="jpa" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.jpa">
-        <param name="default-datasource" value=""/>
         <param name="default-extended-persistence-inheritance" value="DEEP"/>
     </feature>
 </feature-group-spec>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -53,6 +53,23 @@ public class JPADefinition extends SimpleResourceDefinition {
             .addRequirements(JPAServiceNames.LOCAL_TRANSACTION_PROVIDER_CAPABILITY)
             .build();
 
+    protected static final SimpleAttributeDefinition DEFAULT_DATASOURCE =
+            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_DATASOURCE, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setXmlName(CommonAttributes.DEFAULT_DATASOURCE)
+                    .setValidator(new StringLengthValidator(0, Integer.MAX_VALUE, true, true))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .build();
+
+    protected static final SimpleAttributeDefinition DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE =
+            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setXmlName(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setValidator(new EnumValidator<ExtendedPersistenceInheritance>(ExtendedPersistenceInheritance.class,true,true))
+                    .setDefaultValue(new ModelNode(ExtendedPersistenceInheritance.DEEP.toString()))
+                    .build();
+
     public static final JPADefinition INSTANCE = new JPADefinition(true);
     public static final JPADefinition DEPLOYMENT_INSTANCE = new JPADefinition(false);
 
@@ -72,24 +89,6 @@ public class JPADefinition extends SimpleResourceDefinition {
 
         return result;
     }
-
-    protected static final SimpleAttributeDefinition DEFAULT_DATASOURCE =
-            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_DATASOURCE, ModelType.STRING, true)
-                    .setAllowExpression(true)
-                    .setXmlName(CommonAttributes.DEFAULT_DATASOURCE)
-                    .setValidator(new StringLengthValidator(0, Integer.MAX_VALUE, true, true))
-                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(null)
-                    .build();
-
-    protected static final SimpleAttributeDefinition DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE =
-            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE, ModelType.STRING, true)
-                    .setAllowExpression(true)
-                    .setXmlName(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
-                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<ExtendedPersistenceInheritance>(ExtendedPersistenceInheritance.class,true,true))
-                    .setDefaultValue(new ModelNode(ExtendedPersistenceInheritance.DEEP.toString()))
-                    .build();
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
@@ -111,14 +111,10 @@ public class JPAExtension implements Extension {
                 final Element element = Element.forName(reader.getLocalName());
                 Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
 
-                switch (element) {
-                    case JPA: {
-                        subsystemAdd = parseJPA(reader, readerNS);
-                        break;
-                    }
-                    default: {
-                        throw ParseUtils.unexpectedElement(reader);
-                    }
+                if (element == Element.JPA) {
+                    subsystemAdd = parseJPA(reader, readerNS);
+                } else {
+                    throw ParseUtils.unexpectedElement(reader);
                 }
             }
             if (subsystemAdd == null) {
@@ -128,7 +124,6 @@ public class JPAExtension implements Extension {
         }
 
         private ModelNode parseJPA(XMLExtendedStreamReader reader, Namespace readerNS) throws XMLStreamException {
-            String dataSourceName = null;
             final ModelNode operation = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME)));
 
             int count = reader.getAttributeCount();
@@ -137,7 +132,6 @@ public class JPAExtension implements Extension {
                 final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                 switch (attribute) {
                     case DEFAULT_DATASOURCE_NAME: {
-                        dataSourceName = value;
                         JPADefinition.DEFAULT_DATASOURCE.parseAndSetParameter(value, operation, reader);
                         break;
                     }
@@ -151,9 +145,7 @@ public class JPAExtension implements Extension {
             }
             // Require no content
             ParseUtils.requireNoContent(reader);
-            if (dataSourceName == null) {
-                throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.DEFAULT_DATASOURCE_NAME));
-            }
+
             return operation;
         }
 
@@ -165,22 +157,12 @@ public class JPAExtension implements Extension {
             XMLStreamException {
 
             ModelNode node = context.getModelNode();
-            if (node.hasDefined(CommonAttributes.DEFAULT_DATASOURCE) ||
-                    node.hasDefined(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
-                    ) {
-                context.startSubsystemElement(Namespace.JPA_1_1.getUriString(), false);
-                writer.writeStartElement(Element.JPA.getLocalName());
-                JPADefinition.DEFAULT_DATASOURCE.marshallAsAttribute(node, writer);
-                JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE.marshallAsAttribute(node, writer);
-                writer.writeEndElement();
-                writer.writeEndElement();
-            } else {
-                //TODO seems to be a problem with empty elements cleaning up the queue in FormattingXMLStreamWriter.runAttrQueue
-                //context.startSubsystemElement(NewNamingExtension.NAMESPACE, true);
-                context.startSubsystemElement(Namespace.JPA_1_1.getUriString(), false);
-                writer.writeEndElement();
-            }
-
+            context.startSubsystemElement(Namespace.JPA_1_1.getUriString(), false);
+            writer.writeStartElement(Element.JPA.getLocalName());
+            JPADefinition.DEFAULT_DATASOURCE.marshallAsAttribute(node, writer);
+            JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE.marshallAsAttribute(node, writer);
+            writer.writeEndElement();
+            writer.writeEndElement();
         }
     }
 
@@ -197,14 +179,10 @@ public class JPAExtension implements Extension {
                 final Element element = Element.forName(reader.getLocalName());
                 Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
 
-                switch (element) {
-                    case JPA: {
-                        subsystemAdd = parseJPA(reader, readerNS);
-                        break;
-                    }
-                    default: {
-                        throw ParseUtils.unexpectedElement(reader);
-                    }
+                if (element == Element.JPA) {
+                    subsystemAdd = parseJPA(reader, readerNS);
+                } else {
+                    throw ParseUtils.unexpectedElement(reader);
                 }
             }
             if (subsystemAdd == null) {
@@ -215,27 +193,19 @@ public class JPAExtension implements Extension {
 
         private ModelNode parseJPA(XMLExtendedStreamReader reader, Namespace readerNS) throws XMLStreamException {
             final ModelNode operation = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME)));
-            String dataSourceName = null;
             int count = reader.getAttributeCount();
             for (int i = 0; i < count; i++) {
                 final String value = reader.getAttributeValue(i);
                 final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-                switch (attribute) {
-                    case DEFAULT_DATASOURCE_NAME: {
-                        dataSourceName = value;
-                        JPADefinition.DEFAULT_DATASOURCE.parseAndSetParameter(value, operation, reader);
-                        break;
-                    }
-                    default: {
-                        throw ParseUtils.unexpectedAttribute(reader, i);
-                    }
+                if (attribute == Attribute.DEFAULT_DATASOURCE_NAME) {
+                    JPADefinition.DEFAULT_DATASOURCE.parseAndSetParameter(value, operation, reader);
+                } else {
+                    throw ParseUtils.unexpectedAttribute(reader, i);
                 }
             }
             // Require no content
             ParseUtils.requireNoContent(reader);
-            if (dataSourceName == null) {
-                throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.DEFAULT_DATASOURCE_NAME));
-            }
+
             return operation;
         }
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -21,12 +21,14 @@
  */
 package org.jboss.as.jpa.subsystem;
 
+import static org.jboss.as.jpa.subsystem.JPADefinition.DEFAULT_DATASOURCE;
+import static org.jboss.as.jpa.subsystem.JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE;
+
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
-import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.jpa.config.ExtendedPersistenceInheritance;
 import org.jboss.as.jpa.persistenceprovider.PersistenceProviderResolverImpl;
 import org.jboss.as.jpa.platform.PlatformImpl;
@@ -63,20 +65,13 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
 
     public static final JPASubSystemAdd INSTANCE = new JPASubSystemAdd();
 
-    private final ParametersValidator runtimeValidator = new ParametersValidator();
-
     private JPASubSystemAdd() {
-    }
-
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        JPADefinition.DEFAULT_DATASOURCE.validateAndSet(operation, model);
-        JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE.validateAndSet(operation, model);
+        super(DEFAULT_DATASOURCE, DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE);
     }
 
     protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model) throws
         OperationFailedException {
 
-        runtimeValidator.validate(operation.resolve());
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
 
@@ -125,16 +120,8 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
             }
         }, OperationContext.Stage.RUNTIME);
 
-        final ModelNode defaultDSNode = operation.require(CommonAttributes.DEFAULT_DATASOURCE);
-        final String dataSourceName = defaultDSNode.resolve().asString();
-
-        ExtendedPersistenceInheritance defaultExtendedPersistenceInheritance = ExtendedPersistenceInheritance.DEEP;
-        if (operation.hasDefined(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)) {
-            final ModelNode defaultExtendedPersistenceInheritanceNode = operation.get(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE);
-            defaultExtendedPersistenceInheritance =
-                ExtendedPersistenceInheritance.valueOf(defaultExtendedPersistenceInheritanceNode.resolve().asString());
-        }
-
+        final String dataSourceName = DEFAULT_DATASOURCE.resolveModelAttribute(context, model).asStringOrNull();
+        final ExtendedPersistenceInheritance defaultExtendedPersistenceInheritance = ExtendedPersistenceInheritance.valueOf(DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE.resolveModelAttribute(context, model).asString());
 
         final ServiceTarget target = context.getServiceTarget();
         JPAService.addService(target, dataSourceName, defaultExtendedPersistenceInheritance);

--- a/jpa/subsystem/src/main/resources/subsystem-templates/jpa.xml
+++ b/jpa/subsystem/src/main/resources/subsystem-templates/jpa.xml
@@ -3,6 +3,6 @@
 <config>
    <extension-module>org.jboss.as.jpa</extension-module>
    <subsystem xmlns="urn:jboss:domain:jpa:1.1">
-       <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+       <jpa default-extended-persistence-inheritance="DEEP"/>
    </subsystem>
 </config>

--- a/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA10SubsystemTestCase.java
+++ b/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA10SubsystemTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.jpa.subsystem;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -43,5 +44,10 @@ public class JPA10SubsystemTestCase extends AbstractSubsystemBaseTest {
     @Override
     protected void compareXml(String configId, String original, String marshalled) throws Exception {
         //no need to compare
+    }
+
+    @Test
+    public void testEmptySubsystem() throws Exception {
+        standardSubsystemTest("subsystem-1.0-empty.xml");
     }
 }

--- a/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
+++ b/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
@@ -58,4 +58,9 @@ public class JPA11SubsystemTestCase extends AbstractSubsystemBaseTest {
     public void testSchemaOfSubsystemTemplates() throws Exception {
         super.testSchemaOfSubsystemTemplates();
     }
+
+    @Test
+    public void testEmptySubsystem() throws Exception {
+        standardSubsystemTest("subsystem-1.1-empty.xml");
+    }
 }

--- a/jpa/subsystem/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.0-empty.xml
+++ b/jpa/subsystem/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.0-empty.xml
@@ -1,0 +1,3 @@
+<subsystem xmlns="urn:jboss:domain:jpa:1.0">
+    <jpa/>
+</subsystem>

--- a/jpa/subsystem/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.1-empty.xml
+++ b/jpa/subsystem/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.1-empty.xml
@@ -1,0 +1,3 @@
+<subsystem xmlns="urn:jboss:domain:jpa:1.1">
+    <jpa/>
+</subsystem>


### PR DESCRIPTION
… JPASubsystemAdd

Remove the 'default-datasource=""' xml attribute from our standard configs, which was only necessary as a workaround of the fact that JPASubsystemAdd was incorrectly calling 'require' to read an optional attribute.

This also does a bit of code cleanup in the class and associated ResourceDefinition.

https://issues.redhat.com/browse/WFLY-14310