### PR TITLE
Revert "[WFLY-14339] Add the javax.api module back as a module dependency to …"

### DIFF
--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -39,7 +39,7 @@
         <module name="java.naming"/>
         <module name="java.security.sasl"/>
         <module name="java.xml"/>
-        <module name="javax.api"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.security.jacc.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.transaction.api"/>


### PR DESCRIPTION
Reverts wildfly/wildfly#13910

I believe we've solved the internal testsuite config issue that led to #13910.

@ropalka @jamezp @scottmarlow FYI.