### PR TITLE
[WFLY-14578] Upgrade yasson from 1.0.5 to 1.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
         <version.org.eclipse.microprofile.reactive-messaging.api>1.0</version.org.eclipse.microprofile.reactive-messaging.api>
         <version.org.eclipse.microprofile.reactive-streams-operators.api>1.0.1</version.org.eclipse.microprofile.reactive-streams-operators.api>
         <version.org.eclipse.microprofile.rest.client.api>2.0</version.org.eclipse.microprofile.rest.client.api>
-        <version.org.eclipse.yasson>1.0.5</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>1.0.9</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>3.0.3.jbossorg-2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14578

Diff: https://github.com/eclipse-ee4j/yasson/compare/1.0.5...1.0.9
