### PR TITLE
WFLY-14446 Distributed session manager fails to invalidate/expire sessions when Undertow statistics are enabled

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
@@ -30,7 +30,6 @@ import org.wildfly.clustering.ee.cache.CacheProperties;
 import org.wildfly.clustering.ee.cache.Key;
 import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.web.IdentifierFactory;
-import org.wildfly.clustering.web.session.ImmutableSession;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
 import org.wildfly.clustering.web.session.SpecificationProvider;
@@ -50,7 +49,7 @@ public interface InfinispanSessionManagerConfiguration<S, C, AL> {
     IdentifierFactory<String> getIdentifierFactory();
     Batcher<TransactionBatch> getBatcher();
     Scheduler<String, ImmutableSessionMetaData> getExpirationScheduler();
-    Recordable<ImmutableSession> getInactiveSessionRecorder();
+    Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder();
     Registrar<SessionExpirationListener> getExpirationRegistar();
     SpecificationProvider<S, C, AL> getSpecificationProvider();
     Runnable getStartTask();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -58,7 +58,6 @@ import org.wildfly.clustering.web.cache.session.SessionMetaDataFactory;
 import org.wildfly.clustering.web.infinispan.AffinityIdentifierFactory;
 import org.wildfly.clustering.web.infinispan.session.coarse.CoarseSessionAttributesFactory;
 import org.wildfly.clustering.web.infinispan.session.fine.FineSessionAttributesFactory;
-import org.wildfly.clustering.web.session.ImmutableSession;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
 import org.wildfly.clustering.web.session.SessionManager;
@@ -153,7 +152,7 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
             }
 
             @Override
-            public Recordable<ImmutableSession> getInactiveSessionRecorder() {
+            public Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder() {
                 return configuration.getInactiveSessionRecorder();
             }
 

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManagerConfiguration.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManagerConfiguration.java
@@ -28,5 +28,5 @@ public interface SessionManagerConfiguration<SC> {
     SC getServletContext();
     IdentifierFactory<String> getIdentifierFactory();
     SessionExpirationListener getExpirationListener();
-    Recordable<ImmutableSession> getInactiveSessionRecorder();
+    Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder();
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
@@ -31,7 +31,7 @@ import org.wildfly.clustering.ee.Batcher;
 import org.wildfly.clustering.ee.Recordable;
 import org.wildfly.clustering.web.IdentifierFactory;
 import org.wildfly.clustering.web.container.SessionManagerFactoryConfiguration;
-import org.wildfly.clustering.web.session.ImmutableSession;
+import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
 import org.wildfly.clustering.web.session.SessionManager;
 import org.wildfly.clustering.web.session.SessionManagerConfiguration;
@@ -83,7 +83,7 @@ public class DistributableSessionManagerFactory implements io.undertow.servlet.a
             }
 
             @Override
-            public Recordable<ImmutableSession> getInactiveSessionRecorder() {
+            public Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder() {
                 return inactiveSessionStatistics;
             }
         };

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/RecordableInactiveSessionStatistics.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/RecordableInactiveSessionStatistics.java
@@ -30,14 +30,14 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.wildfly.clustering.ee.Recordable;
-import org.wildfly.clustering.web.session.ImmutableSession;
+import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.InactiveSessionStatistics;
 
 /**
  * Records statistics for inactive sessions.
  * @author Paul Ferraro
  */
-public class RecordableInactiveSessionStatistics implements InactiveSessionStatistics, Recordable<ImmutableSession> {
+public class RecordableInactiveSessionStatistics implements InactiveSessionStatistics, Recordable<ImmutableSessionMetaData> {
 
     private final AtomicLong expiredSessions = new AtomicLong();
     private final AtomicReference<Duration> maxLifetime = new AtomicReference<>();
@@ -49,8 +49,8 @@ public class RecordableInactiveSessionStatistics implements InactiveSessionStati
     }
 
     @Override
-    public void record(ImmutableSession session) {
-        Duration lifetime = Duration.between(session.getMetaData().getCreationTime(), Instant.now());
+    public void record(ImmutableSessionMetaData metaData) {
+        Duration lifetime = Duration.between(metaData.getCreationTime(), Instant.now());
         Duration currentMaxLifetime = this.maxLifetime.get();
 
         while (lifetime.compareTo(currentMaxLifetime) > 0) {
@@ -67,7 +67,7 @@ public class RecordableInactiveSessionStatistics implements InactiveSessionStati
             sessions = createNewTotals(currentTotals, lifetime);
         }
 
-        if (session.getMetaData().isExpired()) {
+        if (metaData.isExpired()) {
             this.expiredSessions.incrementAndGet();
         }
     }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/RecordableInactiveSessionStatisticsTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/RecordableInactiveSessionStatisticsTestCase.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.time.Instant;
 
 import org.junit.Test;
-import org.wildfly.clustering.web.session.ImmutableSession;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 
 /**
@@ -43,16 +42,14 @@ public class RecordableInactiveSessionStatisticsTestCase {
 
     @Test
     public void test() {
-        ImmutableSession session = mock(ImmutableSession.class);
         ImmutableSessionMetaData metaData = mock(ImmutableSessionMetaData.class);
         Instant now = Instant.now();
         Instant created = now.minus(Duration.ofMinutes(20L));
 
-        when(session.getMetaData()).thenReturn(metaData);
         when(metaData.isExpired()).thenReturn(false);
         when(metaData.getCreationTime()).thenReturn(created);
 
-        this.statistics.record(session);
+        this.statistics.record(metaData);
 
         assertEquals(0L, this.statistics.getExpiredSessionCount());
         assertEquals(20L, this.statistics.getMaxSessionLifetime().toMinutes());
@@ -64,7 +61,7 @@ public class RecordableInactiveSessionStatisticsTestCase {
         when(metaData.isExpired()).thenReturn(true);
         when(metaData.getCreationTime()).thenReturn(created);
 
-        this.statistics.record(session);
+        this.statistics.record(metaData);
 
         assertEquals(1L, this.statistics.getExpiredSessionCount());
         assertEquals(20L, this.statistics.getMaxSessionLifetime().toMinutes());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/EnableUndertowStatisticsSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/EnableUndertowStatisticsSetupTask.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.web;
+
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.shared.CLIServerSetupTask;
+
+/**
+ * Task that enable Undertow statistics.
+ * @author Paul Ferraro
+ */
+public class EnableUndertowStatisticsSetupTask extends CLIServerSetupTask {
+
+    public EnableUndertowStatisticsSetupTask() {
+        this.builder.node(AbstractClusteringTestCase.FOUR_NODES)
+                .setup("/subsystem=undertow:write-attribute(name=statistics-enabled, value=true)")
+                .teardown("/subsystem=undertow:undefine-attribute(name=statistics-enabled)")
+                ;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -36,8 +36,10 @@ import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.web.DistributableTestCase;
+import org.jboss.as.test.clustering.cluster.web.EnableUndertowStatisticsSetupTask;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -50,6 +52,7 @@ import org.junit.runner.RunWith;
  *
  * @author Paul Ferraro
  */
+@ServerSetup(EnableUndertowStatisticsSetupTask.class)
 @RunWith(Arquillian.class)
 public abstract class SessionExpirationTestCase extends AbstractClusteringTestCase {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
@@ -43,14 +43,17 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.web.DistributableTestCase;
+import org.jboss.as.test.clustering.cluster.web.EnableUndertowStatisticsSetupTask;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 
+@ServerSetup(EnableUndertowStatisticsSetupTask.class)
 public abstract class SessionPassivationTestCase extends AbstractClusteringTestCase {
 
     private static final int MAX_PASSIVATION_WAIT = TimeoutUtil.adjust(10000);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14446