### PR TITLE
WFLY-14440 Add tests to ejb3 subsystem for attributes that allow expr…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -443,9 +443,9 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         if (entityModelNode.hasDefined(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING)) {
             // <optimistic-locking>
             writer.writeStartElement(EJB3SubsystemXMLElement.OPTIMISTIC_LOCKING.getLocalName());
-            final Boolean locking = entityModelNode.get(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING).asBoolean();
+            final String locking = entityModelNode.get(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING).asString();
             // write the value
-            writer.writeAttribute(EJB3SubsystemXMLAttribute.ENABLED.getLocalName(), locking.toString());
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.ENABLED.getLocalName(), locking);
             // <optimistic-locking>
             writer.writeEndElement();
         }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -23,6 +23,10 @@
 package org.jboss.as.ejb3.subsystem;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -33,7 +37,6 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
 
@@ -104,7 +107,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         // Parse the subsystem xml and install into the first controller
         final String subsystemXml = getSubsystemXml();
         final KernelServices ks = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(subsystemXml).build();
-        Assert.assertTrue("Subsystem boot failed!", ks.isSuccessfulBoot());
+        assertTrue("Subsystem boot failed!", ks.isSuccessfulBoot());
 
         PathAddress pa = PathAddress.pathAddress("subsystem", "ejb3").append("strict-max-bean-instance-pool", "slsb-strict-max-pool");
 
@@ -118,7 +121,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
         // none works in combo with max-pool-size
         ModelNode response = ks.executeOperation(composite);
-        Assert.assertEquals(response.toString(), "success", response.get("outcome").asString());
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
 
         validatePoolConfig(ks, pa);
 
@@ -141,7 +144,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
     public void testDefaultPools() throws Exception {
         final String subsystemXml = readResource("subsystem-pools.xml");
         final KernelServices ks = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(subsystemXml).build();
-        Assert.assertTrue("Subsystem boot failed!", ks.isSuccessfulBoot());
+        assertTrue("Subsystem boot failed!", ks.isSuccessfulBoot());
 
         // add a test pool
         String testPoolName = "test-pool";
@@ -149,7 +152,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         PathAddress testPoolAddress = ejb3Address.append("strict-max-bean-instance-pool", testPoolName);
         final ModelNode addPool = Util.createAddOperation(testPoolAddress);
         ModelNode response = ks.executeOperation(addPool);
-        Assert.assertEquals(response.toString(), "success", response.get("outcome").asString());
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
 
         // set default-mdb-instance-pool
         writeAndReadPool(ks, ejb3Address, "default-mdb-instance-pool", testPoolName);
@@ -166,7 +169,137 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
         final ModelNode removePool = Util.createRemoveOperation(testPoolAddress);
         response = ks.executeOperation(removePool);
-        Assert.assertEquals(response.toString(), "success", response.get("outcome").asString());
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
+    }
+
+    /**
+     * Verifies that attributes with expression are handled properly.
+     * @throws Exception for any test failures
+     */
+    @Test
+    public void testExpressionInAttributeValue() throws Exception {
+        final String subsystemXml = readResource("with-expression-subsystem.xml");
+        final KernelServices ks = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXml(subsystemXml).build();
+        final ModelNode ejb3 = ks.readWholeModel().get("subsystem", getMainSubsystemName());
+
+        final String statisticsEnabled = ejb3.get("statistics-enabled").resolve().asString();
+        assertEquals("true", statisticsEnabled);
+
+        final String logSystemException = ejb3.get("log-system-exceptions").resolve().asString();
+        assertEquals("false", logSystemException);
+
+        final String passByValue = ejb3.get("in-vm-remote-interface-invocation-pass-by-value").resolve().asString();
+        assertEquals("false", passByValue);
+
+        final String gracefulTxn = ejb3.get("enable-graceful-txn-shutdown").resolve().asString();
+        assertEquals("false", gracefulTxn);
+
+        final String disableDefaultEjbPermission = ejb3.get("disable-default-ejb-permissions").resolve().asString();
+        assertEquals("false", disableDefaultEjbPermission);
+
+        final int defaultStatefulSessionTimeout = ejb3.get("default-stateful-bean-session-timeout").resolve().asInt();
+        assertEquals(600000, defaultStatefulSessionTimeout);
+
+        final int defaultStatefulAccessTimeout = ejb3.get("default-stateful-bean-access-timeout").resolve().asInt();
+        assertEquals(5000, defaultStatefulAccessTimeout);
+
+        final String defaultSlsbInstancePool = ejb3.get("default-slsb-instance-pool").resolve().asString();
+        assertEquals("slsb-strict-max-pool", defaultSlsbInstancePool);
+
+        final int defaultSingletonAccessTimeout = ejb3.get("default-singleton-bean-access-timeout").resolve().asInt();
+        assertEquals(5000, defaultSingletonAccessTimeout);
+
+        final String defaultSfsbPassivationDisabledCache = ejb3.get("default-sfsb-passivation-disabled-cache").resolve().asString();
+        assertEquals("simple", defaultSfsbPassivationDisabledCache);
+
+        final String defaultSfsbCache = ejb3.get("default-sfsb-cache").resolve().asString();
+        assertEquals("distributable", defaultSfsbCache);
+
+        final String defaultSecurityDomain = ejb3.get("default-security-domain").resolve().asString();
+        assertEquals("domain", defaultSecurityDomain);
+
+        final String defaultResourceAdapterName = ejb3.get("default-resource-adapter-name").resolve().asString();
+        assertEquals("activemq-ra.rar", defaultResourceAdapterName);
+
+        final String defaultMissingMethodPermissionDenyAccess = ejb3.get("default-missing-method-permissions-deny-access").resolve().asString();
+        assertEquals("false", defaultMissingMethodPermissionDenyAccess);
+
+        final String defaultMdbInstancePool = ejb3.get("default-mdb-instance-pool").resolve().asString();
+        assertEquals("mdb-strict-max-pool", defaultMdbInstancePool);
+
+        final String defaultEntityBeanOptimisticLocking = ejb3.get("default-entity-bean-optimistic-locking").resolve().asString();
+        assertEquals("true", defaultEntityBeanOptimisticLocking);
+
+        final String defaultEntityBeanInstancePool = ejb3.get("default-entity-bean-instance-pool").resolve().asString();
+        assertEquals("entity-strict-max-pool", defaultEntityBeanInstancePool);
+
+        final String defaultDistinctName = ejb3.get("default-distinct-name").resolve().asString();
+        assertEquals("myname", defaultDistinctName);
+
+        final String allowEjbNameRegex = ejb3.get("allow-ejb-name-regex").resolve().asString();
+        assertEquals("false", allowEjbNameRegex);
+
+        final String cachePassivationStore = ejb3.get("cache").asPropertyList().get(1).getValue().get("passivation-store").resolve().asString();
+        assertEquals("infinispan", cachePassivationStore);
+
+        final String mdbDeliveryGroupActive = ejb3.get("mdb-delivery-group").asPropertyList().get(1).getValue().get("active").resolve().asString();
+        assertEquals("false", mdbDeliveryGroupActive);
+
+        final ModelNode passivationStore = ejb3.get("passivation-store").asPropertyList().get(0).getValue();
+        assertEquals("default", passivationStore.get("bean-cache").resolve().asString());
+        assertEquals("ejb", passivationStore.get("cache-container").resolve().asString());
+        assertEquals(10, passivationStore.get("max-size").resolve().asInt());
+
+        final ModelNode remotingProfile = ejb3.get("remoting-profile").asPropertyList().get(0).getValue();
+        assertEquals("true", remotingProfile.get("exclude-local-receiver").resolve().asString());
+        assertEquals("true", remotingProfile.get("local-receiver-pass-by-value").resolve().asString());
+
+        final ModelNode remoteHttpConnection = remotingProfile.get("remote-http-connection").asPropertyList().get(0).getValue();
+        assertEquals("http://localhost:8180/wildfly-services", remoteHttpConnection.get("uri").resolve().asString());
+
+        final ModelNode remotingEjbReceiver = remotingProfile.get("remoting-ejb-receiver").asPropertyList().get(0).getValue();
+        assertEquals(5000, remotingEjbReceiver.get("connect-timeout").resolve().asInt());
+        assertEquals("connection-ref", remotingEjbReceiver.get("outbound-connection-ref").resolve().asString());
+
+        final ModelNode channelCreationOption = remotingEjbReceiver.get("channel-creation-options").asPropertyList().get(0).getValue();
+        assertEquals(20, channelCreationOption.get("value").resolve().asInt());
+
+        final String asyncThreadPoolName = ejb3.get("service", "async", "thread-pool-name").resolve().asString();
+        assertEquals("default", asyncThreadPoolName);
+
+        final String iiopEnableByDefault = ejb3.get("service", "iiop", "enable-by-default").resolve().asString();
+        assertEquals("true", iiopEnableByDefault);
+        final String useQualifiedName = ejb3.get("service", "iiop", "use-qualified-name").resolve().asString();
+        assertEquals("true", useQualifiedName);
+
+        final ModelNode remote = ejb3.get("service", "remote");
+        assertEquals("ejb", remote.get("cluster").resolve().asString());
+        assertEquals("false", remote.get("execute-in-worker").resolve().asString());
+        assertEquals("default", remote.get("thread-pool-name").resolve().asString());
+        assertEquals(20, remote.get("channel-creation-options").asPropertyList().get(0).getValue().get("value").resolve().asInt());
+
+        final ModelNode timerService = ejb3.get("service", "timer-service");
+        final String fileDataStorePath = timerService.get("file-data-store").asPropertyList().get(0).getValue().get("path").resolve().asString();
+        assertEquals("timer-service-data", fileDataStorePath);
+
+        final ModelNode databaseStore = timerService.get("database-data-store").asPropertyList().get(0).getValue();
+        assertEquals("java:global/DataSource", databaseStore.get("datasource-jndi-name").resolve().asString());
+        assertEquals("hsql", databaseStore.get("database").resolve().asString());
+        assertEquals("mypartition", databaseStore.get("partition").resolve().asString());
+        assertEquals("true", databaseStore.get("allow-execution").resolve().asString());
+        assertEquals("100", databaseStore.get("refresh-interval").resolve().asString());
+
+        final ModelNode strictMaxBeanInstancePool = ejb3.get("strict-max-bean-instance-pool").asPropertyList().get(0).getValue();
+        assertEquals("from-cpu-count", strictMaxBeanInstancePool.get("derive-size").resolve().asString());
+        assertEquals(5, strictMaxBeanInstancePool.get("timeout").resolve().asInt());
+        assertEquals("MINUTES", strictMaxBeanInstancePool.get("timeout-unit").resolve().asString());
+
+        final ModelNode strictMaxBeanInstancePool2 = ejb3.get("strict-max-bean-instance-pool").asPropertyList().get(1).getValue();
+        assertEquals(20, strictMaxBeanInstancePool2.get("max-pool-size").resolve().asInt());
+
+        final ModelNode threadPool = ejb3.get("thread-pool").asPropertyList().get(0).getValue();
+        assertEquals(10, threadPool.get("max-threads").resolve().asInt());
+        assertEquals(10, threadPool.get("core-threads").resolve().asInt());
     }
 
     private void writeAndReadPool(KernelServices ks, PathAddress ejb3Address, String attributeName, String testPoolName) {
@@ -174,23 +307,23 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
                 Util.getUndefineAttributeOperation(ejb3Address, attributeName) :
                 Util.getWriteAttributeOperation(ejb3Address, attributeName, testPoolName);
         ModelNode response = ks.executeOperation(writeAttributeOperation);
-        Assert.assertEquals(response.toString(), "success", response.get("outcome").asString());
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
 
         final String expectedPoolName = testPoolName == null ? "undefined" : testPoolName;
         final ModelNode readAttributeOperation = Util.getReadAttributeOperation(ejb3Address, attributeName);
         response = ks.executeOperation(readAttributeOperation);
         final String poolName = response.get("result").asString();
-        Assert.assertEquals("Unexpected pool name", expectedPoolName, poolName);
+        assertEquals("Unexpected pool name", expectedPoolName, poolName);
     }
 
     private void validatePoolConfig(KernelServices ks, PathAddress pa) {
         ModelNode ra = Util.createEmptyOperation("read-attribute", pa);
         ra.get("name").set("max-pool-size");
         ModelNode response = ks.executeOperation(ra);
-        Assert.assertEquals(response.toString(), 5, response.get("result").asInt());
+        assertEquals(response.toString(), 5, response.get("result").asInt());
         ra.get("name").set("derive-size");
         response = ks.executeOperation(ra);
-        Assert.assertFalse(response.toString(), response.hasDefined("result"));
+        assertFalse(response.toString(), response.hasDefined("result"));
     }
 
 }

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
@@ -1,0 +1,111 @@
+<subsystem xmlns="urn:jboss:domain:ejb3:8.0">
+    <session-bean>
+        <stateless>
+            <bean-instance-pool-ref pool-name="${sysprop:slsb-strict-max-pool}"/>
+        </stateless>
+        <stateful default-session-timeout="${sysprop:600000}"
+                  default-access-timeout="${prop.default-access-timeout:5000}"
+                  cache-ref="${sysprop:distributable}"
+                  passivation-disabled-cache-ref="${sysprop:simple}"/>
+        <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
+    </session-bean>
+    <mdb>
+        <resource-adapter-ref resource-adapter-name="${ejb.resource-adapter-name:activemq-ra.rar}"/>
+        <bean-instance-pool-ref pool-name="${sysprop:mdb-strict-max-pool}" />
+        <delivery-groups>
+            <delivery-group name="1" active="true"/>
+            <delivery-group name="2" active="${sysprop:false}"/>
+            <delivery-group name="3"/>
+        </delivery-groups>
+    </mdb>
+    <entity-bean>
+        <bean-instance-pool-ref pool-name="${sysprop:entity-strict-max-pool}"/>
+        <optimistic-locking enabled="${sysprop:true}"/>
+    </entity-bean>
+
+    <!-- EJB3 pools -->
+    <pools>
+        <bean-instance-pools>
+            <!-- derive-size and max-pool-size are mutually exclusive, so use one of them in each strict-max-pool element -->
+            <strict-max-pool name="slsb-strict-max-pool"
+                             derive-size="${sysprop:from-cpu-count}"
+                             instance-acquisition-timeout="${prop.instance-acquisition-timeout:5}"
+                             instance-acquisition-timeout-unit="${prop.instance-acquisition-timeout-unit:MINUTES}"/>
+            <strict-max-pool name="mdb-strict-max-pool"
+                             max-pool-size="${prop.strict-max-pool:20}"
+                             instance-acquisition-timeout="${prop.instance-acquisition-timeout:5}"
+                             instance-acquisition-timeout-unit="${prop.instance-acquisition-timeout-unit:MINUTES}"/>
+        </bean-instance-pools>
+    </pools>
+    <caches>
+        <cache name="simple"/>
+        <cache name="distributable" passivation-store-ref="${sysprop:infinispan}"/>
+    </caches>
+    <passivation-stores>
+        <passivation-store name="infinispan" cache-container="${sysprop:ejb}" bean-cache="${sysprop:default}" max-size="${sysprop:10}"/>
+    </passivation-stores>
+    <async thread-pool-name="${sysprop:default}"/>
+    <timer-service thread-pool-name="default" default-data-store="file-data-store">
+        <data-stores>
+            <file-data-store name="file-data-store" path="${prop.timer-service.path:timer-service-data}" relative-to="jboss.server.data.dir"/>
+            <database-data-store name="database-data-store"
+                                 datasource-jndi-name="${prop.timer-service-database:java:global/DataSource}"
+                                 database="${sysprop:hsql}"
+                                 partition="${sysprop:mypartition}"
+                                 allow-execution="${sysprop:true}"
+                                 refresh-interval="${sysprop:100}"/>
+        </data-stores>
+    </timer-service>
+    <remote connectors="http-remoting-connector" thread-pool-name="${sysprop:default}" cluster="${sysprop:ejb}" execute-in-worker="${sysprop:false}">
+        <channel-creation-options>
+            <option name="READ_TIMEOUT" value="${prop.remoting-connector.read.timeout:20}" type="xnio"/>
+            <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
+        </channel-creation-options>
+        <profiles>
+            <profile name="profile" exclude-local-receiver="${sysprop:true}" local-receiver-pass-by-value="${sysprop:true}">
+                <!-- TODO Elytron - emulate old configuration using discovery-->
+                <remoting-ejb-receiver name="receiver" outbound-connection-ref="${sysprop:connection-ref}" connect-timeout="${sysprop:5000}">
+                    <channel-creation-options>
+                        <option name="READ_TIMEOUT" value="${sysprop:20}" type="xnio"/>
+                        <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
+                    </channel-creation-options>
+                </remoting-ejb-receiver>
+                <remote-http-connection name="connection" uri="${sysprop:http://localhost:8180/wildfly-services}"/>
+                <static-ejb-discovery>
+                    <module uri="remote+http://localhost" module-name="somemodule" />
+                    <module uri="remote+http://somehost" app-name="myapp" module-name="mymodule" distinct-name="distict"/>
+                </static-ejb-discovery>
+            </profile>
+        </profiles>
+    </remote>
+
+    <!-- Session bean configurations -->
+    <thread-pools>
+        <thread-pool name="default">
+            <max-threads count="${prop.max-thread-count:10}"/>
+            <core-threads count="${prop.core-thread-count:10}"/>
+            <keepalive-time time="${prop.keepalive-time:60}" unit="${prop.idle-timeout-unit:seconds}"/>
+        </thread-pool>
+    </thread-pools>
+
+    <iiop use-qualified-name="${sysprop:true}" enable-by-default="${sysprop:true}"/>
+    <!-- Disable pass-by-value for in-vm remote interface invocations on EJBs -->
+    <in-vm-remote-interface-invocation pass-by-value="${sysprop:false}"/>
+    <default-distinct-name value="${sysprop:myname}"/>
+    <default-security-domain value="${sysprop:domain}"/>
+    <application-security-domains>
+        <application-security-domain name="test" security-domain="test"/>
+    </application-security-domains>
+    <default-missing-method-permissions-deny-access value="${sysprop:false}" />
+    <disable-default-ejb-permissions value="${sysprop:false}"/>
+    <enable-graceful-txn-shutdown value="${sysprop:false}"/>
+    <statistics enabled="${ejb.enable-statistics:true}" />
+    <log-system-exceptions value="${ejb.log-system-exceptions:false}" />
+    <allow-ejb-name-regex value="${sysprop:false}"/>
+    <server-interceptors>
+        <interceptor module="foo" class="org.foo.ServerInterceptor"/>
+    </server-interceptors>
+    <client-interceptors>
+        <interceptor module="foo" class="org.foo.ServerInterceptor"/>
+    </client-interceptors>
+</subsystem>


### PR DESCRIPTION
…ession

WFLY-14464 EJB3SubsystemXMLPersister should not resolve entity-bean attribute

JIRA: 
https://issues.redhat.com/browse/WFLY-14440 (Add tests to ejb3 subsystem for attributes that allow expression)
https://issues.redhat.com/browse/WFLY-14464 (EJB3SubsystemXMLPersister should not resolve entity-bean attribute )