### PR TITLE
[23.x][WFLY-14608] Ensure the CredentialReferenceWriteAttributeHandler gets registered for the credential-reference attributes for datasources

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
@@ -138,7 +138,7 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
                     resourceRegistration.registerReadWriteAttribute(attribute, PoolConfigurationRWHandler.PoolConfigurationReadHandler.INSTANCE, PoolConfigurationRWHandler.LocalAndXaDataSourcePoolConfigurationWriteHandler.INSTANCE);
                 } else  if (attribute.getName().equals(ENLISTMENT_TRACE.getName())) {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new EnlistmentTraceAttributeWriteHandler());
-                } else if (attribute.getName().equals(CREDENTIAL_REFERENCE) || attribute.getName().equals(RECOVERY_CREDENTIAL_REFERENCE)) {
+                } else if (attribute.getName().equals(CREDENTIAL_REFERENCE.getName()) || attribute.getName().equals(RECOVERY_CREDENTIAL_REFERENCE.getName())) {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
                 } else {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, reloadRequiredWriteAttributeHandler);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14608
Upstream: https://github.com/wildfly/wildfly/pull/14143
