### PR TITLE
[WFLY-14490] Disable the vendor metrics diagnostic logging from Micro…

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/metrics/vendor/BootCheckApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/metrics/vendor/BootCheckApplication.java
@@ -108,14 +108,14 @@ public class BootCheckApplication extends HttpServlet implements ServletContextL
                     overallResponseCode = overallResponse.responseCode;
                     overallResponseContent = overallResponse.content;
                     if (overallResponseCode == 200) {
-                        overallSawVendor = checkSawVendor(overallResponse.content, true);
+                        overallSawVendor = checkSawVendor(overallResponse.content, false);
                     }
 
                     // Now try a scoped request
                     Response scopedResponse = invoke(managementURL + "/metrics/vendor");
                     scopedResponseCode = scopedResponse.responseCode;
                     if (scopedResponseCode == 200) {
-                        scopedSawVendor = checkSawVendor(scopedResponse.content, true);
+                        scopedSawVendor = checkSawVendor(scopedResponse.content, false);
                     }
                 } else {
                     // Management socket may not be open yet; try again


### PR DESCRIPTION
…ProfileVendorMetricsBootTestCase

I considered making this configurable vis a system property but then I'd have to set up security manager perms to allow the prop to be read by the deployment, and... meh.

https://issues.redhat.com/browse/WFLY-14490