### PR TITLE
[WFLY-14849] The java8-test surefire execution should not use the mod…

### DIFF
--- a/clustering/ee/cache/pom.xml
+++ b/clustering/ee/cache/pom.xml
@@ -44,12 +44,6 @@
         This module contains code that is common to the wildfly-clustering-ee-hotrod and wildfly-clustering-ee-infinispan modules.
     </description>
 
-    <properties>
-        <jdk.max.version>9</jdk.max.version>
-        <!-- This property otherwise causes the java8-test execution to crash -->
-        <modular.jdk.args></modular.jdk.args>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/clustering/marshalling/protostream/pom.xml
+++ b/clustering/marshalling/protostream/pom.xml
@@ -45,12 +45,6 @@
         Also contains wildfly-clustering-marshalling-spi implementations using ProtoStream.
     </description>
 
-    <properties>
-        <jdk.max.version>9</jdk.max.version>
-        <!-- This property otherwise causes the java8-test execution to crash -->
-        <modular.jdk.args></modular.jdk.args>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,8 @@
         <!-- Surefire args -->
         <surefire.extra.args></surefire.extra.args>
         <surefire.jpda.args></surefire.jpda.args>
-        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=512m ${surefire.jpda.args} ${surefire.extra.args} ${surefire.jacoco.args}</surefire.system.args>
+        <surefire.non-modular.system.args>-ea -Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=512m ${surefire.jpda.args} ${surefire.extra.args} ${surefire.jacoco.args}</surefire.non-modular.system.args>
+        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} ${surefire.non-modular.system.args}</surefire.system.args>
 
         <!-- Galleon feature pack to use in testsuite provisioning executions that provide content
              that *could* be obtained solely from the wildfly-ee-galleon-pack or its dependencies.
@@ -9654,7 +9655,19 @@
                         </systemProperties>
                         <argLine>${surefire.system.args}</argLine>
                     </configuration>
-
+                    <executions>
+                        <!-- The java8-test execution is defined by the org:jboss:jboss-parent pom
+                             and is used when a SE > 8 build is configured to test a multi-release jar
+                             using a separate SE 8 JDK. Redefine the surefire argline for this
+                             case to not include the modular.jdk.args/modular.jdk.props that will not
+                             work with that SE 8 JDK-->
+                        <execution>
+                            <id>java8-test</id>
+                            <configuration>
+                                <argLine>${surefire.non-modular.system.args}</argLine>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…ular.jdk.args prop, removing the need to mess with its value

https://issues.redhat.com/browse/WFLY-14849