### PR TITLE
[WFLY-14694] Don't return bad data for unavailable metrics

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
@@ -67,4 +67,7 @@ public interface MicroProfileMetricsLogger extends BasicLogger {
     // no longer used
     // @Message(id = 5, value = "Metric attribute %s on %s is undefined and will not be exposed.")
     // IllegalStateException undefinedMetric(String attributeName, PathAddress address);
+
+    @Message(id = 6, value = "The metric was unavailable")
+    IllegalStateException metricUnavailable();
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14694

If a metric is unavailable, throw ISE so smallrye won't add metric or metadata


"Upstream: #14209"

