### PR TITLE
Replace 'Java EE Connector Architecture|JCA' references in java doc w…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -104,14 +104,14 @@ public interface ConnectorLogger extends BasicLogger {
     void boundDataSource(String jndiName);
 
     /**
-     * Logs an informational message indicating the JCA bound the object represented by the {@code description}
+     * Logs an informational message indicating the Jakarta Connectors bound the object represented by the {@code description}
      * parameter.
      *
      * @param description the description of what was bound.
      * @param jndiName    the JNDI name.
      */
     @LogMessage(level = INFO)
-    @Message(id = 2, value = "Bound JCA %s [%s]")
+    @Message(id = 2, value = "Bound Jakarta Connectors %s [%s]")
     void boundJca(String description, String jndiName);
 
     /**
@@ -195,14 +195,14 @@ public interface ConnectorLogger extends BasicLogger {
     void unboundDataSource(String jndiName);
 
     /**
-     * Logs an informational message indicating the JCA inbound the object represented by the {@code description}
+     * Logs an informational message indicating the Jakarta Connectors inbound the object represented by the {@code description}
      * parameter.
      *
      * @param description the description of what was unbound.
      * @param jndiName    the JNDI name.
      */
     @LogMessage(level = INFO)
-    @Message(id = 11, value = "Unbound JCA %s [%s]")
+    @Message(id = 11, value = "Unbound Jakarta Connectors %s [%s]")
     void unboundJca(String description, String jndiName);
 
     @LogMessage(level = WARN)

--- a/connector/src/main/java/org/jboss/as/connector/security/ElytronCallbackHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/security/ElytronCallbackHandler.java
@@ -46,7 +46,7 @@ import org.wildfly.security.evidence.PasswordGuessEvidence;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
- * An Elytron based {@link CallbackHandler} implementation designed for the JCA security inflow. It uses the information
+ * An Elytron based {@link CallbackHandler} implementation designed for the Jakarta Connectors security inflow. It uses the information
  * obtained from the {@link javax.security.auth.callback.Callback}s to authenticate and authorize the identity supplied
  * by the resource adapter and inserts the {@link SecurityIdentity} representing the authorized identity in the subject's
  * private credentials set.

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
@@ -456,7 +456,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
                                         break;
                                     }
                                     case REMOVED: {
-                                        DEPLOYMENT_CONNECTOR_LOGGER.debugf("Removed JCA ConnectionFactory [%s]", jndi);
+                                        DEPLOYMENT_CONNECTOR_LOGGER.debugf("Removed Jakarta Connectors ConnectionFactory [%s]", jndi);
                                     }
                                 }
                             }
@@ -561,7 +561,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
                                 break;
                             }
                             case REMOVED: {
-                                DEPLOYMENT_CONNECTOR_LOGGER.debugf("Removed JCA AdminObject [%s]", jndi);
+                                DEPLOYMENT_CONNECTOR_LOGGER.debugf("Removed Jakarta Connectors AdminObject [%s]", jndi);
                             }
                         }
                     }

--- a/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
@@ -70,7 +70,7 @@ public final class TransactionIntegrationService implements Service<TransactionI
     public void start(StartContext context) throws StartException {
         this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(), tsr.getValue(), utr.getValue(), terminator.getValue(),
                 rr.getValue());
-        ROOT_LOGGER.debugf("Starting JCA TransactionIntegrationService");
+        ROOT_LOGGER.debugf("Starting Jakarta Connectors TransactionIntegrationService");
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/DistributedWorkManagerService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/DistributedWorkManagerService.java
@@ -79,7 +79,7 @@ public final class DistributedWorkManagerService implements Service<NamedDistrib
 
     @Override
     public void start(StartContext context) throws StartException {
-        ROOT_LOGGER.debugf("Starting JCA DistributedWorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Starting Jakarta Connectors DistributedWorkManager: ", value.getName());
 
         CommandDispatcherTransport transport = new CommandDispatcherTransport(this.dispatcherFactory.getValue(), this.value.getName());
 
@@ -115,12 +115,12 @@ public final class DistributedWorkManagerService implements Service<NamedDistrib
         WorkManagerCoordinator.getInstance().registerWorkManager(value);
 
 
-        ROOT_LOGGER.debugf("Started JCA DistributedWorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Started Jakarta Connectors DistributedWorkManager: ", value.getName());
     }
 
     @Override
     public void stop(StopContext context) {
-        ROOT_LOGGER.debugf("Stopping JCA DistributedWorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Stopping Jakarta Connectors DistributedWorkManager: ", value.getName());
 
         value.prepareShutdown();
 
@@ -135,7 +135,7 @@ public final class DistributedWorkManagerService implements Service<NamedDistrib
 
         WorkManagerCoordinator.getInstance().unregisterWorkManager(value);
 
-        ROOT_LOGGER.debugf("Stopped JCA DistributedWorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Stopped Jakarta Connectors DistributedWorkManager: ", value.getName());
     }
 
     public Injector<Executor> getExecutorShortInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/WorkManagerService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/WorkManagerService.java
@@ -75,7 +75,7 @@ public final class WorkManagerService implements Service<NamedWorkManager> {
 
     @Override
     public void start(StartContext context) throws StartException {
-        ROOT_LOGGER.debugf("Starting JCA WorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Starting Jakarta Connectors WorkManager: ", value.getName());
 
         BlockingExecutor longRunning = (BlockingExecutor) executorLong.getOptionalValue();
         if (longRunning != null) {
@@ -105,12 +105,12 @@ public final class WorkManagerService implements Service<NamedWorkManager> {
         } else {
             this.value.setSecurityIntegration(new PicketBoxSecurityIntegration());
         }
-        ROOT_LOGGER.debugf("Started JCA WorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Started Jakarta Connectors WorkManager: ", value.getName());
     }
 
     @Override
     public void stop(StopContext context) {
-        ROOT_LOGGER.debugf("Stopping JCA WorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Stopping Jakarta Connectors WorkManager: ", value.getName());
 
         //shutting down immediately (synchronous method) the workmanager and release all works
         value.shutdown();
@@ -121,7 +121,7 @@ public final class WorkManagerService implements Service<NamedWorkManager> {
             WorkManagerCoordinator.getInstance().unregisterWorkManager(value);
         }
 
-        ROOT_LOGGER.debugf("Stopped JCA WorkManager: ", value.getName());
+        ROOT_LOGGER.debugf("Stopped Jakarta Connectors WorkManager: ", value.getName());
     }
 
     public Injector<Executor> getExecutorShortInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetDataSourceClassInfoOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetDataSourceClassInfoOperationHandler.java
@@ -132,7 +132,7 @@ public class GetDataSourceClassInfoOperationHandler implements OperationStepHand
     }
 
     /**
-     * Check whether the types that JCA Injection knows.
+     * Check whether the types that Jakarta Connectors Injection knows.
      *
      * @see Injection.findMethod()
      * @param clz the class

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaArchiveValidationWriteHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaArchiveValidationWriteHandler.java
@@ -29,7 +29,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 
 /**
- * Write Handler for jca config attribute
+ * Write Handler for Jakarta Connectors config attribute
  *
  * @author Stefano Maestri
  */

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaConfigService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaConfigService.java
@@ -52,7 +52,7 @@ final class JcaConfigService implements Service<JcaSubsystemConfiguration> {
 
     @Override
     public void start(StartContext context) throws StartException {
-        ROOT_LOGGER.startingSubsystem("JCA", Version.FULL_VERSION);
+        ROOT_LOGGER.startingSubsystem("Jakarta Connectors", Version.FULL_VERSION);
         ROOT_LOGGER.tracef("config=%s", value);
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -51,7 +51,7 @@ import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 
 /**
- * JCA subsystem
+ * Jakarta Connectors subsystem
  *
  * @author @author <a href="mailto:stefano.maestri@redhat.com">Stefano Maestri</a>
  * @author @author <a href="mailto:jesper.pedersen@jboss.org">Jesper Pedersen</a>

--- a/connector/src/main/resources/org/jboss/as/connector/subsystems/jca/LocalDescriptions.properties
+++ b/connector/src/main/resources/org/jboss/as/connector/subsystems/jca/LocalDescriptions.properties
@@ -1,6 +1,6 @@
-jca=The Jakarta EE Connector Architecture (JCA) subsystem providing general configuration for resource adapters
-jca.add=Add the JCA subsystem
-jca.remove=Remove the JCA subsystem
+jca=The Jakarta Connectors Architecture subsystem providing general configuration for resource adapters
+jca.add=Add the Jakarta Connectors subsystem
+jca.remove=Remove the Jakarta Connectors subsystem
 jca.archive-validation=Archive validation for resource adapters
 jca.archive-validation.add=Add archive validation functionality
 jca.archive-validation.remove=Remove archive validation functionality

--- a/docs/src/main/asciidoc/JavaEE_Tutorial.adoc
+++ b/docs/src/main/asciidoc/JavaEE_Tutorial.adoc
@@ -46,7 +46,7 @@ include::_javaee-guide/Jakarta_Bean_Validation.adoc[]
 
 include::_javaee-guide/Java_Message_Service_API_(JMS).adoc[]
 
-include::_javaee-guide/JavaEE_Connector_Architecture_(JCA).adoc[]
+include::_javaee-guide/Jakarta_Connectors_Architecture.adoc[]
 
 include::_javaee-guide/Jakarta_Mail.adoc[]
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -46,13 +46,13 @@ on the type of connectors that is used.
 
 There is also a `pooled-connection-factory` which is special in that it
 is essentially a configuration facade for _both_ the inbound and
-outbound connectors of the the Artemis JCA Resource Adapter. An MDB can
+outbound connectors of the the Artemis Jakarta Connectors Resource Adapter. An MDB can
 be configured to use a `pooled-connection-factory` (e.g. using
 `@ResourceAdapter`). In this context, the MDB leverages the _inbound
-connector_ of the Artemis JCA RA. Other kinds of clients can look up the
+connector_ of the Artemis Jakarta Connectors RA. Other kinds of clients can look up the
 pooled-connection-factory in JNDI (or inject it) and use it to send
 messages. In this context, such a client would leverage the _outbound
-connector_ of the Artemis JCA RA. A `pooled-connection-factory` is also
+connector_ of the Artemis Jakarta Connectors RA. A `pooled-connection-factory` is also
 special because:
 
 * It is only available to local clients, although it can be configured
@@ -71,8 +71,8 @@ then this is likely the connection factory you want to use so the send
 operation will be atomically committed along with the rest of the EJB's
 transaction operations.
 
-To be clear, the _inbound connector_ of the Artemis JCA RA (which is for
-consuming messages) is only used by MDBs and other JCA-based components.
+To be clear, the _inbound connector_ of the Artemis Jakarta Connectors RA (which is for
+consuming messages) is only used by MDBs and other Jakarta Connectors based components.
 It is not available to traditional clients.
 
 Both a `connection-factory` and a `pooled-connection-factory` reference

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Security.adoc
@@ -128,7 +128,7 @@ class name to use.
 
 The subject factory is responsible for creating subject instances, this
 also makes use of the authentication manager to actually verify the
-caller. It is used mainly by JCA components to establish a subject. It
+caller. It is used mainly by Jakarta Connectors components to establish a subject. It
 is not likely this would need to be overridden but if it is required the
 "subject-factory-class-name" attribute can be specified on the
 subject-factory element.

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
@@ -19,7 +19,7 @@ The list of {ProductName} new functionality is extensive, being the most relevan
 * Jakarta EE - {ProductName} is a certified implementation of Jakarta EE, meeting both the Web and the Full Platform, and already includes support for the latest iterations of CDI (1.2) and Web Sockets (1.1).
 * Undertow - A new cutting-edge web server in {ProductName}, designed for maximum throughput and scalability, including environments with over a million connections. And the latest web technologies, such as the new HTTP/2 standard, are already onboard.
 * Apache ActiveMQ Artemis - {ProductName}'s new JMS broker. Based on an code donation from HornetQ, this Apache subproject provides outstanding performance based on a proven non-blocking architecture.
-* IronJacamar 1.2 - The latest IronJacamar provides a stable and feature rich JCA & Datasources support.
+* IronJacamar 1.2 - The latest IronJacamar provides a stable and feature rich Jakarta Connectors & Datasources support.
 * JBossWS 5 - The fifth generation of JBossWS, a major leap forward, brings new features and performances improvements to {ProductName} Web Services
 * RESTEasy 3 - {ProductName} which goes beyond the standard Jakarta EE REST APIs (Jakarta RESTful Web Services 2.1), by also providing a number of useful extensions, such as JSON Web Encryption, Jackson, Yaml, Jakarta JSON Processing, and reactive facilities.
 * OpenJDK ORB - {ProductName} switched the IIOP implementation from JacORB, to a downstream branch of the OpenJDK Orb, leading to better interoperability with the JVM ORB and the Jakarta EE RI.

--- a/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
@@ -95,7 +95,7 @@ org.jboss.resteasy.resteasy-multipart-provider
 org.jboss.resteasy.async-http-servlet-30 |The presence of Jakarta RESTful Web Services
 annotations in the deployment
 
-|JCA subsystem |javax.resource.api |javax.jms.api javax.validation.api
+|Jakarta Connectors subsystem |javax.resource.api |javax.jms.api javax.validation.api
 org.jboss.logging org.jboss.ironjacamar.api org.jboss.ironjacamar.impl
 org.hibernate.validator |If the deployment is a resource adaptor (RAR)
 deployment.

--- a/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
+++ b/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
@@ -614,7 +614,7 @@ The following parameters can be provided for each action to specify how to load 
 |Type of entry in credential store
 
 |-o,--other-providers <providers>
-|Comma separated list of JCA provider names. Providers will be supplied to the credential store instance.  Each provider must be installed through java.security file or through service loader from properly packaged jar file on classpath.
+|Comma separated list of Jakarta Connectors provider names. Providers will be supplied to the credential store instance.  Each provider must be installed through java.security file or through service loader from properly packaged jar file on classpath.
 
 |-p,--password <pwd>
 |Password for credential store
@@ -707,7 +707,7 @@ The `vault` command is used to convert a legacy vault to a credential store and 
 |Location of credential store storage file (defaults to "converted-vault.cr-store" in vault encryption directory)
 
 |-o,--other-providers <providers>
-|Comma separated list of JCA provider names. Providers will be supplied to the credential store instance.  Each provider must be installed through java.security file or through service loader from properly packaged jar file on classpath.
+|Comma separated list of Jakarta Connectors provider names. Providers will be supplied to the credential store instance.  Each provider must be installed through java.security file or through service loader from properly packaged jar file on classpath.
 
 |-p,--keystore-password <pwd>
 |Vault keystore password, used to open original vault key store, and used as password for new converted credential store

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -452,7 +452,7 @@ link:#gal.io[io] +
 link:#gal.base-server[base-server] +
 
 |[[gal.resource-adapters]]resource-adapters
-|Support for deployment of JCA adapters.
+|Support for deployment of Jakarta Connectors resource adapters.
 |
 link:#gal.transactions[transactions] +
 

--- a/docs/src/main/asciidoc/_javaee-guide/Jakarta_Connectors_Architecture.adoc
+++ b/docs/src/main/asciidoc/_javaee-guide/Jakarta_Connectors_Architecture.adoc
@@ -1,0 +1,4 @@
+[[Jakarta_Connectors_Architecture]]
+= Jakarta Connectors Architecture
+
+

--- a/docs/src/main/asciidoc/_javaee-guide/JavaEE_Connector_Architecture_(JCA).adoc
+++ b/docs/src/main/asciidoc/_javaee-guide/JavaEE_Connector_Architecture_(JCA).adoc
@@ -1,4 +1,0 @@
-[[JavaEE_Connector_Architecture_(JCA)]]
-= JavaEE Connector Architecture (JCA)
-
-

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
@@ -257,7 +257,7 @@ public class MessageDrivenComponentDescriptionFactory extends EJBComponentDescri
      */
     private String getDefaultResourceAdapterName(final ServiceRegistry serviceRegistry) {
         if (appclient) {
-            // we must report the MDB, but we can't use any MDB/JCA facilities
+            // we must report the MDB, but we can't use any MDB/Jakarta Connectors facilities
             return "n/a";
         }
         final ServiceController<DefaultResourceAdapterService> serviceController = (ServiceController<DefaultResourceAdapterService>) serviceRegistry.getRequiredService(DefaultResourceAdapterService.DEFAULT_RA_NAME_SERVICE_NAME);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -179,7 +179,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
                 throw new DeploymentUnitProcessingException(e);
             }
         } else {
-            // delegate to the resource-adapter subsystem to create a generic JCA connection factory.
+            // delegate to the resource-adapter subsystem to create a generic Jakarta Connectors connection factory.
             ConnectionFactoryDefinitionInjectionSource cfdis = new ConnectionFactoryDefinitionInjectionSource(jndiName, interfaceName, resourceAdapter);
             cfdis.setMaxPoolSize(maxPoolSize);
             cfdis.setMinPoolSize(minPoolSize);
@@ -375,7 +375,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
 
 
     /**
-     * Return whether the definition targets an existing pooled connection factory or use a JCA-based ConnectionFactory.
+     * Return whether the definition targets an existing pooled connection factory or use a Jakarta Connectors-based ConnectionFactory.
      *
      * Checks the service registry for a PooledConnectionFactoryService with the ServiceName
      * created by the {@code server} property (or {@code "default") and the {@code resourceAdapter} property.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
@@ -140,7 +140,7 @@ public class JMSDestinationDefinitionInjectionSource extends ResourceDefinitionI
         if (external || targetsPooledConnectionFactory(getActiveMQServerName(properties), resourceAdapter, phaseContext.getServiceRegistry())) {
             startActiveMQDestination(context, serviceBuilder, phaseContext, injector, external);
         } else {
-            // delegate to the resource-adapter subsystem to create a generic JCA admin object.
+            // delegate to the resource-adapter subsystem to create a generic Jakarta Connectors admin object.
             AdministeredObjectDefinitionInjectionSource aodis = new AdministeredObjectDefinitionInjectionSource(jndiName, className, resourceAdapter);
             aodis.setInterface(interfaceName);
             aodis.setDescription(description);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
@@ -726,7 +726,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         boolean result = true;
         if (address.size() > 1 && address.getLastElement().getKey().equals("bootstrap-context") && address.getLastElement().getValue().equals("default")
             && address.getElement(address.size() - 2).getKey().equals("subsystem") && address.getElement(address.size() - 2).getValue().equals("jca")) {
-            // JCA subsystem doesn't persist this resource
+            // Jakarta Connectors subsystem doesn't persist this resource
             result = false;
         }
         return result;

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -347,7 +347,7 @@
             <artifactId>jipijapa-spi</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- This is not desired, however the JCA tests seem to require this -->
+        <!-- This is not desired, however the Jakarta Connectors tests seem to require this -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
@@ -952,7 +952,7 @@
                                 <exclude>org/jboss/as/test/integration/deployment/xml/datasource/DeployedXmlJpaDataSourceTestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/jaxrs/integration/ejb/*TestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/jaxrs/packaging/ear/*TestCase.java</exclude>
-                                <!-- JCA TBD -->
+                                <!-- Jakarta Connectors TBD -->
                                 <exclude>org/jboss/as/test/integration/jca/ear/*TestCase.java</exclude>
                                 <!-- No legacy security -->
                                 <exclude>org/jboss/as/test/integration/jca/anno/*TestCase.java</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationname/ActivationNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationname/ActivationNameTestCase.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * This tests if IronJacamar follows JCA 1.7 and properly defines {@code activation name} on {@code MessageEndpointFactory}.
+ * This tests if IronJacamar follows Jakarta Connectors 1.7 and properly defines {@code activation name} on {@code MessageEndpointFactory}.
  * For details see {@link SimpleResourceAdapter#endpointActivation(MessageEndpointFactory, ActivationSpec)} and WFLY-8074.
  *
  * @author Ivo Studensky

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaTestsUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaTestsUtil.java
@@ -41,7 +41,7 @@ import org.jboss.jca.core.util.Injection;
 import org.jboss.threads.BlockingExecutor;
 
 /**
- * Utility class for JCA integration test
+ * Utility class for Jakarta Connectors integration test
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
@@ -67,7 +67,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Integration test for JCA capacity policies JBJCA-986 using datasource/xa-datasource
+ * Integration test for Jakarta Connectors capacity policies JBJCA-986 using datasource/xa-datasource
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/DatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/DatasourceCapacityPoliciesTestCase.java
@@ -26,7 +26,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.junit.runner.RunWith;
 
 /**
- * Integration test for JCA capacity policies JBJCA-986 using datasource
+ * Integration test for Jakarta Connectors capacity policies JBJCA-986 using datasource
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
@@ -75,7 +75,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Integration test for JCA capacity policies JBJCA-986 using resource adapter
+ * Integration test for Jakarta Connectors capacity policies JBJCA-986 using resource adapter
  * *
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
@@ -28,7 +28,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.junit.runner.RunWith;
 
 /**
- * Integration test for JCA capacity policies JBJCA-986 using xa-datasource
+ * Integration test for Jakarta Connectors capacity policies JBJCA-986 using xa-datasource
  *
  * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronDisabledTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronDisabledTestCase.java
@@ -44,7 +44,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
 import org.wildfly.test.security.common.elytron.PropertyFileBasedDomain;
 
 /**
- * Test security inflow with JCA work manager where RA is configured with Elytron security domain
+ * Test security inflow with Jakarta Connectors work manager where RA is configured with Elytron security domain
  * and Workmanager is configured with legacy security (it doesn't have elytron-enabled=true),
  * it is not allowed to mix security configuration and it should fail
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronEnabledTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronEnabledTestCase.java
@@ -86,7 +86,7 @@ import org.wildfly.test.security.common.elytron.ConfigurableElement;
 import org.wildfly.test.security.common.elytron.PropertyFileBasedDomain;
 
 /**
- * Test security inflow with JCA work manager using Elytron security domain
+ * Test security inflow with Jakarta Connectors work manager using Elytron security domain
  */
 @RunWith(Arquillian.class)
 @ServerSetup({

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMSecurityDomainWorkManagerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMSecurityDomainWorkManagerTestCase.java
@@ -73,7 +73,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 /**
- * Test security inflow with JCA work manager using legacy security domain
+ * Test security inflow with Jakarta Connectors work manager using legacy security domain
  */
 @RunWith(Arquillian.class)
 @ServerSetup({

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/JcaStatisticsBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/JcaStatisticsBase.java
@@ -29,7 +29,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
 /**
- * Base class for JCA statistics tests
+ * Base class for Jakarta Connectors statistics tests
  *
  * @author <a href="mailto:vrastsel@redhat.com">Vladimir Rastseluev</a>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
@@ -52,7 +52,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Testcase running jca inflow transaction from deployed RAR.
+ * Testcase running Jakarta Connectors inflow transaction from deployed RAR.
  * Two mock XA resources are enlisted inside of MDB to proceed 2PC.
  *
  * @author Ondrej Chaloupka <ochaloup@redhat.com>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTextMessage.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTextMessage.java
@@ -28,7 +28,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 
 /**
- * Test message used for testing in jca inflow transaction rar.
+ * Test message used for testing in Jakarta Connectors inflow transaction rar.
  *
  * @author Ondrej Chaloupka <ochaloup@redhat.com>
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWork.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWork.java
@@ -30,7 +30,7 @@ import javax.resource.spi.work.Work;
 import org.jboss.logging.Logger;
 
 /**
- * JCA work executing onMessage method with text message payload.
+ * Jakarta Connectors work executing onMessage method with text message payload.
  *
  * @author Ondrej Chaloupka <ochaloup@redhat.com>
  */

--- a/transactions/src/main/java/org/jboss/as/txn/integration/JBossContextXATerminator.java
+++ b/transactions/src/main/java/org/jboss/as/txn/integration/JBossContextXATerminator.java
@@ -91,9 +91,9 @@ public class JBossContextXATerminator implements JBossXATerminator {
     @Override
     public void registerWork(Work work, Xid xid, long timeout) throws WorkCompletedException {
         try {
-            // jca provides timeout in milliseconds, SubordinationManager expects seconds
+            // Jakarta Connectors provides timeout in milliseconds, SubordinationManager expects seconds
             int timeout_seconds = (int) timeout/1000;
-            // unlimited timeout for jca means -1 which fails in wfly client
+            // unlimited timeout for Jakarta Connectors means -1 which fails in wfly client
             if(timeout_seconds <= 0) timeout_seconds = ContextTransactionManager.getGlobalDefaultTransactionTimeout();
             localTransactionContext.findOrImportTransaction(xid, timeout_seconds);
         } catch (XAException xae) {

--- a/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
+++ b/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
@@ -212,11 +212,11 @@ public interface TransactionLogger extends BasicLogger {
     void transactionNotFound(Transaction tx);
 
     @LogMessage(level = WARN)
-    @Message(id = 27, value = "The pre-jca synchronization %s associated with tx %s failed during after completion")
+    @Message(id = 27, value = "The pre-Jakarta Connectors synchronization %s associated with tx %s failed during after completion")
     void preJcaSyncAfterCompletionFailed(Synchronization preJcaSync, Transaction tx, @Cause Exception e);
 
     @LogMessage(level = WARN)
-    @Message(id = 28, value = "The jca synchronization %s associated with tx %s failed during after completion")
+    @Message(id = 28, value = "The Jakarta Connectors synchronization %s associated with tx %s failed during after completion")
     void jcaSyncAfterCompletionFailed(Synchronization jcaSync, Transaction tx, @Cause Exception e);
 
     @Message(id = 29, value = "Syncs are not allowed to be registered when the tx is in state %s")
@@ -241,7 +241,7 @@ public interface TransactionLogger extends BasicLogger {
     @Message(id = 35, value = "Cannot find or import inflow transaction for xid %s and work %s")
     WorkCompletedException cannotFindOrImportInflowTransaction(Xid xid, Work work, @Cause Exception e);
 
-    @Message(id = 36, value = "Imported jca inflow transaction with xid %s of work %s is inactive")
+    @Message(id = 36, value = "Imported Jakarta Connectors inflow transaction with xid %s of work %s is inactive")
     WorkCompletedException importedInflowTransactionIsInactive(Xid xid, Work work, @Cause Exception e);
 
     @Message(id = 37, value = "Unexpected error on resuming transaction %s for work %s")

--- a/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/JCAOrderedLastSynchronizationList.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/JCAOrderedLastSynchronizationList.java
@@ -35,13 +35,13 @@ import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 /**
  * This class was added to:
  *
- * 1. workaround an issue discussed in https://java.net/jira/browse/JTA_SPEC-4 whereby the JCA Synchronization(s) need to be
- * called after the Jakarta Persistence Synchronization(s). Currently the implementation orders JCA relative to all interposed Synchronizations,
- * if this is not desirable it would be possible to modify this class to store just the Jakarta Persistence and JCA syncs and the other syncs
+ * 1. workaround an issue discussed in https://java.net/jira/browse/JTA_SPEC-4 whereby the Jakarta Connectors Synchronization(s) need to be
+ * called after the Jakarta Persistence Synchronization(s). Currently the implementation orders Jakarta Connectors relative to all interposed Synchronizations,
+ * if this is not desirable it would be possible to modify this class to store just the Jakarta Persistence and Jakarta Connectors syncs and the other syncs
  * can simply be passed to a delegate (would need the reference to this in the constructor).
  *
- * 2. During afterCompletion the JCA synchronizations should be called last as that allows JCA to detect connection leaks from
- * frameworks that have not closed the JCA managed resources. This is described in (for example)
+ * 2. During afterCompletion the Jakarta Connectors synchronizations should be called last as that allows Jakarta Connectors to detect connection leaks from
+ * frameworks that have not closed the Jakarta Connectors managed resources. This is described in (for example)
  * http://docs.oracle.com/javaee/5/api/javax/transaction/TransactionSynchronizationRegistry
  * .html#registerInterposedSynchronization(javax.transaction.Synchronization) where it says that during afterCompletion
  * "Resources can be closed but no transactional work can be performed with them"

--- a/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/TransactionSynchronizationRegistryWrapper.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/TransactionSynchronizationRegistryWrapper.java
@@ -33,14 +33,14 @@ import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 /**
  * Most of this implementation delegates down to the underlying transactions implementation to provide the services of the
  * TransactionSynchronizationRegistry. The one area it modifies is the registration of the interposed Synchronizations. The
- * reason this implementation needs to differ is because the JCA Synchronization and Jakarta Persistence Synchronizations are both specified as
+ * reason this implementation needs to differ is because the Jakarta Connectors Synchronization and Jakarta Persistence Synchronizations are both specified as
  * Interposed however there are defined ordering requirements between them both.
  *
- * The current implementation orders JCA relative to all other Synchronizations. For beforeCompletion, it would be possible to
- * restrict this to the one case where JCA is ordered before Jakarta Persistence, however it is possible that other interposed Synchronizations
- * would require the services of JCA and as such if the JCA is allowed to execute delistResource during beforeCompletion as
- * mandated in JCA spec the behaviour of those subsequent interactions would be broken. For afterCompletion the JCA
- * synchronizations are called last as that allows JCA to detect connection leaks from frameworks that have not closed the JCA
+ * The current implementation orders Jakarta Connectors relative to all other Synchronizations. For beforeCompletion, it would be possible to
+ * restrict this to the one case where Jakarta Connectors are ordered before Jakarta Persistence, however it is possible that other interposed Synchronizations
+ * would require the services of Jakarta Connectors and as such if the Jakarta Connectors are allowed to execute delistResource during beforeCompletion as
+ * mandated in Jakarta Connectors spec the behaviour of those subsequent interactions would be broken. For afterCompletion the Jakarta Connectors
+ * synchronizations are called last as that allows Jakarta Connectors to detect connection leaks from frameworks that have not closed the Jakarta Connectors
  * managed resources. This is described in (for example)
  * http://docs.oracle.com/javaee/5/api/javax/transaction/TransactionSynchronizationRegistry
  * .html#registerInterposedSynchronization(javax.transaction.Synchronization) where it says that during afterCompletion

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -83,7 +83,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
             .build();
     /**
      * Provides access to the special TransactionSynchronizationRegistry impl that ensures proper ordering between
-     * JCA and other synchronizations.
+     * Jakarta Connectors and other synchronizations.
      */
     public static final RuntimeCapability<Void> TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY =
             RuntimeCapability.Builder.of("org.wildfly.transactions.transaction-synchronization-registry", TransactionSynchronizationRegistry.class)

--- a/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
+++ b/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
@@ -76,8 +76,8 @@ transactions.log-store.transaction.participant.add=Add a transaction participant
 transactions.log-store.transaction.participant.status=Reports the commitment status of this participant (can be one of Pending, Prepared, Failed, Heuristic or Readonly).
 transactions.log-store.transaction.participant.jndi-name=JNDI name of this participant.
 transactions.log-store.transaction.participant.type=The type name under which this record is stored.
-transactions.log-store.transaction.participant.eis-product-name=The JCA enterprise information system's product name.
-transactions.log-store.transaction.participant.eis-product-version=The JCA enterprise information system's product version
+transactions.log-store.transaction.participant.eis-product-name=The Jakarta Connectors enterprise information system's product name.
+transactions.log-store.transaction.participant.eis-product-version=The Jakarta Connectors enterprise information system's product version
 
 transactions.commit-markable-resource=a CMR resource (i.e. a local resource that can reliably participate in an XA transaction)
 transactions.commit-markable-resource.add=add a single CMR resource


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14319
(Replace "Java EE Connector Architecture|JCA" references in java doc with corresponding Jakarta EE ones)
Link with: https://github.com/wildfly/wildfly/pull/13808