### PR TITLE
[WFLY-14673] Utilize org.wildfly.common.Assert for Null-Checks (undertow)

### DIFF
--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <scope>provided</scope>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ImportedClassELResolver.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ImportedClassELResolver.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.undertow;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import javax.el.ELClass;
 import javax.el.ELContext;
 import javax.el.ELResolver;
@@ -108,9 +110,7 @@ public class ImportedClassELResolver extends ELResolver {
 
     @Override
     public boolean isReadOnly(final ELContext context, final Object base, final Object property) {
-        if (context == null) {
-            throw new NullPointerException("ELContext cannot be null");
-        }
+        checkNotNullParamWithNullPointerException("context", context);
         // we don't allow setting any value via this resolver, so this is always read-only
         return true;
     }


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: undertow