### PR TITLE
WFLY-14776 Upgrade smallrye-open-api to 2.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <version.io.reactivex.rxjava2>2.2.20</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.0.11</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.3</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.1.4</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.1.1</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.5.0</version.io.smallrye.smallrye-common>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14776

Fixes MicroProfile OpenAPI TCK failures when using EE9.