### PR TITLE
WFLY-14482 Add tests for weld subsystem property expansion.

### DIFF
--- a/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.weld;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -179,6 +180,21 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
                                 .addConfig(new NewAttributesConfig(WeldResourceDefinition.THREAD_POOL_SIZE_ATTRIBUTE)).build()
 
                 ));
+    }
+
+    @Test
+    public void testExpressionInAttributeValue() throws Exception {
+        ModelVersion modelVersion = ModelVersion.create(3, 0, 0);
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource("subsystem_with_expression.xml");
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        ModelNode weldNode = mainServices.readWholeModel().get("subsystem", getMainSubsystemName());
+
+        assertEquals(true, weldNode.get("require-bean-descriptor").resolve().asBoolean());
+        assertEquals(9, weldNode.get("thread-pool-size").resolve().asInt());
+        assertEquals(true, weldNode.get("development-mode").resolve().asBoolean());
+        assertEquals(true, weldNode.get("non-portable-mode").resolve().asBoolean());
     }
 
 

--- a/weld/subsystem/src/test/resources/org/jboss/as/weld/subsystem_with_expression.xml
+++ b/weld/subsystem/src/test/resources/org/jboss/as/weld/subsystem_with_expression.xml
@@ -1,0 +1,5 @@
+<subsystem xmlns="urn:jboss:domain:weld:4.0"
+           require-bean-descriptor="${sysprop:true}"
+           non-portable-mode="${sysprop:true}"
+           development-mode="${sysprop:true}"
+           thread-pool-size="${sysprop:9}"/>


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-14482

List of Weld subsystem attributes can be seen in [these WildFly docs](https://docs.wildfly.org/22/wildscribe/subsystem/weld/index.html).

I have used some other issues and existing tests for inspiration on how to cobble this kind of test together (e.g. the way I create `ModelVersion` and `KernerServices` is just a copy paste that I did and that somehow worked).
While I think it should get the job done in this form, I am open to criticism/suggestions.