### PR TITLE
[WFLY-14342] Use AttributeDefinition.resolveModelAttribute to read th…

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/ClientConfigAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/ClientConfigAdd.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.webservices.dmr;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.webservices.dmr.PackageUtils.getClientConfigServiceName;
 
 import java.util.ArrayList;
@@ -72,8 +71,8 @@ final class ClientConfigAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
       //modify the runtime if we're booting, otherwise set reload required and leave the runtime unchanged
       if (context.isBooting()) {
-         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-         final String name = address.getLastElement().getValue();
+         final PathAddress address = context.getCurrentAddress();
+         final String name = context.getCurrentAddressValue();
          final ServiceName serviceName = getClientConfigServiceName(name);
          final ServiceTarget target = context.getServiceTarget();
          final ServiceBuilder<?> clientServiceBuilder = target.addService(serviceName);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/EndpointConfigAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/EndpointConfigAdd.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.webservices.dmr;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.webservices.dmr.PackageUtils.getEndpointConfigServiceName;
 
 import java.util.ArrayList;
@@ -73,8 +72,8 @@ final class EndpointConfigAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         //modify the runtime if we're booting, otherwise set reload required and leave the runtime unchanged
         if (context.isBooting()) {
-           final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-           final String name = address.getLastElement().getValue();
+           final PathAddress address = context.getCurrentAddress();
+           final String name = context.getCurrentAddressValue();
            final ServiceName serviceName = getEndpointConfigServiceName(name);
            final ServiceTarget target = context.getServiceTarget();
            final ServiceBuilder<?> serviceBuilder = target.addService(serviceName);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/HandlerAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/HandlerAdd.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.webservices.dmr;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.webservices.dmr.Constants.CLASS;
 import static org.jboss.as.webservices.dmr.PackageUtils.getConfigServiceName;
 import static org.jboss.as.webservices.dmr.PackageUtils.getHandlerChainServiceName;
 import static org.jboss.as.webservices.dmr.PackageUtils.getHandlerServiceName;
@@ -70,14 +68,14 @@ final class HandlerAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         // modify the runtime if we're booting, otherwise set reload required and leave the runtime unchanged
         if (context.isBooting()) {
-            final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            final PathAddress address = context.getCurrentAddress();
             final PathElement confElem = address.getElement(address.size() - 3);
             final String configType = confElem.getKey();
             final String configName = confElem.getValue();
             final String handlerChainType = address.getElement(address.size() - 2).getKey();
             final String handlerChainId = address.getElement(address.size() - 2).getValue();
             final String handlerName = address.getElement(address.size() - 1).getValue();
-            final String handlerClass = operation.require(CLASS).asString();
+            final String handlerClass = Attributes.CLASS.resolveModelAttribute(context, model).asString();
 
             final ServiceTarget target = context.getServiceTarget();
             final ServiceName configServiceName = getConfigServiceName(configType, configName);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/HandlerChainAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/HandlerChainAdd.java
@@ -21,9 +21,7 @@
  */
 package org.jboss.as.webservices.dmr;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.webservices.dmr.Constants.HANDLER;
-import static org.jboss.as.webservices.dmr.Constants.PROTOCOL_BINDINGS;
 import static org.jboss.as.webservices.dmr.PackageUtils.getConfigServiceName;
 import static org.jboss.as.webservices.dmr.PackageUtils.getHandlerChainServiceName;
 
@@ -71,8 +69,8 @@ final class HandlerChainAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         //modify the runtime if we're booting, otherwise set reload required and leave the runtime unchanged
         if (context.isBooting()) {
-            final String protocolBindings = getAttributeValue(operation, PROTOCOL_BINDINGS);
-            final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            final String protocolBindings = Attributes.PROTOCOL_BINDINGS.resolveModelAttribute(context, model).asStringOrNull();
+            final PathAddress address = context.getCurrentAddress();
             final PathElement confElem = address.getElement(address.size() - 2);
             final String configType = confElem.getKey();
             final String configName = confElem.getValue();
@@ -97,10 +95,6 @@ final class HandlerChainAdd extends AbstractAddStepHandler {
         } else {
             context.reloadRequired();
         }
-    }
-
-    private static String getAttributeValue(final ModelNode node, final String propertyName) {
-        return node.hasDefined(propertyName) ? node.get(propertyName).asString() : null;
     }
 
     @Override

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/PropertyAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/PropertyAdd.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.webservices.dmr;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.webservices.dmr.PackageUtils.getConfigServiceName;
 import static org.jboss.as.webservices.dmr.PackageUtils.getPropertyServiceName;
 
@@ -65,12 +63,12 @@ final class PropertyAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         //modify the runtime if we're booting, otherwise set reload required and leave the runtime unchanged
         if (context.isBooting()) {
-            final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-            final String propertyName = address.getElement(address.size() - 1).getValue();
+            final PathAddress address = context.getCurrentAddress();
+            final String propertyName = context.getCurrentAddressValue();
             final PathElement confElem = address.getElement(address.size() - 2);
             final String configType = confElem.getKey();
             final String configName = confElem.getValue();
-            final String propertyValue = operation.has(VALUE) ? Attributes.VALUE.resolveModelAttribute(context,operation).asString() : null;
+            final String propertyValue = Attributes.VALUE.resolveModelAttribute(context, model).asStringOrNull();
             final ServiceTarget target = context.getServiceTarget();
             final ServiceName configServiceName = getConfigServiceName(configType, configName);
             if (context.getServiceRegistry(false).getService(configServiceName) == null) {


### PR DESCRIPTION
…e PROTOCOL_BINDINGS attribute from the model

[WFLY-14343] Don't pass 'undefined' into the runtime as a value of a property value when the model node is undefined.

Also update other add handlers in the webservices subsystem to use current idioms. I found the PROTOCOL_BINDINGS issue while reviewing all these add handlers so might as well update things a bit.

https://issues.redhat.com/browse/WFLY-14342
https://issues.redhat.com/browse/WFLY-14343
