### PR TITLE
[WFLY-14277] Upgrade to SmallRye JWT 3.0.0-RC3

### DIFF
--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -160,6 +160,16 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-jwt-cdi-extension</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt-common</artifactId>
             <exclusions>
                 <exclusion>
@@ -168,7 +178,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-jwt-http-mechanism</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-metrics</artifactId>

--- a/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/license/microprofile-feature-pack-licenses.xml
@@ -157,7 +157,29 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-jwt-cdi-extension</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-jwt-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-jwt-http-mechanism</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/jwt/main/module.xml
@@ -26,7 +26,9 @@
     
     <resources>
         <artifact name="${io.smallrye:smallrye-jwt}"/>
+        <artifact name="${io.smallrye:smallrye-jwt-cdi-extension}"/>
         <artifact name="${io.smallrye:smallrye-jwt-common}"/>
+        <artifact name="${io.smallrye:smallrye-jwt-http-mechanism}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <version.io.smallrye.smallrye-config>2.0.2</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>4.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.0.0</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-jwt>3.0.0-RC1</version.io.smallrye.smallrye-jwt>
+        <version.io.smallrye.smallrye-jwt>3.0.0-RC3</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>2.1.0</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0-RC1</version.io.smallrye.opentracing>
@@ -2157,7 +2157,17 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-jwt-cdi-extension</artifactId>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-common</artifactId>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-jwt-http-mechanism</artifactId>
                 <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14277
wildfly/wildfly-proposals#358

This is a follow up PR to upgrade to SmallRye JWT 3.0.0-RC3 - this adds two new Maven dependencies however these are produced by the same SmallRye JWT project.

A follow up PR will be required to move to the 3.0.0 release once available.
