### PR TITLE
[WFLY-14461] Upgrade WildFly Core 15.0.0.Beta1

### DIFF
--- a/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:15.0">
+<server xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:15.0">
+<server xmlns="urn:jboss:domain:16.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:15.0">
+<domain xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="master">
+<host xmlns="urn:jboss:domain:16.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0">
+<host xmlns="urn:jboss:domain:16.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="master">
+<host xmlns="urn:jboss:domain:16.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:15.0">
+<server xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>14.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>15.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.5.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:15.0">
+<domain xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="master">
+<host xmlns="urn:jboss:domain:16.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0">
+<host xmlns="urn:jboss:domain:16.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="master">
+<host xmlns="urn:jboss:domain:16.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:15.0">
+<server xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0"
+<domain xmlns="urn:jboss:domain:16.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0">
+<domain xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0"
+<domain xmlns="urn:jboss:domain:16.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0">
+<domain xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0">
+<domain xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="master">
+<host xmlns="urn:jboss:domain:16.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:15.0" name="slave">
+<host xmlns="urn:jboss:domain:16.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:15.0"
+<host xmlns="urn:jboss:domain:16.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/LoginServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/LoginServlet.java
@@ -52,7 +52,7 @@ public class LoginServlet extends HttpServlet {
         if (remoteUser == null)
             throw new ServletException("getRemoteUser returned null");
         String authType = req.getAuthType();
-        if (authType == null || !authType.equals("Programatic"))
+        if (authType == null || !(authType.equals("Programmatic") || "Programatic".equals(authType)))
             throw new ServletException(String.format("getAuthType returned wrong type '%s'", authType));
         if (!req.isUserInRole("gooduser")) {
             resp.sendError(403);

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:15.0">
+<server xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:15.0"
+<domain xmlns="urn:jboss:domain:16.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:15.0">
+<host name="master" xmlns="urn:jboss:domain:16.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:15.0">
+<host name="master" xmlns="urn:jboss:domain:16.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
This replaces #14024. It includes an extra test fix.

JIRA: https://issues.redhat.com/browse/WFLY-14465
JIRA: https://issues.redhat.com/browse/WFLY-14461

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/15.0.0.Beta1
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/14.0.0.Final...15.0.0.Beta1

---



## Release Notes - WildFly Core - Version 15.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5237'>WFCORE-5237</a>] -         Upgrade bouncycastle to 1.68
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5244'>WFCORE-5244</a>] -         Upgrade tests to bootable JAR 3.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5251'>WFCORE-5251</a>] -         Upgrade Undertow to 2.2.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5259'>WFCORE-5259</a>] -         Upgrade jboss-logmanager to 2.1.18.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5266'>WFCORE-5266</a>] -         Upgrade WildFly OpenSSL to 2.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5282'>WFCORE-5282</a>] -         Upgrade WildFly Elytron to 1.14.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5290'>WFCORE-5290</a>] -         Upgrade WildFly Elytron to 1.15.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5291'>WFCORE-5291</a>] -         Upgrade Elytron Web to 1.9.0.CR1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2687'>WFCORE-2687</a>] -         Expose the current step operation&#39;s name and parameters via the OperationContext
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5252'>WFCORE-5252</a>] -         Log WARN if wildfly.config.url is set on the server.
</li>
</ul>
                                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4291'>WFCORE-4291</a>] -         Restore legacy (not &quot;graceful&quot;) startup mode
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4360'>WFCORE-4360</a>] -         Support encrypted expression resolution using a CredentialStore
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5261'>WFCORE-5261</a>] -         Ability to specify a configuration file for env variables where the location can also be configurable.
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3825'>WFCORE-3825</a>] -         Unify &quot;-server&quot; option in windows scripts (ps1, bat) for domain mode (and its servers) on all JDKs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4516'>WFCORE-4516</a>] -         Documentation says server-identities expressions should resolve to Base64 values, but only resolving to plain text works.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5216'>WFCORE-5216</a>] -         EAP Pod fails to start when env JBOSS_MODULEPATH=${JBOSS_HOME}/modules:${HOME} is set
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5248'>WFCORE-5248</a>] -         TCCL should be set to logging custom-handler module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5256'>WFCORE-5256</a>] -         Server does not resolve console-enabled attribute expression in http management interface
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5265'>WFCORE-5265</a>] -         The Elytron subsystem is missing rejecting transformer tests for EAP 7.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5268'>WFCORE-5268</a>] -         Web services support was added to version 9 of the model but is being accepted against older schemas.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5269'>WFCORE-5269</a>] -         case-principal-tranformer ended up in version 12 of the model but is parsed against version 7 of the schema
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5225'>WFCORE-5225</a>] -         Bump the elytron subsystem management model and schema to the next version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5246'>WFCORE-5246</a>] -         Bump the kernel management API version to 16.0.0 and the xsd to 16.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5292'>WFCORE-5292</a>] -         Remove Java EE References from the i18n strings
</li>
</ul>
                                                
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4584'>WFCORE-4584</a>] -         Include the new wildfly-elytron-encryption module
</li>
</ul>
        