### PR TITLE
Add a test case for WFLY-12982 "MP FT: CDI contexts not available in …

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsyncService.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsyncService.java
@@ -19,11 +19,10 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.microprofile.faulttolerance.async.requestcontext;
+package org.wildfly.test.integration.microprofile.faulttolerance.context.asynchronous;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsynchronousRequestContextTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsynchronousRequestContextTestCase.java
@@ -19,14 +19,11 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.microprofile.faulttolerance.async.requestcontext;
+package org.wildfly.test.integration.microprofile.faulttolerance.context.asynchronous;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.FilePermission;
-import java.util.PropertyPermission;
 import java.util.concurrent.ExecutionException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -44,19 +41,13 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-public class AsynchronousRequestContextTest {
+public class AsynchronousRequestContextTestCase {
 
     @Deployment
     public static WebArchive createTestArchive() {
-        return ShrinkWrap.create(WebArchive.class, AsynchronousRequestContextTest.class.getSimpleName() + ".war")
+        return ShrinkWrap.create(WebArchive.class, AsynchronousRequestContextTestCase.class.getSimpleName() + ".war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addPackage(AsynchronousRequestContextTest.class.getPackage())
-                .addAsManifestResource(createPermissionsXmlAsset(
-                        new FilePermission("<<ALL FILES>>", "read"),
-                        new PropertyPermission("*", "read,write"),
-                        new RuntimePermission("getenv.*"),
-                        new RuntimePermission("modifyThread")
-                ), "permissions.xml")
+                .addPackage(AsynchronousRequestContextTestCase.class.getPackage())
                 ;
     }
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/RequestFoo.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/RequestFoo.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.microprofile.faulttolerance.context.asynchronous;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.RequestScoped;
+
+/**
+ * Adapted from Thorntail.
+ *
+ * @author Radoslav Husar
+ */
+@RequestScoped
+public class RequestFoo {
+
+    static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+
+    private String foo;
+
+    @PostConstruct
+    void init() {
+        foo = "ok";
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    @PreDestroy
+    void destroy() {
+        DESTROYED.set(true);
+    }
+
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/RequestScopedService.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/RequestScopedService.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.faulttolerance.context.timeout;
+
+import javax.enterprise.context.RequestScoped;
+
+/**
+ * @author Radoslav Husar
+ */
+@RequestScoped
+public class RequestScopedService {
+
+    public String call() {
+        return "bar";
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/TimeoutBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/TimeoutBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2019, Red Hat, Inc., and individual contributors
+ * Copyright 2021, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,38 +19,23 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.microprofile.faulttolerance.async.requestcontext;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+package org.wildfly.test.integration.microprofile.faulttolerance.context.timeout;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.Timeout;
 
 /**
- * Adapted from Thorntail.
- *
  * @author Radoslav Husar
  */
-@RequestScoped
-public class RequestFoo {
+public class TimeoutBean {
 
-    static final AtomicBoolean DESTROYED = new AtomicBoolean(false);
+    @Inject
+    RequestScopedService service;
 
-    private String foo;
-
-    @PostConstruct
-    void init() {
-        foo = "ok";
+    @Timeout
+    public String greet() throws InterruptedException {
+        return "Hello " + service.call();
     }
-
-    public String getFoo() {
-        return foo;
-    }
-
-    @PreDestroy
-    void destroy() {
-        DESTROYED.set(true);
-    }
-
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/TimeoutContextTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/timeout/TimeoutContextTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.faulttolerance.context.timeout;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case for https://issues.redhat.com/browse/WFLY-12982 which used to fail on legacy SR FT with:
+ * <p>
+ * UT005023: Exception handling request to /: org.jboss.weld.context.ContextNotActiveException:
+ * WELD-001303: No active contexts for scope type javax.enterprise.context.RequestScoped
+ *
+ * @author Radoslav Husar
+ */
+@RunWith(Arquillian.class)
+public class TimeoutContextTestCase {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, TimeoutContextTestCase.class.getSimpleName() + ".war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addPackage(TimeoutContextTestCase.class.getPackage())
+                ;
+    }
+
+    @Test
+    public void testRequestContextActive(TimeoutBean timeoutBean) throws Exception {
+        assertEquals("Hello bar", timeoutBean.greet());
+    }
+
+}


### PR DESCRIPTION
…@Timeout methods" and restructure tests

+ adds test case for https://issues.redhat.com/browse/WFLY-12982 (verified this failed with legacy SR FT, see jira)
+ moves tests for context into one package
+ removes unnecessary permissions (those were needed by hystrix in the past)