### PR TITLE
[WFLY-14957] Skip the Jakarta transformer if a system property is set.

### DIFF
--- a/ee-9/deployment-transformer/src/main/java/org/wildfly/ee8to9/transformer/DeploymentTransformer.java
+++ b/ee-9/deployment-transformer/src/main/java/org/wildfly/ee8to9/transformer/DeploymentTransformer.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 
 import org.jboss.logging.Logger;
 import org.wildfly.galleon.plugin.transformer.JakartaTransformer;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * WildFly Core DeploymentTransformer implementation that uses the WF Galleon integration with Eclipse Transformer to
@@ -35,14 +36,18 @@ public final class DeploymentTransformer implements org.jboss.as.server.deployme
 
     public InputStream transform(InputStream in, String name) throws IOException {
         final boolean verbose = logger.isTraceEnabled();
-        // first parameter represents external configs directory - null indicates use provided transformation defaults
-        // The name captures the type of file.
-        return JakartaTransformer.transform(null, in, name, verbose, new JakartaTransformer.LogHandler() {
-            @Override
-            public void print(String format, Object... args) {
-                logger.tracef(format, args);
-            }
-        });
+        if (isEnabled()) {
+            // first parameter represents external configs directory - null indicates use provided transformation defaults
+            // The name captures the type of file.
+            return JakartaTransformer.transform(null, in, name, verbose, new JakartaTransformer.LogHandler() {
+                @Override
+                public void print(String format, Object... args) {
+                    logger.tracef(format, args);
+                }
+            });
+        }
+        logger.tracef("Skipping processing of %s", name);
+        return in;
     }
 
     public void transform(Path src, Path target) throws IOException {
@@ -56,5 +61,10 @@ public final class DeploymentTransformer implements org.jboss.as.server.deployme
             }
         });
         */
+    }
+
+    private boolean isEnabled() {
+        final String value = WildFlySecurityManager.getPropertyPrivileged("org.wildfly.unsupported.skip.jakarta.transformer", "");
+        return value.isEmpty() || Boolean.parseBoolean(value);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14957

This will be useful for projects which use WildFly for testing to ensure they didn't miss anything that has not been transformed.
