### PR TITLE
WFLY-14946 More efficient way of getting batch job executions by job …

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
@@ -209,6 +209,18 @@ public class JobOperatorService extends AbstractJobOperator implements WildFlyJo
     }
 
     @Override
+    public List<Long> getJobExecutionsByJob(final String jobName) {
+        checkState(jobName);
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            return super.getJobExecutionsByJob(jobName);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
     public Properties getParameters(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
         checkState();
         final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/WildFlyJobOperator.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/WildFlyJobOperator.java
@@ -17,6 +17,7 @@
 package org.wildfly.extension.batch.jberet.deployment;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.batch.operations.JobOperator;
@@ -52,6 +53,14 @@ interface WildFlyJobOperator extends JobOperator {
      * @return a collection of all the jobs this operator has access to
      */
     Set<String> getAllJobNames();
+
+    /**
+     * Gets job execution ids belonging to the job identified by the {@code jobName}.
+     * @param jobName the job name identifying the job
+     * @return job execution ids belonging to the job
+     * @since 25.0.0.Beta1
+     */
+    List<Long> getJobExecutionsByJob(final String jobName);
 
     /**
      * Allows safe execution of a method catching any {@link NoSuchJobException} thrown. If the exception is thrown the

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
@@ -199,6 +199,11 @@ abstract class JobRepositoryService implements JobRepository, Service<JobReposit
         return getAndCheckDelegate().savePersistentDataIfNotStopping(jobExecution, abstractStepExecution);
     }
 
+    @Override
+    public List<Long> getJobExecutionsByJob(final String jobName) {
+        return getAndCheckDelegate().getJobExecutionsByJob(jobName);
+    }
+
     protected abstract void startJobRepository(StartContext context) throws StartException;
 
     protected abstract void stopJobRepository(StopContext context);

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
         <version.org.infinispan.protostream>4.4.1.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.23.2-GA</version.org.javassist>
-        <version.org.jberet>1.3.8.Final</version.org.jberet>
+        <version.org.jberet>1.3.9.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
…name

WFLY-14952 Upgrade jberet-core from 1.3.8.Final to 1.3.9.Final

https://issues.redhat.com/browse/WFLY-14946 https://issues.redhat.com/browse/JBEAP-22172
https://issues.redhat.com/browse/WFLY-14952

diff between jberet-core 1.3.8.Final to 1.3.9.Final: https://github.com/jberet/jsr352/compare/1.3.8.Final...1.3.9.Final
(the real changes are in this commit: https://github.com/jberet/jsr352/commit/2d347cfe8672a22b0c0632f0a89df6b344a785af, which implements [JBERET-506](https://issues.redhat.com/browse/JBERET-506) Support retrieving job executions by job name)