### PR TITLE
[WFLY-14372] Prevent multiple metrics scans

### DIFF
--- a/metrics/src/main/java/org/wildfly/extension/metrics/MetricCollector.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/MetricCollector.java
@@ -49,7 +49,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 public class MetricCollector {
-
     private final LocalModelControllerClient modelControllerClient;
     private final ProcessStateNotifier processStateNotifier;
 
@@ -130,12 +129,10 @@ public class MetricCollector {
         }
 
         for (String type : current.getChildTypes()) {
-            if (current.hasChildren(type)) {
-                for (Resource.ResourceEntry entry : current.getChildren(type)) {
-                    final PathElement pathElement = entry.getPathElement();
-                    final PathAddress childAddress = address.append(pathElement);
-                    collectResourceMetrics0(entry, managementResourceRegistration, childAddress, resourceAddressResolver, registration, exposeAnySubsystem, exposedSubsystems, prefix);
-                }
+            for (Resource.ResourceEntry entry : current.getChildren(type)) {
+                final PathElement pathElement = entry.getPathElement();
+                final PathAddress childAddress = address.append(pathElement);
+                collectResourceMetrics0(entry, managementResourceRegistration, childAddress, resourceAddressResolver, registration, exposeAnySubsystem, exposedSubsystems, prefix);
             }
         }
     }

--- a/metrics/src/main/java/org/wildfly/extension/metrics/MetricsSubsystemDefinition.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/MetricsSubsystemDefinition.java
@@ -46,6 +46,7 @@ public class MetricsSubsystemDefinition extends PersistentResourceDefinition {
     static final String PROCESS_STATE_NOTIFIER = "org.wildfly.management.process-state-notifier";
     static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
     public static final String METRICS_HTTP_SECURITY_CAPABILITY = "org.wildfly.extension.metrics.http-context.security-enabled";
+    public static final String METRICS_SCAN_CAPABILITY = "org.wildfly.extension.metrics.scan";
 
     private static final RuntimeCapability<Void> METRICS_COLLECTOR_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.metrics.wildfly-collector", MetricCollector.class)
             .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR, PROCESS_STATE_NOTIFIER)

--- a/metrics/src/main/java/org/wildfly/extension/metrics/deployment/DeploymentMetricProcessor.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/deployment/DeploymentMetricProcessor.java
@@ -52,10 +52,12 @@ public class DeploymentMetricProcessor implements DeploymentUnitProcessor {
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {
-        rootResource = phaseContext.getDeploymentUnit().getAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE);
-        managementResourceRegistration = phaseContext.getDeploymentUnit().getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
 
-        DeploymentMetricService.install(phaseContext.getServiceTarget(), phaseContext.getDeploymentUnit(), rootResource, managementResourceRegistration,
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        rootResource = deploymentUnit.getAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE);
+        managementResourceRegistration = deploymentUnit.getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
+
+        DeploymentMetricService.install(phaseContext.getServiceTarget(), deploymentUnit, rootResource, managementResourceRegistration,
                 exposeAnySubsystem, exposedSubsystems, prefix);
     }
 

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -99,8 +99,7 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 MetricRegistration registration = new MetricRegistration(new MicroProfileVendorMetricRegistry());
 
                 metricCollector.collectResourceMetrics(rootResource, rootResourceRegistration, Function.identity(),
-                        exposeAnySubsystem, exposedSubsystems, prefix,
-                        registration);
+                        exposeAnySubsystem, exposedSubsystems, prefix, registration);
 
                 JmxRegistrar jmxRegistrar = new JmxRegistrar();
                 try {

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -51,6 +51,9 @@ public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDe
             .build();
     static final RuntimeCapability<Void> MICROPROFILE_METRICS_HTTP_SECURITY_CAPABILITY = RuntimeCapability.Builder.of(MetricsSubsystemDefinition.METRICS_HTTP_SECURITY_CAPABILITY, Boolean.class)
             .build();
+    static final RuntimeCapability<Void> MICROPROFILE_METRICS_SCAN = RuntimeCapability.Builder.of(MetricsSubsystemDefinition.METRICS_SCAN_CAPABILITY)
+            .addRequirements(METRICS_HTTP_CONTEXT_CAPABILITY, MP_CONFIG)
+            .build();
 
     static final AttributeDefinition SECURITY_ENABLED = SimpleAttributeDefinitionBuilder.create("security-enabled", ModelType.BOOLEAN)
             .setDefaultValue(ModelNode.TRUE)
@@ -77,7 +80,8 @@ public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDe
                 MicroProfileMetricsExtension.getResourceDescriptionResolver(MicroProfileMetricsExtension.SUBSYSTEM_NAME))
                 .setAddHandler(MicroProfileMetricsSubsystemAdd.INSTANCE)
                 .setRemoveHandler(new ServiceRemoveStepHandler(MicroProfileMetricsSubsystemAdd.INSTANCE))
-                .setCapabilities(MICROPROFILE_METRIC_HTTP_CONTEXT_CAPABILITY, MICROPROFILE_METRICS_HTTP_SECURITY_CAPABILITY));
+                .setCapabilities(MICROPROFILE_METRIC_HTTP_CONTEXT_CAPABILITY, MICROPROFILE_METRICS_HTTP_SECURITY_CAPABILITY,
+                        MICROPROFILE_METRICS_SCAN));
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14372

Define a capability in WF Metrics
Implement capability in MP Metrics module
Remove extraneous, expensive hasChildren() call
Avoid installing WF Metrics DPU and scanning if MP Metrics is installed
