### PR TITLE
[WFLY-14401] Upgrade Mojarra to 2.3.14.SP04

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <version.com.squareup.okhttp3>3.9.0</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.2</version.com.sun.activation.jakarta.activation>
-        <version.com.sun.faces>2.3.14.SP02</version.com.sun.faces>
+        <version.com.sun.faces>2.3.14.SP04</version.com.sun.faces>
         <version.com.sun.istack>3.0.10</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.13</version.com.sun.xml.fastinfoset>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14401

Mojarra 2.3.14.SP04 contains fixes for the following two issues:

* [WFLY-14248](https://issues.redhat.com/browse/WFLY-14248) - Sync fixes/improvements of o:socket into f:websocket
* [WFLY-13691](https://issues.redhat.com/browse/WFLY-13691) - PropertyNotFoundException when nested entity is null