### PR TITLE
[WFLY-13779] Require reload when removing config source

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ClassConfigSourceRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ClassConfigSourceRegistrationService.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.config.smallrye;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.extension.microprofile.config.smallrye._private.MicroProfileConfigLogger;
+
+/**
+ * Service to register a ConfigSource reading its configuration from a directory (where files are property keys and
+ * their content is the property values).
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+class ClassConfigSourceRegistrationService implements Service {
+
+    private final String name;
+    private final ConfigSource configSource;
+    private final Registry<ConfigSource> sources;
+
+    ClassConfigSourceRegistrationService(String name, ConfigSource configSource, Registry<ConfigSource> sources) {
+        this.name = name;
+        this.configSource = configSource;
+        this.sources = sources;
+    }
+
+    static void install(OperationContext context, String name, ConfigSource configSource, Registry registry) {
+        ServiceBuilder<?> builder = context.getServiceTarget()
+                .addService(ServiceNames.CONFIG_SOURCE.append(name));
+
+        builder.setInstance(new ClassConfigSourceRegistrationService(name, configSource, registry))
+                .install();
+    }
+
+    @Override
+    public void start(StartContext startContext) {
+        MicroProfileConfigLogger.ROOT_LOGGER.loadConfigSourceFromClass(configSource.getClass());
+        this.sources.register(this.name, configSource);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.sources.unregister(this.name);
+    }
+}

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
@@ -30,11 +30,10 @@ import static org.wildfly.extension.microprofile.config.smallrye._private.MicroP
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 
+import io.smallrye.config.PropertiesConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeMarshallers;
@@ -44,15 +43,14 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
-import org.wildfly.extension.microprofile.config.smallrye._private.MicroProfileConfigLogger;
-
-import io.smallrye.config.PropertiesConfigSource;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
@@ -104,49 +102,13 @@ class ConfigSourceDefinition extends PersistentResourceDefinition {
             .setCapabilityReference("org.wildfly.management.path-manager")
             .build();
 
-    static AttributeDefinition[] ATTRIBUTES = { ORDINAL, PROPERTIES, CLASS, DIR };
+    static AttributeDefinition[] ATTRIBUTES = {ORDINAL, PROPERTIES, CLASS, DIR};
 
     protected ConfigSourceDefinition(Registry<ConfigSource> sources) {
-        super(MicroProfileConfigExtension.CONFIG_SOURCE_PATH,
-                MicroProfileConfigExtension.getResourceDescriptionResolver(MicroProfileConfigExtension.CONFIG_SOURCE_PATH.getKey()),
-                new AbstractAddStepHandler(ATTRIBUTES) {
-                    @Override
-                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-                        super.performRuntime(context, operation, model);
-                        String name = context.getCurrentAddressValue();
-                        int ordinal = ORDINAL.resolveModelAttribute(context, model).asInt();
-                        ModelNode props = PROPERTIES.resolveModelAttribute(context, model);
-                        ModelNode classModel = CLASS.resolveModelAttribute(context, model);
-                        ModelNode dirModel = DIR.resolveModelAttribute(context, model);
-                        if (classModel.isDefined()) {
-                            Class configSourceClass = unwrapClass(classModel);
-                            try {
-                                sources.register(name, ConfigSource.class.cast(configSourceClass.newInstance()));
-                                MicroProfileConfigLogger.ROOT_LOGGER.loadConfigSourceFromClass(configSourceClass);
-                            } catch (Exception e) {
-                                throw new OperationFailedException(e);
-                            }
-                        } else if (dirModel.isDefined()) {
-                            String path = PATH.resolveModelAttribute(context, dirModel).asString();
-                            String relativeTo = RELATIVE_TO.resolveModelAttribute(context, dirModel).asStringOrNull();
-                            DirConfigSourceRegistrationService.install(context, name, path, relativeTo, ordinal, sources);
-                        } else {
-                            Map<String, String> properties = PropertiesAttributeDefinition.unwrapModel(context, props);
-                            sources.register(name, new PropertiesConfigSource(properties, name, ordinal));
-                        }
-                    }
-                }, new AbstractRemoveStepHandler() {
-                    @Override
-                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-                        String name = context.getCurrentAddressValue();
-                        ModelNode dirModel = DIR.resolveModelAttribute(context, model);
-                        if (dirModel.isDefined()) {
-                            context.removeService(ServiceNames.CONFIG_SOURCE.append(name));
-                        } else {
-                            sources.unregister(name);
-                        }
-                    }
-                });
+        super(new SimpleResourceDefinition.Parameters(MicroProfileConfigExtension.CONFIG_SOURCE_PATH,
+                MicroProfileConfigExtension.getResourceDescriptionResolver(MicroProfileConfigExtension.CONFIG_SOURCE_PATH.getKey()))
+                .setAddHandler(new ConfigSourceDefinitionAddHandler(sources))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
     }
 
     @Override
@@ -164,6 +126,51 @@ class ConfigSourceDefinition extends PersistentResourceDefinition {
             return clazz;
         } catch (Exception e) {
             throw ROOT_LOGGER.unableToLoadClassFromModule(className, moduleName);
+        }
+    }
+
+    private static class ConfigSourceDefinitionAddHandler extends AbstractAddStepHandler {
+        private final Registry<ConfigSource> sources;
+
+        ConfigSourceDefinitionAddHandler(Registry<ConfigSource> sources) {
+            super(ATTRIBUTES);
+            this.sources = sources;
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+            super.performRuntime(context, operation, model);
+            String name = context.getCurrentAddressValue();
+            int ordinal = ORDINAL.resolveModelAttribute(context, model).asInt();
+            ModelNode classModel = CLASS.resolveModelAttribute(context, model);
+            ModelNode dirModel = DIR.resolveModelAttribute(context, model);
+
+            if (classModel.isDefined()) {
+                try {
+                    ClassConfigSourceRegistrationService.install(context,
+                            name,
+                            ConfigSource.class.cast(unwrapClass(classModel).getDeclaredConstructor().newInstance()),
+                            sources);
+                } catch (Exception e) {
+                    throw new OperationFailedException(e);
+                }
+            } else if (dirModel.isDefined()) {
+                DirConfigSourceRegistrationService.install(context,
+                        name,
+                        PATH.resolveModelAttribute(context, dirModel).asString(),
+                        RELATIVE_TO.resolveModelAttribute(context, dirModel).asStringOrNull(),
+                        ordinal,
+                        sources);
+            } else {
+                PropertiesConfigSourceRegistrationService.install(context,
+                        name,
+                        new PropertiesConfigSource(
+                                PropertiesAttributeDefinition.unwrapModel(context,
+                                        PROPERTIES.resolveModelAttribute(context, model)),
+                                name,
+                                ordinal),
+                        sources);
+            }
         }
     }
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
@@ -32,13 +32,14 @@ import java.util.Collection;
 
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
@@ -65,30 +66,10 @@ class ConfigSourceProviderDefinition extends PersistentResourceDefinition {
     static AttributeDefinition[] ATTRIBUTES = { CLASS };
 
     protected ConfigSourceProviderDefinition(Registry<ConfigSourceProvider> providers) {
-        super(MicroProfileConfigExtension.CONFIG_SOURCE_PROVIDER_PATH,
-                MicroProfileConfigExtension.getResourceDescriptionResolver(MicroProfileConfigExtension.CONFIG_SOURCE_PROVIDER_PATH.getKey()),
-                new AbstractAddStepHandler(ATTRIBUTES) {
-                    @Override
-                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-                        super.performRuntime(context, operation, model);
-                        String name = context.getCurrentAddressValue();
-                        ModelNode classModel = CLASS.resolveModelAttribute(context, model);
-                        if (classModel.isDefined()) {
-                            Class configSourceProviderClass = unwrapClass(classModel);
-                            try {
-                                providers.register(name, ConfigSourceProvider.class.cast(configSourceProviderClass.newInstance()));
-                            } catch (Exception e) {
-                                throw new OperationFailedException(e);
-                            }
-                        }
-                    }
-                }, new AbstractRemoveStepHandler() {
-                    @Override
-                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-                        String name = context.getCurrentAddressValue();
-                        providers.unregister(name);
-                    }
-                });
+        super(new SimpleResourceDefinition.Parameters(MicroProfileConfigExtension.CONFIG_SOURCE_PROVIDER_PATH,
+                MicroProfileConfigExtension.getResourceDescriptionResolver(MicroProfileConfigExtension.CONFIG_SOURCE_PROVIDER_PATH.getKey()))
+                .setAddHandler(new ConfigSourceProviderDefinitionAddHandler(providers))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
     }
 
     @Override
@@ -106,6 +87,32 @@ class ConfigSourceProviderDefinition extends PersistentResourceDefinition {
             return clazz;
         } catch (Exception e) {
             throw ROOT_LOGGER.unableToLoadClassFromModule(className, moduleName);
+        }
+    }
+
+    private static class ConfigSourceProviderDefinitionAddHandler extends AbstractAddStepHandler {
+        private final Registry<ConfigSourceProvider> providers;
+
+        private ConfigSourceProviderDefinitionAddHandler(Registry<ConfigSourceProvider> providers) {
+            super(ATTRIBUTES);
+            this.providers = providers;
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+            super.performRuntime(context, operation, model);
+            ModelNode classModel = CLASS.resolveModelAttribute(context, model);
+            if (classModel.isDefined()) {
+                Class configSourceProviderClass = unwrapClass(classModel);
+                try {
+                    ConfigSourceProviderRegistrationService.install(context,
+                            context.getCurrentAddressValue(),
+                            ConfigSourceProvider.class.cast(configSourceProviderClass.getDeclaredConstructor().newInstance()),
+                            providers);
+                } catch (Exception e) {
+                    throw new OperationFailedException(e);
+                }
+            }
         }
     }
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderRegistrationService.java
@@ -1,0 +1,37 @@
+package org.wildfly.extension.microprofile.config.smallrye;
+
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+public class ConfigSourceProviderRegistrationService implements Service {
+    private final String name;
+    private ConfigSourceProvider configSourceProvider;
+    private final Registry<ConfigSourceProvider> sources;
+
+    ConfigSourceProviderRegistrationService(String name, ConfigSourceProvider configSourceProvider, Registry<ConfigSourceProvider> sources) {
+        this.name = name;
+        this.configSourceProvider = configSourceProvider;
+        this.sources = sources;
+    }
+
+    static void install(OperationContext context, String name, ConfigSourceProvider configSourceProvider, Registry registry) {
+        context.getServiceTarget()
+                .addService(ServiceNames.CONFIG_SOURCE_PROVIDER.append(name))
+                .setInstance(new ConfigSourceProviderRegistrationService(name, configSourceProvider, registry))
+                .install();
+    }
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+        sources.register(name, configSourceProvider);
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+        sources.unregister(name);
+    }
+}

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/PropertiesConfigSourceRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/PropertiesConfigSourceRegistrationService.java
@@ -1,0 +1,38 @@
+package org.wildfly.extension.microprofile.config.smallrye;
+
+import io.smallrye.config.PropertiesConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+public class PropertiesConfigSourceRegistrationService implements Service {
+
+    private final String name;
+    private final PropertiesConfigSource configSource;
+    private final Registry<ConfigSource> sources;
+
+    PropertiesConfigSourceRegistrationService(String name, PropertiesConfigSource configSource, Registry<ConfigSource> sources) {
+        this.name = name;
+        this.configSource = configSource;
+        this.sources = sources;
+    }
+
+    static void install(OperationContext context, String name, PropertiesConfigSource configSource, Registry registry) {
+        context.getServiceTarget()
+                .addService(ServiceNames.CONFIG_SOURCE.append(name))
+                .setInstance(new PropertiesConfigSourceRegistrationService(name, configSource, registry))
+                .install();
+    }
+
+    @Override
+    public void start(StartContext startContext) {
+        this.sources.register(this.name, configSource);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.sources.unregister(this.name);
+    }
+}

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ServiceNames.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ServiceNames.java
@@ -33,4 +33,6 @@ public interface ServiceNames {
     ServiceName MICROPROFILE_CONFIG = ServiceName.JBOSS.append("eclipse", "microprofile", "config");
 
     ServiceName CONFIG_SOURCE = MICROPROFILE_CONFIG.append("config-source");
+
+    ServiceName CONFIG_SOURCE_PROVIDER = MICROPROFILE_CONFIG.append("config-source-provider");
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/SubsystemConfigSourceTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/SubsystemConfigSourceTask.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.test.integration.microprofile.config.smallrye.app.MicroProfileConfigTestCase;
 
@@ -145,6 +146,7 @@ public class SubsystemConfigSourceTask implements ServerSetupTask {
     public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
         ModelControllerClient mgmtCli = managementClient.getControllerClient();
         removeConfigSource(mgmtCli, registeredConfigSources);
+        ServerReload.reloadIfRequired(managementClient);
     }
 
     /**

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/ConfigSourceFromClassTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/ConfigSourceFromClassTestCase.java
@@ -73,7 +73,6 @@ public class ConfigSourceFromClassTestCase extends AbstractMicroProfileConfigTes
     @ArquillianResource
     private URL url;
 
-
     @Test
     public void testGetWithConfigProperties() throws Exception {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/SetupTask.java
@@ -60,6 +60,7 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -103,6 +104,7 @@ public class SetupTask implements ServerSetupTask {
         testModule.addJavaArchive(moduleFile);
         testModule.create();
         testModules.add(testModule);
+        ServerReload.reloadIfRequired(managementClient);
     }
 
     @Override
@@ -113,6 +115,7 @@ public class SetupTask implements ServerSetupTask {
         }
         final File archiveDir = new File("target/archives");
         cleanFile(archiveDir);
+        ServerReload.reloadIfRequired(managementClient);
     }
 
     private void addConfigSource(ModelControllerClient client) throws IOException {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/SetupTask.java
@@ -36,6 +36,7 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.CustomConfigSource;
 
@@ -67,6 +68,7 @@ public class SetupTask implements ServerSetupTask {
         removeConfigSourceProvider(managementClient.getControllerClient());
 
         testModule.remove();
+        ServerReload.reloadIfRequired(managementClient);
     }
 
     private void addConfigSourceProvider(ModelControllerClient client) throws IOException {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ConfigHttpPathTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ConfigHttpPathTask.java
@@ -35,6 +35,7 @@ import java.util.LinkedList;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -61,6 +62,7 @@ public class ConfigHttpPathTask implements ServerSetupTask {
     public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
         ModelControllerClient mgmtCli = managementClient.getControllerClient();
         removeConfigSource(mgmtCli, registeredConfigSources);
+        ServerReload.reloadIfRequired(managementClient);
     }
 
     /**

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
@@ -28,6 +28,7 @@ import java.net.SocketPermission;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 @RunWith(Arquillian.class)
 public class ResourceWithCustomOperationNameBeanTestCase {
@@ -72,6 +73,9 @@ public class ResourceWithCustomOperationNameBeanTestCase {
         performCall("opentracing/with-custom-operation-name");
 
         List<MockSpan> spans = mockTracer.finishedSpans();
+        IntStream.range(0, spans.size())
+                .forEach(idx -> System.out.println("*** " + idx + ": " + spans.get(idx).toString()));
+
         Assert.assertEquals(3, spans.size());
 
         Assert.assertEquals("my-custom-method-operation-name", spans.get(0).operationName());

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithCustomOperationNameEndpoint.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithCustomOperationNameEndpoint.java
@@ -15,6 +15,6 @@ public class WithCustomOperationNameEndpoint {
     public String get() {
         customOperationNameBean.doSomething();
         customOperationNameBean.doSomethingElse();
-        return "wit-custom-operation-name-called";
+        return "with-custom-operation-name-called";
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13779

Flag the config-source and config-source-provider :remove operations with RESTART-ALL-SERVICES
