### PR TITLE
[WFLY-14806] Upgrade wildfly-http-client to 1.1.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>16.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.6.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.13.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14806


        Release Notes - WildFly EJB HTTP Client - Version 1.1.7.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-57'>WEJBHTTP-57</a>] -         Use error code and initCause of XAException
</li>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-58'>WEJBHTTP-58</a>] -         Wildfly Http Client HttpServerHelper should log initial exception
</li>
</ul>
                                                                                                                                                                                                                                            
