### PR TITLE
[WFLY-14473]: Null Tracer injected on redeploy of WAR.

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDeploymentProcessor.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDeploymentProcessor.java
@@ -201,10 +201,11 @@ public class TracingDeploymentProcessor implements DeploymentUnitProcessor {
             boolean isRegistered = (Boolean) globalTracerClass.getMethod("isRegistered").invoke(null);
             if (isRegistered) {
                 TracingLogger.ROOT_LOGGER.alreadyRegistered();
-                return;
+                tracer = (Tracer) globalTracerClass.getMethod("get").invoke(null);
+            } else {
+                Class tracerResolverClass = moduleCL.loadClass("io.opentracing.contrib.tracerresolver.TracerResolver");
+                tracer = (Tracer) tracerResolverClass.getMethod("resolveTracer").invoke(null);
             }
-            Class tracerResolverClass = moduleCL.loadClass("io.opentracing.contrib.tracerresolver.TracerResolver");
-            tracer = (Tracer) tracerResolverClass.getMethod("resolveTracer").invoke(null);
         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             ROOT_LOGGER.errorResolvingTracer(ex);
         } finally {


### PR DESCRIPTION
 * When a GlobalTracer has been registered we do not make it available
   via CDI thus providing a Null tracer instead of the Global one.

Jira: https://issues.redhat.com/browse/WFLY-14473