### PR TITLE
[WFLY-14768] Switch to the Jakarta EE 9 variants of the Elytron Authentication and Authorization Implementations

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -89,6 +89,7 @@
         <version.org.jboss.metadata>14.0.0.Beta1</version.org.jboss.metadata>
         <version.org.jboss.weld.weld>4.0.1.SP1</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>4.0.SP1</version.org.jboss.weld.weld-api>
+        <version.org.wildfly.security.jakarta.elytron-ee>2.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
 
         <!-- TODO Glassfish uses org.glassfish:jakarta-el for this, which we use for the impl
              but we have a separate API jar -->
@@ -1324,6 +1325,29 @@
         <dependency>
             <groupId>org.jboss.spec.javax.xml.rpc</groupId>
             <artifactId>jboss-jaxrpc-api_1.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.security.jakarta</groupId>
+            <artifactId>jakarta-authentication</artifactId>
+            <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.jakarta</groupId>
+            <artifactId>jakarta-authorization</artifactId>
+            <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -472,7 +472,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
+        <!--<dependency>
             <groupId>org.jboss.spec.javax.security.jacc</groupId>
             <artifactId>jboss-jacc-api_1.5_spec</artifactId>
             <scope>provided</scope>
@@ -482,8 +482,8 @@
                     <artifactId>jboss-servlet-api_3.1_spec</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!--<dependency>
+        </dependency>-->
+        <dependency>
             <groupId>jakarta.authorization</groupId>
             <artifactId>jakarta.authorization-api</artifactId>
             <version>${version.jakarta.authorization.jakarta-authorization-api}</version>
@@ -494,7 +494,7 @@
                     <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>-->
+        </dependency>
 
         <!-- EE 9 API - Servlet -->
 

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/jacc/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/jacc/api/main/module.xml
@@ -25,8 +25,8 @@
 <module xmlns="urn:jboss:module:1.9" name="jakarta.security.jacc.api">
 
     <resources>
-        <artifact name="${org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec}"/>
-        <!--<artifact name="${jakarta.authorization:jakarta.authorization-api}"/>-->
+        <!--<artifact name="${org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec}"/>-->
+        <artifact name="${jakarta.authorization:jakarta.authorization-api}"/>
     </resources>
 
     <dependencies>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authentication/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authentication/main/module.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2021 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.jakarta.authentication">
+    <properties>
+        <!--
+             Although this module is private see the module 'org.wildfly.security.elytron' for the re-exported public API.
+         -->
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <exports>
+        <exclude path="org/wildfly/security/auth/jaspi/_private"/>
+    </exports>
+
+    <resources>
+        <artifact name="${org.wildfly.security.jakarta:jakarta-authentication}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jdk.security.auth"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
+        <module name="javax.security.auth.message.api"/>
+        <module name="javax.servlet.api" optional="true"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-base"/>
+    </dependencies>
+</module>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/jakarta/authorization/main/module.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2021 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.jakarta.authorization">
+    <properties>
+        <!--
+             Although this module is private see the module 'org.wildfly.security.elytron' for the re-exported public API.
+         -->
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly.security.jakarta:jakarta-authorization}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jdk.security.auth"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
+        <module name="javax.security.jacc.api" optional="true"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-base"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14768

This depends on the next tag of WildFly Core as a new common module "org.wildfly.security.elytron-base" which is needed.