### PR TITLE
[WFLY-14823] Upgrade WildFly Core 16.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>16.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>16.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14823

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/16.0.0.Beta4
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/16.0.0.Beta3...16.0.0.Beta4

<details>
<summary>Release Notes - WildFly Core - Version 16.0.0.Beta4</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4324'>WFCORE-4324</a>] -         CommandTimeoutHandlerTestCase.testComandExecutor random failure
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5169'>WFCORE-5169</a>] -         Migrate all tests to use version AM26 of Apache DS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5185'>WFCORE-5185</a>] -         Update ProviderDefinition to use optimised service loading API
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5367'>WFCORE-5367</a>] -         Duplicate resource error after removing a server group
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5382'>WFCORE-5382</a>] -         The same Additional Runtime Dependency can be added several times for a single resource definition
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5384'>WFCORE-5384</a>] -         RemoveManagementRealmTestCase tests intermittently fail
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5406'>WFCORE-5406</a>] -         For JDK 16+ server requires --add-opens to allow reflective access to JDK classes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5407'>WFCORE-5407</a>] -         Dependency Tree Input Builder/check github action does not account for testbom
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5408'>WFCORE-5408</a>] -         Upgrade JBoss Classfilewriter to 1.2.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5416'>WFCORE-5416</a>] -         Jgit incorrect reference in org.jboss.as.controller module
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5033'>WFCORE-5033</a>] -         Move org.wildfly.security:wildfly-elytron-jacc into it&#39;s own module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5375'>WFCORE-5375</a>] -         Update all projects with a dependency on deprecated Elytron modules to no longer rely on deprecated classes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5383'>WFCORE-5383</a>] -         Fix test failure in LdapTestCase that happens with openjdk-1.8.0.292
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5389'>WFCORE-5389</a>] -         Split JASPIC and JACC into their own modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5403'>WFCORE-5403</a>] -         Control mockserver dependencies from the testbom
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5405'>WFCORE-5405</a>] -         Move xom to testbom; update to 1.3.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5424'>WFCORE-5424</a>] -         Remoting requires wildfly security manager
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5427'>WFCORE-5427</a>] -         ClassCastException: org.wildfly.extension.elytron.LdapKeyStoreService incompatible with org.wildfly.extension.elytron.KeyStoreService while executing CLI command
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5429'>WFCORE-5429</a>] -         Require Java 8 as a minimum when executing the deploy lifecycle phase.
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5255'>WFCORE-5255</a>] -         Migrate all tests to use org.apache.directory.api version 2.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5397'>WFCORE-5397</a>] -         Upgrade galleon-plugins 5.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5398'>WFCORE-5398</a>] -         Upgrade JavaEWAH 1.1.8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5399'>WFCORE-5399</a>] -         Update Google guava to 30.1.1-jre
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5400'>WFCORE-5400</a>] -         Upgrade Mockito to 3.x
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5401'>WFCORE-5401</a>] -         Upgrade to Byteman 4.0.15
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5402'>WFCORE-5402</a>] -         Upgrade to JBoss Marshalling 2.0.12.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5412'>WFCORE-5412</a>] -         Upgrade WildFly OpenSSL to 2.1.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5414'>WFCORE-5414</a>] -         Upgrade to WildFly Elytron 1.15.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5415'>WFCORE-5415</a>] -         Upgrade Elytron Web to 1.9.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5423'>WFCORE-5423</a>] -         Upgrade remoting from 5.0.21.Final to 5.0.23.Final (fixes CVE-2020-35510)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5425'>WFCORE-5425</a>] -         Upgrade Undertow from 2.2.6.Final to 2.2.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5431'>WFCORE-5431</a>] -         Upgrade jboss-logging to 3.4.2.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2925'>WFCORE-2925</a>] -         Separate heap settings in standalone.conf and domain.conf from rest of JAVA_OPTS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5410'>WFCORE-5410</a>] -         Enhance JDK17 testing support
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5417'>WFCORE-5417</a>] -         Upgrade galleon-plugins to 5.2.0.Alpha1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5418'>WFCORE-5418</a>] -         Minimize modular JDK params needed
</li>
</ul>
                                                                                                                        
</details>

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

