### PR TITLE
[WFLY-14484] Upgrade JBoss Modules XML schema version to 1.9 for lega…

### DIFF
--- a/dist-legacy/src/distribution/resources/modules/system/layers/base/org/jboss/as/product/main/module.xml
+++ b/dist-legacy/src/distribution/resources/modules/system/layers/base/org/jboss/as/product/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.product" slot="main">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.product">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/dist-legacy/src/verifier/verifications.xml
+++ b/dist-legacy/src/verifier/verifications.xml
@@ -27,12 +27,11 @@ limitations under the License.
     6) JBoss-Product-Release-Name key in manifest.mf above has value equal to the value of the 
        'ee.dist.product.release.name' property
     7) modules/system/layers/base/org/jboss/as/product/${ee.dist.product.slot}/module.xml exists
-    8) The 'slot' attribute in the module.xml above has a value equal to the value of the 'ee.dist.product.slot' property
-    9) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
+    8) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property
-    10) Schemas coming from a module distributed directly by the ee-galleon-pack are copied to docs/schema
-    11) Schemas coming from a module distributed by the transitive servlet-galleon-pack are copied to docs/schema
-    12) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
+    9) Schemas coming from a module distributed directly by the ee-galleon-pack are copied to docs/schema
+    10) Schemas coming from a module distributed by the transitive servlet-galleon-pack are copied to docs/schema
+    11) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -58,10 +57,6 @@ limitations under the License.
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${ee.dist.product.slot}/module.xml</location>
       <exists>true</exists>
-    </file>
-    <file>
-      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${ee.dist.product.slot}/module.xml</location>
-      <contains>slot="${ee.dist.product.slot}"</contains>
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.1.x (works with Hibernate 4.2.x jars also) module  -->
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate" slot="4.1">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate:4.1">
     <resources>
         <artifact name="${org.wildfly:jipijapa-hibernate4-1}"/>
     </resources>

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.3.x module  -->
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate" slot="4.3">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate:4.3">
    <resources>
     </resources>
 

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/5.0/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/5.0/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 5.1.x module-->
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate" slot="5.0">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate:5.0">
    <resources>
     </resources>
 

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate4-3/main/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate4-3/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.hibernate.jipijapa-hibernate4-3">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate4-3">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -32,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.hibernate" slot="4.3" />
+        <module name="org.hibernate:4.3" />
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
@@ -29,7 +29,7 @@
      or use module org.hibernate which contains the Jakarta Persistence integration classes for Hibernate 4.3.x
 -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jpa.hibernate" slot="4">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jpa.hibernate:4">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/myfaces/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/myfaces/module.xml
@@ -22,13 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.sun.jsf-impl" slot="myfaces">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.jsf-impl:myfaces">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <dependencies>
-        <module name="javax.faces.api" slot="myfaces"/>
+        <module name="javax.faces.api:myfaces"/>
         <module name="javax.annotation.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.servlet.jsp.api"/>

--- a/jsf/subsystem/src/test/resources/modules/javax/faces/api/myfaces/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/javax/faces/api/myfaces/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.faces.api" slot="myfaces">
+<module xmlns="urn:jboss:module:1.9" name="javax.faces.api:myfaces">
     <dependencies>
         <module name="javax.el.api" export="true"/>
         <module name="javax.servlet.api" export="true"/>

--- a/jsf/subsystem/src/test/resources/modules/org/jboss/as/jsf-injection/1.2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/org/jboss/as/jsf-injection/1.2/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jsf-injection" slot="1.2">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:1.2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.jsf-impl" slot="1.2"/>
+        <module name="com.sun.jsf-impl:1.2"/>
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>

--- a/jsf/subsystem/src/test/resources/modules/org/jboss/as/jsf-injection/myfaces/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/org/jboss/as/jsf-injection/myfaces/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jsf-injection" slot="myfaces">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:myfaces">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,13 +33,13 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.jsf-impl" slot="myfaces"/>
+        <module name="com.sun.jsf-impl:myfaces"/>
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>
         <module name="org.jboss.logging"/>
 
         <!-- added this for MyFacesAnnotationProvider -->
-        <module name="javax.faces.api" slot="myfaces"/>
+        <module name="javax.faces.api:myfaces"/>
     </dependencies>
 </module>

--- a/jsf/subsystem/src/test/resources/modules2/com/sun/jsf-impl/myfaces2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/com/sun/jsf-impl/myfaces2/module.xml
@@ -22,13 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="com.sun.jsf-impl" slot="myfaces2">
+<module xmlns="urn:jboss:module:1.9" name="com.sun.jsf-impl:myfaces2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <dependencies>
-        <module name="javax.faces.api" slot="myfaces"/>
+        <module name="javax.faces.api:myfaces"/>
         <module name="javax.annotation.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.servlet.jsp.api"/>

--- a/jsf/subsystem/src/test/resources/modules2/javax/faces/api/myfaces2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/javax/faces/api/myfaces2/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.faces.api" slot="myfaces2">
+<module xmlns="urn:jboss:module:1.9" name="javax.faces.api:myfaces2">
     <dependencies>
         <module name="javax.el.api" export="true"/>
         <module name="javax.servlet.api" export="true"/>

--- a/jsf/subsystem/src/test/resources/modules2/org/jboss/as/jsf-injection/bogus2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/org/jboss/as/jsf-injection/bogus2/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jsf-injection" slot="myfaces2">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:myfaces2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,13 +33,13 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.jsf-impl" slot="myfaces"/>
+        <module name="com.sun.jsf-impl:myfaces"/>
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>
         <module name="org.jboss.logging"/>
 
         <!-- added this for MyFacesAnnotationProvider -->
-        <module name="javax.faces.api" slot="myfaces"/>
+        <module name="javax.faces.api:myfaces"/>
     </dependencies>
 </module>

--- a/jsf/subsystem/src/test/resources/modules2/org/jboss/as/jsf-injection/myfaces2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/org/jboss/as/jsf-injection/myfaces2/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jsf-injection" slot="myfaces2">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:myfaces2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -33,13 +33,13 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.jsf-impl" slot="myfaces"/>
+        <module name="com.sun.jsf-impl:myfaces"/>
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>
         <module name="org.jboss.logging"/>
 
         <!-- added this for MyFacesAnnotationProvider -->
-        <module name="javax.faces.api" slot="myfaces"/>
+        <module name="javax.faces.api:myfaces"/>
     </dependencies>
 </module>

--- a/servlet-dist-legacy/src/distribution/resources/modules/system/layers/base/org/jboss/as/product/wildfly-web/module.xml
+++ b/servlet-dist-legacy/src/distribution/resources/modules/system/layers/base/org/jboss/as/product/wildfly-web/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.product" slot="wildfly-web">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.product:wildfly-web">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsTestCase.java
@@ -47,7 +47,7 @@ public class EarJbossStructureCascadeExclusionsTestCase {
                         "<ear-exclusions-cascaded-to-subdeployments>true</ear-exclusions-cascaded-to-subdeployments>" +
                         "<deployment>" +
                         "   <exclusions>" +
-                        "      <module name=\"org.jboss.logging\" slot=\"main\" />" +
+                        "      <module name=\"org.jboss.logging\" />" +
                         "   </exclusions>" +
                         "</deployment>" +
                         "<sub-deployment name=\"test.war\">" +

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentArchiveTestCase.java
@@ -76,7 +76,7 @@ public class DeploymentArchiveTestCase extends AbstractCliTestBase {
 
     private static final String MODULE_XML =
               "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-              "<module xmlns=\"urn:jboss:module:1.5\" name=\"" + MODULE_NAME + "\" slot=\"main\">" +
+              "<module xmlns=\"urn:jboss:module:1.9\" name=\"" + MODULE_NAME + ">" +
               "    <resources>" +
               "        <resource-root path=\"" + MODULE_ARCHIVE + "\"/>" +
               "    </resources>" +

--- a/testsuite/integration/manualmode/src/test/resources/layered/product-module.xml
+++ b/testsuite/integration/manualmode/src/test/resources/layered/product-module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.product" slot="test">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.product:test">
 
     <resources>
         <resource-root path="classes"/>

--- a/testsuite/integration/manualmode/src/test/resources/layered/test-module.xml
+++ b/testsuite/integration/manualmode/src/test/resources/layered/test-module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.ldtc" slot="main">
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.ldtc">
 
     <resources>
         <resource-root path="test-module.jar"/>


### PR DESCRIPTION
…cy module identifiers that contain a slot

Jira issue: https://issues.redhat.com/browse/WFLY-14484

Notice some of them are not flagged with jboss.api=private, so I'm not sure if we can deal with them bumping the XML NS version.