### PR TITLE
[WFLY-14673] Utilize o.w.common.Assert for Null-Checks (ee-injection)

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/url/URLConnectionFactoryResourceInjectionTestEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/url/URLConnectionFactoryResourceInjectionTestEJB.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.ee.injection.resource.url;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import java.net.URL;
@@ -43,12 +45,8 @@ public class URLConnectionFactoryResourceInjectionTestEJB {
      * @throws Exception
      */
     public void validateResourceInjection() throws Exception {
-        if (url1 == null) {
-           throw new NullPointerException("url1 resource not injected");
-        }
-        if (url2 == null) {
-            throw new NullPointerException("url2 resource not injected");
-        }
+        checkNotNullParamWithNullPointerException("url1", url1);
+        checkNotNullParamWithNullPointerException("url2", url2);
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/TestReadListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/TestReadListener.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.ee.injection.support.servlet;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -38,10 +40,7 @@ public class TestReadListener implements ReadListener {
     private final TestHttpUpgradeHandler handler;
 
     public TestReadListener(TestHttpUpgradeHandler handler) {
-        if (handler == null) {
-            throw new IllegalArgumentException("No upgrade handler set");
-        }
-        this.handler = handler;
+        this.handler = checkNotNullParam("handler", handler);
     }
 
     @Override


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: testsuite - ee - injection