### PR TITLE
WFLY-14522 Don't enable near-cache in HotRodSessionManager if max-active-sessions is undefined

### DIFF
--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/SessionManagerNearCacheFactory.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/SessionManagerNearCacheFactory.java
@@ -68,7 +68,7 @@ public class SessionManagerNearCacheFactory<K, V> implements NearCacheFactory<K,
 
     @Override
     public NearCacheMode getMode() {
-        return (this.maxActiveSessions != null) && (this.maxActiveSessions.intValue() == 0) ? NearCacheMode.DISABLED : NearCacheMode.INVALIDATED;
+        return (this.maxActiveSessions == null) || (this.maxActiveSessions.intValue() == 0) ? NearCacheMode.DISABLED : NearCacheMode.INVALIDATED;
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14522
