### PR TITLE
WFLY-14746 Remove deprecated STABLE.stability_delay from jgroups-defaults.xml

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -70,7 +70,6 @@
         xmit_table_num_rows="50"
     />
     <pbcast.STABLE
-        stability_delay="500"
         desired_avg_gossip="5000"
         max_bytes="1m"
     />


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14746
