### PR TITLE
[WFLY-14389] Resource-adapters: correctly marshall application elemen…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -110,6 +110,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.jca.common.api.metadata.common.Capacity;
 import org.jboss.jca.common.api.metadata.common.Pool;
@@ -373,7 +374,7 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
                 || conDef.hasDefined(SECURITY_DOMAIN_AND_APPLICATION.getName())
                 || conDef.hasDefined(ELYTRON_ENABLED.getName())) {
             streamWriter.writeStartElement(ConnectionDefinition.Tag.SECURITY.getLocalName());
-            if (conDef.hasDefined(APPLICATION.getName()) && conDef.get(APPLICATION.getName()).asBoolean()) {
+            if (conDef.hasDefined(APPLICATION.getName()) && conDef.get(APPLICATION.getName()).getType().equals(ModelType.BOOLEAN) && conDef.get(APPLICATION.getName()).asBoolean()) {
                 streamWriter.writeEmptyElement(APPLICATION.getXmlName());
             } else {
                 APPLICATION.marshallAsElement(conDef, streamWriter);

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
@@ -43,7 +43,7 @@
           <security>
             <!--You have a CHOICE of the next 3 items at this level-->
             <!--Optional:-->
-            <application/>
+            <application>${test.expr:true}</application>
           </security>
           <!--Optional:-->
           <timeout>


### PR DESCRIPTION
…t with expression value

https://issues.redhat.com/browse/WFLY-14389

This fix seem to work for me. In case of application being set to true, it is marshalled as an empty element. In other cases, expression included, it is fully marshalled.
