### PR TITLE
WFLY-14457 CDI module now depends on and exports javax.annotation.api.

### DIFF
--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
@@ -32,6 +32,8 @@
         <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.inject.api" export="true"/>
         <module name="javax.interceptor.api" export="true"/>
+        <!-- This is so that all modules depending on CDI automatically get access to annotations such as @PreDestroy -->
+        <module name="javax.annotation.api" export="true" />
 
         <!-- CDIProvider -->
         <module name="org.jboss.as.weld" services="import" optional="true"/>

--- a/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/servlet-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -27,6 +27,8 @@
         <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.inject.api" export="true"/>
         <module name="javax.interceptor.api" export="true"/>
+        <!-- This is so that all modules depending on CDI automatically get access to annotations such as @PreDestroy -->
+        <module name="javax.annotation.api" export="true" />
 
         <!-- CDIProvider -->
         <module name="org.jboss.as.weld" services="import" optional="true"/>


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-14457

The PR makes sure that any WFLY module depending on CDI will automatically have access to common annotations such as `@PreDestroy` (which CDI allows you to use).