### PR TITLE
[WFLY-14486] Don't run tests outside of the testsuite modules when -D…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10176,6 +10176,9 @@
             <properties>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
                 <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
+                <!-- Disable the default surefire test execution for all modules except for
+                     those where this profile turns them back on. -->
+                <surefire.default-test.phase>none</surefire.default-test.phase>
             </properties>
         </profile>
 

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -351,7 +351,11 @@
                 <property>
                     <name>ts.bootable.ee9</name>
                 </property>
-            </activation>           
+            </activation>
+            <properties>
+                <!-- Re-enable the default surefire execution -->
+                <surefire.default-test.phase>test</surefire.default-test.phase>
+            </properties>
             <modules>
                 <module>basic</module>
                 <module>clustering</module>


### PR DESCRIPTION
…ts.bootable.ee9 is used

https://issues.redhat.com/browse/WFLY-14486