### PR TITLE
[WFLY-14566] Fix JSFDeploymentProcessorTestCase on Java11+secmgr

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.jsf.version;
 
 import java.io.FilePermission;
+import java.lang.reflect.ReflectPermission;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -97,6 +98,7 @@ public class JSFDeploymentProcessorTestCase {
         ear.addAsManifestResource(createPermissionsXmlAsset(
                 new RuntimePermission("getClassLoader"),
                 new RuntimePermission("accessDeclaredMembers"),
+                new ReflectPermission("suppressAccessChecks"),
                 new PropertyPermission("*", "read"),
                 new FilePermission("/-", "read")), "permissions.xml");
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14566

Adding "suppressAccessChecks" persmission to the JSFDeploymentProcessorTestCase to workaround an issue in commons-beanutils library. 
During myfaces startup commons-beanutil's MethodUtils attempts to call Method.setAccessible(true) in order to workaround accessibility issue. If that fails, there is logic to check java version and log additional warnings. This logic fails with Java 11+ (https://issues.apache.org/jira/browse/BEANUTILS-547)