### PR TITLE
[WFLY-14516]:SecurityIdentity is not re-used when using SubjectCreatingPolicyInterceptor in a CXF endpoint

### DIFF
--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -484,6 +484,7 @@
                                         <exclude>org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ws/wsse/usernametoken/UsernameTokenElytronTestCase.java</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>
@@ -529,6 +530,7 @@
                                         <include>org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java</include>
                                         <include>org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java</include>
                                         <include>org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ws/wsse/usernametoken/UsernameTokenElytronTestCase.java</include>
                                     </includes>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/ElytronUsernameTokenImpl.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/ElytronUsernameTokenImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.ws.wsse;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+import javax.jws.WebService;
+import org.apache.cxf.annotations.EndpointProperties;
+import org.apache.cxf.annotations.EndpointProperty;
+import org.apache.cxf.interceptor.InInterceptors;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * <p>Implementation for the ServiceIface that obtains the current elytron
+ * security identity and checks that it is correctly filled (roles and
+ * attributes are not empty). It is only allowed for users with role
+ * <em>Users</em>.</p>
+ *
+ * @author rmartinc
+ */
+@Stateless
+@RolesAllowed("Users")
+@WebService(
+        portName = "UsernameTokenPort",
+        serviceName = "UsernameToken",
+        wsdlLocation = "WEB-INF/wsdl/UsernameToken.wsdl",
+        targetNamespace = "http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy",
+        endpointInterface = "org.jboss.as.test.integration.ws.wsse.ServiceIface"
+)
+@EndpointProperties(value = {
+    @EndpointProperty(key = "ws-security.validate.token", value = "false")
+})
+@InInterceptors(interceptors = {
+    "org.jboss.wsf.stack.cxf.security.authentication.SubjectCreatingPolicyInterceptor"
+})
+public class ElytronUsernameTokenImpl implements ServiceIface {
+
+    @Override
+    public String sayHello() {
+        String username = "World";
+        boolean roles = false, attributes = false;
+        SecurityDomain sd = SecurityDomain.getCurrent();
+        if (sd != null && sd.getCurrentSecurityIdentity() != null) {
+            SecurityIdentity si = sd.getCurrentSecurityIdentity();
+            username = si.getPrincipal().getName();
+            roles = !si.getRoles().isEmpty();
+            attributes = !si.getAttributes().isEmpty();
+        }
+
+        return new StringBuilder("Hello ")
+                .append(username)
+                .append(roles? " with roles" : " without roles")
+                .append(attributes? " and with attributes" : " and without attributes")
+                .append("!")
+                .toString();
+    }
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
@@ -144,6 +144,9 @@ public class WSTrustTestCaseElytronSecuritySetupTask implements ServerSetupTask 
     }
 
     private void removeElytronSecurityDomain(List<ModelNode> operations) throws Exception {
+        final ModelNode removeElytronHttpAuthOp = ModelUtil.createOpNode(
+                "subsystem=elytron/http-authentication-factory=application-http-authentication", REMOVE);
+        operations.add(removeElytronHttpAuthOp);
         final ModelNode removeUndertowDomainOp = ModelUtil.createOpNode(
                 "subsystem=undertow/application-security-domain=" + SECURITY_DOMAIN_NAME, REMOVE);
         operations.add(removeUndertowDomainOp);

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/usernametoken/UsernameTokenElytronTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/usernametoken/UsernameTokenElytronTestCase.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.ws.wsse.usernametoken;
+
+import java.net.URL;
+import java.util.ArrayList;
+import javax.xml.namespace.QName;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.Service;
+import javax.xml.ws.soap.SOAPFaultException;
+import org.apache.cxf.rt.security.SecurityConstants;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.integration.ws.wsse.ElytronUsernameTokenImpl;
+import org.jboss.as.test.integration.ws.wsse.ServiceIface;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.PropertiesRealm;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.UserWithAttributeValues;
+import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
+
+/**
+ * <p>Test case for SubjectCreatingPolicyInterceptor integrated with elytron
+ * security. The username and password are requested by a UsernameToken
+ * policy.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({UsernameTokenElytronTestCase.ElytronDomainSetup.class, UsernameTokenElytronTestCase.EjbElytronDomainSetup.class})
+public class UsernameTokenElytronTestCase {
+
+    @ArquillianResource
+    private URL serviceURL;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, UsernameTokenElytronTestCase.class.getSimpleName() + ".war");
+        archive.setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.apache.cxf\n"))
+                .addClasses(ServiceIface.class, ElytronUsernameTokenImpl.class)
+                .addAsWebInfResource(UsernameTokenElytronTestCase.class.getPackage(), "jboss-ejb3-elytron-properties.xml", "jboss-ejb3.xml")
+                .addAsWebInfResource(ServiceIface.class.getPackage(), "wsdl/UsernameToken.wsdl", "wsdl/UsernameToken.wsdl")
+                .addAsWebInfResource(ServiceIface.class.getPackage(), "wsdl/UsernameToken_schema1.xsd", "wsdl/UsernameToken_schema1.xsd")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
+        return archive;
+    }
+
+    @Test
+    public void testBadPassword() throws Exception {
+        final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy", "UsernameToken");
+        final URL wsdlURL = new URL(serviceURL + "UsernameToken/ElytronUsernameTokenImpl?wsdl");
+        Service service = Service.create(wsdlURL, serviceName);
+        ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);
+
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.USERNAME, "user1");
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.PASSWORD, "passwordWrong");
+
+        // JBWS024057: Failed Authentication : Subject has not been created
+        SOAPFaultException e = Assert.assertThrows(SOAPFaultException.class, () -> proxy.sayHello());
+        MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("JBWS024057"));
+    }
+
+    @Test
+    public void testNoAllowedRole() throws Exception {
+        final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy", "UsernameToken");
+        final URL wsdlURL = new URL(serviceURL + "UsernameToken/ElytronUsernameTokenImpl?wsdl");
+        Service service = Service.create(wsdlURL, serviceName);
+        ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);
+
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.USERNAME, "user2");
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.PASSWORD, "password2");
+
+        // WFLYEJB0364: Invocation on method: xxx.sayHello() of bean: ElytronUsernameTokenImpl is not allowed
+        SOAPFaultException e = Assert.assertThrows(SOAPFaultException.class, () -> proxy.sayHello());
+        MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("WFLYEJB0364"));
+    }
+
+    @Test
+    public void testOk() throws Exception {
+        final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy", "UsernameToken");
+        final URL wsdlURL = new URL(serviceURL + "UsernameToken/ElytronUsernameTokenImpl?wsdl");
+        Service service = Service.create(wsdlURL, serviceName);
+        ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);
+
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.USERNAME, "user1");
+        ((BindingProvider) proxy).getRequestContext().put(SecurityConstants.PASSWORD, "password1");
+
+        Assert.assertEquals("Hello user1 with roles and with attributes!", proxy.sayHello());
+    }
+
+    /**
+     * Elements needed for the elytron configuration: a properties realm with
+     * a user (user1/password1), the security domain with that realm and
+     * the undertow association.
+     */
+    public static class ElytronDomainSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            ArrayList<ConfigurableElement> configurableElements = new ArrayList<>();
+            // creat a properties builder with users (user1 is allowed and user2 is not)
+            configurableElements.add(PropertiesRealm.builder()
+                    .withName("PropertiesRealm")
+                    .withUser(UserWithAttributeValues.builder()
+                            .withName("user1")
+                            .withPassword("password1")
+                            .withValues("Users", "Role1")
+                            .build())
+                    .withUser(UserWithAttributeValues.builder()
+                            .withName("user2")
+                            .withPassword("password2")
+                            .withValues("Role2")
+                            .build())
+                    .build());
+            // create the domain with the properties realm
+            configurableElements.add(SimpleSecurityDomain.builder()
+                    .withName("PropertiesDomain")
+                    .withDefaultRealm("PropertiesRealm")
+                    .withPermissionMapper("default-permission-mapper")
+                    .withRealms(SimpleSecurityDomain.SecurityDomainRealm.builder()
+                            .withRealm("PropertiesRealm")
+                            .withRoleDecoder("groups-to-roles")
+                            .build())
+                    .build());
+            // undertow domain
+            configurableElements.add(UndertowApplicationSecurityDomain.builder()
+                    .withName("PropertiesDomain")
+                    .withSecurityDomain("PropertiesDomain")
+                    .build());
+            return configurableElements.toArray(new ConfigurableElement[0]);
+        }
+    }
+
+    /**
+     * Server task to create the ejb3 domain association.
+     * /subsystem=ejb3/application-security-domain=PropertiesDomain:add(security-domain=PropertiesDomain)
+     */
+    public static class EjbElytronDomainSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            PathAddress ejbDomainAddress = PathAddress.pathAddress()
+                .append(ModelDescriptionConstants.SUBSYSTEM, "ejb3")
+                .append("application-security-domain", "PropertiesDomain");
+            ModelNode addEjbDomain = Util.createAddOperation(ejbDomainAddress);
+            addEjbDomain.get("security-domain").set("PropertiesDomain");
+            CoreUtils.applyUpdate(addEjbDomain, managementClient.getControllerClient());
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            PathAddress ejbDomainAddress = PathAddress.pathAddress()
+                .append(ModelDescriptionConstants.SUBSYSTEM, "ejb3")
+                .append("application-security-domain", "PropertiesDomain");
+            ModelNode addEjbDomain = Util.createRemoveOperation(ejbDomainAddress);
+            CoreUtils.applyUpdate(addEjbDomain, managementClient.getControllerClient());
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+    }
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/usernametoken/jboss-ejb3-elytron-properties.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/usernametoken/jboss-ejb3-elytron-properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss:jboss
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+        xmlns:s="urn:security:1.1"
+        version="3.1" impl-version="2.0">
+    <assembly-descriptor>
+        <s:security>
+            <ejb-name>*</ejb-name>
+            <s:security-domain>PropertiesDomain</s:security-domain>
+        </s:security>
+    </assembly-descriptor>
+</jboss:jboss>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/wsdl/UsernameToken.wsdl
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/wsdl/UsernameToken.wsdl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions targetNamespace="http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy" name="UsernameToken"
+             xmlns:tns="http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:wsp="http://www.w3.org/ns/ws-policy"
+             xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+             xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+             xmlns:wsaws="http://www.w3.org/2005/08/addressing"
+             xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702"
+             xmlns:t="http://docs.oasis-open.org/ws-sx/ws-trust/200512">
+    <types>
+        <xsd:schema>
+            <xsd:import namespace="http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy" schemaLocation="UsernameToken_schema1.xsd"/>
+        </xsd:schema>
+    </types>
+    <message name="sayHello">
+        <part name="parameters" element="tns:sayHello"/>
+    </message>
+    <message name="sayHelloResponse">
+        <part name="parameters" element="tns:sayHelloResponse"/>
+    </message>
+    <portType name="ServiceIface">
+        <operation name="sayHello">
+            <input message="tns:sayHello"/>
+            <output message="tns:sayHelloResponse"/>
+        </operation>
+    </portType>
+    <binding name="UsernameTokenPortBinding" type="tns:ServiceIface">
+        <wsp:PolicyReference URI="#UsernameTokenPolicy"/>
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="sayHello">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="UsernameToken">
+        <port name="UsernameTokenPort" binding="tns:UsernameTokenPortBinding">
+            <soap:address location="http://@jboss.bind.address@:8080/UsernameTokenElytronTestCase/UsernameToken/ElytronUsernameTokenImpl"/>
+        </port>
+    </service>
+
+    <wsp:Policy wsu:Id="UsernameTokenPolicy">
+        <wsp:ExactlyOne>
+            <wsp:All>
+                <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+                    <wsp:Policy>
+                        <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                            <wsp:Policy>
+                                <sp:WssUsernameToken10/>
+                            </wsp:Policy>
+                        </sp:UsernameToken>
+                    </wsp:Policy>
+                </sp:SupportingTokens>
+            </wsp:All>
+        </wsp:ExactlyOne>
+    </wsp:Policy>
+
+</definitions>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/wsdl/UsernameToken_schema1.xsd
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/wsdl/UsernameToken_schema1.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0" targetNamespace="http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy"
+           xmlns:tns="http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="sayHello" type="tns:sayHello"/>
+
+    <xs:element name="sayHelloResponse" type="tns:sayHelloResponse"/>
+
+    <xs:complexType name="sayHello">
+        <xs:sequence/>
+    </xs:complexType>
+
+    <xs:complexType name="sayHelloResponse">
+        <xs:sequence>
+            <xs:element name="return" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>
+

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
@@ -76,6 +76,7 @@ public class ElytronSecurityDomainContextImpl implements SecurityDomainContext {
         if (identity == null) {
             return false;
         }
+        this.currentIdentity.set(identity);
         SubjectUtil.fromSecurityIdentity(identity, subject);
         return true;
     }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
@@ -130,7 +130,16 @@ public final class SubjectUtil {
 
     public static SecurityIdentity convertToSecurityIdentity(Subject subject, Principal principal, SecurityDomain domain,
             String roleCategory) {
-        SecurityIdentity identity = domain.createAdHocIdentity(principal);
+        SecurityIdentity identity = null;
+        for (Object obj : subject.getPrivateCredentials()) {
+            if (obj instanceof SecurityIdentity) {
+                identity = (SecurityIdentity)obj;
+                break;
+            }
+        }
+        if (identity == null) {
+            identity = domain.createAdHocIdentity(principal);
+        }
         // convert subject Group
         Set<String> roles = new HashSet<>();
         for (Principal prin : subject.getPrincipals()) {
@@ -157,8 +166,9 @@ public final class SubjectUtil {
                 publicCredentials = publicCredentials.withCredential((Credential) credential);
             }
         }
-        identity = identity.withPublicCredentials(publicCredentials);
-
+        if (!publicCredentials.equals(IdentityCredentials.NONE)) {
+            identity = identity.withPublicCredentials(publicCredentials);
+        }
         // convert private credentials
         IdentityCredentials privateCredentials = IdentityCredentials.NONE;
         for (Object credential : subject.getPrivateCredentials()) {
@@ -175,7 +185,9 @@ public final class SubjectUtil {
                 privateCredentials = privateCredentials.withCredential((Credential) credential);
             }
         }
-        identity = identity.withPrivateCredentials(privateCredentials);
+        if (!privateCredentials.equals(IdentityCredentials.NONE)) {
+            identity = identity.withPrivateCredentials(privateCredentials);
+        }
 
         return identity;
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14516

Fix for WFLY-14516. @jimma did the first commit with the real code fixing and I added a second commit with a test that checks jbossws/elytron integration. The test uses a SubjectCreatingPolicyInterceptor to force the login into the elytron/JavaEE security.
