### PR TITLE
[WFLY-14535] Upgrade WildFly Core 15.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>15.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>15.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.5.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14535

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/15.0.0.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/15.0.0.Beta1...15.0.0.Final

---


# Release Notes - WildFly Core - Version 15.0.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5276'>WFCORE-5276</a>] -         Upgrade jgit to 5.10.0.202012080955-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5293'>WFCORE-5293</a>] -         Upgrade aesh-readline to 2.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5294'>WFCORE-5294</a>] -         Upgrade Jandex to 2.2.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5309'>WFCORE-5309</a>] -         Upgrade WildFly Elytron to 1.15.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5310'>WFCORE-5310</a>] -         Upgrade Elytron Web to 1.9.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5317'>WFCORE-5317</a>] -         Upgrade galleon-plugins to 5.1.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5318'>WFCORE-5318</a>] -         Upgrade to byteman 4.0.14
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5321'>WFCORE-5321</a>] -         Upgrade to xalan 2.7.1.jbossorg-5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5327'>WFCORE-5327</a>] -         Upgrade WildFly Elytron to 1.15.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5329'>WFCORE-5329</a>] -         Upgrade Undertow to 2.2.5.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5323'>WFCORE-5323</a>] -         Better output for errors during CLI script execution at boot
</li>
</ul>
                                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5324'>WFCORE-5324</a>] -         Ability to execute CLI script at runtime
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5226'>WFCORE-5226</a>] -         No acceptedIssuers is sent when CRLs are configured
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5241'>WFCORE-5241</a>] -         Jboss-cli issue with spaces in JAVA_OPTS on Unix
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5247'>WFCORE-5247</a>] -         IllegalArgumentException and CLI crash with read-attribute in /system-property
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5249'>WFCORE-5249</a>] -         NoClassDefFoundError: Failed to link org/bouncycastle/openpgp/PGPEncryptedDataList: org/bouncycastle/util/Iterable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5253'>WFCORE-5253</a>] -         Incorrect use of &#39;operation&#39; instead of Resource in the remoting subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5254'>WFCORE-5254</a>] -         Kernel domain-management module has a couple OSHs populating the runtime with data from the operation, not the model
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5257'>WFCORE-5257</a>] -         Service org.wildfly.network.outbound-socket-binding might not get installed correctly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5271'>WFCORE-5271</a>] -         NullPointerException creating new KeyStore without type
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5295'>WFCORE-5295</a>] -         Indexing org.postgresq.jdbc.PgConnection$1 fails
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5296'>WFCORE-5296</a>] -         The error message from import-secret-key on (secret-key-)credential-store should be more helpful
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5297'>WFCORE-5297</a>] -         Incosistency in naming of location/path attribute of credential-store and secret-key-credential-store
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5298'>WFCORE-5298</a>] -         The error message from export-secret-key on (secret-key-)credential-store should be more helpful
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5300'>WFCORE-5300</a>] -         (secret-key-)credential-store overwrites existing aliases when generating or importing keys
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5301'>WFCORE-5301</a>] -         NullPointerException when expression=encryption:create-expression uses resolver with invalid secret-key
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5302'>WFCORE-5302</a>] -         secret-key-credential-store reload results in an error
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5303'>WFCORE-5303</a>] -         :resolve-expression does not resolve encrypted expressions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5322'>WFCORE-5322</a>] -         Setting jboss.server.log.dir has no effect
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5288'>WFCORE-5288</a>] -         Improve subsystem test coverage for JMX
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5306'>WFCORE-5306</a>] -         Clarifications needed for Message Translations II
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5311'>WFCORE-5311</a>] -         Add subsystem test with hierarchy of resources using expression resolution
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5325'>WFCORE-5325</a>] -         Additional tests for credential stores
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5326'>WFCORE-5326</a>] -         Extend SlaveHostControllerAuthenticationTestCase with test for Elytron expression resolver
</li>
</ul>
                                                        