### PR TITLE
[WFLY-14639] Upgrade Jakarta Mail to 1.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
         <version.io.vertx.vertx>4.0.2</version.io.vertx.vertx>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
-        <version.jakarta.mail>1.6.5</version.jakarta.mail>
+        <version.jakarta.mail>1.6.6</version.jakarta.mail>
         <version.jakarta.persistence>2.2.3</version.jakarta.persistence>
         <version.jakarta.security.enterprise>1.0.2</version.jakarta.security.enterprise>
         <version.jakarta.validation>2.0.2</version.jakarta.validation>


### PR DESCRIPTION
Jakarta Mail 1.6.6 Final Release
https://github.com/eclipse-ee4j/mail/releases/tag/1.6.6

Jira issue: https://issues.redhat.com/browse/WFLY-14639
