### PR TITLE
[WFLY-14567] Add error message when Remoting connector not correctly configured for EJB client invocations.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3241,4 +3241,7 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 526, value = "Timer %s does not exist")
     OperationFailedException timerNotFound(String timerId);
 
+    @LogMessage(level = ERROR)
+    @Message(id = 527, value = "Remoting connector (address %s, port %s) is not correctly configured for EJB client invocations, the connector must be listed in <remote/> 'connectors' attribute to receive EJB client invocations")
+    void connectorNotConfiguredForEJBClientInvocations(String address, int port);
 }


### PR DESCRIPTION
This PR does the following:
* adds an ERROR level message to the server log when an EJB client invocation arrives on a Remoting connector which is not properly configured for EJB client invocations

For more details, see: https://issues.redhat.com/browse/WFLY-14567