### PR TITLE
[WFLY-14901] Fix uses of removed methods

### DIFF
--- a/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
@@ -490,7 +490,7 @@ new SimpleAttributeDefinitionBuilder(TrackerExtension.TICK, ModelType.LONG)
   .setXmlName(TrackerExtension.TICK)
   .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
   .setDefaultValue(new ModelNode(1000))
-  .setAllowNull(false)
+  .setRequired(true)
   .build();
  
 private TypeDefinition(){

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -217,7 +217,6 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public static final ObjectListAttributeDefinition SERVER_INTERCEPTORS = ObjectListAttributeDefinition.Builder.of(EJB3SubsystemModel.SERVER_INTERCEPTORS, SERVER_INTERCEPTOR)
             .setRequired(false)
             .setAllowExpression(false)
-            .setAllowNull(true)
             .setMinSize(1)
             .setMaxSize(Integer.MAX_VALUE)
             .build();
@@ -234,7 +233,6 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public static final ObjectListAttributeDefinition CLIENT_INTERCEPTORS = ObjectListAttributeDefinition.Builder.of(EJB3SubsystemModel.CLIENT_INTERCEPTORS, CLIENT_INTERCEPTOR)
             .setRequired(false)
             .setAllowExpression(false)
-            .setAllowNull(true)
             .setMinSize(1)
             .setMaxSize(Integer.MAX_VALUE)
             .build();

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
@@ -96,7 +96,7 @@ class ConfigSourceDefinition extends PersistentResourceDefinition {
 
     static ObjectTypeAttributeDefinition DIR = ObjectTypeAttributeDefinition.Builder.of("dir", PATH, RELATIVE_TO)
             .setAlternatives("properties", "class")
-            .setAllowNull(true)
+            .setRequired(false)
             .setAttributeMarshaller(AttributeMarshaller.ATTRIBUTE_OBJECT)
             .setRestartAllServices()
             .setCapabilityReference("org.wildfly.management.path-manager")

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
@@ -57,8 +57,7 @@ class ConfigSourceProviderDefinition extends PersistentResourceDefinition {
             create(MODULE, ModelType.STRING, false)
                     .setAllowExpression(false)
                     .build())
-            .setAllowNull(false)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAttributeMarshaller(AttributeMarshaller.ATTRIBUTE_OBJECT)
             .setRestartAllServices()
             .build();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14901

Remove lingering uses of deprecated methods removed in WFCORE-5467.

@jmesnil - There's a change here in code you own that probably deserves careful attention from you, SVP. :)