### PR TITLE
[WFLY-11855] Reenable test

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsDifferentFormatsValueTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsDifferentFormatsValueTestCase.java
@@ -56,7 +56,6 @@ import org.wildfly.test.integration.microprofile.metrics.application.resource.Re
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@org.junit.Ignore("https://issues.jboss.org/browse/WFLY-11855")
 public class MicroProfileMetricsDifferentFormatsValueTestCase {
 
     /**


### PR DESCRIPTION
The full CI run has passed (outside a random test failure that seems to be plaguing other PRs as well). I'm reasonably comfortable stating that the cause of the intermittent failure has been cleaned up since this issue was filed.