### PR TITLE
[WFLY-14994] Upgrade WildFly Core 17.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-14994

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.0.Beta2
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Beta1...17.0.0.Beta2

---

<details>

<summary>Release Notes - WildFly Core - Version 17.0.0.Beta2</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3825'>WFCORE-3825</a>] -         Unify &quot;-server&quot; option in windows scripts (ps1, bat) for domain mode (and its servers) on all JDKs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5441'>WFCORE-5441</a>] -         Logic in try/finally blocks hides exceptions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5442'>WFCORE-5442</a>] -         Math operands should be cast before assignment
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5443'>WFCORE-5443</a>] -         JMX MBeanInfoFactory OR Statement has same comparision multiple
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5450'>WFCORE-5450</a>] -         TlsTestCase is failing on IBM JDK
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5457'>WFCORE-5457</a>] -         Add missing permission for JmxControlledStateNotificationsTestCase on J9
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5480'>WFCORE-5480</a>] -         Bouncyclastle provider module requires a dependency on java.sql and java.naming
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3467'>WFCORE-3467</a>] -         Require existence of the AttributeDefinition in AbstractWriteAttributeHandler
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5217'>WFCORE-5217</a>] -         Add deployment Phase constants for Reactive Messaging and RSO
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5396'>WFCORE-5396</a>] -         Remove the wildlfy-elytron-http-deprecated dependency module to no longer rely on deprecated classes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5444'>WFCORE-5444</a>] -         Unused code for ~8 years
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5461'>WFCORE-5461</a>] -         Upgrade bouncycastle to 1.69
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5495'>WFCORE-5495</a>] -         Upgrade JBoss Invocation from 1.6.0 to 1.6.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5496'>WFCORE-5496</a>] -         Upgrade to JBoss MSC 1.4.13.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5467'>WFCORE-5467</a>] -         Remove deprecated properties and methods in AbstractAttributeDefinitionBuilder
</li>
</ul>
                                                                                                                        
</details>