### PR TITLE
[WFLY-14390] WildFly does not start when async-registration attribute in XTS subsystem is set to an expression

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
@@ -214,9 +214,6 @@ class XTSSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
             final String value = reader.getAttributeValue(index);
             switch (attribute) {
                 case ENABLED:
-                    if (value == null || (!value.toLowerCase().equals("true") && !value.toLowerCase().equals("false"))) {
-                        throw ParseUtils.invalidAttributeValue(reader, index);
-                    }
                     ASYNC_REGISTRATION.parseAndSetParameter(value, subsystem, reader);
                     break;
                 default:

--- a/xts/src/test/resources/org/jboss/as/xts/subsystem-3.0.0.xml
+++ b/xts/src/test/resources/org/jboss/as/xts/subsystem-3.0.0.xml
@@ -24,5 +24,5 @@
     <host name="bad-host-for-6.4"/>
     <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
     <default-context-propagation enabled="true"/>
-    <async-registration enabled="true" />
+    <async-registration enabled="${org.jboss.as.xts.asyncRegistration:true}" />
 </subsystem>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14390

Just removing the lines that checks for the true/false value and let the `parseAndSetParameter` do the job. The sample subsystem test file is updated to set a expression that defaults to true as before, this way the expression value is tested in the subsystem tests.

@ochaloup Please review the PR. 