### PR TITLE
[WFLY-14688] Add the java.se module dependency to the org.bouncycastl…

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -34,6 +34,8 @@
 
     <dependencies>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <!-- Required for the IBM J9 1.8 -->
+        <module name="java.se"/>
         <module name="javax.mail.api" optional="true"/>
         <module name="javax.activation.api" optional="true"/>
         <module name="org.bouncycastle.bcpkix"/>


### PR DESCRIPTION
…e.bcmail module for the IBM J9 JVM.

https://issues.redhat.com/browse/WFLY-14688

Upstream PR: https://github.com/wildfly/wildfly/pull/14204
