### PR TITLE
[WFLY-14999] Prepare removal of wildfly-core-feature-pack-common

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -372,6 +372,12 @@
             <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
             <type>pom</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
With WFCORE-5505, the _wildfly-core-feature-pack-common maven module
will be removed from WildFly Core and its content will be provided by
the _wildfly-core-feature-pack-galleon-common module.

To prepare this removal, we also exclude org.glassfish:jakarta.json from
the wildfly-core-feature-pack-galleon-common dependency that will
provide all the dependencies for WildFly Core Galleon feature pack post
WFCORE-5505

JIRA: https://issues.redhat.com/browse/WFLY-14999

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
