### PR TITLE
[WFLY-14478] Tidy up the testsuite/scripts handling; allow it to test…

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -69,7 +69,6 @@
 
     <modules>
         <module>integration</module>
-        <module>scripts</module>
     </modules>
 
 
@@ -496,12 +495,25 @@
                 <module>layers</module>
             </modules>
         </profile>
+
         <profile>
-            <id>ee9.module.profile</id>
+            <id>scripts.module.profile</id>
+            <activation><property><name>scripts.module</name></property></activation>
+            <modules><module>scripts</module></modules>
+        </profile>
+        <profile>
+            <id>scripts_.module.profile</id>
+            <activation><property><name>ts.scripts</name></property></activation>
+            <modules><module>scripts</module></modules>
+        </profile>
+
+        <profile>
+            <id>ee9.profile</id>
             <activation><property><name>ts.ee9</name></property></activation>
             <modules>
                 <module>integration</module>
                 <module>layers</module>
+                <module>scripts</module>
             </modules>
         </profile>
 

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -32,6 +32,8 @@
         <jboss.test.script.address>127.0.0.1</jboss.test.script.address>
         <jboss.test.start.timeout>120</jboss.test.start.timeout>
 
+        <jbossas.ts.dir>${basedir}/..</jbossas.ts.dir>
+
         <wildfly.home>${project.basedir}${file.separator}target${file.separator}${server.output.dir.prefix}</wildfly.home>
     </properties>
 
@@ -109,5 +111,57 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+
+        <!-- Test against EE 9 dist -->
+        <profile>
+            <id>ee9.profile</id>
+            <activation>
+                <property>
+                    <name>ts.ee9</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>server-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <plugin-options combine.self="append">
+                                        <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
+                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
+                                    </plugin-options>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <!--Re-enable the default surefire execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
… WildFly Preview

1) Remove 'scripts' from the default testsuite module set; only run these when triggered by some profile. (The -DallTests profile already triggers them.)
2) Add the standard triggering profiles used for triggering modules, so -Dscripts.module or -Dts.scripts will now run the testsuite/scripts module.
3) Add an ee9.profile (-Dts.ee9) to testsuite/scripts/pom.xml to allow it to run properly against WildFly Preview

https://issues.redhat.com/browse/WFLY-14478