### PR TITLE
[WFLY-14898] transactions subsystem log-store transactions attributes are read-only

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionDefinition.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.txn.subsystem;
 
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -56,7 +55,7 @@ class LogStoreTransactionDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         for (SimpleAttributeDefinition def : TRANSACTION_ATTRIBUTE) {
-            resourceRegistration.registerReadWriteAttribute(def, null, new ReloadRequiredWriteAttributeHandler(def));
+            resourceRegistration.registerReadOnlyAttribute(def, null);
         }
     }
 }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
@@ -31,9 +31,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
 public class LogStoreTransactionParticipantDefinition extends SimpleResourceDefinition {
-    static final SimpleAttributeDefinition[] PARTECIPANT_RW_ATTRIBUTE = new SimpleAttributeDefinition[]{
-    };
-    static final SimpleAttributeDefinition[] PARTECIPANT_ATTRIBUTE = new SimpleAttributeDefinition[]{
+    static final SimpleAttributeDefinition[] PARTICIPANT_ATTRIBUTES = new SimpleAttributeDefinition[]{
             LogStoreConstants.JMX_NAME, LogStoreConstants.PARTICIPANT_JNDI_NAME,
             LogStoreConstants.PARTICIPANT_STATUS, LogStoreConstants.RECORD_TYPE,
             LogStoreConstants.EIS_NAME, LogStoreConstants.EIS_VERSION};
@@ -61,10 +59,7 @@ public class LogStoreTransactionParticipantDefinition extends SimpleResourceDefi
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        for (final SimpleAttributeDefinition attribute : PARTECIPANT_RW_ATTRIBUTE) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, new ParticipantWriteAttributeHandler(attribute));
-        }
-        for (final SimpleAttributeDefinition attribute : PARTECIPANT_ATTRIBUTE) {
+        for (final SimpleAttributeDefinition attribute : PARTICIPANT_ATTRIBUTES) {
             resourceRegistration.registerReadOnlyAttribute(attribute, null);
         }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/ParticipantWriteAttributeHandler.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/ParticipantWriteAttributeHandler.java
@@ -31,7 +31,17 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 
-
+/**
+ * The participant is a runtime resource which is created by {@link LogStoreProbeHandler}
+ * and loaded with data from Narayana object store.
+ * There is no way in Narayana API and no reason from processing perspective
+ * to directly write to the participant record. The participant can be managed
+ * by operations like {@code :delete}, {@code :recover} but not with direct write access
+ * to attributes.
+ *
+ * This handler can be deleted in future.
+ */
+@Deprecated
 public class ParticipantWriteAttributeHandler extends AbstractWriteAttributeHandler<Void> {
 
     public ParticipantWriteAttributeHandler(final AttributeDefinition... definitions) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14898