### PR TITLE
WFLY-14667 Add a dependency on java.management module in the io.netty

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="java.logging"/>
+        <module name="java.management"/>
         <module name="java.naming"/>
         <module name="java.xml"/>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14667

This prevents a warning from netty:

```
2021-03-30 19:45:52,817 WARNING [io.netty.channel.DefaultChannelId] (Thread-0 (ActiveMQ-server-org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl$6@78ae60ee)) Failed to find the current process ID from ''; using a random value: 950044066
```