### PR TITLE
[WFLY-14311] javax.naming.OperationNotSupportedException should be thrown when read-only remote naming operations failed

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/WritableServiceBasedNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/WritableServiceBasedNamingStore.java
@@ -39,6 +39,7 @@ import org.jboss.msc.value.ImmediateValue;
 import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
 import java.util.Hashtable;
 import java.util.concurrent.CountDownLatch;
 
@@ -156,7 +157,7 @@ public class WritableServiceBasedNamingStore extends ServiceBasedNamingStore imp
         return new NamingContext(name, WritableServiceBasedNamingStore.this, new Hashtable<String, Object>());
     }
 
-    private Object requireOwner() {
+    private Object requireOwner() throws OperationNotSupportedException {
         final Object owner = WRITE_OWNER.peek();
         if (owner == null) {
             throw NamingLogger.ROOT_LOGGER.readOnlyNamingContext();

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -33,6 +33,7 @@ import javax.naming.InvalidNameException;
 import javax.naming.Name;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
+import javax.naming.OperationNotSupportedException;
 import javax.naming.spi.ObjectFactory;
 
 import org.jboss.as.controller.OperationFailedException;
@@ -426,10 +427,10 @@ public interface NamingLogger extends BasicLogger {
     /**
      * Creates an exception indicating the naming context is read-only.
      *
-     * @return an {@link UnsupportedOperationException} for the error.
+     * @return an {@link OperationNotSupportedException} for the error.
      */
     @Message(id = 43, value = "Naming context is read-only")
-    UnsupportedOperationException readOnlyNamingContext();
+    OperationNotSupportedException readOnlyNamingContext();
 
     /**
      * Creates an exception indicating the service name has already been bound.

--- a/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import javax.naming.CompositeName;
 import javax.naming.Name;
 import javax.naming.NameNotFoundException;
+import javax.naming.OperationNotSupportedException;
 
 import org.wildfly.naming.java.permission.JndiPermission;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -137,7 +138,7 @@ public class WritableServiceBasedNamingStoreTestCase {
         try {
             store.bind(new CompositeName("test"), new Object());
             fail("Should have failed with a read-only context exception");
-        } catch (UnsupportedOperationException expected) {
+        } catch (OperationNotSupportedException expected) {
         }
     }
 
@@ -190,7 +191,7 @@ public class WritableServiceBasedNamingStoreTestCase {
         try {
             store.unbind(new CompositeName("test"));
             fail("Should have failed with a read-only context exception");
-        } catch (UnsupportedOperationException expected) {
+        } catch (OperationNotSupportedException expected) {
         }
     }
 
@@ -209,7 +210,7 @@ public class WritableServiceBasedNamingStoreTestCase {
         try {
             store.createSubcontext(new CompositeName("test"));
             fail("Should have failed with a read-only context exception");
-        } catch (UnsupportedOperationException expected) {
+        } catch (OperationNotSupportedException expected) {
         }
     }
 
@@ -233,7 +234,7 @@ public class WritableServiceBasedNamingStoreTestCase {
         try {
             store.rebind(new CompositeName("test"), new Object());
             fail("Should have failed with a read-only context exception");
-        } catch (UnsupportedOperationException expected) {
+        } catch (OperationNotSupportedException expected) {
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14311
