### PR TITLE
[WFLY-14609] CLI ...service=timer-service/timer=* throws NullPointerException

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3238,4 +3238,7 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 525, value = "The 'mappedName' in Jakarta Enterprise Beans  annotations is not supported. Value of '%s' for Jakarta Enterprise Beans '%s' will be ignored.")
     void mappedNameNotSupported(String mappedName, String ejb);
 
+    @Message(id = 526, value = "Timer %s does not exist")
+    OperationFailedException timerNotFound(String timerId);
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/AbstractTimerManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/AbstractTimerManagementTestCase.java
@@ -183,15 +183,19 @@ public abstract class AbstractTimerManagementTestCase {
         return executeForResult(operation, false);
     }
 
-    protected PathAddress getTimerAddress() throws Exception {
-        if (this.timerAddress != null) {
-            return this.timerAddress;
-        }
-        final PathAddress address = PathAddress.pathAddress(
+    protected PathAddress getTimerAddressBase() {
+        return PathAddress.pathAddress(
                 PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT, APP_NAME + ".jar"),
                 PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "ejb3"),
                 PathElement.pathElement("stateless-session-bean", getBeanClassName()),
                 PathElement.pathElement("service", "timer-service"));
+    }
+
+    protected PathAddress getTimerAddress() throws Exception {
+        if (this.timerAddress != null) {
+            return this.timerAddress;
+        }
+        final PathAddress address = getTimerAddressBase();
         final ModelNode operation = Util.createOperation("read-resource", address);
         operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).set(true);
         final ModelNode result = managementClient.getControllerClient().execute(operation);
@@ -260,6 +264,10 @@ public abstract class AbstractTimerManagementTestCase {
 
     protected String getCalendarTimerDetail(){
         return this.bean.getComparableTimerDetail();
+    }
+
+    protected ModelNode executeForResult(ModelNode operation) throws OperationFailedException, IOException {
+        return this.managementClient.getControllerClient().execute(operation);
     }
 
     private ModelNode executeForResult(ModelNode operation, boolean useOpForFailureMsg) throws OperationFailedException, IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/TimerManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/TimerManagementTestCase.java
@@ -7,6 +7,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -86,6 +90,19 @@ public class TimerManagementTestCase extends AbstractTimerManagementTestCase {
             final ModelNode failureDescription = ofe.getFailureDescription();
             Assert.assertThat("Wrong failure description", failureDescription.toString(), containsString("WFLYCTL0216"));
         }
+    }
+
+    @Test
+    @InSequence(4)
+    public void testWildcard() throws Exception {
+        assertNoTimers();
+        this.bean.createTimer();
+        final PathAddress address = PathAddress.pathAddress(getTimerAddressBase(), PathElement.pathElement("timer", "*"));
+        final ModelNode operation = Util.createOperation("suspend", address);
+        ModelNode response = executeForResult(operation);
+        Assert.assertFalse(Operations.isSuccessfulOutcome(response));
+        Assert.assertThat("Wrong failure description", Operations.getFailureDescription(response).toString(), containsString("WFLYEJB0526"));
+        this.waitOverTimer();
     }
 
     protected String getBeanClassName() {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14609

This PR tries to provide more meaningful failure message instead of NPE in case of `*` is used for the timer id.

