### PR TITLE
Include --add-opens to let subsystem tests to run with SE 16

### DIFF
--- a/clustering/marshalling/protostream/pom.xml
+++ b/clustering/marshalling/protostream/pom.xml
@@ -93,4 +93,32 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>jdk16</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <properties>
+                <!-- We're going to disable the java8-test execution,
+                so restore the standard JDK 9+ args. We need them with SE 16+-->
+                <modular.jdk.args>${default.modular.jdk.args}</modular.jdk.args>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>java8-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10136,10 +10136,13 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                <default.modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
-                    --add-modules=java.se</modular.jdk.args>
+                    --add-modules=java.se
+				    --add-opens=java.base/java.util=ALL-UNNAMED
+				    --add-opens=java.base/java.security=ALL-UNNAMED</default.modular.jdk.args>
+                <modular.jdk.args>${default.modular.jdk.args}</modular.jdk.args>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
This is WIP on what JPMS settings are needed to allow WildFly to operate properly with SE 16+.