### PR TITLE
[WFLY-14538] Upgrade WildFly Preview's JAX-RS API to org.jboss.spec.j…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -78,7 +78,7 @@
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>
         <version.org.apache.activemq.artemis>2.17.0</version.org.apache.activemq.artemis>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
-        <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.0.Alpha1</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
+        <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
         <version.org.jboss.activemq.artemis.integration>1.0.4</version.org.jboss.activemq.artemis.integration>


### PR DESCRIPTION
…avax.ws.rs:jboss-jaxrs-api_3.0_spec:1.0.0.Final

https://issues.redhat.com/browse/WFLY-14538

There is no difference vs 1.0.0.Alpha1 beyond the version number.
