### PR TITLE
WFLY-14795 Upgrade smallrye-fault-tolerance to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <version.io.smallrye.reactive-utils>2.1.1</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.5.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.0.2</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>5.0.0</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>5.1.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.0.0</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.3</version.io.smallrye.smallrye-metrics>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14795