### PR TITLE
[WFLY-14673] Utilize o.w.common.Assert for Null-Checks (ee-concurrent)

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorHungTasksPeriodicTerminationService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorHungTasksPeriodicTerminationService.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.as.ee.concurrent.service;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.ee.concurrent.ManagedExecutorWithHungThreads;
 import org.jboss.msc.Service;
@@ -69,9 +71,7 @@ public class ManagedExecutorHungTasksPeriodicTerminationService implements Servi
      * @return a Future instance which may be used to cancel the hung task periodic termination
      */
     public synchronized Future startHungTaskPeriodicTermination(final ManagedExecutorWithHungThreads executor, final long hungTaskTerminationPeriod) {
-        if (executor == null) {
-            throw new NullPointerException("executor is null");
-        }
+        checkNotNullParamWithNullPointerException("executor", executor);
         if (hungTaskTerminationPeriod <= 0) {
             throw new IllegalArgumentException("hungTaskTerminationPeriod is not > 0");
         }


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: ee-concurrent