### PR TITLE
[WFLY-14328] Update Smallrye-Metrics to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         <version.io.smallrye.smallrye-fault-tolerance>5.0.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.0.0</version.io.smallrye.smallrye-jwt>
-        <version.io.smallrye.smallrye-metrics>3.0.0</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>3.0.1</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>2.1.1</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0-RC1</version.io.smallrye.opentracing>
         <version.io.smallrye.smallrye-reactive-converters>2.0.0.RC3</version.io.smallrye.smallrye-reactive-converters>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14328

Bump the version number