### PR TITLE
[WFLY-14673] Utilize o.w.common.Assert for Null-Checks (jca)

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/annorar/AnnoManagedConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/annorar/AnnoManagedConnection.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.annorar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -140,7 +142,7 @@ public class AnnoManagedConnection implements ManagedConnection {
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
         log.trace("addConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -152,7 +154,7 @@ public class AnnoManagedConnection implements ManagedConnection {
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         log.trace("removeConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/annorar/AnnoManagedConnection1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/annorar/AnnoManagedConnection1.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.annorar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -140,7 +142,7 @@ public class AnnoManagedConnection1 implements ManagedConnection {
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
         log.trace("addConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -152,7 +154,7 @@ public class AnnoManagedConnection1 implements ManagedConnection {
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         log.trace("removeConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidManagedConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidManagedConnection.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.beanvalidation.ra;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +120,7 @@ public class ValidManagedConnection implements ManagedConnection {
      * @param listener A new ConnectionEventListener to be registered
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -128,7 +130,7 @@ public class ValidManagedConnection implements ManagedConnection {
      * @param listener already registered connection event listener to be removed
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidManagedConnection1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidManagedConnection1.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.beanvalidation.ra;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -118,7 +120,7 @@ public class ValidManagedConnection1 implements ManagedConnection {
      * @param listener A new ConnectionEventListener to be registered
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -128,7 +130,7 @@ public class ValidManagedConnection1 implements ManagedConnection {
      * @param listener already registered connection event listener to be removed
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 
 import java.lang.reflect.ReflectPermission;
 import java.sql.Connection;
@@ -306,15 +307,16 @@ public abstract class AbstractDatasourceCapacityPoliciesTestCase extends JcaMgmt
 
         void addCapacityDecrementerProperty(String name, String value) {
             if (capacityDecrementerClass == null) { throw new IllegalStateException("capacityDecrementerClass isn't set"); }
-            if (name == null) { throw new NullPointerException("name"); }
-            if (value == null) { throw new NullPointerException("value"); }
+            checkNotNullParamWithNullPointerException("name", name);
+            checkNotNullParamWithNullPointerException("value", value);
+
             capacityDecrementerProperties.put(name, value);
         }
 
         void addCapacityIncrementerProperty(String name, String value) {
             if (capacityIncrementerClass == null) { throw new IllegalStateException("capacityIncrementerClass isn't set"); }
-            if (name == null) { throw new NullPointerException("name"); }
-            if (value == null) { throw new NullPointerException("value"); }
+            checkNotNullParamWithNullPointerException("name", name);
+            checkNotNullParamWithNullPointerException("value", value);
             capacityIncrementerProperties.put(name, value);
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnection.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -132,7 +134,7 @@ public class LazyManagedConnection implements ManagedConnection, DissociatableMa
     @Override
     public void addConnectionEventListener(ConnectionEventListener listener) {
         logger.trace("#LazyManagedConnection.addConnectionEventListener");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
 
     }
@@ -140,7 +142,7 @@ public class LazyManagedConnection implements ManagedConnection, DissociatableMa
     @Override
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         logger.trace("#LazyManagedConnection.removeConnectionEventListener");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCase.java
@@ -67,7 +67,7 @@ public abstract class AbstractModuleDeploymentTestCase extends
         if (withDependencies) {
             ja.addAsManifestResource(
                     new StringAsset(
-                            "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,javax.inject.api,org.jboss.as.connector\n"),
+                            "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,javax.inject.api,org.jboss.as.connector,org.wildfly.common\n"),
                     "MANIFEST.MF");
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
@@ -43,5 +43,6 @@
         <module name="org.jboss.threads"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.jms.api"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
@@ -41,5 +41,6 @@
         <module name="org.jboss.threads"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.jms.api"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
@@ -42,5 +42,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
         <module name="javax.xml.stream.api"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
@@ -42,5 +42,6 @@
         <module name="org.jboss.threads"/>
         <module name="javax.xml.stream.api"/>
         <module name="javax.jms.api"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnection1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnection1.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.rar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -132,7 +134,7 @@ public class MultipleManagedConnection1 implements ManagedConnection {
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
         log.trace("addConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -143,7 +145,7 @@ public class MultipleManagedConnection1 implements ManagedConnection {
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         log.trace("removeConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnection2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnection2.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.rar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -132,7 +134,7 @@ public class MultipleManagedConnection2 implements ManagedConnection {
      */
     public void addConnectionEventListener(ConnectionEventListener listener) {
         log.trace("addConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.add(listener);
     }
 
@@ -143,7 +145,7 @@ public class MultipleManagedConnection2 implements ManagedConnection {
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         log.trace("removeConnectionEventListener()");
-        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        checkNotNullParam("listener", listener);
         listeners.remove(listener);
     }
 


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: testsuite - jca
