### PR TITLE
[WF-14962] resolve composite indexes for parent deployment units for open api definitions

### DIFF
--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
@@ -131,7 +131,10 @@ public class OpenAPIModelServiceConfigurator extends SimpleServiceNameProvider i
         this.deploymentName = unit.getName();
         this.root = unit.getAttachment(Attachments.DEPLOYMENT_ROOT).getRoot();
         // Convert org.jboss.as.server.deployment.annotation.CompositeIndex to org.jboss.jandex.CompositeIndex
-        Collection<Index> indexes = unit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes();
+        Collection<Index> indexes = new ArrayList<>(unit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes());
+        if (unit.getParent() != null) {
+            indexes.addAll(unit.getParent().getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes());
+        }
         this.index = CompositeIndex.create(indexes.stream().map(IndexView.class::cast).collect(Collectors.toList()));
         this.module = unit.getAttachment(Attachments.MODULE);
         this.metaData = unit.getAttachment(WarMetaData.ATTACHMENT_KEY).getMergedJBossWebMetaData();

--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
@@ -133,7 +133,13 @@ public class OpenAPIModelServiceConfigurator extends SimpleServiceNameProvider i
         // Convert org.jboss.as.server.deployment.annotation.CompositeIndex to org.jboss.jandex.CompositeIndex
         Collection<Index> indexes = new ArrayList<>(unit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes());
         if (unit.getParent() != null) {
+            // load all composite indexes of the parent deployment unit
             indexes.addAll(unit.getParent().getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes());
+            // load all composite indexes of the parent's accessible sub deployments
+            unit.getParent()
+                .getAttachment(Attachments.ACCESSIBLE_SUB_DEPLOYMENTS)
+                .forEach(subdeployment -> indexes.addAll(
+                        subdeployment.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX).getIndexes()));
         }
         this.index = CompositeIndex.create(indexes.stream().map(IndexView.class::cast).collect(Collectors.toList()));
         this.module = unit.getAttachment(Attachments.MODULE);

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -129,7 +129,7 @@
             <artifactId>weld-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- MicroProfile JWT Test Dependencies -->
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -223,6 +223,11 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -589,7 +594,7 @@
                             <systemPropertyVariables>
                                 <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
-                                <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is 
+                                <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is
                                         expected by microprofile-config tests -->
                                 <server.jvm.args>-Dnode0=${node0} -Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
                             </systemPropertyVariables>
@@ -773,7 +778,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>bootablejar.ee9.profile</id>
             <activation>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.openapi;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.openapi.service.TestApplication;
+import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestEjb;
+import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestRequest;
+import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestResource;
+import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestResponse;
+
+/**
+ * Validates OpenAPI endpoint for a multi-module deployment with classes shared of several libraries and accessible
+ * submodules.
+ *
+ * @author Joachim Grimm
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OpenAPIMultiModuleDeploymentIndexTestCase {
+
+    private static final String PARENT_DEPLOYMENT_NAME =
+            OpenAPIMultiModuleDeploymentIndexTestCase.class.getSimpleName() + ".ear";
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+        WebArchive jaxrs = ShrinkWrap.create(WebArchive.class, "rest.war")
+                                     .addAsResource(TestResource.class.getResource("beans.xml"), "WEB-INF/beans.xml")
+                                     .addClasses(TestApplication.class, TestResource.class);
+        JavaArchive core = ShrinkWrap.create(JavaArchive.class, "core.jar")
+                                     .addClasses(TestEjb.class, TestRequest.class)
+                                     .addAsResource(new StringAsset(
+                                                     "<ejb-jar version=\"3.0\" "
+                                                             + "metadata-complete=\"true\"></ejb-jar>"),
+                                             "META-INF/ejb-jar.xml");
+        JavaArchive common = ShrinkWrap.create(JavaArchive.class, "common.jar").addClass(TestResponse.class);
+        return ShrinkWrap.create(EnterpriseArchive.class, PARENT_DEPLOYMENT_NAME)
+                         .addAsModules(jaxrs, core)
+                         .addAsManifestResource(
+                                 TestEjb.class.getResource("application.xml"),
+                                 "application.xml")
+                         .addAsLibraries(common);
+    }
+
+    @Test
+    public void test(@ArquillianResource URL baseURL) throws IOException, URISyntaxException {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(baseURL.toURI().resolve("/openapi")))) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals("application/yaml", response.getEntity().getContentType().getValue());
+                JsonNode node =
+                        new ObjectMapper(new YAMLFactory()).reader().readTree(response.getEntity().getContent());
+                JsonNode schemas = node.get("components").get("schemas");
+                Assert.assertNotNull(schemas);
+                Assert.assertNotNull(schemas.get("TestRequest"));
+                Assert.assertNotNull(schemas.get("TestResponse"));
+            }
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestEjb.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestEjb.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
+
+import javax.ejb.Stateless;
+
+/**
+ * @author Joachim Grimm
+ */
+@Stateless
+public class TestEjb {
+
+    public TestResponse hello(TestRequest request) {
+        TestResponse testResponse = new TestResponse();
+        testResponse.setValue(request.getValue() + "1");
+        return testResponse;
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestRequest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestRequest.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
+
+/**
+ * @author Joachim Grimm
+ */
+public class TestRequest {
+
+   private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.infinispan.commons.dataconversion.MediaType;
+
+/**
+ * @author Joachim Grimm
+ */
+@Path("/echo")
+@Produces(MediaType.APPLICATION_JSON_TYPE)
+@Consumes(MediaType.APPLICATION_JSON_TYPE)
+public class TestResource {
+
+    @Inject
+    private TestEjb testEjb;
+
+    @POST
+    @Operation(summary = "Test the indexing of multi module deployments")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = TestResponse.class)),
+            description = "Indexes found")
+    public TestResponse echo(TestRequest request) {
+        return testEjb.hello(request);
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
@@ -27,19 +27,19 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.infinispan.commons.dataconversion.MediaType;
 
 /**
  * @author Joachim Grimm
  */
 @Path("/echo")
-@Produces(MediaType.APPLICATION_JSON_TYPE)
-@Consumes(MediaType.APPLICATION_JSON_TYPE)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class TestResource {
 
     @Inject

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResponse.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResponse.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
+
+/**
+ * @author Joachim Grimm
+ */
+public class TestResponse {
+
+   private String value;
+
+   public String getValue() {
+      return value;
+   }
+
+   public void setValue(String value) {
+      this.value = value;
+   }
+}

--- a/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/application.xml
+++ b/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/application.xml
@@ -1,0 +1,15 @@
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd"
+             version="6">
+    <initialize-in-order>true</initialize-in-order>
+    <module>
+        <ejb>core.jar</ejb>
+    </module>
+    <module>
+        <web>
+            <web-uri>rest.war</web-uri>
+            <context-root>rest</context-root>
+        </web>
+    </module>
+</application>

--- a/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/application.xml
+++ b/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/application.xml
@@ -1,7 +1,6 @@
-<application xmlns="http://java.sun.com/xml/ns/javaee"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd"
-             version="6">
+<application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd"
+             version="8">
     <initialize-in-order>true</initialize-in-order>
     <module>
         <ejb>core.jar</ejb>

--- a/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/beans.xml
+++ b/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/beans.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee 
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0" bean-discovery-mode="annotated">
+
 </beans>
+

--- a/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/beans.xml
+++ b/testsuite/integration/microprofile/src/test/resources/org/wildfly/test/integration/microprofile/openapi/service/multimodule/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>


### PR DESCRIPTION
this fixes the missing open api definitions for classes located in the ear's lib directory or other ear modules

related issue in openapi-smallrye: smallrye/smallrye-open-api#785

https://issues.redhat.com/browse/WFLY-14962 