### PR TITLE
[WFLY-14999] Remove dependency to wildfly-core-feature-pack-common

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -143,11 +143,6 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-feature-pack-common</artifactId>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
                                     <type>zip</type>
                                 </artifactItem>
@@ -272,7 +267,7 @@
                 <configuration>
                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                     <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                    <excludedArtifacts>wildfly-ee-galleon-pack|wildfly-jar-boot|infinispan-hibernate-cache-v51|jboss-ejb-client-legacy|wildfly-core-feature-pack-common|wildfly-core-feature-pack-galleon-common|wildfly-servlet-galleon-pack|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-elytron\z</excludedArtifacts>
+                    <excludedArtifacts>wildfly-ee-galleon-pack|wildfly-jar-boot|infinispan-hibernate-cache-v51|jboss-ejb-client-legacy|wildfly-core-feature-pack-galleon-common|wildfly-servlet-galleon-pack|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-elytron\z</excludedArtifacts>
                 </configuration>
                 <executions>
                     <execution>
@@ -353,10 +348,9 @@
         <!-- module and copy artifact dependencies -->
 
         <!-- WildFly Core feature pack content -->
-
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack-common</artifactId>
+            <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
             <type>pom</type>
             <scope>provided</scope>
             <exclusions>
@@ -365,13 +359,6 @@
                     <artifactId>jakarta.json</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -1443,7 +1430,7 @@
                                                 <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
-                                                <exclude>org.wildfly.core:wildfly-core-feature-pack-common</exclude>
+                                                <exclude>org.wildfly.core:wildfly-core-feature-pack-galleon-common</exclude>
                                                 <exclude>${full.maven.groupId}:wildfly-mp-feature-pack-galleon-common</exclude>
                                                 <exclude>${ee.maven.groupId}:wildfly-ee-feature-pack-common</exclude>
                                                 <exclude>${ee.maven.groupId}:wildfly-servlet-feature-pack-common</exclude>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -85,11 +85,6 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-feature-pack-common</artifactId>
-                                    <type>zip</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-feature-pack-ee-8-api</artifactId>
                                     <type>zip</type>
                                 </artifactItem>
@@ -283,7 +278,7 @@
                             </licensesConfigFiles>
                             <licensesOutputFile>${license.directory}/full-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                            <excludedArtifacts>wildfly-jar-boot|infinispan-hibernate-cache-v51|jboss-ejb-client-legacy|wildfly-core-feature-pack-common|wildfly-core-feature-pack-ee-8-api|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-servlet-feature-pack-common|wildfly-servlet-feature-pack-ee-8-api|wildfly-servlet-feature-pack-galleon-common|wildfly-servlet-feature-pack-galleon-legacy|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-8-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
+                            <excludedArtifacts>wildfly-jar-boot|infinispan-hibernate-cache-v51|jboss-ejb-client-legacy|wildfly-core-feature-pack-ee-8-api|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-servlet-feature-pack-common|wildfly-servlet-feature-pack-ee-8-api|wildfly-servlet-feature-pack-galleon-common|wildfly-servlet-feature-pack-galleon-legacy|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-8-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
                         </configuration>
                     </execution>
                 </executions>
@@ -328,13 +323,6 @@
         </dependency>
 
         <!-- module and copy artifact dependencies -->
-
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack-common</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -492,7 +480,6 @@
                                                 <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
-                                                <exclude>org.wildfly.core:wildfly-core-feature-pack-common</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-ee-8-api</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-galleon-pruned</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-galleon-common</exclude>

--- a/servlet-feature-pack/galleon-feature-pack/pom.xml
+++ b/servlet-feature-pack/galleon-feature-pack/pom.xml
@@ -70,14 +70,6 @@
         <!-- module and copy artifact dependencies -->
 
         <!-- WildFly Core feature pack content -->
-
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack-common</artifactId>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-feature-pack-ee-8-api</artifactId>
@@ -159,11 +151,6 @@
                         </goals>
                         <configuration>
                             <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-feature-pack-common</artifactId>
-                                    <type>zip</type>
-                                </artifactItem>
                                 <artifactItem>
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-feature-pack-ee-8-api</artifactId>
@@ -290,7 +277,7 @@
                             </licensesConfigFiles>
                             <licensesOutputFile>${license.directory}/servlet-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                            <excludedArtifacts>wildfly-jar-boot|wildfly-core-feature-pack-galleon-pruned|wildfly-core-feature-pack-common|wildfly-core-feature-pack-ee-8-api|wildfly-core-feature-pack-galleon-common|wildfly-servlet-feature-pack-common|wildfly-servlet-feature-pack-ee-8-api|wildfly-servlet-feature-pack-galleon-common|wildfly-servlet-feature-pack-galleon-legacy|wildfly-elytron\z</excludedArtifacts>
+                            <excludedArtifacts>wildfly-jar-boot|wildfly-core-feature-pack-galleon-pruned|wildfly-core-feature-pack-ee-8-api|wildfly-core-feature-pack-galleon-common|wildfly-servlet-feature-pack-common|wildfly-servlet-feature-pack-ee-8-api|wildfly-servlet-feature-pack-galleon-common|wildfly-servlet-feature-pack-galleon-legacy|wildfly-elytron\z</excludedArtifacts>
                         </configuration>
                     </execution>
                 </executions>
@@ -347,7 +334,6 @@
                                                 <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
-                                                <exclude>org.wildfly.core:wildfly-core-feature-pack-common</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-ee-8-api</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-galleon-pruned</exclude>
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-galleon-common</exclude>


### PR DESCRIPTION
Resources from this dependency are not provided by
wildfly-core-feature-pack-galleon-common

JIRA: https://issues.redhat.com/browse/WFLY-14999

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>