### PR TITLE
[23.x][WFLY-14710] Run ws and layers tests when -Dts.ee9 is used

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -374,6 +374,7 @@
             </activation>
             <modules>
                 <module>basic</module>
+                <module>ws</module>
                 <module>clustering</module>
                 <module>microprofile</module>
                 <module>microprofile-tck</module>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -95,7 +95,7 @@
                 <!-- Turn on normal plugin execution by changing the phase props from 'none'.
                      Note that we leave 'provisioning.phase.preview.excluded' as 'none' -->
                 <provisioning.phase>compile</provisioning.phase>
-                <surefire.phase>test</surefire.phase>
+                <surefire.default-test.phase>test</surefire.default-test.phase>
                 <!-- Reset the feature pack GAV props to use wildfly-preview -->
                 <servlet.feature.pack.artifactId>wildfly-preview-feature-pack</servlet.feature.pack.artifactId>
                 <ee.feature.pack.groupId>${project.groupId}</ee.feature.pack.groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14710
Upstream: #14226 