### PR TITLE
[WFLY-14773] Don't add the resteasy-rxjava2 module in the RSO deployer

### DIFF
--- a/microprofile/reactive-streams-operators-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/deployment/ReactiveStreamsOperatorsDependencyProcessor.java
+++ b/microprofile/reactive-streams-operators-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/deployment/ReactiveStreamsOperatorsDependencyProcessor.java
@@ -64,7 +64,6 @@ public class ReactiveStreamsOperatorsDependencyProcessor implements DeploymentUn
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "io.smallrye.reactive.converters.api", true, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "io.smallrye.reactive.converters.rxjava2", true, false, true, false));
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.jboss.resteasy.resteasy-rxjava2", true, false, true, false));
     }
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14773


~EDIT: I noticed that the module has actually been around for a while, and was not added by me as I thought. So let's see what @asoldano says. If he disagrees, I will change it to just contain the change to the deployer~
EDIT 2: This has now been updated to just remove resteasy-rxjava2 from the dependencies added by the RSO deployer