### PR TITLE
Remove duplicated string descriptions in distributable-web extension

### DIFF
--- a/clustering/web/extension/src/main/resources/org/wildfly/extension/clustering/web/LocalDescriptions.properties
+++ b/clustering/web/extension/src/main/resources/org/wildfly/extension/clustering/web/LocalDescriptions.properties
@@ -47,7 +47,3 @@ distributable-web.routing.local=The local routing provider, used to generate loc
 distributable-web.routing.infinispan=The Infinispan routing provider, used to generate non-local affinities.
 distributable-web.routing.infinispan.cache-container=The name of the cache container associated this provider
 distributable-web.routing.infinispan.cache=The name of the cache associated this provider
-
-distributable-web.affinity=An affinity configuration
-distributable-web.affinity.add=Adds an affinity configuration
-distributable-web.affinity.remove=Removes an affinity configuration


### PR DESCRIPTION
These are already defined on lines 15-17.