### PR TITLE
[WFLY-14427] Fix usages of the credential-reference schema in the Undertow subsystem

### DIFF
--- a/undertow/src/main/resources/schema/wildfly-undertow_10_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_10_0.xsd
@@ -19,12 +19,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:undertow:10.0"
            targetNamespace="urn:jboss:domain:undertow:10.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
-
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
     <!-- The undertow subsystem root element -->
     <xs:element name="subsystem" type="undertow-subsystemType"/>
 

--- a/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
@@ -1052,7 +1052,7 @@
         <xs:complexContent>
             <xs:extension base="singleSignOnType">
                 <xs:sequence>
-                    <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0"/>
+                    <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0"/>
                 </xs:sequence>
                 <xs:attribute name="key-store" type="xs:string" use="required">
                     <xs:annotation>
@@ -1073,47 +1073,5 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <!-- Copied from elytron subsystem schema -->
-    <xs:attributeGroup name="credentialReferenceStoreBased">
-        <xs:annotation>
-            <xs:documentation>
-                Group of attributes used when referencing credential through credential store.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="store" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    Credential store name used to fetch credential with given 'alias' from.
-                    Credential store name has to be defined elsewhere.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="alias" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    Alias of credential in the credential store.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="type" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    Type of credential to be fetched from credential store.
-                    It is usually fully qualified class name.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:complexType name="credentialReferenceType">
-        <xs:attributeGroup ref="credentialReferenceStoreBased"/>
-        <xs:attribute name="clear-text" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    Credential/password in clear text. Use just for testing purpose.
-                    Otherwise use credential store to mask the actual credential from your configuration.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14427
