### PR TITLE
[WFCORE-4291] Add support for non-graceful startup

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
@@ -77,4 +77,9 @@ public class Capabilities {
      * The capability name for the kernel SuspendController
      */
     public static final String SUSPEND_CONTROLLER_CAPABILITY = "org.wildfly.server.suspend-controller";
+
+    /**
+     * The capability name for the kernel ProcessStateNotifier.
+     */
+    public static final String PROCESS_STATE_NOTIFIER_CAPABILITY = "org.wildfly.management.process-state-notifier";
 }

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
@@ -32,6 +32,7 @@ import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.ContextClassLoaderJobOperatorContextSelector;
 import org.jberet.spi.JobExecutor;
 import org.jberet.spi.JobOperatorContext;
+import org.jboss.as.controller.ProcessStateNotifier;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.structure.DeploymentType;
@@ -185,6 +186,7 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
             Services.addServerExecutorDependency(serviceTarget.addService(jobOperatorServiceName, jobOperatorService)
                             .addDependency(support.getCapabilityServiceName(Capabilities.BATCH_CONFIGURATION_CAPABILITY.getName()), BatchConfiguration.class, jobOperatorService.getBatchConfigurationInjector())
                             .addDependency(support.getCapabilityServiceName(Capabilities.SUSPEND_CONTROLLER_CAPABILITY), SuspendController.class, jobOperatorService.getSuspendControllerInjector())
+                            .addDependency(support.getCapabilityServiceName(Capabilities.PROCESS_STATE_NOTIFIER_CAPABILITY), ProcessStateNotifier.class, jobOperatorService.getProcessStateInjector())
                             .addDependency(BatchServiceNames.batchEnvironmentServiceName(deploymentUnit), SecurityAwareBatchEnvironment.class, jobOperatorService.getBatchEnvironmentInjector()),
                     jobOperatorService.getExecutorServiceInjector())
                     .install();

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
@@ -197,6 +197,8 @@ be relative to jboss.server.config.dir. This is similar to
 overwrite the file when the management model is changed. However a full
 versioned history is maintained of the file.
 
+|--graceful-startup | true | Start the servers in gracefully, queuing or cleanly rejecting incoming requests until the server is fully started.
+
 |--git-repo |- | remote Git repository URL to use for configuration directory and content repository content or `local` if only a local repository is to be used.
 
 |--git-branch |master |The Git branch or tag to be used. If a `tag` name is used then the future commits will go into the detached state.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
@@ -232,3 +232,42 @@ the proper way to control the lifecycle of a domain mode server process is via t
 management API and its managing Host Controller, not via direct signals to the server
 process.
 
+[[non-graceful-startup]]
+== Non-graceful Startup
+
+By default, WildFly starts up gracefully, meaning that incoming requests are queued or cleanly rejected
+until the server is ready to process them. In some instances, though, it may be desirable to allow the
+server to begin to process requests at the earliest possible moment. One such example might be
+when two deployed applications need to interact with one another during the deployment or
+application startup. In one such scenario, Application A needs to make a REST request to
+Application B to get information vital to its own startup. Under a graceful startup, the request
+to Application B will block until the server is fully started. However, the server can't fully
+start, as Application A is waiting for data from Application B before its deploy/startup can
+complete. In this situation, a deadlock occurs, and the server startup times out.
+
+A non-graceful startup is intended to address this situation in that it will allow WildFly to
+begin attempting to answer requests as soon as possible. In the scenario above, assuming
+Application B has successfully deployed/started, Application A can also start immediately, as its
+request will be fulfilled. Note, however, that a race condition can occur: if Application B is
+not yet deployed (e.g., the deploy order is incorrect, or B has not finished starting), then
+Application A may still fail to start since Application B is not available. WildFly users making
+use of non-graceful startups must be aware of this and take steps to remedy those scenarios. With
+a non-graceful startup, however, WildFly will no longer be the cause of a deployment failure in
+such a configuration.
+
+Some discussion here of how this relates to reloading and restarting, as well as to suspended starts, is
+important. When reloading, the `ApplicationServerService` is stopped, and a new one started. It is equivalent
+to if it was being started the first time: all the same stuff happens, but it happens faster because a lot of
+classloading and static initialization doesn't have to happen again. This includes honoring the value of
+`graceful-startup`, so if the server was initially started non-gracefully, it will be reloaded in the same manner.
+
+Restarting the server is similar. A restart means a new JVM, so all the initialization happens again, exactly
+as it did on the first start. When restarting in domain mode, the Host Controller simply rereads the config
+file and does the same thing it did the first time. In standalone, the restart is driven by `standalone.[sh|ps1|bat]`.
+The running JVM exits with a specific exit code, which the script recognizes and starts a new server, using the
+same parameters as the first start, so if you start a server non-gracefully, you will restart a server
+non-gracefully.
+
+Finally, there's `start-mode=suspend`. In the event that an administrator specifies a suspended start as well as a
+non-graceful start, the suspended start will "win". That is to say, the server will start in a suspended mode,
+the `graceful-start=false` will be disregarded, and the server will log a message indicating that this is happening.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
@@ -247,6 +247,15 @@ be matched
 
 |default-web-module |The name of a deployment that should be used to
 serve up requests that do not match anything.
+
+|queue-requests-on-start| If requests should be queued on start for this host. If this is set to false the default
+response code will be returned instead.
+
+Note: If a <<non-graceful-startup>> is requested, and the queue-requests-on-start attribute is not set, requests will NOT be
+queued despite the default value of true for the property. In the instance of a non-graceful startup, non-queued requests
+are required. However, if non-graceful is configured, but queue-requests-on-start is explicitly set to true, then requests
+will be queued, effectively disabling the non-graceful mode for requests to that host.
+
 |=======================================================================
 
 ==== Console Access Logging

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -75,5 +75,6 @@
         <module name="org.jboss.remoting" optional="true"/>
 
         <module name="java.xml"/>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
@@ -65,5 +65,6 @@
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="java.xml"/>
+        <module name="java.desktop"/>
     </dependencies>
 </module>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -297,6 +297,23 @@
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
+
+        <container qualifier="non-graceful-server" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=non-graceful-server</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args} --graceful-startup=false</property>
+                <property name="allowConnectingToRunningServer">false</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/NongracefulStartTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/NongracefulStartTestCase.java
@@ -1,0 +1,92 @@
+package org.jboss.as.test.manualmode.server.nongraceful;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.manualmode.server.nongraceful.deploymenta.TestApplicationA;
+import org.jboss.as.test.manualmode.server.nongraceful.deploymentb.TestApplicationB;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This test will exercise the non-graceful startup feature of WildFly. This test will deploy two applications,
+ * ApplicationA and ApplicationB. ApplicationB, however, while it is starting, tries to access ApplicationA.
+ * If the server has started in normal mode, no requests will be allowed until the server has completely
+ * started, which will cause the deployment of ApplicationB to fail, as it will block indefinitely. We start the
+ * container, though, with --graceful-startup=false, which will allow requests to be processed or rejected cleanly
+ * during the server startup process.
+ */
+@RunWith(Arquillian.class)
+public class NongracefulStartTestCase {
+    private static final String CONTAINER = "non-graceful-server";
+    private static final String DEPLOYMENTA = "deploymenta";
+    private static final String DEPLOYMENTB = "deploymentb";
+    private static final Logger logger = Logger.getLogger(NongracefulStartTestCase.class);
+
+    @ArquillianResource
+    private static ContainerController containerController;
+
+    @ArquillianResource
+    Deployer deployer;
+
+    @Deployment(name = DEPLOYMENTA, managed = false, testable = false)
+    @TargetsContainer(CONTAINER)
+    public static Archive<?> getDeploymentA() {
+        return buildBaseArchive(DEPLOYMENTA)
+                .addPackage(TestApplicationA.class.getPackage());
+    }
+
+    @Deployment(name = DEPLOYMENTB, managed = false, testable = false)
+    @TargetsContainer(CONTAINER)
+    public static Archive<?> getDeploymentB() {
+        return buildBaseArchive(DEPLOYMENTB)
+                .addPackage(TestApplicationB.class.getPackage());
+    }
+
+    private static WebArchive buildBaseArchive(String name) {
+        return ShrinkWrap
+                .create(WebArchive.class, name + ".war")
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
+                .addClass(TimeoutUtil.class);
+    }
+
+    /**
+     * 1. Start the container
+     * 2. Deploy the applications
+     * 3. Stop the container
+     * 4. Restart the container. If non-graceful mode is working, the container should start successfully.
+     */
+    @Test
+    public void testNonGracefulDeployment() {
+        try {
+            containerController.start(CONTAINER);
+
+            deployer.deploy(DEPLOYMENTA);
+            deployer.deploy(DEPLOYMENTB);
+
+            containerController.stop(CONTAINER);
+            containerController.start(CONTAINER);
+        } finally {
+            executeCleanup(() -> deployer.undeploy(DEPLOYMENTA));
+            executeCleanup(() -> deployer.undeploy(DEPLOYMENTB));
+            executeCleanup(() -> containerController.stop(CONTAINER));
+        }
+    }
+
+    private void executeCleanup(Runnable func) {
+        try {
+            func.run();
+        } catch (Exception e) {
+            logger.trace("Exception during container cleanup and shutdown", e);
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/ResourceA.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/ResourceA.java
@@ -1,0 +1,14 @@
+package org.jboss.as.test.manualmode.server.nongraceful.deploymenta;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@ApplicationScoped
+@Path("/resourcea")
+public class ResourceA {
+    @GET
+    public String get() {
+        return "Hello";
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/TestApplicationA.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/TestApplicationA.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.manualmode.server.nongraceful.deploymenta;
+
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Paul Ferraro
+ */
+@ApplicationPath("/testa")
+public class TestApplicationA extends Application {
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/web.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymenta/web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+    <display-name>Test application A</display-name>
+    <description>This is my test application description</description>
+</web-app>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/ResourceB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/ResourceB.java
@@ -1,0 +1,42 @@
+package org.jboss.as.test.manualmode.server.nongraceful.deploymentb;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+@ApplicationScoped
+@Path("/resourceb")
+public class ResourceB {
+    public void postConstruct(@Observes @Initialized(ApplicationScoped.class) Object o) throws InterruptedException {
+        final Client client = ClientBuilder.newClient();
+        final int sleepTime = 100;
+        int tries = 0;
+        int maxLoopCount = TimeoutUtil.adjust(4500) / sleepTime;
+        boolean complete = false;
+
+        while (!complete && tries < maxLoopCount) {
+            Response response = client.target("http://localhost:8080/deploymenta/testa/resourcea")
+                    .request()
+                    .get();
+            int status = response.getStatus();
+            if (status != 200) {
+                tries++;
+                Thread.sleep(sleepTime);
+            } else {
+                complete = true;
+            }
+        }
+    }
+
+    @GET
+    public String get() {
+        return "Hello";
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/TestApplicationB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/TestApplicationB.java
@@ -1,0 +1,12 @@
+package org.jboss.as.test.manualmode.server.nongraceful.deploymentb;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Paul Ferraro
+ */
+@ApplicationPath("/testb")
+public class TestApplicationB extends Application {
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/web.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/deploymentb/web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+    <display-name>Test application B</display-name>
+    <description>This is my test application description</description>
+</web-app>

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ProcessStateNotifier;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManagerService;
@@ -428,7 +429,8 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addCapabilityRequirement("org.wildfly.network.socket-binding", SocketBinding.class, recoveryManagerService.getRecoveryBindingInjector(), recoveryBindingName)
                 .addCapabilityRequirement("org.wildfly.network.socket-binding", SocketBinding.class, recoveryManagerService.getStatusBindingInjector(), recoveryStatusBindingName)
                 .addCapabilityRequirement("org.wildfly.management.socket-binding-manager", SocketBindingManager.class, recoveryManagerService.getBindingManager())
-                .addCapabilityRequirement("org.wildfly.server.suspend-controller", SuspendController.class, recoveryManagerService.getSuspendControllerInjector());
+                .addCapabilityRequirement("org.wildfly.server.suspend-controller", SuspendController.class, recoveryManagerService.getSuspendControllerInjector())
+                .addCapabilityRequirement("org.wildfly.management.process-state-notifier", ProcessStateNotifier.class, recoveryManagerService.getProcessStateInjector());
         recoveryManagerServiceServiceBuilder.requires(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT);
         recoveryManagerServiceServiceBuilder.requires(TxnServices.JBOSS_TXN_ARJUNA_OBJECTSTORE_ENVIRONMENT);
         recoveryManagerServiceServiceBuilder.addAliases(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER);

--- a/transactions/src/main/java/org/jboss/as/txn/suspend/RecoverySuspendController.java
+++ b/transactions/src/main/java/org/jboss/as/txn/suspend/RecoverySuspendController.java
@@ -23,22 +23,38 @@
 package org.jboss.as.txn.suspend;
 
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.server.suspend.ServerActivity;
 import org.jboss.as.server.suspend.ServerActivityCallback;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 /**
+ * Listens for notifications from a {@code SuspendController} and a {@code ProcessStateNotifier} and reacts
+ * to them by {@link RecoveryManagerService#suspend() suspending} or {@link RecoveryManagerService#resume() resuming}
+ * the {@link RecoveryManagerService}.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
-public class RecoverySuspendController implements ServerActivity {
+public class RecoverySuspendController implements ServerActivity, PropertyChangeListener {
 
     private final RecoveryManagerService recoveryManagerService;
+    private boolean suspended;
+    private boolean running;
 
     public RecoverySuspendController(RecoveryManagerService recoveryManagerService) {
         this.recoveryManagerService = recoveryManagerService;
     }
 
+    /**
+     * {@link RecoveryManagerService#suspend() Suspends} the {@link RecoveryManagerService}.
+     */
     @Override
     public void preSuspend(ServerActivityCallback serverActivityCallback) {
+        synchronized (this) {
+            suspended = true;
+        }
         recoveryManagerService.suspend();
         serverActivityCallback.done();
     }
@@ -48,9 +64,45 @@ public class RecoverySuspendController implements ServerActivity {
         serverActivityCallback.done();
     }
 
+    /**
+     * {@link RecoveryManagerService#resume() Resumes} the {@link RecoveryManagerService} if the current
+     * process state {@link ControlledProcessState.State#isRunning() is running}. Otherwise records that
+     * the service can be resumed once a {@link #propertyChange(PropertyChangeEvent) notification is received} that
+     * the process state is running.
+     */
     @Override
     public void resume() {
-        recoveryManagerService.resume();
+        boolean doResume;
+        synchronized (this) {
+            suspended = false;
+            doResume = running;
+        }
+        if (doResume) {
+            resumeRecovery();
+        }
     }
 
+    /**
+     * Receives notifications from a {@code ProcessStateNotifier} to detect when the process has reached a
+     * {@link ControlledProcessState.State#isRunning()}  running state}, reacting to them by
+     * {@link RecoveryManagerService#resume() resuming} the {@link RecoveryManagerService} if we haven't been
+     * {@link #preSuspend(ServerActivityCallback) suspended}.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        boolean doResume;
+        synchronized (this) {
+            ControlledProcessState.State newState = (ControlledProcessState.State) evt.getNewValue();
+            running = newState.isRunning();
+            doResume = running && !suspended;
+        }
+        if (doResume) {
+            resumeRecovery();
+        }
+
+    }
+
+    private void resumeRecovery() {
+        recoveryManagerService.resume();
+    }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -86,7 +86,11 @@ class HostAdd extends AbstractAddStepHandler {
         final boolean isDefaultHost = defaultServerName.equals(serverName) && name.equals(defaultHostName);
         final int defaultResponseCode = HostDefinition.DEFAULT_RESPONSE_CODE.resolveModelAttribute(context, model).asInt();
         final boolean enableConsoleRedirect = !HostDefinition.DISABLE_CONSOLE_REDIRECT.resolveModelAttribute(context, model).asBoolean();
-        final boolean queueRequestsOnStart = HostDefinition.QUEUE_REQUESTS_ON_START.resolveModelAttribute(context, model).asBoolean();
+        Boolean queueRequestsOnStart = null;
+
+        if (model.hasDefined(HostDefinition.QUEUE_REQUESTS_ON_START.getName())) {
+            queueRequestsOnStart = HostDefinition.QUEUE_REQUESTS_ON_START.resolveModelAttribute(context, model).asBoolean();
+        }
 
         if (!defaultWebModule.equals(HostDefinition.DEFAULT_WEB_MODULE_DEFAULT) || DefaultDeploymentMappingProvider.instance().getMapping(HostDefinition.DEFAULT_WEB_MODULE_DEFAULT) == null) {
             DefaultDeploymentMappingProvider.instance().addMapping(defaultWebModule, serverName, name);


### PR DESCRIPTION
Add test for non-graceful server start
Add test applications

Modify Host to handle state where queueRequestsOnStart is not explicitly configured.
Take into account "non-graceful" status when deciding whether to queue request or not

Do not use GateHandlerWrapper if we're running in non-graceful/non-enqueued mode

Minor code cleanup

https://issues.redhat.com/browse/WFCORE-4291