### PR TITLE
[23.x]WFLY-14667 Add a dependency on java.management module in the io.netty

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="java.logging"/>
+        <module name="java.management"/>
         <module name="java.naming"/>
         <module name="java.xml"/>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->


### PR DESCRIPTION
Netty needs it in order to determine a process ID.

Issue: https://issues.redhat.com/browse/WFLY-14667
Upstream: #14176