### PR TITLE
[WFLY-14993] Upgrade WildFly HTTP Client to 1.1.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>17.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.14.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-14993


        Release Notes - WildFly EJB HTTP Client - Version 1.1.8.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-59'>WEJBHTTP-59</a>] -         EJB over HTTP getting java.lang.ClassNotFoundException to Unchecked Exception
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-60'>WEJBHTTP-60</a>] -         Update project with a dependency on wildfly-elytron to use individual modules
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-61'>WEJBHTTP-61</a>] -         Upgrade wildfly-transaction-client from 1.1.11.Final to 1.1.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-62'>WEJBHTTP-62</a>] -         Upgrade XNIO to 3.8.4.Final
</li>
</ul>
                                                                                                                            