### PR TITLE
[WFLY-14673] Utilize org.wildfly.common.Assert for Null-Checks (metrics)

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/metrics/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/metrics/main/module.xml
@@ -45,5 +45,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -68,6 +68,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
         </dependency>

--- a/metrics/src/main/java/org/wildfly/extension/metrics/WildFlyMetricMetadata.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/WildFlyMetricMetadata.java
@@ -21,10 +21,10 @@
  */
 package org.wildfly.extension.metrics;
 
-import static java.util.Objects.requireNonNull;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,18 +50,13 @@ public class WildFlyMetricMetadata implements MetricMetadata {
     private MetricID metricID;
 
     public WildFlyMetricMetadata(String attributeName, PathAddress address, String prefix, String description, MeasurementUnit unit, Type type) {
-        requireNonNull(attributeName);
-        requireNonNull(address);
-        requireNonNull(prefix);
-        requireNonNull(description);
-        requireNonNull(type);
+        this.attributeName = checkNotNullParamWithNullPointerException("attributeName", attributeName);
+        this.address = checkNotNullParamWithNullPointerException("address", address);
+        this.globalPrefix =checkNotNullParamWithNullPointerException("prefix", prefix);
+        this.description = checkNotNullParamWithNullPointerException("description", description);
+        this.type = checkNotNullParamWithNullPointerException("type", type);
 
-        this.attributeName = attributeName;
-        this.address = address;
-        this.globalPrefix = prefix;
-        this.description = description;
         this.unit = unit != null ? unit : MeasurementUnit.NONE;
-        this.type = type;
 
         init();
     }

--- a/metrics/src/main/java/org/wildfly/extension/metrics/jmx/JmxMetricCollector.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/jmx/JmxMetricCollector.java
@@ -22,6 +22,7 @@
 package org.wildfly.extension.metrics.jmx;
 
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.NONE;
+import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -200,10 +201,9 @@ public class JmxMetricCollector {
     }
 
     private static OptionalDouble getValueFromMBean(MBeanServer mbs, String mbeanExpression) {
+        checkNotNullParam("mbs", mbs);
+        checkNotNullParam("mbeanExpression", mbeanExpression);
 
-        if (mbeanExpression == null) {
-            throw new IllegalArgumentException("MBean Expression is null");
-        }
         if (!mbeanExpression.contains("/")) {
             throw new IllegalArgumentException(mbeanExpression);
         }


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: metrics