### PR TITLE
WFLY-14542 Cache entries in heap can exceed max-active-sessions when distributed session manager configured with local, passivating caches

### DIFF
--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/listener/PostActivateListener.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/listener/PostActivateListener.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.listener;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.BiConsumer;
+
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
+import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+/**
+ * Generic non-blocking passivation listener that consumes an activation event.
+ * @author Paul Ferraro
+ */
+@Listener(observation = Listener.Observation.POST)
+public class PostActivateListener<K, V> {
+    private final BiConsumer<K, V> consumer;
+    private final Executor executor;
+
+    public PostActivateListener(BiConsumer<K, V> consumer, Executor executor) {
+        this.consumer = consumer;
+        this.executor = executor;
+    }
+
+    @CacheEntryActivated
+    public CompletionStage<Void> activated(CacheEntryActivatedEvent<K, V> event) {
+        if (!event.isPre()) {
+            try {
+                return CompletableFuture.runAsync(() -> this.consumer.accept(event.getKey(), event.getValue()), this.executor);
+            } catch (RejectedExecutionException e) {
+                // Executor was shutdown
+            }
+        }
+        return CompletableFutures.completedNull();
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/listener/PrePassivateListener.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/listener/PrePassivateListener.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.listener;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.BiConsumer;
+
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
+import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
+import org.infinispan.util.concurrent.CompletableFutures;
+
+/**
+ * Generic non-blocking passivation listener that consumes a passivation event.
+ * @author Paul Ferraro
+ */
+@Listener(observation = Listener.Observation.PRE)
+public class PrePassivateListener<K, V> {
+    private final BiConsumer<K, V> consumer;
+    private final Executor executor;
+
+    public PrePassivateListener(BiConsumer<K, V> consumer, Executor executor) {
+        this.consumer = consumer;
+        this.executor = executor;
+    }
+
+    @CacheEntryPassivated
+    public CompletionStage<Void> passivated(CacheEntryPassivatedEvent<K, V> event) {
+        if (event.isPre()) {
+            try {
+                return CompletableFuture.runAsync(() -> this.consumer.accept(event.getKey(), event.getValue()), this.executor);
+            } catch (RejectedExecutionException e) {
+                // Executor was shutdown
+            }
+        }
+        return CompletableFutures.completedNull();
+    }
+}

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactory.java
@@ -127,6 +127,7 @@ public class CompositeSessionFactory<C, V, L> extends CompositeImmutableSessionF
 
     @Override
     public void close() {
-        // Nothing to close
+        this.metaDataFactory.close();
+        this.attributesFactory.close();
     }
 }

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/ImmutableSessionActivationNotifier.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/ImmutableSessionActivationNotifier.java
@@ -44,6 +44,8 @@ public class ImmutableSessionActivationNotifier<S, C, L> implements SessionActiv
     private final C context;
     private final SessionAttributesFilter filter;
     private final AtomicBoolean active = new AtomicBoolean(false);
+    private final Function<L, Consumer<S>> prePassivateNotifier;
+    private final Function<L, Consumer<S>> postActivateNotifier;
 
     public ImmutableSessionActivationNotifier(HttpSessionActivationListenerProvider<S, C, L> provider, ImmutableSession session, C context) {
         this(provider, session, context, new ImmutableSessionAttributesFilter(session));
@@ -54,19 +56,21 @@ public class ImmutableSessionActivationNotifier<S, C, L> implements SessionActiv
         this.session = session;
         this.context = context;
         this.filter = filter;
+        this.prePassivateNotifier = this.provider::prePassivateNotifier;
+        this.postActivateNotifier = this.provider::postActivateNotifier;
     }
 
     @Override
     public void prePassivate() {
         if (this.active.compareAndSet(true, false)) {
-            this.notify(this.provider::prePassivateNotifier);
+            this.notify(this.prePassivateNotifier);
         }
     }
 
     @Override
     public void postActivate() {
         if (this.active.compareAndSet(false, true)) {
-            this.notify(this.provider::postActivateNotifier);
+            this.notify(this.postActivateNotifier);
         }
     }
 

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionAttributeActivationNotifier.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionAttributeActivationNotifier.java
@@ -22,10 +22,15 @@
 
 package org.wildfly.clustering.web.cache.session;
 
+import java.util.function.BiConsumer;
+
 /**
  * @author Paul Ferraro
  */
 public interface SessionAttributeActivationNotifier extends AutoCloseable {
+    BiConsumer<SessionAttributeActivationNotifier, Object> PRE_PASSIVATE = SessionAttributeActivationNotifier::prePassivate;
+    BiConsumer<SessionAttributeActivationNotifier, Object> POST_ACTIVATE = SessionAttributeActivationNotifier::postActivate;
+
     /**
      * Notifies the specified attribute that it will be passivated, if interested.
      */

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionAttributesFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionAttributesFactory.java
@@ -32,6 +32,11 @@ import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
  * @param <V> the marshalled value type
  * @author Paul Ferraro
  */
-public interface SessionAttributesFactory<C, V> extends ImmutableSessionAttributesFactory<V>, Creator<String, V, Void>, Remover<String> {
+public interface SessionAttributesFactory<C, V> extends ImmutableSessionAttributesFactory<V>, Creator<String, V, Void>, Remover<String>, AutoCloseable {
     SessionAttributes createSessionAttributes(String id, V value, ImmutableSessionMetaData metaData, C context);
+
+    @Override
+    default void close() {
+        // Nothing to close
+    }
 }

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionMetaDataFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionMetaDataFactory.java
@@ -28,6 +28,11 @@ import org.wildfly.clustering.ee.Remover;
 /**
  * @author Paul Ferraro
  */
-public interface SessionMetaDataFactory<V> extends ImmutableSessionMetaDataFactory<V>, Creator<String, V, Void>, Remover<String> {
+public interface SessionMetaDataFactory<V> extends ImmutableSessionMetaDataFactory<V>, Creator<String, V, Void>, Remover<String>, AutoCloseable {
     InvalidatableSessionMetaData createSessionMetaData(String id, V value);
+
+    @Override
+    default void close() {
+        // Nothing to close
+    }
 }

--- a/clustering/web/cache/src/test/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactoryTestCase.java
+++ b/clustering/web/cache/src/test/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactoryTestCase.java
@@ -164,4 +164,12 @@ public class CompositeSessionFactoryTestCase {
         assertSame(metaData, result.getMetaData());
         assertSame(attributes, result.getAttributes());
     }
+
+    @Test
+    public void close() {
+        this.factory.close();
+
+        verify(this.metaDataFactory).close();
+        verify(this.attributesFactory).close();
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanConfiguration.java
@@ -22,25 +22,18 @@
 
 package org.wildfly.clustering.web.infinispan.session;
 
-import java.util.concurrent.Executor;
-
+import org.infinispan.Cache;
 import org.wildfly.clustering.ee.cache.CacheProperties;
-import org.wildfly.clustering.web.cache.session.SessionAttributesFactoryConfiguration;
+import org.wildfly.clustering.ee.infinispan.InfinispanCacheProperties;
 
 /**
- * @param <S> the HttpSession specification type
- * @param <C> the ServletContext specification type
- * @param <L> the HttpSessionActivationListener specification type
- * @param <V> attributes cache entry type
- * @param <SV> attributes serialized form type
  * @author Paul Ferraro
  */
-public interface InfinispanSessionAttributesFactoryConfiguration<S, C, L, V, SV> extends InfinispanConfiguration, SessionAttributesFactoryConfiguration<S, C, L, V, SV> {
+public interface InfinispanConfiguration {
 
-    @Override
+    <K, V> Cache<K, V> getCache();
+
     default CacheProperties getCacheProperties() {
-        return InfinispanConfiguration.super.getCacheProperties();
+        return new InfinispanCacheProperties(this.getCache().getCacheConfiguration());
     }
-
-    Executor getExecutor();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionAttributesFactoryConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionAttributesFactoryConfiguration.java
@@ -23,8 +23,10 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 import org.wildfly.clustering.ee.cache.CacheProperties;
+import org.wildfly.clustering.web.cache.session.SessionAttributeActivationNotifier;
 import org.wildfly.clustering.web.cache.session.SessionAttributesFactoryConfiguration;
 
 /**
@@ -43,4 +45,6 @@ public interface InfinispanSessionAttributesFactoryConfiguration<S, C, L, V, SV>
     }
 
     Executor getExecutor();
+
+    Function<String, SessionAttributeActivationNotifier> getActivationNotifierFactory();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import java.time.Duration;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -35,28 +36,21 @@ import java.util.stream.Stream;
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
 import org.infinispan.notifications.Listener;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
-import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.util.concurrent.CompletableFutures;
 import org.wildfly.clustering.Registrar;
 import org.wildfly.clustering.Registration;
-import org.wildfly.clustering.ee.BatchContext;
 import org.wildfly.clustering.ee.Batcher;
 import org.wildfly.clustering.ee.Recordable;
 import org.wildfly.clustering.ee.Scheduler;
-import org.wildfly.clustering.ee.cache.CacheProperties;
 import org.wildfly.clustering.ee.cache.Key;
 import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.infinispan.spi.PredicateKeyFilter;
 import org.wildfly.clustering.infinispan.spi.distribution.CacheLocality;
 import org.wildfly.clustering.infinispan.spi.distribution.Locality;
 import org.wildfly.clustering.web.IdentifierFactory;
-import org.wildfly.clustering.web.cache.session.ImmutableSessionActivationNotifier;
 import org.wildfly.clustering.web.cache.session.SessionFactory;
 import org.wildfly.clustering.web.cache.session.SessionMetaDataFactory;
 import org.wildfly.clustering.web.cache.session.SimpleImmutableSession;
@@ -67,43 +61,39 @@ import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
 import org.wildfly.clustering.web.session.SessionManager;
-import org.wildfly.clustering.web.session.SpecificationProvider;
 
 /**
  * Generic session manager implementation - independent of cache mapping strategy.
- * @param <S> the HttpSession specification type
  * @param <SC> the ServletContext specification type
- * @param <AL> the HttpSessionAttributeListener specification type
  * @param <MV> the meta-data value type
  * @param <AV> the attributes value type
  * @param <LC> the local context type
  * @author Paul Ferraro
  */
 @Listener(primaryOnly = true)
-public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionManager<LC, TransactionBatch> {
+public class InfinispanSessionManager<SC, MV, AV, LC> implements SessionManager<LC, TransactionBatch> {
 
     private final Registrar<SessionExpirationListener> expirationRegistrar;
     private final SessionExpirationListener expirationListener;
     private final Batcher<TransactionBatch> batcher;
     private final Cache<Key<String>, ?> cache;
-    private final CacheProperties properties;
     private final SessionFactory<SC, MV, AV, LC> factory;
     private final IdentifierFactory<String> identifierFactory;
     private final Scheduler<String, ImmutableSessionMetaData> expirationScheduler;
     private final Recordable<ImmutableSessionMetaData> recorder;
     private final SC context;
-    private final SpecificationProvider<S, SC, AL> provider;
     private final Runnable startTask;
     private final Consumer<ImmutableSession> closeTask;
     private final Executor executor;
+    private final Registrar<Map.Entry<SC, SessionManager<LC, TransactionBatch>>> contextRegistrar;
 
     private volatile Duration defaultMaxInactiveInterval = Duration.ofMinutes(30L);
     private volatile Registration expirationRegistration;
+    private volatile Registration contextRegistration;
 
-    public InfinispanSessionManager(SessionFactory<SC, MV, AV, LC> factory, InfinispanSessionManagerConfiguration<S, SC, AL> configuration) {
+    public InfinispanSessionManager(SessionFactory<SC, MV, AV, LC> factory, InfinispanSessionManagerConfiguration<SC, LC> configuration) {
         this.factory = factory;
         this.cache = configuration.getCache();
-        this.properties = configuration.getProperties();
         this.expirationRegistrar = configuration.getExpirationRegistar();
         this.expirationListener = configuration.getExpirationListener();
         this.identifierFactory = configuration.getIdentifierFactory();
@@ -111,7 +101,7 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
         this.expirationScheduler = configuration.getExpirationScheduler();
         this.recorder = configuration.getInactiveSessionRecorder();
         this.context = configuration.getServletContext();
-        this.provider = configuration.getSpecificationProvider();
+        this.contextRegistrar = configuration.getContextRegistrar();
         this.startTask = configuration.getStartTask();
         this.executor = configuration.getExecutor();
         this.closeTask = new Consumer<ImmutableSession>() {
@@ -126,6 +116,7 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
 
     @Override
     public void start() {
+        this.contextRegistration = this.contextRegistrar.register(new SimpleImmutableEntry<>(this.context, this));
         if (this.recorder != null) {
             this.recorder.reset();
         }
@@ -133,8 +124,6 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
         this.expirationRegistration = this.expirationRegistrar.register(this.expirationListener);
         CacheEventFilter<Object, Object> filter = new PredicateKeyFilter<>(SessionCreationMetaDataKeyFilter.INSTANCE);
         this.cache.addListener(this, filter, null);
-        this.cache.addListener(this.factory.getMetaDataFactory(), filter, null);
-        this.cache.addListener(this.factory.getAttributesFactory(), filter, null);
         this.startTask.run();
     }
 
@@ -142,9 +131,8 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
     public void stop() {
         this.expirationRegistration.close();
         this.cache.removeListener(this);
-        this.cache.removeListener(this.factory.getMetaDataFactory());
-        this.cache.removeListener(this.factory.getAttributesFactory());
         this.identifierFactory.stop();
+        this.contextRegistration.close();
     }
 
     @Override
@@ -228,50 +216,6 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
     @Override
     public long getActiveSessionCount() {
         return this.getActiveSessions().size();
-    }
-
-    @CacheEntryActivated
-    public CompletionStage<Void> activated(CacheEntryActivatedEvent<SessionCreationMetaDataKey, ?> event) {
-        if (!event.isPre() && !this.properties.isPersistent()) {
-            String id = event.getKey().getId();
-            InfinispanWebLogger.ROOT_LOGGER.tracef("Session %s was activated", id);
-            try (TransactionBatch batch = this.batcher.suspendBatch()) {
-                return CompletableFuture.runAsync(() -> {
-                    try (BatchContext context = this.batcher.resumeBatch(batch)) {
-                        Map.Entry<MV, AV> value = this.factory.tryValue(id);
-                        if (value != null) {
-                            ImmutableSession session = this.factory.createImmutableSession(id, value);
-                            new ImmutableSessionActivationNotifier<>(this.provider, session, this.context).postActivate();
-                        }
-                    }
-                }, this.executor);
-            } catch (RejectedExecutionException e) {
-                // Session manager is stopped
-            }
-        }
-        return CompletableFutures.completedNull();
-    }
-
-    @CacheEntryPassivated
-    public CompletionStage<Void> passivated(CacheEntryPassivatedEvent<SessionCreationMetaDataKey, ?> event) {
-        if (event.isPre() && !this.properties.isPersistent()) {
-            String id = event.getKey().getId();
-            InfinispanWebLogger.ROOT_LOGGER.tracef("Session %s will be passivated", id);
-            try (TransactionBatch batch = this.batcher.suspendBatch()) {
-                return CompletableFuture.runAsync(() -> {
-                    try (BatchContext context = this.batcher.resumeBatch(batch)) {
-                        Map.Entry<MV, AV> value = this.factory.tryValue(id);
-                        if (value != null) {
-                            ImmutableSession session = this.factory.createImmutableSession(id, value);
-                            new ImmutableSessionActivationNotifier<>(this.provider, session, this.context).prePassivate();
-                        }
-                    }
-                }, this.executor);
-            } catch (RejectedExecutionException e) {
-                // Session manager is stopped
-            }
-        }
-        return CompletableFutures.completedNull();
     }
 
     @CacheEntryRemoved

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -26,10 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,8 +43,6 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEven
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.util.concurrent.CompletableFutures;
-import org.jboss.as.clustering.context.DefaultExecutorService;
-import org.jboss.as.clustering.context.DefaultThreadFactory;
 import org.wildfly.clustering.Registrar;
 import org.wildfly.clustering.Registration;
 import org.wildfly.clustering.ee.BatchContext;
@@ -72,7 +68,6 @@ import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
 import org.wildfly.clustering.web.session.SessionManager;
 import org.wildfly.clustering.web.session.SpecificationProvider;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Generic session manager implementation - independent of cache mapping strategy.
@@ -100,10 +95,10 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
     private final SpecificationProvider<S, SC, AL> provider;
     private final Runnable startTask;
     private final Consumer<ImmutableSession> closeTask;
+    private final Executor executor;
 
     private volatile Duration defaultMaxInactiveInterval = Duration.ofMinutes(30L);
     private volatile Registration expirationRegistration;
-    private volatile ExecutorService executor;
 
     public InfinispanSessionManager(SessionFactory<SC, MV, AV, LC> factory, InfinispanSessionManagerConfiguration<S, SC, AL> configuration) {
         this.factory = factory;
@@ -118,6 +113,7 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
         this.context = configuration.getServletContext();
         this.provider = configuration.getSpecificationProvider();
         this.startTask = configuration.getStartTask();
+        this.executor = configuration.getExecutor();
         this.closeTask = new Consumer<ImmutableSession>() {
             @Override
             public void accept(ImmutableSession session) {
@@ -130,7 +126,6 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
 
     @Override
     public void start() {
-        this.executor = Executors.newCachedThreadPool(new DefaultThreadFactory(this.getClass()));
         if (this.recorder != null) {
             this.recorder.reset();
         }
@@ -150,12 +145,6 @@ public class InfinispanSessionManager<S, SC, AL, MV, AV, LC> implements SessionM
         this.cache.removeListener(this.factory.getMetaDataFactory());
         this.cache.removeListener(this.factory.getAttributesFactory());
         this.identifierFactory.stop();
-        WildFlySecurityManager.doUnchecked(this.executor, DefaultExecutorService.SHUTDOWN_NOW_ACTION);
-        try {
-            this.executor.awaitTermination(this.cache.getCacheConfiguration().transaction().cacheStopTimeout(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
@@ -22,7 +22,6 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import org.infinispan.Cache;
 import org.wildfly.clustering.Registrar;
@@ -55,5 +54,4 @@ public interface InfinispanSessionManagerConfiguration<SC, LC> {
     Registrar<SessionExpirationListener> getExpirationRegistar();
     Runnable getStartTask();
     Registrar<Map.Entry<SC, SessionManager<LC, TransactionBatch>>> getContextRegistrar();
-    Executor getExecutor();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.clustering.web.infinispan.session;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.infinispan.Cache;
@@ -34,17 +35,16 @@ import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.web.IdentifierFactory;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
-import org.wildfly.clustering.web.session.SpecificationProvider;
+import org.wildfly.clustering.web.session.SessionManager;
 
 /**
  * Configuration for an {@link InfinispanSessionManager}.
- * @param <S> the HttpSession specification type
- * @param <C> the ServletContext specification type
- * @param <AL> the HttpSessionAttributeListener specification type
+ * @param <SC> the ServletContext specification type
+ * @param <LC> the local context type
  * @author Paul Ferraro
  */
-public interface InfinispanSessionManagerConfiguration<S, C, AL> {
-    C getServletContext();
+public interface InfinispanSessionManagerConfiguration<SC, LC> {
+    SC getServletContext();
     SessionExpirationListener getExpirationListener();
     Cache<Key<String>, ?> getCache();
     CacheProperties getProperties();
@@ -53,7 +53,7 @@ public interface InfinispanSessionManagerConfiguration<S, C, AL> {
     Scheduler<String, ImmutableSessionMetaData> getExpirationScheduler();
     Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder();
     Registrar<SessionExpirationListener> getExpirationRegistar();
-    SpecificationProvider<S, C, AL> getSpecificationProvider();
     Runnable getStartTask();
+    Registrar<Map.Entry<SC, SessionManager<LC, TransactionBatch>>> getContextRegistrar();
     Executor getExecutor();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.clustering.web.infinispan.session;
 
+import java.util.concurrent.Executor;
+
 import org.infinispan.Cache;
 import org.wildfly.clustering.Registrar;
 import org.wildfly.clustering.ee.Batcher;
@@ -53,4 +55,5 @@ public interface InfinispanSessionManagerConfiguration<S, C, AL> {
     Registrar<SessionExpirationListener> getExpirationRegistar();
     SpecificationProvider<S, C, AL> getSpecificationProvider();
     Runnable getStartTask();
+    Executor getExecutor();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -190,11 +190,6 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
             }
 
             @Override
-            public Executor getExecutor() {
-                return InfinispanSessionManagerFactory.this.executor;
-            }
-
-            @Override
             public Registrar<Map.Entry<SC, SessionManager<LC, TransactionBatch>>> getContextRegistrar() {
                 return InfinispanSessionManagerFactory.this.notifierFactory;
             }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -22,11 +22,13 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 import org.infinispan.Cache;
 import org.jboss.as.clustering.context.DefaultExecutorService;
@@ -58,6 +60,7 @@ import org.wildfly.clustering.web.cache.session.CompositeSessionFactory;
 import org.wildfly.clustering.web.cache.session.CompositeSessionMetaDataEntry;
 import org.wildfly.clustering.web.cache.session.ConcurrentSessionManager;
 import org.wildfly.clustering.web.cache.session.MarshalledValueSessionAttributesFactoryConfiguration;
+import org.wildfly.clustering.web.cache.session.SessionAttributeActivationNotifier;
 import org.wildfly.clustering.web.cache.session.SessionAttributesFactory;
 import org.wildfly.clustering.web.cache.session.SessionFactory;
 import org.wildfly.clustering.web.cache.session.SessionMetaDataFactory;
@@ -90,6 +93,7 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
     final org.wildfly.clustering.ee.Scheduler<String, ImmutableSessionMetaData> scheduler;
     final SpecificationProvider<S, SC, AL> provider;
     final ExecutorService executor = Executors.newCachedThreadPool(new DefaultThreadFactory(this.getClass()));
+    final SessionAttributeActivationNotifierFactory<S, SC, AL, LC, TransactionBatch> notifierFactory;
 
     private final KeyAffinityServiceFactory affinityFactory;
     private final SessionFactory<SC, CompositeSessionMetaDataEntry<LC>, ?, LC> factory;
@@ -102,6 +106,7 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
         this.batcher = new InfinispanBatcher(this.cache);
         this.properties = config.getCacheProperties();
         this.provider = config.getSpecificationProvider();
+        this.notifierFactory = new SessionAttributeActivationNotifierFactory<>(this.provider);
         SessionMetaDataFactory<CompositeSessionMetaDataEntry<LC>> metaDataFactory = new InfinispanSessionMetaDataFactory<>(new InfinispanSessionMetaDataFactoryConfiguration() {
             @Override
             public <K, V> Cache<K, V> getCache() {
@@ -133,7 +138,7 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
     @Override
     public SessionManager<LC, TransactionBatch> createSessionManager(final SessionManagerConfiguration<SC> configuration) {
         IdentifierFactory<String> factory = new AffinityIdentifierFactory<>(configuration.getIdentifierFactory(), this.cache, this.affinityFactory);
-        InfinispanSessionManagerConfiguration<S, SC, AL> config = new InfinispanSessionManagerConfiguration<S, SC, AL>() {
+        InfinispanSessionManagerConfiguration<SC, LC> config = new InfinispanSessionManagerConfiguration<SC, LC>() {
             @Override
             public SessionExpirationListener getExpirationListener() {
                 return configuration.getExpirationListener();
@@ -180,11 +185,6 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
             }
 
             @Override
-            public SpecificationProvider<S, SC, AL> getSpecificationProvider() {
-                return InfinispanSessionManagerFactory.this.provider;
-            }
-
-            @Override
             public Runnable getStartTask() {
                 return InfinispanSessionManagerFactory.this;
             }
@@ -193,6 +193,11 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
             public Executor getExecutor() {
                 return InfinispanSessionManagerFactory.this.executor;
             }
+
+            @Override
+            public Registrar<Map.Entry<SC, SessionManager<LC, TransactionBatch>>> getContextRegistrar() {
+                return InfinispanSessionManagerFactory.this.notifierFactory;
+            }
         };
         return new ConcurrentSessionManager<>(new InfinispanSessionManager<>(this.factory, config), this.properties.isTransactional() ? SimpleManager::new : ConcurrentManager::new);
     }
@@ -200,10 +205,10 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
     private SessionAttributesFactory<SC, ?> createSessionAttributesFactory(InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> configuration) {
         switch (configuration.getAttributePersistenceStrategy()) {
             case FINE: {
-                return new FineSessionAttributesFactory<>(new InfinispanMarshalledValueSessionAttributesFactoryConfiguration<>(configuration, this.executor));
+                return new FineSessionAttributesFactory<>(new InfinispanMarshalledValueSessionAttributesFactoryConfiguration<>(configuration, this.notifierFactory, this.executor));
             }
             case COARSE: {
-                return new CoarseSessionAttributesFactory<>(new InfinispanMarshalledValueSessionAttributesFactoryConfiguration<>(configuration, this.executor));
+                return new CoarseSessionAttributesFactory<>(new InfinispanMarshalledValueSessionAttributesFactoryConfiguration<>(configuration, this.notifierFactory, this.executor));
             }
             default: {
                 // Impossible
@@ -227,11 +232,13 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
 
     private static class InfinispanMarshalledValueSessionAttributesFactoryConfiguration<S, SC, AL, V, MC, LC> extends MarshalledValueSessionAttributesFactoryConfiguration<S, SC, AL, V, MC, LC> implements InfinispanSessionAttributesFactoryConfiguration<S, SC, AL, V, MarshalledValue<V, MC>> {
         private final InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> configuration;
+        private final Function<String, SessionAttributeActivationNotifier> notifierFactory;
         private final Executor executor;
 
-        InfinispanMarshalledValueSessionAttributesFactoryConfiguration(InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> configuration, Executor executor) {
+        InfinispanMarshalledValueSessionAttributesFactoryConfiguration(InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> configuration, Function<String, SessionAttributeActivationNotifier> notifierFactory, Executor executor) {
             super(configuration);
             this.configuration = configuration;
+            this.notifierFactory = notifierFactory;
             this.executor = executor;
         }
 
@@ -243,6 +250,11 @@ public class InfinispanSessionManagerFactory<S, SC, AL, MC, LC> implements Sessi
         @Override
         public Executor getExecutor() {
             return this.executor;
+        }
+
+        @Override
+        public Function<String, SessionAttributeActivationNotifier> getActivationNotifierFactory() {
+            return this.notifierFactory;
         }
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryConfiguration.java
@@ -36,7 +36,7 @@ import org.wildfly.clustering.web.session.SessionManagerFactoryConfiguration;
  * @param <LC> the local context type
  * @author Paul Ferraro
  */
-public interface InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> extends DistributableSessionManagementConfiguration, SessionManagerFactoryConfiguration<S, SC, AL, MC, LC>, InfinispanSessionMetaDataFactoryConfiguration {
+public interface InfinispanSessionManagerFactoryConfiguration<S, SC, AL, MC, LC> extends DistributableSessionManagementConfiguration, SessionManagerFactoryConfiguration<S, SC, AL, MC, LC>, InfinispanConfiguration {
 
     KeyAffinityServiceFactory getKeyAffinityServiceFactory();
 

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionMetaDataFactoryConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionMetaDataFactoryConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2019, Red Hat, Inc., and individual contributors
+ * Copyright 2021, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,18 +22,11 @@
 
 package org.wildfly.clustering.web.infinispan.session;
 
-import org.infinispan.Cache;
-import org.wildfly.clustering.ee.cache.CacheProperties;
-import org.wildfly.clustering.ee.infinispan.InfinispanCacheProperties;
+import java.util.concurrent.Executor;
 
 /**
  * @author Paul Ferraro
  */
-public interface InfinispanSessionMetaDataFactoryConfiguration {
-
-    <K, V> Cache<K, V> getCache();
-
-    default CacheProperties getCacheProperties() {
-        return new InfinispanCacheProperties(this.getCache().getCacheConfiguration());
-    }
+public interface InfinispanSessionMetaDataFactoryConfiguration extends InfinispanConfiguration {
+    Executor getExecutor();
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionAttributeActivationNotifierFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionAttributeActivationNotifierFactory.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.wildfly.clustering.Registrar;
+import org.wildfly.clustering.Registration;
+import org.wildfly.clustering.ee.Batch;
+import org.wildfly.clustering.web.cache.session.SessionAttributeActivationNotifier;
+import org.wildfly.clustering.web.session.HttpSessionActivationListenerProvider;
+import org.wildfly.clustering.web.session.Session;
+import org.wildfly.clustering.web.session.SessionManager;
+import org.wildfly.clustering.web.session.oob.OOBSession;
+
+/**
+ * Factory for creating a SessionAttributeActivationNotifier for a given session identifier.
+ * Session activation events will created using OOB sessions.
+ * @author Paul Ferraro
+ * @param <S> the HttpSession specification type
+ * @param <SC> the ServletContext specification type
+ * @param <AL> the HttpSessionActivationListener specification type
+ * @param <LC> the local context type
+ * @param <B> the batch type
+ */
+public class SessionAttributeActivationNotifierFactory<S, SC, AL, LC, B extends Batch> implements Function<String, SessionAttributeActivationNotifier>, Registrar<Map.Entry<SC, SessionManager<LC, B>>> {
+
+    private final Map<SC, SessionManager<LC, B>> contexts = new ConcurrentHashMap<>();
+    private final HttpSessionActivationListenerProvider<S, SC, AL> provider;
+    private final Function<AL, Consumer<S>> prePassivateNotifier;
+    private final Function<AL, Consumer<S>> postActivateNotifier;
+
+    public SessionAttributeActivationNotifierFactory(HttpSessionActivationListenerProvider<S, SC, AL> provider) {
+        this.provider = provider;
+        this.prePassivateNotifier = provider::prePassivateNotifier;
+        this.postActivateNotifier = provider::postActivateNotifier;
+    }
+
+    @Override
+    public Registration register(Map.Entry<SC, SessionManager<LC, B>> entry) {
+        SC context = entry.getKey();
+        this.contexts.put(context, entry.getValue());
+        return () -> this.contexts.remove(context);
+    }
+
+    @Override
+    public SessionAttributeActivationNotifier apply(String sessionId) {
+        Map<SC, SessionManager<LC, B>> contexts = this.contexts;
+        HttpSessionActivationListenerProvider<S, SC, AL> provider = this.provider;
+        Function<AL, Consumer<S>> prePassivateNotifier = this.prePassivateNotifier;
+        Function<AL, Consumer<S>> postActivateNotifier = this.postActivateNotifier;
+
+        return new SessionAttributeActivationNotifier() {
+            @Override
+            public void prePassivate(Object value) {
+                this.notify(prePassivateNotifier, value);
+            }
+
+            @Override
+            public void postActivate(Object value) {
+                this.notify(postActivateNotifier, value);
+            }
+
+            public void notify(Function<AL, Consumer<S>> notifier, Object value) {
+                Class<AL> listenerClass = provider.getHttpSessionActivationListenerClass();
+                if (listenerClass.isInstance(value)) {
+                    AL listener = listenerClass.cast(value);
+                    for (Map.Entry<SC, SessionManager<LC, B>> entry : contexts.entrySet()) {
+                        SC context = entry.getKey();
+                        SessionManager<LC, B> manager = entry.getValue();
+                        Session<LC> session = new OOBSession<>(manager, sessionId, null);
+                        notifier.apply(listener).accept(provider.createHttpSession(session, context));
+                    }
+                }
+            }
+
+            @Override
+            public void close() {
+                // Nothing to close
+            }
+        };
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesKeyFilter.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesKeyFilter.java
@@ -20,14 +20,19 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.web.infinispan.session;
+package org.wildfly.clustering.web.infinispan.session.coarse;
 
-import java.util.concurrent.Executor;
+import org.infinispan.util.function.SerializablePredicate;
 
 /**
+ * Filter for cache keys of type {@link SessionAttributesKey}.
  * @author Paul Ferraro
  */
-public interface InfinispanSessionMetaDataFactoryConfiguration extends InfinispanConfiguration {
+public enum SessionAttributesKeyFilter implements SerializablePredicate<Object> {
+    INSTANCE;
 
-    Executor getExecutor();
+    @Override
+    public boolean test(Object key) {
+        return key instanceof SessionAttributesKey;
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeKeyFilter.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeKeyFilter.java
@@ -20,14 +20,19 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.web.infinispan.session;
+package org.wildfly.clustering.web.infinispan.session.fine;
 
-import java.util.concurrent.Executor;
+import org.infinispan.util.function.SerializablePredicate;
 
 /**
+ * Filter for cache keys of type {@link SessionAttributeKey}.
  * @author Paul Ferraro
  */
-public interface InfinispanSessionMetaDataFactoryConfiguration extends InfinispanConfiguration {
+public enum SessionAttributeKeyFilter implements SerializablePredicate<Object> {
+    INSTANCE;
 
-    Executor getExecutor();
+    @Override
+    public boolean test(Object key) {
+        return key instanceof SessionAttributeKey;
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyFilter.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyFilter.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session.fine;
+
+import org.infinispan.util.function.SerializablePredicate;
+
+/**
+ * Filter for cache keys of type {@link SessionAttributeNamesKey}.
+ * @author Paul Ferraro
+ */
+public enum SessionAttributeNamesKeyFilter implements SerializablePredicate<Object> {
+    INSTANCE;
+
+    @Override
+    public boolean test(Object key) {
+        return key instanceof SessionAttributeNamesKey;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
@@ -47,6 +47,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.web.DistributableTestCase;
 import org.jboss.as.test.clustering.cluster.web.EnableUndertowStatisticsSetupTask;
+import org.jboss.as.test.clustering.single.web.passivation.SessionOperationServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalCoarseSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalCoarseSessionPassivationTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.single.web.passivation;
+
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.runner.RunWith;
+
+/**
+ * Validates the correctness of session passivation events for a distributed session manager using a local, passivating cache and SESSION granularity.
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+public class LocalCoarseSessionPassivationTestCase extends LocalSessionPassivationTestCase {
+
+    private static final String MODULE_NAME = LocalCoarseSessionPassivationTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, testable = false)
+    public static Archive<?> deployment() {
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(LocalSessionPassivationTestCase.class.getPackage(), "distributable-web-coarse.xml", "distributable-web.xml");
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalFineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalFineSessionPassivationTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.single.web.passivation;
+
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.runner.RunWith;
+
+/**
+ * Validates the correctness of session passivation events for a distributed session manager using a local, passivating cache and ATTRIBUTE granularity.
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+public class LocalFineSessionPassivationTestCase extends LocalSessionPassivationTestCase {
+
+    private static final String MODULE_NAME = LocalFineSessionPassivationTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, testable = false)
+    public static Archive<?> deployment() {
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(LocalSessionPassivationTestCase.class.getPackage(), "distributable-web-fine.xml", "distributable-web.xml");
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalSessionPassivationTestCase.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.single.web.passivation;
+
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * Validates the correctness of session activation/passivation events for a distributed session manager using a local, passivating cache.
+ * @author Paul Ferraro
+ */
+public abstract class LocalSessionPassivationTestCase {
+
+    private static final Duration MAX_PASSIVATION_DURATION = Duration.ofSeconds(TimeoutUtil.adjust(10));
+
+    static WebArchive getBaseDeployment(String moduleName) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, moduleName + ".war");
+        war.addClasses(SessionOperationServlet.class);
+        war.addAsWebInfResource(LocalSessionPassivationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.setWebXML(SimpleServlet.class.getPackage(), "web.xml");
+        return war;
+    }
+
+    @Test
+    public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL) throws IOException, URISyntaxException {
+
+        try (CloseableHttpClient client1 = HttpClients.createDefault()) {
+            try (CloseableHttpClient client2 = HttpClients.createDefault()) {
+
+                String session1 = null;
+
+                // This should not trigger any passivation/activation events
+                try (CloseableHttpResponse response = client1.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL, "a", "1")))) {
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                    assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                    session1 = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
+                }
+
+                Map<String, Queue<SessionOperationServlet.EventType>> events = new HashMap<>();
+                Map<String, SessionOperationServlet.EventType> expectedEvents = new HashMap<>();
+                events.put(session1, new LinkedList<>());
+                expectedEvents.put(session1, SessionOperationServlet.EventType.PASSIVATION);
+
+                Instant start = Instant.now();
+                String session2 = null;
+
+                // This will trigger passivation of session1
+                try (CloseableHttpResponse response = client2.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL, "a", "2")))) {
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                    assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                    session2 = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
+                    events.put(session2, new LinkedList<>());
+                    expectedEvents.put(session2, SessionOperationServlet.EventType.PASSIVATION);
+                    collectEvents(response, events);
+                }
+
+                // Ensure session1 was passivated
+                while (events.get(session1).isEmpty() && Duration.between(start, Instant.now()).compareTo(MAX_PASSIVATION_DURATION) < 0) {
+                    try (CloseableHttpResponse response = client2.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a")))) {
+                        assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                        assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                        assertEquals(session2, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                        assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
+                        assertEquals("2", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
+                        collectEvents(response, events);
+                    }
+                    Thread.yield();
+                }
+
+                assertFalse(events.get(session1).isEmpty());
+                validateEvents(session1, events, expectedEvents);
+
+                start = Instant.now();
+
+                // This should trigger activation of session1 and passivation of session2
+                try (CloseableHttpResponse response = client1.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a")))) {
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                    assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                    assertEquals(session1, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                    assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
+                    assertEquals("1", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
+                    collectEvents(response, events);
+                    assertFalse(events.get(session1).isEmpty());
+                    assertTrue(events.get(session1).contains(SessionOperationServlet.EventType.ACTIVATION));
+                }
+
+                // Verify session2 was passivated
+                while (events.get(session2).isEmpty() && Duration.between(start, Instant.now()).compareTo(MAX_PASSIVATION_DURATION) < 0) {
+                    try (CloseableHttpResponse response = client1.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a")))) {
+                        assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                        assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                        assertEquals(session1, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                        assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
+                        assertEquals("1", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
+                        collectEvents(response, events);
+                    }
+                    Thread.yield();
+                }
+
+                assertFalse(events.get(session2).isEmpty());
+                validateEvents(session2, events, expectedEvents);
+
+                start = Instant.now();
+
+                // This should trigger activation of session2 and passivation of session1
+                try (CloseableHttpResponse response = client2.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a")))) {
+                    assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                    assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                    assertEquals(session2, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                    assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
+                    assertEquals("2", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
+                    collectEvents(response, events);
+                    assertFalse(events.get(session2).isEmpty());
+                    assertTrue(events.get(session2).contains(SessionOperationServlet.EventType.ACTIVATION));
+                }
+
+                // Verify session1 was passivated
+                while (!events.get(session1).isEmpty() && Duration.between(start, Instant.now()).compareTo(MAX_PASSIVATION_DURATION) < 0) {
+                    try (CloseableHttpResponse response = client2.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a")))) {
+                        assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                        assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                        assertEquals(session2, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                        assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
+                        assertEquals("2", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
+                        collectEvents(response, events);
+                    }
+                    Thread.yield();
+                }
+
+                assertFalse(events.get(session1).isEmpty());
+                validateEvents(session1, events, expectedEvents);
+
+                validateEvents(session2, events, expectedEvents);
+            }
+        }
+    }
+
+    private static void collectEvents(HttpResponse response, Map<String, Queue<SessionOperationServlet.EventType>> events) {
+        events.entrySet().forEach((Map.Entry<String, Queue<SessionOperationServlet.EventType>> entry) -> {
+            String sessionId = entry.getKey();
+            if (response.containsHeader(sessionId)) {
+                Stream.of(response.getHeaders(sessionId)).forEach((Header header) -> {
+                    entry.getValue().add(SessionOperationServlet.EventType.valueOf(header.getValue()));
+                });
+            }
+        });
+    }
+
+    private static void validateEvents(String sessionId, Map<String, Queue<SessionOperationServlet.EventType>> events, Map<String, SessionOperationServlet.EventType> expectedEvents) {
+        Queue<SessionOperationServlet.EventType> types = events.get(sessionId);
+        SessionOperationServlet.EventType type = types.poll();
+        SessionOperationServlet.EventType expected = expectedEvents.get(sessionId);
+        while (type != null) {
+            assertSame(expected, type);
+            type = types.poll();
+            // ACTIVATE event must follow PASSIVATE event and vice versa
+            expected = SessionOperationServlet.EventType.values()[(expected.ordinal() + 1) % 2];
+        }
+        expectedEvents.put(sessionId, expected);
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/distributable-web-coarse.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/distributable-web-coarse.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<distributable-web xmlns="urn:jboss:distributable-web:2.0">
+    <infinispan-session-management cache-container="web" granularity="SESSION">
+        <local-affinity/>
+    </infinispan-session-management>
+</distributable-web>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/distributable-web-fine.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/distributable-web-fine.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<distributable-web xmlns="urn:jboss:distributable-web:2.0">
+    <infinispan-session-management cache-container="web" granularity="ATTRIBUTE">
+        <local-affinity/>
+    </infinispan-session-management>
+</distributable-web>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/jboss-web.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/jboss-web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-web version="14.0" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
+    <max-active-sessions>1</max-active-sessions>
+</jboss-web>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14542

Also resolves: WFLY-14531 InfinispanSessionManager should be more discriminating about listener registration
https://issues.redhat.com/browse/WFLY-14531

Backport of https://github.com/wildfly/wildfly/pull/14106