### PR TITLE
[WFLY-14006] Deprecate the extensions where the root subsystem is alr…

### DIFF
--- a/legacy/cmp/src/main/java/org/jboss/as/cmp/subsystem/CmpExtension.java
+++ b/legacy/cmp/src/main/java/org/jboss/as/cmp/subsystem/CmpExtension.java
@@ -55,7 +55,7 @@ public class CmpExtension extends AbstractLegacyExtension {
     @Override
     protected Set<ManagementResourceRegistration> initializeLegacyModel(final ExtensionContext context) {
 
-        final SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
 
         subsystemRegistration.registerXMLElementWriter(new CmpSubsystem11Parser());
 

--- a/legacy/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
+++ b/legacy/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
@@ -49,6 +49,7 @@ public class ConfigAdminExtension extends AbstractLegacyExtension {
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
 
     private static final ModelVersion MANAGEMENT_API_VERSION = ModelVersion.create(1, 1, 0);
+    static final ModelVersion DEPRECATED_SINCE = ModelVersion.create(1, 1, 0);
 
     private static final String RESOURCE_NAME = ConfigAdminExtension.class.getPackage().getName() + ".LocalDescriptions";
     public static final String EXTENSION_NAME = "org.jboss.as.configadmin";
@@ -69,7 +70,7 @@ public class ConfigAdminExtension extends AbstractLegacyExtension {
     @Override
     public Set<ManagementResourceRegistration> initializeLegacyModel(ExtensionContext context) {
 
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_VERSION, true);
         ManagementResourceRegistration subsystemRoot = subsystem.registerSubsystemModel(new ConfigAdminRootResource());
 
         //no need to register transformers as whole extension was deprecated in EAP 6.1 and hasn't changed since, so 1.1.0 in 6.2+ is same as current

--- a/legacy/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminRootResource.java
+++ b/legacy/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminRootResource.java
@@ -35,6 +35,7 @@ class ConfigAdminRootResource extends SimpleResourceDefinition {
 
     public ConfigAdminRootResource() {
         super(ConfigAdminExtension.SUBSYSTEM_PATH, ConfigAdminExtension.getResourceDescriptionResolver(SUBSYSTEM), ConfigAdminAdd.INSTANCE, new ReloadRequiredRemoveStepHandler());
+        this.setDeprecated(ConfigAdminExtension.DEPRECATED_SINCE);
     }
 
     @Override

--- a/legacy/configadmin/src/main/resources/org/jboss/as/configadmin/parser/LocalDescriptions.properties
+++ b/legacy/configadmin/src/main/resources/org/jboss/as/configadmin/parser/LocalDescriptions.properties
@@ -1,5 +1,6 @@
 subsystem=The ConfigAdmin subsystem configuration.
 subsystem.activate=Activate the ConfigAdmin subsystem.
+subsystem.deprecated=The ConfigAdmin subsystem is deprecated and may be removed or moved in future versions.
 
 subsystem.add=Add the ConfigAdmin subsystem configuration.
 subsystem.remove=Remove the ConfigAdmin subsystem configuration.

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
@@ -74,7 +74,7 @@ public class JacORBExtension extends AbstractLegacyExtension {
 
     @Override
     protected Set<ManagementResourceRegistration> initializeLegacyModel(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
         final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(JacORBSubsystemResource.INSTANCE);
         subsystem.registerXMLElementWriter(PARSER);
 

--- a/legacy/jaxr/src/main/java/org/jboss/as/jaxr/extension/JAXRExtension.java
+++ b/legacy/jaxr/src/main/java/org/jboss/as/jaxr/extension/JAXRExtension.java
@@ -45,6 +45,7 @@ import org.jboss.as.jaxr.extension.JAXRConstants.Namespace;
 public class JAXRExtension extends AbstractLegacyExtension {
 
     private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 2, 0);
+    static final ModelVersion DEPRECATED_SINCE = ModelVersion.create(1, 2, 0);
     static final String SUBSYSTEM_NAME = "jaxr";
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
 
@@ -64,7 +65,7 @@ public class JAXRExtension extends AbstractLegacyExtension {
 
     @Override
     protected Set<ManagementResourceRegistration> initializeLegacyModel(ExtensionContext context) {
-        SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
 
         subsystemRegistration.registerXMLElementWriter(JAXRSubsystemWriter.INSTANCE);
 

--- a/legacy/jaxr/src/main/java/org/jboss/as/jaxr/extension/JAXRSubsystemRootResource.java
+++ b/legacy/jaxr/src/main/java/org/jboss/as/jaxr/extension/JAXRSubsystemRootResource.java
@@ -50,6 +50,7 @@ class JAXRSubsystemRootResource extends ModelOnlyResourceDefinition {
         super(JAXRExtension.SUBSYSTEM_PATH,
                 JAXRExtension.getResolver(),
                 CONNECTION_FACTORY_ATTRIBUTE, CONNECTION_FACTORY_IMPL_ATTRIBUTE);
+        this.setDeprecated(JAXRExtension.DEPRECATED_SINCE);
     }
 
     @Override

--- a/legacy/jaxr/src/main/resources/org/jboss/as/jaxr/LocalDescriptions.properties
+++ b/legacy/jaxr/src/main/resources/org/jboss/as/jaxr/LocalDescriptions.properties
@@ -1,5 +1,6 @@
 jaxr=The configuration of the JAXR subsystem.
 jaxr.add=Adds the JAXR subsystem.
+jaxr.deprecated=The JAXR subsystem is deprecated and may be removed or moved in future versions.
 jaxr.jndi-name=The JNDI name under which the JAXR ConnectionFactory is bound
 jaxr.class=The JAXR ConnectionFactory implementation class
 jaxr.remove=Removes the JAXR subsystem.

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -160,7 +160,7 @@ public class MessagingExtension extends AbstractLegacyExtension {
 
     @Override
     protected Set<ManagementResourceRegistration> initializeLegacyModel(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
         subsystem.registerXMLElementWriter(MessagingXMLWriter.INSTANCE);
 
         // Root resource

--- a/legacy/web/src/main/java/org/jboss/as/web/WebExtension.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebExtension.java
@@ -92,7 +92,7 @@ public class WebExtension extends AbstractLegacyExtension {
 
     @Override
     protected Set<ManagementResourceRegistration> initializeLegacyModel(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
 
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(WebDefinition.INSTANCE);
         subsystem.registerXMLElementWriter(new WebSubsystemParser());

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/FederationExtension.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/FederationExtension.java
@@ -63,7 +63,7 @@ public class FederationExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
-        SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
 
         subsystemRegistration.registerSubsystemModel(new FederationSubsystemRootResourceDefinition(context));
         subsystemRegistration.registerXMLElementWriter(FederationSubsystemWriter.INSTANCE);

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/IDMExtension.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/IDMExtension.java
@@ -61,7 +61,7 @@ public class IDMExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
-        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
 
         subsystem.registerSubsystemModel(IDMSubsystemRootResourceDefinition.INSTANCE);
         subsystem.registerXMLElementWriter(Namespace.CURRENT.getXMLWriter());

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -89,7 +89,7 @@ import org.jboss.msc.service.ServiceName;
 
         final boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
 
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(SecuritySubsystemRootResourceDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 

--- a/xts/src/main/java/org/jboss/as/xts/XTSExtension.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSExtension.java
@@ -56,7 +56,7 @@ public class XTSExtension implements Extension {
 
     public void initialize(ExtensionContext context) {
         XtsAsLogger.ROOT_LOGGER.debug("Initializing XTS Extension");
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION, true);
         subsystem.registerSubsystemModel(new XTSSubsystemDefinition());
         subsystem.registerXMLElementWriter(new XTSSubsystemParser());
     }


### PR DESCRIPTION
…eady deprecated

Jira issue: https://issues.redhat.com/browse/WFLY-14006

@jmesnil @bstansberry The following extensions are suspicious, they are registered via [AbstractLegacyExtension.java#L101](https://github.com/wildfly/wildfly-core/blob/master/controller/src/main/java/org/jboss/as/controller/extension/AbstractLegacyExtension.java#L101), which means are allowed to be registered to manage a legacy server instance. As such, it looks like they should have been deprecated. However, their root subsystems have not been deprecated yet:

```
/extension=org.jboss.as.configadmin:add()
/extension=org.jboss.as.jaxr:add()
/extension=org.wildfly.extension.rts:add()
```
