### PR TITLE
[23.x][WFLY-14711] In WildFly Preview enable use of an alternate XJC variant 

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -76,6 +76,7 @@
         <version.jakarta.xml.bind.jakarta-xml-bind-api>3.0.0</version.jakarta.xml.bind.jakarta-xml-bind-api>
         <version.org.eclipse.yasson>2.0.1</version.org.eclipse.yasson>
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>
+        <version.org.glassfish.jaxb.jaxb-xjc>${version.sun.jaxb}</version.org.glassfish.jaxb.jaxb-xjc>
         <version.org.apache.activemq.artemis>2.17.0</version.org.apache.activemq.artemis>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
         <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
@@ -379,6 +380,12 @@
             <version>${ee.maven.version}</version>
             <type>pom</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-xjc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -865,6 +872,19 @@
                 <exclusion>
                     <groupId>jakarta.json</groupId>
                     <artifactId>jakarta.json-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-xjc</artifactId>
+            <version>${version.org.glassfish.jaxb.jaxb-xjc}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.xml.dtd-parser</groupId>
+                    <artifactId>dtd-parser</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -374,6 +374,7 @@
             </activation>
             <modules>
                 <module>basic</module>
+                <module>ws</module>
                 <module>clustering</module>
                 <module>microprofile</module>
                 <module>microprofile-tck</module>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -95,7 +95,7 @@
                 <!-- Turn on normal plugin execution by changing the phase props from 'none'.
                      Note that we leave 'provisioning.phase.preview.excluded' as 'none' -->
                 <provisioning.phase>compile</provisioning.phase>
-                <surefire.phase>test</surefire.phase>
+                <surefire.default-test.phase>test</surefire.default-test.phase>
                 <!-- Reset the feature pack GAV props to use wildfly-preview -->
                 <servlet.feature.pack.artifactId>wildfly-preview-feature-pack</servlet.feature.pack.artifactId>
                 <ee.feature.pack.groupId>${project.groupId}</ee.feature.pack.groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14711
Upstream: #14228

This build on #14227 so it can get the test benefit of that change

Note that as the PR currently stands it's not expected to have any functional impact. It just sets things up to make it easy to do a possible XJC upgrade via a simple version property change PR.