### PR TITLE
[WFLY-13820] Close tracer on application undeployment

### DIFF
--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
@@ -58,6 +58,10 @@ public class TracingCDIExtension implements Extension {
      * @param bs
      */
     public void beforeShutdown(@Observes final BeforeShutdown bs) {
+        Tracer tracer = TRACERS.get(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+        if (tracer != null) {
+            tracer.close();
+        }
         TRACERS.remove(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13820

We're creating Tracers with a call to `.withManualShutdown()`, but we're not actually shutting them down, resulting in an INFO message in the log (see https://github.com/jaegertracing/jaeger-client-java/issues/585 for more context). The scenario is *probably* harmless, but this change closes the Tracer and helps insure things are cleaned up on undeploy or app server shutdown.