### PR TITLE
WFLY-14430 Singleton lifecycle transition throws wrong exception type if target service was removed

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/ServiceLifecycle.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/ServiceLifecycle.java
@@ -28,14 +28,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
-import javax.management.ServiceNotFoundException;
-
 import org.jboss.msc.service.LifecycleEvent;
 import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.clustering.service.CountDownLifecycleListener;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceController.State;
+import org.jboss.msc.service.ServiceNotFoundException;
 
 /**
  * Starts/stops a given {@link ServiceController}.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14430

This is one of the causes (if not *the* cause) of intermittent failures in singleton deployment tests.