### PR TITLE
[WFLY-14697] Allow null metrics prefix

### DIFF
--- a/metrics/src/main/java/org/wildfly/extension/metrics/WildFlyMetricMetadata.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/WildFlyMetricMetadata.java
@@ -52,9 +52,9 @@ public class WildFlyMetricMetadata implements MetricMetadata {
     public WildFlyMetricMetadata(String attributeName, PathAddress address, String prefix, String description, MeasurementUnit unit, Type type) {
         this.attributeName = checkNotNullParamWithNullPointerException("attributeName", attributeName);
         this.address = checkNotNullParamWithNullPointerException("address", address);
-        this.globalPrefix =checkNotNullParamWithNullPointerException("prefix", prefix);
         this.description = checkNotNullParamWithNullPointerException("description", description);
         this.type = checkNotNullParamWithNullPointerException("type", type);
+        this.globalPrefix = prefix;
 
         this.unit = unit != null ? unit : MeasurementUnit.NONE;
 


### PR DESCRIPTION
Remove not-null check in ctor. Null values are properly handled later.