### PR TITLE
[WFLY-14885] Upgrade WildFly Core 16.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>16.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>16.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14885

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/16.0.0.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/16.0.0.Beta5...16.0.0.Final

<details>

<summary>Release Notes - WildFly Core - Version 16.0.0.Final</summary>
                                                       
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5406'>WFCORE-5406</a>] -         For JDK 16+ server requires --add-opens to allow reflective access to JDK classes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5452'>WFCORE-5452</a>] -         Three elytron tests started to fail on JDK17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5453'>WFCORE-5453</a>] -         Include add-opens and add-exports to Bootable JAR runtime manifest
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5438'>WFCORE-5438</a>] -         For modular VMs include --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5409'>WFCORE-5409</a>] -         Upgrade JGit to 5.11.1.202105131744-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5446'>WFCORE-5446</a>] -         Upgrade galleon-plugins to 5.2.0.Alpha2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5447'>WFCORE-5447</a>] -         Upgrade galleon-plugins to 5.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5448'>WFCORE-5448</a>] -         Upgrade JavaEWAH 1.1.12
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5460'>WFCORE-5460</a>] -         Upgrade WildFly Elytron to 1.16.0.Final
</li>
</ul>
                                                                                                                            
</details>