### PR TITLE
[WFLY-14972] Check emptiness with Collection.isEmpty() (Messaging-AMQ)

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
@@ -126,9 +126,9 @@ public class ActiveMQServerResource implements Resource {
     @Override
     public boolean hasChildren(String childType) {
         if (CORE_ADDRESS.equals(childType)) {
-            return getChildrenNames(CORE_ADDRESS).size() > 0;
+            return !getChildrenNames(CORE_ADDRESS).isEmpty();
         } else if (RUNTIME_QUEUE.equals(childType)) {
-            return getChildrenNames(RUNTIME_QUEUE).size() > 0;
+            return !getChildrenNames(RUNTIME_QUEUE).isEmpty();
         } else {
             return delegate.hasChildren(childType);
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
@@ -89,7 +89,7 @@ public class CoreAddressResource implements Resource {
 
     @Override
     public boolean hasChildren(String childType) {
-        return getChildrenNames(childType).size() > 0;
+        return !getChildrenNames(childType).isEmpty();
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
@@ -144,11 +144,11 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
             config.setProtocolManagerFactoryStr(clientProtocolManagerFactory.asString());
         }
         List<String> deserializationBlackList = Common.DESERIALIZATION_BLACKLIST.unwrap(context, model);
-        if (deserializationBlackList.size() > 0) {
+        if (!deserializationBlackList.isEmpty()) {
             config.setDeserializationBlackList(String.join(",", deserializationBlackList));
         }
         List<String> deserializationWhiteList = Common.DESERIALIZATION_WHITELIST.unwrap(context, model);
-        if (deserializationWhiteList.size() > 0) {
+        if (!deserializationWhiteList.isEmpty()) {
             config.setDeserializationWhiteList(String.join(",", deserializationWhiteList));
         }
         JMSFactoryType jmsFactoryType = ConnectionFactoryType.valueOf(ConnectionFactoryAttributes.Regular.FACTORY_TYPE.resolveModelAttribute(context, model).asString()).getType();

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -342,7 +342,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
             // pick the first connector available if pickAnyConnectors is true
             if (discoveryGroupName == null && connectors.isEmpty() && pickAnyConnectors) {
                 Set<String> connectorNames = activeMQServer.getValue().getConfiguration().getConnectorConfigurations().keySet();
-                if (connectorNames.size() > 0) {
+                if (!connectorNames.isEmpty()) {
                     String connectorName = connectorNames.iterator().next();
                     MessagingLogger.ROOT_LOGGER.connectorForPooledConnectionFactory(name, connectorName);
                     connectors.add(connectorName);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/WFLY-14972
PRs splitted by component.
