### PR TITLE
WFLY-5390 Fix ClusteredMessagingTestCase

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -720,7 +720,7 @@
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
                                         <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3} -Djboss.messaging.cluster.password=testsuite-messaging-password</server.jvm.args>
                                         <infinispan.server.home>${project.build.directory}/infinispan-server-${version.org.infinispan.server}</infinispan.server.home>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -241,6 +241,21 @@ public abstract class AbstractClusteringTestCase {
         return NODE_TO_DEPLOYMENT.get(node);
     }
 
+    public static int getPortOffsetForNode(String node) {
+        switch (node) {
+            case NODE_1:
+                return 0;
+            case NODE_2:
+                return 100;
+            case NODE_3:
+                return 200;
+            case NODE_4:
+                return 300;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
     public interface Lifecycle {
         void start(String... nodes);
         void stop(String... nodes);


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-5390

Includes a cleanup of the testcase (e.g. removes code duplication) and also attempts to greatly speed this up by removing probably unnecessary waits (saves 20 seconds).
