### PR TITLE
[22.x] WFLY-14356 Infinispan heap-memory caches transcoding key/values unnecessarily

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationServiceConfigurator.java
@@ -28,6 +28,7 @@ import static org.jboss.as.clustering.infinispan.subsystem.CacheResourceDefiniti
 import java.util.function.Consumer;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.ExpirationConfiguration;
 import org.infinispan.configuration.cache.GroupsConfigurationBuilder;
@@ -120,6 +121,10 @@ public class CacheConfigurationServiceConfigurator extends CapabilityServiceName
         builder.transaction().read(tx);
         builder.statistics().enabled(this.statisticsEnabled);
 
+        // See WFLY-14356
+        if (this.memory.get().storage().canStoreReferences()) {
+            builder.encoding().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
+        }
         try {
             // Configure invocation batching based on transaction configuration
             builder.invocationBatching().enable(tx.transactionMode().isTransactional() && (tx.transactionManagerLookup().getTransactionManager() != ContextTransactionManager.getInstance()));


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14356

Upstream PR: https://github.com/wildfly/wildfly/pull/13925
