### PR TITLE
[WFLY-13679] Make legacy security optional for "org.wildfly.iiop-openjdk"

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -227,6 +227,11 @@ link:#gal.h2-datasource[h2-datasource] +
 |
 link:#gal.base-server[base-server] +
 
+|[[gal.iiop-openjdk]]iiop-openjdk
+|Support for IIOP
+|
+link:#gal.naming[naming] +
+
 |[[gal.io]]io
 |Support for XNIO workers and buffer pools.
 |

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
@@ -52,6 +52,6 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.jts" />
         <module name="org.jboss.jts.integration"/>
-        <module name="org.picketbox"/>
+        <module name="org.picketbox" optional="true"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk-legacy.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk-legacy.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="iiop-openjdk-legacy" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.iiop-openjdk">
+        <param name="socket-binding" value="iiop"/>
+        <param name="security" value="identity"/>
+        <param name="transactions" value="spec"/>
+        <param name="server-requires-ssl" value="false"/>
+        <param name="client-requires-ssl" value="false"/>
+    </feature>
+    <packages>
+        <package name="org.picketbox" />
+    </packages>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk.xml
@@ -7,4 +7,7 @@
         <param name="server-requires-ssl" value="false"/>
         <param name="client-requires-ssl" value="false"/>
     </feature>
+    <packages>
+        <package name="org.picketbox" />
+    </packages>
 </feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/iiop-openjdk.xml
@@ -2,12 +2,9 @@
 <feature-group-spec name="iiop-openjdk" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.iiop-openjdk">
         <param name="socket-binding" value="iiop"/>
-        <param name="security" value="identity"/>
+        <param name="security" value="elytron"/>
         <param name="transactions" value="spec"/>
         <param name="server-requires-ssl" value="false"/>
         <param name="client-requires-ssl" value="false"/>
     </feature>
-    <packages>
-        <package name="org.picketbox" />
-    </packages>
 </feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="iiop-openjdk">
+    <dependencies>
+        <layer name="base-server"/> 
+        <layer name="naming"/>
+    </dependencies>
+
+    <feature spec="interface">
+        <param name="interface" value="unsecure"/>
+        <param name="inet-address" value="${jboss.bind.address.unsecure:127.0.0.1}"/>
+    </feature>
+    <feature spec="socket-binding-group">
+        <param name="socket-binding-group" value="standard-sockets" />
+        <param name="port-offset" value="${jboss.socket.binding.port-offset:0}"/>
+        <param name="default-interface" value="public"/>
+        <feature-group name="iiop-sockets"/>
+    </feature>
+
+    <feature-group name="iiop-openjdk"/>
+</layer-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -115,7 +115,7 @@
             </feature>
         </feature-group>
         <feature-group name="jsr77"/>
-        <feature-group name="iiop-openjdk"/>
+        <feature-group name="iiop-openjdk-legacy"/>
         <feature-group name="messaging-activemq-ha"/>
         <feature spec="subsystem.ejb3">
             <feature spec="subsystem.ejb3.service.iiop">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-full-ha.xml
@@ -23,7 +23,7 @@
         <param name="profile" value="full-ha"/>
         <feature-group name="domain-ha-profile"/>
         <feature-group name="jsr77"/>
-        <feature-group name="iiop-openjdk"/>
+        <feature-group name="iiop-openjdk-legacy"/>
         <feature-group name="messaging-activemq-ha"/>
         <feature spec="subsystem.ejb3">
             <feature spec="subsystem.ejb3.service.iiop">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-full.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/domain-full.xml
@@ -22,7 +22,7 @@
         <param name="profile" value="full"/>
         <feature-group name="domain-profile"/>
         <feature-group name="jsr77"/>
-        <feature-group name="iiop-openjdk"/>
+        <feature-group name="iiop-openjdk-legacy"/>
         <feature-group name="messaging-activemq"/>
         <feature spec="subsystem.ejb3">
             <feature spec="subsystem.ejb3.service.iiop">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-azure-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-azure-full-ha.xml
@@ -106,7 +106,7 @@
         </feature>
     </feature-group>
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq-ha"/>
 
     <feature spec="subsystem.ejb3">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-ec2-full-ha.xml
@@ -106,7 +106,7 @@
         </feature>
     </feature-group>
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq-ha"/>
 
     <feature spec="subsystem.ejb3">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-full-ha.xml
@@ -15,7 +15,7 @@
     </feature>
 
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq-ha"/>
 
     <feature spec="subsystem.ejb3">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-full.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-full.xml
@@ -15,7 +15,7 @@
     </feature>
 
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq"/>
 
     <feature spec="subsystem.ejb3">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-genericjms.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-genericjms.xml
@@ -37,7 +37,7 @@
     </feature>
 
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
 
     <feature spec="subsystem.ejb3">
         <feature spec="subsystem.ejb3.service.iiop">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-gossip-full-ha.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-gossip-full-ha.xml
@@ -14,7 +14,7 @@
 
     <feature-group name="standalone-gossip-ha"/>
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq-ha"/>
 
     <feature spec="subsystem.ejb3">

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-jts.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-jts.xml
@@ -24,5 +24,5 @@
         <feature-group name="iiop-sockets"/>
     </feature>
 
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
 </feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-rts.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-rts.xml
@@ -14,7 +14,7 @@
     </feature>
 
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq"/>
 
     <!-- uncomment to make it the match the legacy configs

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-xts.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/standalone-xts.xml
@@ -16,7 +16,7 @@
     </feature>
 
     <feature-group name="jsr77"/>
-    <feature-group name="iiop-openjdk"/>
+    <feature-group name="iiop-openjdk-legacy"/>
     <feature-group name="messaging-activemq"/>
     <!-- uncomment to make it the match the legacy configs
     <feature spec="subsystem.ee">

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/Capabilities.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/Capabilities.java
@@ -34,6 +34,8 @@ final class Capabilities {
     /*
     References to capabilities outside of the subsystem
      */
+
+    public static final String LEGACY_SECURITY = "org.wildfly.legacy-security";
     public static final String LEGACY_SECURITY_DOMAIN_CAPABILITY = "org.wildfly.security.legacy-security-domain";
 
     public static final String SSL_CONTEXT_CAPABILITY = "org.wildfly.security.ssl-context";

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
@@ -46,6 +47,7 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -456,6 +458,45 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
 
                 })
                 .addCapabilities(IIOP_CAPABILITY));
+    }
+
+
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        ReloadRequiredWriteAttributeHandler handler = new ReloadRequiredWriteAttributeHandler(ALL_ATTRIBUTES) {
+            @Override
+            protected void recordCapabilitiesAndRequirements(OperationContext context, AttributeDefinition attributeDefinition,
+                    ModelNode newValue, ModelNode oldValue) {
+
+                if (attributeDefinition != SECURITY) {
+                    return;
+                }
+
+                boolean oldIsLegacy;
+                boolean newIsLegacy;
+                try {
+                    // For historic reasons this attribute supports expressions so resolution is required.
+                    oldIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, oldValue).asStringOrNull());
+                    newIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, newValue).asStringOrNull());
+                } catch (OperationFailedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (oldIsLegacy && !newIsLegacy) {
+                    // Capability was registered but no longer required.
+                    context.deregisterCapabilityRequirement(LEGACY_SECURITY, Capabilities.IIOP_CAPABILITY, Constants.ORB_INIT_SECURITY);
+                } else if (!oldIsLegacy && newIsLegacy) {
+                    // Capability wasn't required but now is.
+                    context.registerAdditionalCapabilityRequirement(LEGACY_SECURITY, LEGACY_SECURITY, LEGACY_SECURITY);
+                }
+                // Other permutations mean no change in requirement.
+            }
+        };
+
+        for (AttributeDefinition attr : ALL_ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(attr, null, handler);
+        }
     }
 
     @Override

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.iiop.openjdk;
 
+import static org.wildfly.iiop.openjdk.Capabilities.IIOP_CAPABILITY;
+import static org.wildfly.iiop.openjdk.Capabilities.LEGACY_SECURITY;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -118,6 +121,20 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
         super.populateModel(context, operation, resource);
         final ModelNode model = resource.getModel();
         ConfigValidator.validateConfig(context, model);
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource)
+            throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+
+        if (IIOPExtension.SUBSYSTEM_NAME.equals(context.getCurrentAddressValue())) {
+            ModelNode model = resource.getModel();
+            String security = IIOPRootDefinition.SECURITY.resolveModelAttribute(context, model).asStringOrNull();
+            if (SecurityAllowedValues.IDENTITY.toString().equals(security)) {
+                context.registerAdditionalCapabilityRequirement(LEGACY_SECURITY, IIOP_CAPABILITY, Constants.ORB_INIT_SECURITY);
+            }
+        }
     }
 
     protected void launchServices(final OperationContext context, final ModelNode model) throws OperationFailedException {

--- a/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
@@ -11,10 +11,13 @@ echo INFO: Updating configuration to use elytron
 /subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
 
-# This applies to full configurations only.
+# These apply to full configurations only.
 if (outcome == success) of /subsystem=messaging-activemq/server=default:read-resource
   /subsystem=messaging-activemq/server=default:write-attribute(name=security-domain)
   /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
+end-if
+if (outcome == success) of /subsystem=iiop-openjdk:read-resource
+    /subsystem=iiop-openjdk:write-attribute(name=security, value=elytron)
 end-if
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)

--- a/testsuite/integration/elytron/enable-elytron.cli
+++ b/testsuite/integration/elytron/enable-elytron.cli
@@ -19,9 +19,6 @@ embed-server --admin-only=true --server-config=standalone-full.xml
 /core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
 /core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
 
-stop-embedded-server
-embed-server --server-config=standalone-full.xml
-
 # Legacy security subsystem is not needed
 /subsystem=security:remove
 /extension=org.jboss.as.security:remove

--- a/testsuite/integration/elytron/enable-elytron.cli
+++ b/testsuite/integration/elytron/enable-elytron.cli
@@ -5,6 +5,7 @@ embed-server --admin-only=true --server-config=standalone-full.xml
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
 /subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
 /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
+/subsystem=iiop-openjdk:write-attribute(name=security, value=elytron)
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
 /subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
@@ -18,8 +19,10 @@ embed-server --admin-only=true --server-config=standalone-full.xml
 /core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
 /core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
 
-# Legacy security subsystem is not needed
+stop-embedded-server
+embed-server --server-config=standalone-full.xml
 
+# Legacy security subsystem is not needed
 /subsystem=security:remove
 /extension=org.jboss.as.security:remove
 

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -460,6 +460,34 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>iiop-openjdk-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/iiop-openjdk-server</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>iiop-openjdk</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>jaxrs-server-provisioning-test</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -2306,6 +2334,7 @@
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>
                                                 <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
@@ -2407,6 +2436,7 @@
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>
                                                 <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13679

This also corrects the configuration in WildFly Preview which presently assumes it is using legacy security even though the subsystem is not provisioned.
