### PR TITLE
[WFLY-14038] Skip unreliable test

### DIFF
--- a/testsuite/integration/microprofile-tck/metrics/pom.xml
+++ b/testsuite/integration/microprofile-tck/metrics/pom.xml
@@ -186,6 +186,30 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- On Windows hosts, we want to skip some intermittent tests. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TimerTest.java</exclude>
+                                <exclude>**/MeterTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14038

Modify POM to skip intermittently failing TCK test on Windows hosts