### PR TITLE
[WFLY-14738] Improve HostExcludesTestCase to force us to rewrite the list of expected exclusions when necessary

### DIFF
--- a/ee-9/feature-pack/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/ee-9/feature-pack/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -66,4 +66,9 @@
         <param name="host-release" value="WildFly21.0"/>
         <param name="excluded-extensions" value="[&quot;org.wildfly.extension.health&quot;,&quot;org.wildfly.extension.metrics&quot;,&quot;org.wildfly.extension.microprofile.reactive-messaging-smallrye&quot;,&quot;org.wildfly.extension.microprofile.reactive-streams-operators-smallrye&quot;]"/>
     </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly22.0"/>
+        <param name="host-release" value="WildFly22.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.reactive-messaging-smallrye&quot;,&quot;org.wildfly.extension.microprofile.reactive-streams-operators-smallrye&quot;]"/>
+    </feature>
 </feature-group-spec>

--- a/galleon-pack/galleon-content/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/galleon-pack/galleon-content/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -68,4 +68,9 @@
         <param name="host-release" value="WildFly21.0"/>
         <param name="excluded-extensions" value="[&quot;org.wildfly.extension.health&quot;,&quot;org.wildfly.extension.metrics&quot;,&quot;org.wildfly.extension.microprofile.reactive-messaging-smallrye&quot;,&quot;org.wildfly.extension.microprofile.reactive-streams-operators-smallrye&quot;]"/>
     </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly22.0"/>
+        <param name="host-release" value="WildFly22.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.reactive-messaging-smallrye&quot;,&quot;org.wildfly.extension.microprofile.reactive-streams-operators-smallrye&quot;]"/>
+    </feature>
 </feature-group-spec>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-14738

This patch is built on top of https://github.com/wildfly/wildfly/pull/14249, once resolved I will rebase this one.

It tries to force us to track down any extension addition / removal done on the current release. Those additions/removals should be added as a new host-exclude at the end of the current release cycle.

Related EAP exclusions will be moved to the conversion branches.