### PR TITLE
[WFLY-14550] Upgrading WildFly Http Client to 1.1.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>15.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.5.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.6.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.13.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14550

Brings in fix for:
 * [WEJBHTTP-56] set SSLContext according to target context uri when creating HttpSubordinateTransactionHandle
