### PR TITLE
[WFLY-14277] Upgrade SmallRye JWT to 3.0.0-RC5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <version.io.smallrye.smallrye-config>2.0.2</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>5.0.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.0.0</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-jwt>3.0.0-RC4</version.io.smallrye.smallrye-jwt>
+        <version.io.smallrye.smallrye-jwt>3.0.0-RC5</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>2.1.1</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0-RC1</version.io.smallrye.opentracing>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14277

Upgrade to RC5, the final release should be available to us at the end of the week.