### PR TITLE
[WFLY-14365] Programmatic web authentication (HttpServletRequest.login()) does not trigger sso

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/DistributableSingleSignOn.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/DistributableSingleSignOn.java
@@ -65,6 +65,12 @@ public class DistributableSingleSignOn implements SingleSignOn {
         }
     }
 
+    public boolean isProgrammatic() {
+        try (BatchContext context = this.batcher.resumeBatch(this.batch)) {
+            return this.sso.getAuthentication().isProgrammatic();
+        }
+    }
+
     @Override
     public String getName() {
         try (BatchContext context = this.batcher.resumeBatch(this.batch)) {

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/DistributableSingleSignOnManager.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/DistributableSingleSignOnManager.java
@@ -46,14 +46,14 @@ public class DistributableSingleSignOnManager implements SingleSignOnManager {
     }
 
     @Override
-    public SingleSignOn create(String mechanismName, SecurityIdentity identity) {
+    public SingleSignOn create(String mechanismName, boolean programmatic, SecurityIdentity identity) {
         String id = this.manager.createIdentifier();
         Batcher<Batch> batcher = this.manager.getBatcher();
         // Batch will be closed when SSO is closed
         @SuppressWarnings("resource")
         Batch batch = batcher.createBatch();
         try {
-            SSO<ElytronAuthentication, String, Entry<String, URI>, LocalSSOContext> sso = this.manager.createSSO(id, new ElytronAuthentication(mechanismName, identity.getPrincipal().getName()));
+            SSO<ElytronAuthentication, String, Entry<String, URI>, LocalSSOContext> sso = this.manager.createSSO(id, new ElytronAuthentication(mechanismName, programmatic, identity.getPrincipal().getName()));
             sso.getLocalContext().setSecurityIdentity(identity);
             return new DistributableSingleSignOn(sso, batcher, batcher.suspendBatch());
         } catch (RuntimeException | Error e) {

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthentication.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthentication.java
@@ -31,15 +31,21 @@ public class ElytronAuthentication implements Serializable {
     private static final long serialVersionUID = -8708162054415948335L;
 
     private final String mechanism;
+    private final boolean programmatic;
     private final String name;
 
-    public ElytronAuthentication(String mechanism, String name) {
+    public ElytronAuthentication(String mechanism, boolean programmatic, String name) {
         this.mechanism = mechanism;
+        this.programmatic = programmatic;
         this.name = name;
     }
 
     public String getMechanism() {
         return this.mechanism;
+    }
+
+    public boolean isProgrammatic() {
+        return programmatic;
     }
 
     public String getName() {

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthenticationMarshaller.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthenticationMarshaller.java
@@ -39,6 +39,7 @@ public class ElytronAuthenticationMarshaller implements ProtoStreamMarshaller<El
 
     private static final int MECHANISM_INDEX = 1;
     private static final int NAME_INDEX = 2;
+    private static final int PROGRAMMATIC_INDEX = 3;
 
     private static final String DEFAULT_MECHANISM = HttpServletRequest.FORM_AUTH;
 
@@ -46,6 +47,7 @@ public class ElytronAuthenticationMarshaller implements ProtoStreamMarshaller<El
     public ElytronAuthentication readFrom(ProtoStreamReader reader) throws IOException {
         String mechanism = DEFAULT_MECHANISM;
         String name = null;
+        boolean programmatic = false;
         boolean reading = true;
         while (reading) {
             int tag = reader.readTag();
@@ -56,11 +58,14 @@ public class ElytronAuthenticationMarshaller implements ProtoStreamMarshaller<El
                 case NAME_INDEX:
                     name = reader.readString();
                     break;
+                case PROGRAMMATIC_INDEX:
+                    programmatic = reader.readBool();
+                    break;
                 default:
                     reading = (tag != 0) && reader.skipField(tag);
             }
         }
-        return new ElytronAuthentication(mechanism, name);
+        return new ElytronAuthentication(mechanism, programmatic, name);
     }
 
     @Override
@@ -72,6 +77,10 @@ public class ElytronAuthenticationMarshaller implements ProtoStreamMarshaller<El
         String name = auth.getName();
         if (name != null) {
             writer.writeString(NAME_INDEX, name);
+        }
+        boolean programmatic = auth.isProgrammatic();
+        if (programmatic) {
+            writer.writeBool(PROGRAMMATIC_INDEX, programmatic);
         }
     }
 

--- a/clustering/web/undertow/src/main/resources/org.wildfly.clustering.web.undertow.sso.elytron.proto
+++ b/clustering/web/undertow/src/main/resources/org.wildfly.clustering.web.undertow.sso.elytron.proto
@@ -8,4 +8,5 @@ package org.wildfly.clustering.web.undertow.sso.elytron;
 message ElytronAuthentication {
 	optional	string	mechanism	= 1;
 	optional	string	name	= 2;
+	optional	bool	programmatic	= 3;
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthenticationMarshallingTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/elytron/ElytronAuthenticationMarshallingTestCase.java
@@ -42,14 +42,16 @@ public class ElytronAuthenticationMarshallingTestCase {
     }
 
     private static void test(Tester<ElytronAuthentication> tester) throws IOException {
-        tester.test(new ElytronAuthentication(HttpServletRequest.BASIC_AUTH, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
-        tester.test(new ElytronAuthentication(HttpServletRequest.CLIENT_CERT_AUTH, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
-        tester.test(new ElytronAuthentication(HttpServletRequest.DIGEST_AUTH, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
-        tester.test(new ElytronAuthentication(HttpServletRequest.FORM_AUTH, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
+        tester.test(new ElytronAuthentication(HttpServletRequest.BASIC_AUTH, false, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
+        tester.test(new ElytronAuthentication(HttpServletRequest.CLIENT_CERT_AUTH, false, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
+        tester.test(new ElytronAuthentication(HttpServletRequest.DIGEST_AUTH, false, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
+        tester.test(new ElytronAuthentication(HttpServletRequest.FORM_AUTH, false, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
+        tester.test(new ElytronAuthentication("Programmatic", true, "user"), ElytronAuthenticationMarshallingTestCase::assertEquals);
     }
 
     static void assertEquals(ElytronAuthentication auth1, ElytronAuthentication auth2) {
         Assert.assertEquals(auth1.getMechanism(), auth2.getMechanism());
         Assert.assertEquals(auth1.getName(), auth2.getName());
+        Assert.assertEquals(auth1.isProgrammatic(), auth2.isProgrammatic());
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -295,7 +295,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
             }
 
             final Supplier<UnaryOperator<HttpServerAuthenticationMechanismFactory>> transformerSupplier;
-            final Function<HttpExchangeSpi, IdentityCache> identityCacheSupplier;
+            final BiFunction<HttpExchangeSpi, String, IdentityCache> identityCacheSupplier;
             if (resource.hasChild(UndertowExtension.PATH_SSO)) {
                 ModelNode ssoModel = resource.getChild(UndertowExtension.PATH_SSO).getModel();
 
@@ -331,7 +331,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
                 Supplier<SingleSignOnSessionFactory> singleSignOnSessionFactorySupplier = serviceBuilder.requires(factoryConfigurator.getServiceName());
                 UnaryOperator<HttpServerAuthenticationMechanismFactory> transformer = (factory) -> new SingleSignOnServerMechanismFactory(factory, singleSignOnSessionFactorySupplier.get(), singleSignOnConfiguration);
 
-                identityCacheSupplier = (HttpExchangeSpi httpExchangeSpi) -> ProgrammaticSingleSignOnCache.newInstance(httpExchangeSpi, singleSignOnSessionFactorySupplier.get(), singleSignOnConfiguration);
+                identityCacheSupplier = (HttpExchangeSpi httpExchangeSpi, String mechanismName) -> ProgrammaticSingleSignOnCache.newInstance(httpExchangeSpi, mechanismName, singleSignOnSessionFactorySupplier.get(), singleSignOnConfiguration);
                 transformerSupplier = () -> transformer;
 
             } else {
@@ -413,7 +413,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
         private final Supplier<HttpAuthenticationFactory> httpAuthenticationFactorySupplier;
         private final Supplier<SecurityDomain> securityDomainSupplier;
         private final Supplier<UnaryOperator<HttpServerAuthenticationMechanismFactory>> singleSignOnTransformerSupplier;
-        private final Function<HttpExchangeSpi, IdentityCache> identityCacheSupplier;
+        private final BiFunction<HttpExchangeSpi, String, IdentityCache> identityCacheSupplier;
 
         private final Consumer<BiFunction<DeploymentInfo, Function<String, RunAsIdentityMetaData>, Registration>> deploymentConsumer;
         private final Consumer<SecurityDomain> securityDomainConsumer;
@@ -429,7 +429,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
 
         private ApplicationSecurityDomainService(final boolean overrideDeploymentConfig, boolean enableJacc, boolean enableJaspi, boolean integratedJaspi,
                 final Supplier<HttpAuthenticationFactory> httpAuthenticationFactorySupplier, final Supplier<SecurityDomain> securityDomainSupplier,
-                Supplier<UnaryOperator<HttpServerAuthenticationMechanismFactory>> singleSignOnTransformerSupplier, Function<HttpExchangeSpi, IdentityCache> identityCacheSupplier,
+                Supplier<UnaryOperator<HttpServerAuthenticationMechanismFactory>> singleSignOnTransformerSupplier, BiFunction<HttpExchangeSpi, String, IdentityCache> identityCacheSupplier,
                 Consumer<BiFunction<DeploymentInfo, Function<String, RunAsIdentityMetaData>, Registration>> deploymentConsumer, Consumer<SecurityDomain> securityDomainConsumer) {
             this.overrideDeploymentConfig = overrideDeploymentConfig;
             this.enableJacc = enableJacc;


### PR DESCRIPTION
As with the PRs to WildFly Elytron and Elytron Web I am submitting this as a draft PR as there is some follow up work required which I will likely complete just after feature freeze but as clustered SSO is a sensitive area of code I would like to get reviews started in case a different strategy is needed.

This PR depends on the following PRs so will not compile without component upgrades:
  https://github.com/wildfly-security/wildfly-elytron/pull/1483
  https://github.com/wildfly-security/elytron-web/pull/184

The WildFly changes really cover two areas:
1. Enabling the use of the ProgrammaticSingleSignOnCache to activate SSO for programmatic authentication.
2. Adding an additional field to the replicated CachedIdentity to track if the identity was created as a result of programmatic authentication.

https://issues.redhat.com/browse/WFLY-14365