### PR TITLE
[WFLY-14339] Add the javax.api module back as a module dependency to …

### DIFF
--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -39,7 +39,7 @@
         <module name="java.naming"/>
         <module name="java.security.sasl"/>
         <module name="java.xml"/>
-        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="javax.api"/>
         <module name="javax.security.jacc.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.transaction.api"/>


### PR DESCRIPTION
…the legacy security. Note the explicit required dependencies were not reverted and only the javax.api dependency was reintroduced.

https://issues.redhat.com/browse/WFLY-14339