### PR TITLE
[WFLY-14625]: WARN message jaegertracing: FlushCommand execution failed!

### DIFF
--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 Red Hat, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+~ Copyright 2018 Red Hat, Inc.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
 <module xmlns="urn:jboss:module:1.9" name="io.jaegertracing.jaeger">
 
     <properties>
@@ -24,7 +24,11 @@
         <artifact name="${io.jaegertracing:jaeger-core}"/>
 
         <!-- The concrete transport should be transparent to the consumer -->
-        <artifact name="${io.jaegertracing:jaeger-thrift}"/>
+        <artifact name="${io.jaegertracing:jaeger-thrift}">
+            <filter>
+                <exclude path="META-INF/services"/>
+            </filter>
+        </artifact>
     </resources>
 
     <dependencies>
@@ -33,6 +37,7 @@
 
         <module name="io.opentracing.opentracing-api"/>
         <module name="io.opentracing.opentracing-util"/>
+        <module name="org.wildfly.extension.microprofile.opentracing-smallrye" services="import"/>
 
         <module name="org.apache.thrift"/>
         <module name="org.slf4j"/>

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySender.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySender.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.microprofile.opentracing.spi.sender;
+
+import io.jaegertracing.internal.JaegerSpan;
+import io.jaegertracing.internal.exceptions.SenderException;
+import io.jaegertracing.spi.Sender;
+import org.wildfly.extension.microprofile.opentracing.TracingExtensionLogger;
+
+/**
+ * Jaeger client Sende implementation to be able to 'swallow' exceptions when sending the spans to a Jaeger server.
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+public class WildFlySender implements Sender {
+
+    private Sender delegate;
+
+    WildFlySender(Sender sender) {
+        TracingExtensionLogger.ROOT_LOGGER.debugf("Creating new WildFly Sender with %s", sender);
+        this.delegate = sender;
+    }
+
+    @Override
+    public int append(JaegerSpan span) throws SenderException {
+        return delegate.append(span);
+    }
+
+    @Override
+    public int flush() throws SenderException {
+        try {
+            return delegate.flush();
+        } catch (SenderException ex) {
+            TracingExtensionLogger.ROOT_LOGGER.debugf("Error while flushing %s spans", ex.getDroppedSpanCount(), ex);
+            return 0;
+        }
+    }
+
+    @Override
+    public int close() throws SenderException {
+        return delegate.close();
+    }
+
+}

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySenderFactory.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySenderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.microprofile.opentracing.spi.sender;
+
+import io.jaegertracing.Configuration;
+import io.jaegertracing.spi.Sender;
+import io.jaegertracing.spi.SenderFactory;
+import io.jaegertracing.thrift.internal.senders.ThriftSenderFactory;
+
+/**
+ * Jaeger client SenderFactory implementation to be able to 'swallow' exceptions when sending the spans to a Jaeger server.
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+public class WildFlySenderFactory implements SenderFactory {
+
+    private final SenderFactory delegate = new ThriftSenderFactory();
+
+    @Override
+    public Sender getSender(Configuration.SenderConfiguration configuration) {
+        return new WildFlySender(delegate.getSender(configuration));
+    }
+
+    @Override
+    public String getType() {
+        return delegate.getType();
+    }
+}

--- a/microprofile/opentracing-extension/src/main/resources/META-INF/services/io.jaegertracing.spi.SenderFactory
+++ b/microprofile/opentracing-extension/src/main/resources/META-INF/services/io.jaegertracing.spi.SenderFactory
@@ -1,0 +1,1 @@
+org.wildfly.extension.microprofile.opentracing.spi.sender.WildFlySenderFactory


### PR DESCRIPTION
* replacing Jaeger ThriftSenderFactory with our own to swallow
  exceptions thrown by the UdpSender which were swallowed before.
* some module.xml magic for the ServiceLoader to load our
  implementation.

Jira: https://issues.redhat.com/browse/WFLY-14625