### PR TITLE
Fix for WFLY-14744, Upgrade tests to use bootable JAR 4.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.galleon-plugins>5.1.3.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.jar.plugin>4.0.0.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>4.0.3.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14744
Diff with previous release: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/4.0.0.Final...4.0.3.Final
