### PR TITLE
[WFLY-14579]: The threadpool name of a workmanager must be the name o…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -949,4 +949,8 @@ public interface ConnectorLogger extends BasicLogger {
      */
     @Message(id = 121, value = "Unable to start the data source '%s' because there is more than one(%s) connection factory defined.")
     StartException cannotStartDSTooManyConnectionFactories(String dataSourceJNDIName, int factoriesCount);
+
+
+    @Message(id = 122, value = "Thread pool name %s(type: %s) must match the workmanager name %s.")
+    OperationFailedException threadPoolNameMustMatchWorkManagerName(String threadPoolName, String threadPoolType, String workManagerName);
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
@@ -144,6 +144,9 @@ public class JcaWorkManagerDefinition extends SimpleResourceDefinition {
                 && !entrySet.iterator().next().equals(threadPoolPath.getLastElement().getValue())) {
             throw ConnectorLogger.ROOT_LOGGER.oneThreadPoolWorkManager(threadPoolPath.getLastElement().getValue(), type, workManagerPath.getLastElement().getValue());
         }
+        if(!context.getCurrentAddressValue().equals(workManagerPath.getLastElement().getValue())) {
+            throw ConnectorLogger.ROOT_LOGGER.threadPoolNameMustMatchWorkManagerName(threadPoolPath.getLastElement().getValue(), type, workManagerPath.getLastElement().getValue());
+        }
     }
 
     public enum WmParameters {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
@@ -23,16 +23,15 @@ package org.jboss.as.test.integration.jca.workmanager;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 
 import java.io.IOException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
+
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
@@ -52,6 +51,8 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
 
+    private static final PathAddress WORKMANAGER_ADDRESS = PathAddress.pathAddress("subsystem", "jca").append("workmanager", "default");
+
     @Deployment
     public static Archive<?> deploytRar() {
         return ShrinkWrap.create(JavaArchive.class, "dummy.jar");
@@ -59,14 +60,7 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
 
     @Test
     public void testOneLongRunningThreadPool() throws IOException {
-        ModelNode address = new ModelNode();
-        address.add("subsystem", "jca");
-        address.add("workmanager", "default");
-        address.add("long-running-threads", "Long");
-
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(address);
-        operation.get(OP).set(ADD);
+        ModelNode operation = Operations.createAddOperation(WORKMANAGER_ADDRESS.append("long-running-threads", "Long").toModelNode());
         operation.get("max-threads").set(10);
         operation.get("queue-length").set(10);
         try {
@@ -85,14 +79,7 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
 
     @Test
     public void testOneShortRunningThreadPool() throws IOException {
-        ModelNode address = new ModelNode();
-        address.add("subsystem", "jca");
-        address.add("workmanager", "default");
-        address.add("short-running-threads", "Short");
-
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(address);
-        operation.get(OP).set(ADD);
+        ModelNode operation = Operations.createAddOperation(WORKMANAGER_ADDRESS.append("short-running-threads", "Short").toModelNode());
         operation.get("max-threads").set(10);
         operation.get("queue-length").set(10);
         try {
@@ -110,20 +97,38 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
     }
 
     @Test
+    public void testShortRunningThreadPoolName() throws Exception {
+        PathAddress address = PathAddress.pathAddress("subsystem", "jca").append("workmanager", "name-test");
+        ModelNode operation = Operations.createAddOperation(address.toModelNode());
+        operation.get("name").set("name-test");
+        executeOperation(operation);
+        operation = Operations.createAddOperation(address.append("short-running-threads", "Short").toModelNode());
+        operation.get("max-threads").set(10);
+        operation.get("queue-length").set(10);
+        try {
+            executeOperation(operation);
+            Assert.fail("NOT HERE!");
+        } catch (MgmtOperationException e) {
+            String reason = e.getResult().get("failure-description").asString();
+            Assert.assertThat("Wrong error message", reason, allOf(
+                    containsString("WFLYJCA0122"),
+                    containsString("Short"),
+                    containsString("short-running-threads"),
+                    containsString("name-test")
+            ));
+        } finally {
+            executeOperation(Operations.createRemoveOperation(address.toModelNode()));
+        }
+    }
+
+    @Test
     public void testBlockingThreadPool() throws IOException {
         Assert.assertTrue(isBlockingThreadPool("short-running-threads"));
         Assert.assertTrue(isBlockingThreadPool("long-running-threads"));
     }
 
     protected boolean isBlockingThreadPool(String pool) throws IOException {
-        ModelNode address = new ModelNode();
-        address.add("subsystem", "jca");
-        address.add("workmanager", "default");
-        address.add(pool, "default");
-
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(address);
-        operation.get(OP).set(READ_RESOURCE_DESCRIPTION_OPERATION);
+        ModelNode operation = Operations.createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, WORKMANAGER_ADDRESS.append(pool, "default").toModelNode());
         try {
             ModelNode result = executeOperation(operation);
             return result.asString().contains("A thread pool executor with a bounded queue where threads submittings tasks may block");


### PR DESCRIPTION
…f the workmanager.

* Checking the threadpool name on its creation.

Jira: https://issues.redhat.com/browse/WFLY-14579