### PR TITLE
[WFLY-14931] Remove the javax.jms.api dependency from the org.apache.…

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
@@ -29,6 +29,5 @@
 
     <dependencies>
         <module name="java.logging" />
-        <module name="javax.jms.api" />
     </dependencies>
 </module>


### PR DESCRIPTION
…qpid.proton module

https://issues.redhat.com/browse/WFLY-14931