### PR TITLE
[WFLY-14673] Utilize org.wildfly.common.Assert for Null-Checks (testsuite_misc)

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/pojo/support/TcclChecker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/pojo/support/TcclChecker.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.pojo.support;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.net.URL;
 
 /**
@@ -29,8 +31,6 @@ import java.net.URL;
  */
 public class TcclChecker {
     public void start() {
-        URL url = Thread.currentThread().getContextClassLoader().getResource("tccl.txt");
-        if (url == null)
-            throw new IllegalArgumentException("tccl.txt should not be null!");
+        URL url = checkNotNullParam("tccl.txt", Thread.currentThread().getContextClassLoader().getResource("tccl.txt"));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/rar/HelloWorldManagedConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/rar/HelloWorldManagedConnection.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.rar;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,9 +144,7 @@ public class HelloWorldManagedConnection implements ManagedConnection {
      */
 
     public void addConnectionEventListener(ConnectionEventListener listener) {
-
-        if (listener == null)
-            throw new IllegalArgumentException("Listener is null");
+        checkNotNullParam("listener", listener);
 
         listeners.add(listener);
 
@@ -159,9 +159,7 @@ public class HelloWorldManagedConnection implements ManagedConnection {
      * @param listener Already registered connection event listener to be removed
      */
     public void removeConnectionEventListener(ConnectionEventListener listener) {
-
-        if (listener == null)
-            throw new IllegalArgumentException("Listener is null");
+        checkNotNullParam("listener", listener);
 
         listeners.remove(listener);
 

--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/InboundBridgeUtilities.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/InboundBridgeUtilities.java
@@ -1,5 +1,7 @@
 package org.wildfly.test.extension.rts;
 
+import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
+
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.jboss.jbossts.star.util.TxLinkNames;
@@ -65,7 +67,7 @@ final class InboundBridgeUtilities {
      * is placed exactly once in the {@link JSONArray}.
      */
     protected void assertJsonArray(JSONArray invocationsJSONArray, String recordToAssert, int expectedRecordFoundCount) throws JSONException {
-        if(recordToAssert == null) throw new NullPointerException("recordToAssert");
+        checkNotNullParamWithNullPointerException("recordToAssert", recordToAssert);
         int recordFoundCount = 0;
         for(int i = 0; i < invocationsJSONArray.length(); i++) {
             if(recordToAssert.equals(invocationsJSONArray.get(i))) {


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/WFLY-14673

The PR 14180 was too big to verify. It has been splitted up, here: testsuite classes. Last PR of the WFLY-14673 series.