### PR TITLE
[WFLY-14635]:  Upgrade artemis-wildfly-integration to 1.0.4 in WildFl…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -81,7 +81,7 @@
         <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.0.Alpha1</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
-        <version.org.jboss.activemq.artemis.integration>1.0.3</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>1.0.4</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.metadata>14.0.0.Beta1</version.org.jboss.metadata>
         <version.org.jboss.weld.weld>4.0.1.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>4.0.SP1</version.org.jboss.weld.weld-api>


### PR DESCRIPTION
…y Preview.

* Upgrading artemis-wildfly-integration to 1.0.4 in WildFly preview since it requires Artemis 2.17.0

Jira: https://issues.redhat.com/browse/WFLY-14635