### PR TITLE
[WFLY-14815] Fix ForwardedHandlerTestCase to comply with UNDERTOW-1837

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
@@ -6,6 +6,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
 
 import org.apache.http.Header;
@@ -130,8 +131,10 @@ public class ForwardedHandlerTestCase {
             final String proto = "https";
             final String forAddrOnly = "192.121.210.60";
             final String forAddr = forAddrOnly + ":455";
-            final String byAddrOnly = "203.0.113.43";
-            final String by = byAddrOnly + ":777";
+            final String by = "203.0.113.43:777";
+            final InetAddress addr = InetAddress.getByName(url.getHost());
+            final String localAddrName = addr.getHostName();
+            final String localAddr = addr.getHostAddress() + ":" + url.getPort();
 
             HttpGet httpget = new HttpGet(url.toExternalForm());
             httpget.addHeader("Forwarded", "for=" + forAddr + ";proto=" + proto + ";by=" + by);
@@ -145,12 +148,10 @@ public class ForwardedHandlerTestCase {
             if (header) {
                 Header[] hdrs = response.getHeaders(ForwardedTestHelperHandler.FORWARD_TEST_HEADER);
                 Assert.assertEquals(1, hdrs.length);
-                // FIXME WFLY-14815
-                //Assert.assertEquals("/" + forAddr + "|" + proto + "|" + "/" + by, hdrs[0].getValue());
+                Assert.assertEquals("/" + forAddr + "|" + proto + "|" + "/" + localAddr, hdrs[0].getValue());
             } else {
                 String result = EntityUtils.toString(entity);
-                // FIXME WFLY-14815
-                //Assert.assertEquals(forAddrOnly + "|" + forAddr + "|" + proto + "|" + byAddrOnly + "|" + by, result);
+                Assert.assertEquals(forAddrOnly + "|" + forAddr + "|" + proto + "|" + localAddrName + "|" + localAddr, result);
             }
         }
     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
@@ -3,10 +3,12 @@ package org.jboss.as.test.integration.web.handlers;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.SocketPermission;
 import java.net.URL;
 
 import org.apache.http.Header;
@@ -71,7 +73,11 @@ public class ForwardedHandlerTestCase {
         return ShrinkWrap.create(WebArchive.class, FORWARDED_HANDLER_NO_UT_HANDLERS + ".war")
                 .addPackage(ForwardedHandlerTestCase.class.getPackage())
                 .addAsWebInfResource(new StringAsset(JBOSS_WEB_TEXT), "jboss-web.xml")
-                .addAsWebResource(new StringAsset("A file"), "index.html");
+                .addAsWebResource(new StringAsset("A file"), "index.html")
+                .addAsManifestResource(
+                    createPermissionsXmlAsset(
+                       new SocketPermission("*:0", "listen,resolve")),
+                    "permissions.xml");
     }
 
     @Deployment(name = FORWARDED_SERVLET)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14815

This is the second part of the fix required to make ForwardedHandlerTestCase compliant with UNDERTOW-1837.
The first part is #14314 
Requires upgrade of WildFly Core with Undertow upgrade: https://github.com/wildfly/wildfly-core/pull/4604