### PR TITLE
[WFLY-14564] Close EJBClientContext when related service is closed

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientContextService.java
@@ -178,6 +178,7 @@ public final class EJBClientContextService implements Service<EJBClientContextSe
     }
 
     public void stop(final StopContext context) {
+        clientContext.close();
         clientContext = null;
         if (makeGlobal) {
             doPrivileged((PrivilegedAction<Void>) () -> {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14564

Not closing the context leads to connection leaks. This issue is related to:
https://issues.redhat.com/browse/EAPSUP-439