### PR TITLE
[WFCORE-3467] Require existence of the AttributeDefinition in AbstractWriteAttributeHandler

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConfigPropertyResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConfigPropertyResourceDefinition.java
@@ -46,7 +46,7 @@ public class ConfigPropertyResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(Constants.CONFIG_PROPERTY_VALUE, null, new ReloadRequiredWriteAttributeHandler());
+        resourceRegistration.registerReadWriteAttribute(Constants.CONFIG_PROPERTY_VALUE, null, new ReloadRequiredWriteAttributeHandler(Constants.CONFIG_PROPERTY_VALUE));
     }
 
 

--- a/ee/src/test/java/org/jboss/as/ee/subsystem/EeLegacySubsystemTestCase.java
+++ b/ee/src/test/java/org/jboss/as/ee/subsystem/EeLegacySubsystemTestCase.java
@@ -56,7 +56,6 @@ import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredAddStepHandler;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
@@ -182,7 +181,7 @@ public class EeLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
 
                     PathElement bvExtension = PathElement.pathElement(EXTENSION, "org.wildfly.extension.bean-validation");
                     ManagementResourceRegistration extensionRegistration = rootRegistration.registerSubModel(new SimpleResourceDefinition(bvExtension, NonResolvingResourceDescriptionResolver.INSTANCE));
-                    extensionRegistration.registerReadOnlyAttribute(new SimpleAttributeDefinitionBuilder("module", ModelType.STRING).setRequired(true).build(), new ReloadRequiredWriteAttributeHandler());
+                    extensionRegistration.registerReadOnlyAttribute(new SimpleAttributeDefinitionBuilder("module", ModelType.STRING).setRequired(true).build(), null);
                     extensionRegistration.registerOperationHandler(removeExtension, new ReloadRequiredRemoveStepHandler());
                     extensionRegistration.registerOperationHandler(addExtension,
                             new ReloadRequiredAddStepHandler(


### PR DESCRIPTION
This PR contains tests changes for https://issues.redhat.com/browse/WFCORE-3467

Link to WFCORE PR is https://github.com/wildfly/wildfly-core/pull/4451