### PR TITLE
[MP4] WFLY-14281 Upgrade smallrye-reactive-utils to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,9 @@
         <version.io.smallrye.smallrye-health>3.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.0.0</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.1</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-reactive-utils>2.1.1</version.io.smallrye.smallrye-reactive-utils>
         <version.io.smallrye.open-api>2.1.1</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0-RC1</version.io.smallrye.opentracing>
-        <version.io.smallrye.smallrye-reactive-converters>2.0.0.RC3</version.io.smallrye.smallrye-reactive-converters>
         <version.io.undertow.jastow>2.0.9.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
@@ -2106,7 +2106,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-converter-api</artifactId>
-                <version>${version.io.smallrye.smallrye-reactive-converters}</version>
+                <version>${version.io.smallrye.smallrye-reactive-utils}</version>
             </dependency>
 
 


### PR DESCRIPTION
Upgrading to final version of reactive-utils.

SR FT .next is going to be using 2.1.1 upstream as well.