### PR TITLE
[WFLY-14648] resolve expression for enabled attribute in Undertow subsystem

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -338,6 +338,11 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
     }
 
     private static class EnabledAttributeHandler extends AbstractWriteAttributeHandler<Boolean> {
+
+        protected EnabledAttributeHandler() {
+            super(ListenerResourceDefinition.ENABLED);
+        }
+
         @Override
         protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Boolean> handbackHolder) throws OperationFailedException {
 

--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -188,6 +188,18 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
 
         ModelNode res = ModelTestUtils.checkOutcome(mainServices.executeOperation(op));
         Assert.assertNotNull(res);
+
+        // WFLY-14648 Check expression in enabled attribute is resolved.
+        op = Util.createOperation("write-attribute",
+                PathAddress.pathAddress(UndertowExtension.SUBSYSTEM_PATH)
+                        .append("server", virtualHostName)
+                        .append("http-listener", "default")
+        );
+        op.get("name").set("enabled");
+        op.get("value").set("${env.val:true}");
+
+        res = ModelTestUtils.checkOutcome(mainServices.executeOperation(op));
+        Assert.assertNotNull(res);
     }
 
     public static void testRuntimeOther(KernelServices mainServices) {


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-14648

Add missing `AttributeDefinition` parameter in `EnabledAttributeHandler.java` in order to resolve expression for `enabled` attribute in Undertow subsystem.