### PR TITLE
[24.x][WFLY-15034] Upgrade WildFly Core 16.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>16.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>16.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15034

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/16.0.1.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/16.0.0.Final...16.0.1.Final

---

<details>
<summary>Release Notes</summary>

<h1>WildFly Core - Version 16.0.1.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5480'>WFCORE-5480</a>] -         Bouncyclastle provider module requires a dependency on java.sql and java.naming
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5482'>WFCORE-5482</a>] -         Bouncyclastle bcpkix module requires a dependency on java.logging and java.naming
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5511'>WFCORE-5511</a>] -         CVE-2021-3644 wildfly-core: Invalid Sensitivity Classification of Vault Expression
</li>
</ul>
                                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5461'>WFCORE-5461</a>] -         Upgrade bouncycastle to 1.69
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5510'>WFCORE-5510</a>] -         Upgrade WildFly Elytron to 1.16.1.Final
</li>
</ul>
                                                                                                                            
</details>