### PR TITLE
[WFLY-14673] Utilize org.wildfly.common.Assert for Null-Checks (clust…

### DIFF
--- a/clustering/ee/cache/src/main/java9/org/wildfly/clustering/ee/cache/scheduler/FastConcurrentDirectDeque.java
+++ b/clustering/ee/cache/src/main/java9/org/wildfly/clustering/ee/cache/scheduler/FastConcurrentDirectDeque.java
@@ -24,6 +24,8 @@
 
 package org.wildfly.clustering.ee.cache.scheduler;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -1257,7 +1259,7 @@ public class FastConcurrentDirectDeque<E> extends AbstractCollection<E> implemen
     @Override
     @SuppressWarnings("unchecked")
     public <T> T[] toArray(T[] a) {
-        if (a == null) throw new NullPointerException();
+        checkNotNullParamWithNullPointerException("a", a);
         return (T[]) toArrayInternal(a);
     }
 

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/IndexedKeyFormatMapper.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/IndexedKeyFormatMapper.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.clustering.infinispan.spi.persistence;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +59,7 @@ public class IndexedKeyFormatMapper implements TwoWayKey2StringMapper {
 
     @Override
     public String getStringMapping(Object key) {
+        checkNotNullParam("key", key);
         Integer index = this.indexes.get(key.getClass());
         if (index == null) {
             throw new IllegalArgumentException(key.getClass().getName());

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
@@ -45,6 +45,7 @@
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.service"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.clustering.cluster;
 
+import static org.wildfly.common.Assert.checkNotNullArrayParam;
+
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Map;
@@ -257,10 +259,7 @@ public abstract class AbstractClusteringTestCase {
         String[] getContainers(String... nodes) {
             String[] containers = new String[nodes.length];
             for (int i = 0; i < nodes.length; ++i) {
-                String node = nodes[i];
-                if (node == null) {
-                    throw new IllegalArgumentException();
-                }
+                String node = checkNotNullArrayParam("nodes", i, nodes[i]);
                 containers[i] = node;
             }
             return containers;


### PR DESCRIPTION
…ering)

Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: clustering.
