### PR TITLE
WFLY-14512 Add EAP 7.3.0 transformers tests for mod_cluster subsystem

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterModel.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterModel.java
@@ -37,7 +37,7 @@ public enum ModClusterModel implements Model {
     VERSION_4_0_0(4, 0, 0), // WildFly 10, EAP 7.0
     VERSION_5_0_0(5, 0, 0), // WildFly 11 & 12 & 13, EAP 7.1
     VERSION_6_0_0(6, 0, 0), // WildFly 14 & 15, EAP 7.2
-    VERSION_7_0_0(7, 0, 0), // WildFly 16
+    VERSION_7_0_0(7, 0, 0), // WildFly 16 - 23, EAP 7.3
     ;
     public static final ModClusterModel CURRENT = VERSION_7_0_0;
 

--- a/mod_cluster/extension/src/test/java/org/wildfly/extension/mod_cluster/ModClusterTransformersTestCase.java
+++ b/mod_cluster/extension/src/test/java/org/wildfly/extension/mod_cluster/ModClusterTransformersTestCase.java
@@ -69,6 +69,8 @@ public class ModClusterTransformersTestCase extends AbstractSubsystemTest {
                 return ModClusterModel.VERSION_5_0_0;
             case EAP_7_2_0:
                 return ModClusterModel.VERSION_6_0_0;
+            case EAP_7_3_0:
+                return ModClusterModel.VERSION_7_0_0;
         }
         throw new IllegalArgumentException();
     }
@@ -89,7 +91,13 @@ public class ModClusterTransformersTestCase extends AbstractSubsystemTest {
             case EAP_7_2_0:
                 return new String[] {
                         formatArtifact("org.jboss.eap:wildfly-mod_cluster-extension:%s", version),
-                        "org.jboss.mod_cluster:mod_cluster-core:1.4.0.Final",
+                        "org.jboss.mod_cluster:mod_cluster-core:1.4.0.Final-redhat-1",
+                        formatArtifact("org.jboss.eap:wildfly-clustering-common:%s", version),
+                };
+            case EAP_7_3_0:
+                return new String[] {
+                        formatArtifact("org.jboss.eap:wildfly-mod_cluster-extension:%s", version),
+                        "org.jboss.mod_cluster:mod_cluster-core:1.4.1.Final-redhat-00001",
                         formatArtifact("org.jboss.eap:wildfly-clustering-common:%s", version),
                 };
         }
@@ -114,6 +122,11 @@ public class ModClusterTransformersTestCase extends AbstractSubsystemTest {
     @Test
     public void testTransformerEAP_7_2_0() throws Exception {
         this.testTransformation(ModelTestControllerVersion.EAP_7_2_0);
+    }
+
+    @Test
+    public void testTransformerEAP_7_3_0() throws Exception {
+        this.testTransformation(ModelTestControllerVersion.EAP_7_3_0);
     }
 
     private void testTransformation(ModelTestControllerVersion controllerVersion) throws Exception {
@@ -171,6 +184,11 @@ public class ModClusterTransformersTestCase extends AbstractSubsystemTest {
     @Test
     public void testRejectionsEAP_7_2_0() throws Exception {
         this.testRejections(ModelTestControllerVersion.EAP_7_2_0);
+    }
+
+    @Test
+    public void testRejectionsEAP_7_3_0() throws Exception {
+        this.testRejections(ModelTestControllerVersion.EAP_7_3_0);
     }
 
     private void testRejections(ModelTestControllerVersion controllerVersion) throws Exception {
@@ -292,7 +310,7 @@ public class ModClusterTransformersTestCase extends AbstractSubsystemTest {
         }
     }
 
-    static class InitialLoadFailedAttributeConfig extends FailedOperationTransformationConfig.AttributesPathAddressConfig {
+    static class InitialLoadFailedAttributeConfig extends FailedOperationTransformationConfig.AttributesPathAddressConfig<InitialLoadFailedAttributeConfig> {
         InitialLoadFailedAttributeConfig() {
             super(DynamicLoadProviderResourceDefinition.Attribute.INITIAL_LOAD.getName());
         }

--- a/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem-transform-7_0_0.xml
+++ b/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem-transform-7_0_0.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ Copyright 2021, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,7 +21,8 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
-    <proxy advertise="${modcluster.advertise:true}"
+    <proxy name="default"
+           advertise="${modcluster.advertise:true}"
            advertise-security-key="${modcluster.advertise-security-key:mysecurekey!}"
            advertise-socket="modcluster"
            auto-enable-contexts="${modcluster.auto-enable-contexts:true}"
@@ -32,14 +33,14 @@
            flush-wait="${modcluster.flush-wait:10}"
            load-balancing-group="${modcluster.load-balancing-group:mylbgroup}"
            max-attempts="${modcluster.max-attempts:10}"
-           name="default"
            node-timeout="${modcluster.node-timeout:123}"
            ping="${modcluster.ping:10}"
+           proxies="proxy1 proxy2"
            proxy-url="${modcluster.proxy-url:/}"
-           session-draining-strategy="${modcluster.session-draining-strategy:ALWAYS}"
+           session-draining-strategy="DEFAULT"
            smax="${modcluster.smax:2}"
            socket-timeout="${modcluster.socket-timeout:20}"
-           status-interval="15"
+           status-interval="99"
            sticky-session-force="${modcluster.sticky-session-force:false}"
            sticky-session-remove="${modcluster.sticky-session-remove:false}"
            sticky-session="${modcluster.sticky-session:true}"
@@ -70,11 +71,13 @@
             </load-metric>
             <custom-load-metric capacity="${modcluster.custom-load-metric.capacity:1.1}"
                                 class="SomeFakeLoadMetricClass1"
-                                module="com.radoslavhusar.mod_cluster"
+                                module="org.wildfly.extension.mod_cluster"
                                 weight="${modcluster.custom-load-metric.weight:5}"
             />
             <custom-load-metric class="SomeFakeLoadMetricClass2"
-                                capacity="${modcluster.custom-load-metric.capacity:1.1}"/>
+                                capacity="${modcluster.custom-load-metric.capacity:1.1}"
+                                module="my.custom.package"
+            />
             <custom-load-metric class="SomeFakeLoadMetricClass3"
                                 weight="${modcluster.custom-load-metric.weight:5}"/>
         </dynamic-load-provider>
@@ -84,10 +87,23 @@
              cipher-suite="${modcluster.cipher-suite:SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA}"
              key-alias="${modcluster.key-alias:mykeyalias}"
              password="${modcluster.password:mypassword}"
-             protocol="${modcluster.protocol:TLS}"/>
+             protocol="${modcluster.protocol:TLSv1}"/>
     </proxy>
-    <!--<proxy name="other"-->
-           <!--connector="default">-->
-        <!--<simple-load-provider factor="${modcluster.simple-load-provider.factor:15}"/>-->
-    <!--</proxy>-->
+    <proxy name="with-legacy-ssl-configuration"
+           listener="default">
+        <simple-load-provider factor="50"/>
+        <ssl ca-certificate-file="${modcluster.ca-certificate-file:/home/rhusar/client-keystore.jks}"
+             ca-revocation-url="${modcluster.ca-revocation-url:/home/rhusar/revocations}"
+             certificate-key-file="${modcluster.certificate-key-file:/home/rhusar/client-keystore.jks}"
+             cipher-suite="${modcluster.cipher-suite:SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA}"
+             key-alias="${modcluster.key-alias:mykeyalias}"
+             password="${modcluster.password:mypassword}"
+             protocol="${modcluster.protocol:TLSv1}"/>
+    </proxy>
+    <proxy name="with-floating-decay-load-provider"
+           listener="default">
+        <dynamic-load-provider decay="0.5">
+            <load-metric type="sessions"/>
+        </dynamic-load-provider>
+    </proxy>
 </subsystem>

--- a/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_5_0.xml
+++ b/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_5_0.xml
@@ -70,9 +70,11 @@
                 <property name="name2"
                           value="${property2:value2}"/>
             </load-metric>
-            <custom-load-metric class="SomeFakeLoadMetricClass1"
+            <custom-load-metric capacity="${modcluster.custom-load-metric.capacity:1.1}"
+                                class="SomeFakeLoadMetricClass1"
+                                module="com.radoslavhusar.mod_cluster"
                                 weight="${modcluster.custom-load-metric.weight:5}"
-                                capacity="${modcluster.custom-load-metric.capacity:1.1}"/>
+            />
             <custom-load-metric class="SomeFakeLoadMetricClass2"
                                 capacity="${modcluster.custom-load-metric.capacity:1.1}"/>
             <custom-load-metric class="SomeFakeLoadMetricClass3"


### PR DESCRIPTION
* fix mod_cluster jar version for EAP 7.2 to use the productized jar
* add missing module=".." attribute to 5_0 test file

https://issues.redhat.com/browse/WFLY-14512