### PR TITLE
WFLY-14551 EJB subsystem should not allow expressions for cache-container/bean-cache in passivation-store resource and client-mappings-clustering-name in remote resource

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClusterPassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClusterPassivationStoreResourceDefinition.java
@@ -57,7 +57,8 @@ public class ClusterPassivationStoreResourceDefinition extends LegacyPassivation
     static final SimpleAttributeDefinition CACHE_CONTAINER = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CACHE_CONTAINER, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.CACHE_CONTAINER.getLocalName())
             .setDefaultValue(new ModelNode(BeanManagerFactoryServiceConfiguratorConfiguration.DEFAULT_CONTAINER_NAME))
-            .setAllowExpression(true)
+            // Capability references should not allow expressions
+            .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_NONE)
             // a CapabilityReference to a UnaryRequirement
             .setCapabilityReference(new CapabilityReference(()->CLUSTER_PASSIVATION_STORE_CAPABILITY, InfinispanDefaultCacheRequirement.CONFIGURATION))
@@ -66,7 +67,8 @@ public class ClusterPassivationStoreResourceDefinition extends LegacyPassivation
     @Deprecated
     static final SimpleAttributeDefinition BEAN_CACHE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.BEAN_CACHE, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.BEAN_CACHE.getLocalName())
-            .setAllowExpression(true)
+            // Capability references should not allow expressions
+            .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_NONE)
             // a CapabilityReference to a BinaryRequirement (including a parent attribute)
             .setCapabilityReference(new CapabilityReference(()->CLUSTER_PASSIVATION_STORE_CAPABILITY, InfinispanCacheRequirement.CONFIGURATION, ()->CACHE_CONTAINER))
@@ -76,7 +78,8 @@ public class ClusterPassivationStoreResourceDefinition extends LegacyPassivation
     static final SimpleAttributeDefinition CLIENT_MAPPINGS_CACHE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CLIENT_MAPPINGS_CACHE, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.CLIENT_MAPPINGS_CACHE.getLocalName())
             .setDefaultValue(new ModelNode("remote-connector-client-mappings"))
-            .setAllowExpression(true)
+            // Capability references should not allow expressions
+            .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_NONE)
             .setDeprecated(DEPRECATED_VERSION)
             // TODO: replace this with a Requirement reference when the ejb-spi module for clustering is available

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -72,7 +72,8 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition CLIENT_MAPPINGS_CLUSTER_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME, ModelType.STRING, true)
-                    .setAllowExpression(true)
+                    // Capability references should not allow expressions
+                    .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(BeanManagerFactoryServiceConfiguratorConfiguration.DEFAULT_CONTAINER_NAME))
                     // TODO: replace this with a Requirement reference when the ejb-spi module for clustering is available

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
@@ -52,7 +52,8 @@ public class PassivationStoreResourceDefinition extends SimpleResourceDefinition
     static final SimpleAttributeDefinition CACHE_CONTAINER = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CACHE_CONTAINER, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.CACHE_CONTAINER.getLocalName())
             .setDefaultValue(new ModelNode(BeanManagerFactoryServiceConfiguratorConfiguration.DEFAULT_CONTAINER_NAME))
-            .setAllowExpression(true)
+            // Capability references should not allow expressions
+            .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             // a CapabilityReference to a UnaryRequirement
             .setCapabilityReference(new CapabilityReference(()->PASSIVATION_STORE_CAPABILITY, InfinispanDefaultCacheRequirement.CONFIGURATION))
@@ -60,7 +61,8 @@ public class PassivationStoreResourceDefinition extends SimpleResourceDefinition
 
     static final SimpleAttributeDefinition BEAN_CACHE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.BEAN_CACHE, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.BEAN_CACHE.getLocalName())
-            .setAllowExpression(true)
+            // Capability references should not allow expressions
+            .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             // a CapabilityReference to a BinaryRequirement (including a parent attribute)
             .setCapabilityReference(new CapabilityReference(()->PASSIVATION_STORE_CAPABILITY, InfinispanCacheRequirement.CONFIGURATION, ()->CACHE_CONTAINER))

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -273,7 +273,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         assertEquals("true", useQualifiedName);
 
         final ModelNode remote = ejb3.get("service", "remote");
-        assertEquals("ejb", remote.get("cluster").resolve().asString());
+        assertEquals("ejb", remote.get("cluster").asString());
         assertEquals("false", remote.get("execute-in-worker").resolve().asString());
         assertEquals("default", remote.get("thread-pool-name").resolve().asString());
         assertEquals(20, remote.get("channel-creation-options").asPropertyList().get(0).getValue().get("value").resolve().asInt());

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -246,8 +246,8 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         assertEquals("false", mdbDeliveryGroupActive);
 
         final ModelNode passivationStore = ejb3.get("passivation-store").asPropertyList().get(0).getValue();
-        assertEquals("default", passivationStore.get("bean-cache").resolve().asString());
-        assertEquals("ejb", passivationStore.get("cache-container").resolve().asString());
+        assertEquals("default", passivationStore.get("bean-cache").asString());
+        assertEquals("ejb", passivationStore.get("cache-container").asString());
         assertEquals(10, passivationStore.get("max-size").resolve().asInt());
 
         final ModelNode remotingProfile = ejb3.get("remoting-profile").asPropertyList().get(0).getValue();

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
@@ -42,7 +42,7 @@
         <cache name="distributable" passivation-store-ref="${sysprop:infinispan}"/>
     </caches>
     <passivation-stores>
-        <passivation-store name="infinispan" cache-container="${sysprop:ejb}" bean-cache="${sysprop:default}" max-size="${sysprop:10}"/>
+        <passivation-store name="infinispan" cache-container="ejb" bean-cache="default" max-size="${sysprop:10}"/>
     </passivation-stores>
     <async thread-pool-name="${sysprop:default}"/>
     <timer-service thread-pool-name="default" default-data-store="file-data-store">

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/with-expression-subsystem.xml
@@ -56,7 +56,7 @@
                                  refresh-interval="${sysprop:100}"/>
         </data-stores>
     </timer-service>
-    <remote connectors="http-remoting-connector" thread-pool-name="${sysprop:default}" cluster="${sysprop:ejb}" execute-in-worker="${sysprop:false}">
+    <remote connectors="http-remoting-connector" thread-pool-name="${sysprop:default}" cluster="ejb" execute-in-worker="${sysprop:false}">
         <channel-creation-options>
             <option name="READ_TIMEOUT" value="${prop.remoting-connector.read.timeout:20}" type="xnio"/>
             <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-14551
https://issues.redhat.com/browse/WFLY-14552