### PR TITLE
WFLY-14698 Caching of managed beans in WebInjectionContainer can cause memory leaks in distributed JSF applications following session timeout

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/BasicComponent.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/BasicComponent.java
@@ -101,6 +101,13 @@ public class BasicComponent implements Component {
         return obj;
     }
 
+    @Override
+    public ComponentInstance getInstance(Object instance) {
+        BasicComponentInstance obj = constructComponentInstance(new ImmediateManagedReference(instance), false);
+        obj.constructionFinished();
+        return obj;
+    }
+
     public void waitForComponentStart() {
         if (!gate) {
             EeLogger.ROOT_LOGGER.tracef("Waiting for component %s (%s)", componentName, componentClass);

--- a/ee/src/main/java/org/jboss/as/ee/component/Component.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/Component.java
@@ -64,6 +64,13 @@ public interface Component {
 
     ComponentInstance createInstance(Object instance);
 
+    /**
+     * Returns a component instance for a pre-existing instance.
+     * @param instance the actual object instance
+     * @return a component instance
+     */
+    ComponentInstance getInstance(Object instance);
+
     NamespaceContextSelector getNamespaceContextSelector();
 
     /**

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentRegistry.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentRegistry.java
@@ -89,6 +89,15 @@ public class ComponentRegistry {
         if (factory == null) {
             return classIntrospectorInjectedValue.getValue().createInstance(instance);
         }
+        return factory.createReference(instance);
+    }
+
+    public ManagedReference getInstance(final Object instance) {
+
+        final ComponentManagedReferenceFactory factory = componentsByClass.get(instance.getClass());
+        if (factory == null) {
+            return classIntrospectorInjectedValue.getValue().getInstance(instance);
+        }
         return factory.getReference(instance);
     }
 
@@ -161,8 +170,7 @@ public class ComponentRegistry {
             }
         }
 
-
-        public ManagedReference getReference(final Object instance) {
+        public ManagedReference createReference(final Object instance) {
             if (component == null) {
                 synchronized (this) {
                     if (component == null) {
@@ -174,6 +182,20 @@ public class ComponentRegistry {
                 return null;
             }
             return new ComponentManagedReference(component.getValue().createInstance(instance));
+        }
+
+        ManagedReference getReference(final Object instance) {
+            if (component == null) {
+                synchronized (this) {
+                    if (component == null) {
+                        component = (ServiceController<Component>) serviceRegistry.getService(serviceName);
+                    }
+                }
+            }
+            if (component == null) {
+                return null;
+            }
+            return new ComponentManagedReference(component.getValue().getInstance(instance));
         }
 
         public ServiceName getServiceName() {

--- a/ee/src/main/java/org/jboss/as/ee/component/EEClassIntrospector.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/EEClassIntrospector.java
@@ -12,5 +12,17 @@ public interface EEClassIntrospector {
 
     ManagedReferenceFactory createFactory(final Class<?> clazz);
 
+    /**
+     * Returns the managed reference of an new instance.
+     * @param instance an object instance
+     * @return a managed reference
+     */
     ManagedReference createInstance(Object instance);
+
+    /**
+     * Returns the managed reference of an existing instance.
+     * @param instance an object instance
+     * @return a managed reference
+     */
+    ManagedReference getInstance(Object instance);
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/ReflectiveClassIntrospector.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ReflectiveClassIntrospector.java
@@ -67,6 +67,11 @@ public class ReflectiveClassIntrospector implements EEClassIntrospector, Service
     }
 
     @Override
+    public ManagedReference getInstance(Object instance) {
+        return null;
+    }
+
+    @Override
     public void start(StartContext startContext) throws StartException {
     }
 

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
@@ -71,11 +71,7 @@ public class MyFacesLifecycleProvider implements LifecycleProvider2 {
 
     public void postConstruct(Object obj) throws IllegalAccessException, InvocationTargetException {
         // WFLY-3387 MyFaces injects managed properties before calling this method
-        try {
-            injectionContainer.newInstance(obj);
-        } catch (NamingException e) {
-            throw new FacesException(e);
-        }
+        injectionContainer.newInstance(obj);
     }
 
     public void destroyInstance(Object obj) throws IllegalAccessException, InvocationTargetException {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -77,9 +77,9 @@ import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.suspend.ServerActivity;
 import org.jboss.as.server.suspend.ServerActivityCallback;
 import org.jboss.as.server.suspend.SuspendController;
+import org.jboss.as.web.common.CachingWebInjectionContainer;
 import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.ServletContextAttribute;
-import org.jboss.as.web.common.WebInjectionContainer;
 import org.jboss.as.web.session.SessionIdentifierCodec;
 import org.jboss.as.web.session.SharedSessionManagerConfig;
 import org.jboss.metadata.javaee.jboss.RunAsIdentityMetaData;
@@ -669,7 +669,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
             final ServletInfo jspServlet = jspConfig != null ? jspConfig.createJSPServletInfo() : null;
             if (jspServlet != null) { //this would be null if jsp support is disabled
                 HashMap<String, JspPropertyGroup> propertyGroups = createJspConfig(mergedMetaData);
-                JspServletBuilder.setupDeployment(d, propertyGroups, tldInfo, new UndertowJSPInstanceManager(new WebInjectionContainer(module.getClassLoader(), componentRegistry)));
+                JspServletBuilder.setupDeployment(d, propertyGroups, tldInfo, new UndertowJSPInstanceManager(new CachingWebInjectionContainer(module.getClassLoader(), componentRegistry)));
 
                 if (mergedMetaData.getJspConfig() != null) {
                     Collection<JspPropertyGroup> values = new LinkedHashSet<>(propertyGroups.values());

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -83,6 +83,7 @@ import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.as.web.common.CachingWebInjectionContainer;
 import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.ServletContextAttribute;
+import org.jboss.as.web.common.SimpleWebInjectionContainer;
 import org.jboss.as.web.common.WarMetaData;
 import org.jboss.as.web.common.WebComponentDescription;
 import org.jboss.as.web.common.WebInjectionContainer;
@@ -258,7 +259,8 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor, Fun
 
         final boolean componentRegistryExists = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.COMPONENT_REGISTRY) != null;
         final ComponentRegistry componentRegistry = componentRegistryExists ? deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.COMPONENT_REGISTRY) : new ComponentRegistry(null);
-        final WebInjectionContainer injectionContainer = new CachingWebInjectionContainer(module.getClassLoader(), componentRegistry);
+        final ClassLoader loader = module.getClassLoader();
+        final WebInjectionContainer injectionContainer = (metaData.getDistributable() == null) ? new CachingWebInjectionContainer(loader, componentRegistry) : new SimpleWebInjectionContainer(loader, componentRegistry);
 
         String jaccContextId = metaData.getJaccContextID();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -80,6 +80,7 @@ import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.server.security.SecurityMetaData;
 import org.jboss.as.server.suspend.SuspendController;
+import org.jboss.as.web.common.CachingWebInjectionContainer;
 import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.ServletContextAttribute;
 import org.jboss.as.web.common.WarMetaData;
@@ -257,7 +258,7 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor, Fun
 
         final boolean componentRegistryExists = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.COMPONENT_REGISTRY) != null;
         final ComponentRegistry componentRegistry = componentRegistryExists ? deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.COMPONENT_REGISTRY) : new ComponentRegistry(null);
-        final WebInjectionContainer injectionContainer = new WebInjectionContainer(module.getClassLoader(), componentRegistry);
+        final WebInjectionContainer injectionContainer = new CachingWebInjectionContainer(module.getClassLoader(), componentRegistry);
 
         String jaccContextId = metaData.getJaccContextID();
 

--- a/web-common/src/main/java/org/jboss/as/web/common/AbstractWebInjectionContainer.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/AbstractWebInjectionContainer.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.common;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.jboss.as.ee.component.ComponentRegistry;
+
+/**
+ * @author Paul Ferraro
+ */
+public abstract class AbstractWebInjectionContainer implements WebInjectionContainer {
+
+    private final ClassLoader loader;
+    private final ComponentRegistry registry;
+
+    public AbstractWebInjectionContainer(ClassLoader loader, ComponentRegistry registry) {
+        this.loader = loader;
+        this.registry = registry;
+    }
+
+    @Override
+    public Object newInstance(String className) throws IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException {
+        return this.newInstance(className, this.loader);
+    }
+
+    @Override
+    public ComponentRegistry getComponentRegistry() {
+        return this.registry;
+    }
+}

--- a/web-common/src/main/java/org/jboss/as/web/common/CachingWebInjectionContainer.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/CachingWebInjectionContainer.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.common;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.Map;
+
+import org.jboss.as.ee.component.ComponentRegistry;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ManagedReferenceFactory;
+
+/**
+ * A {@link WebInjectionContainer} that caches {@link ManagedReference} instances between {@link #newInstance(Object)} and {@link #destroyInstance(Object)}.
+ * @author Emanuel Muckenhuber
+ * @author Paul Ferraro
+ */
+public class CachingWebInjectionContainer extends AbstractWebInjectionContainer {
+
+    private final Map<Object, ManagedReference> references;
+
+    public CachingWebInjectionContainer(ClassLoader loader, ComponentRegistry componentRegistry) {
+        super(loader, componentRegistry);
+        this.references = new ConcurrentReferenceHashMap<>(256, ConcurrentReferenceHashMap.DEFAULT_LOAD_FACTOR,
+                Runtime.getRuntime().availableProcessors(), ConcurrentReferenceHashMap.ReferenceType.STRONG,
+                ConcurrentReferenceHashMap.ReferenceType.STRONG, EnumSet.of(ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS));
+    }
+
+    @Override
+    public void destroyInstance(Object instance) {
+        final ManagedReference reference = this.references.remove(instance);
+        if (reference != null) {
+            reference.release();
+        }
+    }
+
+    @Override
+    public Object newInstance(Class<?> clazz) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        final ManagedReferenceFactory factory = this.getComponentRegistry().createInstanceFactory(clazz);
+        ManagedReference reference = factory.getReference();
+        if (reference != null) {
+            this.references.put(reference.getInstance(), reference);
+            return reference.getInstance();
+        }
+        return clazz.newInstance();
+    }
+
+    @Override
+    public void newInstance(Object instance) {
+        final ManagedReference reference = this.getComponentRegistry().createInstance(instance);
+        if (reference != null) {
+            this.references.put(instance, reference);
+        }
+    }
+}

--- a/web-common/src/main/java/org/jboss/as/web/common/SimpleWebInjectionContainer.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/SimpleWebInjectionContainer.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.common;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.jboss.as.ee.component.ComponentRegistry;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ManagedReferenceFactory;
+
+/**
+ * A {@link WebInjectionContainer} implementation for use with distributable web applications that does not cache {@link ManagedReference} instances.
+ * @author Paul Ferraro
+ */
+public class SimpleWebInjectionContainer extends AbstractWebInjectionContainer {
+
+    public SimpleWebInjectionContainer(ClassLoader loader, ComponentRegistry componentRegistry) {
+        super(loader, componentRegistry);
+    }
+
+    @Override
+    public void destroyInstance(Object instance) {
+        ManagedReference reference = this.getComponentRegistry().getInstance(instance);
+        if (reference != null) {
+            reference.release();
+        }
+    }
+
+    @Override
+    public Object newInstance(Class<?> clazz) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        final ManagedReferenceFactory factory = this.getComponentRegistry().createInstanceFactory(clazz);
+        ManagedReference reference = factory.getReference();
+        if (reference != null) {
+            return reference.getInstance();
+        }
+        return clazz.newInstance();
+    }
+
+    @Override
+    public void newInstance(Object instance) {
+        this.getComponentRegistry().createInstance(instance);
+    }
+}

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -119,11 +119,22 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service {
 
     @Override
     public ManagedReference createInstance(final Object instance) {
+        return this.getReference(instance, true);
+    }
+
+    @Override
+    public ManagedReference getInstance(Object instance) {
+        return this.getReference(instance, false);
+    }
+
+    private ManagedReference getReference(Object instance, boolean newInstance) {
         final BeanManager beanManager = beanManagerSupplier.get();
         final InjectionTarget injectionTarget = getInjectionTarget(instance.getClass());
         final CreationalContext context = beanManager.createCreationalContext(null);
-        injectionTarget.inject(instance, context);
-        injectionTarget.postConstruct(instance);
+        if (newInstance) {
+            injectionTarget.inject(instance, context);
+            injectionTarget.postConstruct(instance);
+        }
         return new WeldManagedReference(injectionTarget, context, instance);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14698