### PR TITLE
Add a profile so the preview transformations can be disabled.

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -42,11 +42,22 @@
         <preview.dist.product.release.version>${full.dist.product.release.version}</preview.dist.product.release.version>
     </properties>
 
-    <modules>
-        <module>build</module>
-        <module>deployment-transformer</module>
-        <module>dist</module>
-        <module>feature-pack</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>skip.preview</id>
+            <activation>
+                <property>
+                    <name>!skip.preview</name>
+                </property>
+            </activation>
+
+            <modules>
+                <module>build</module>
+                <module>deployment-transformer</module>
+                <module>dist</module>
+                <module>feature-pack</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Maybe using a property name like `skip.ee-9` is better. I went with `skip.preview` because it's the final name of the build where as `ee-9` is the module. I'm happy to change it to whatever though.