### PR TITLE
[WFLY-1909][UNDERTOW-1909] Changing Eclipse JDT groupId coordinates to by in sync with latest Eclipse JDT maven releases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
         <version.org.cryptacular>1.2.4</version.org.cryptacular>
-        <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
+        <version.org.eclipse.jdt>3.26.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile.config.api>2.0</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.fault-tolerance.api>3.0</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.fault-tolerance.tck>${version.org.eclipse.microprofile.fault-tolerance.api}</version.org.eclipse.microprofile.fault-tolerance.tck>
@@ -6066,9 +6066,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.eclipse.jdt.core.compiler</groupId>
+                <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>${version.org.eclipse.jdt.core.compiler}</version>
+                <version>${version.org.eclipse.jdt}</version>
             </dependency>
 
             <dependency>

--- a/servlet-feature-pack/common/pom.xml
+++ b/servlet-feature-pack/common/pom.xml
@@ -102,7 +102,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <groupId>org.eclipse.jdt</groupId>
             <artifactId>ecj</artifactId>
         </dependency>
 

--- a/servlet-feature-pack/common/src/main/resources/license/servlet-feature-pack-common-licenses.xml
+++ b/servlet-feature-pack/common/src/main/resources/license/servlet-feature-pack-common-licenses.xml
@@ -51,12 +51,12 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
       <licenses>
         <license>
-          <name>Eclipse Public License 1.0</name>
-          <url>http://repository.jboss.org/licenses/epl-1.0.txt</url>
+          <name>Eclipse Public License 2.0</name>
+          <url>https://www.eclipse.org/legal/epl-2.0/</url>
           <distribution>repo</distribution>
         </license>
       </licenses>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.eclipse.jdt.core.compiler:ecj}"/>
+        <artifact name="${org.eclipse.jdt:ecj}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14945

Fixes identified JDK17 regression.