### PR TITLE
WFLY-14902 Clustering TS: Enable authentication and authorization for Infinispan Server tests + enable on Windows + instances provisioned by testsuite never shutdown

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -618,8 +618,6 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- Workaround for @ClassRule Infinispan Server -->
-                                    <reuseForks>false</reuseForks>
                                     <!-- Fix test order to speed up execution by grouping tests that run against same group of containers -->
                                     <runOrder>alphabetical</runOrder>
                                     <!-- Tests to execute. -->

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -46,6 +46,9 @@
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
         <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.org.infinispan.server>12.1.7.Final</version.org.infinispan.server>
+        <version.org.infinispan.server.driver>13.0.0.Dev03</version.org.infinispan.server.driver>
+        <!-- Avoids REST call timeout on cluster shutdown -->
+        <version.com.squareup.okhttp3>3.14.8</version.com.squareup.okhttp3>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>
         <!-- properties to enable plugins shared by various bootable jar executions -->
         <bootable-jar-cloud-profile-packaging.phase>none</bootable-jar-cloud-profile-packaging.phase>
@@ -113,26 +116,14 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-testdriver-junit4</artifactId>
-            <version>${version.org.infinispan}</version>
+            <version>${version.org.infinispan.server.driver}</version>
             <exclusions>
+                <!-- Avoids issue on deploy - "Caused by: org.jboss.as.cli.CommandRegistry$RegisterHandlerException: The following command names could not be registered since they conflict with the already registered ones: cd" -->
                 <exclusion>
                     <groupId>org.infinispan</groupId>
-                    <artifactId>infinispan-server-runtime</artifactId>
+                    <artifactId>infinispan-cli-client</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-client-rest</artifactId>
-            <version>${version.org.infinispan}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
         <!-- Arquillian extension for Byteman -->
         <dependency>
@@ -409,7 +400,7 @@
                                     <outputDirectory>${basedir}/target/infinispan-server-${version.org.infinispan.server}/server/conf</outputDirectory>
                                     <resources>
                                         <resource>
-                                            <directory>src/test/resources/infinispan-server</directory>
+                                            <directory>src/test/resources/infinispan-server-overlay</directory>
                                             <filtering>true</filtering>
                                         </resource>
                                     </resources>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -34,7 +34,6 @@ import java.util.stream.Stream;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.core.TestSystemPropertyNames;
 import org.infinispan.server.test.junit4.InfinispanServerRule;
@@ -101,7 +100,6 @@ public abstract class AbstractClusteringTestCase {
     // Infinispan Server
     public static final String INFINISPAN_SERVER_HOME = System.getProperty("infinispan.server.home");
     public static final String INFINISPAN_SERVER_PROFILE = "infinispan.xml";
-    public static final String INFINISPAN_SERVER_PROTOCOL_VERSION = ProtocolVersion.DEFAULT_PROTOCOL_VERSION.toString();
     public static final String INFINISPAN_SERVER_ADDRESS = "127.0.0.1";
     public static final int INFINISPAN_SERVER_PORT = 11222;
     public static final String INFINISPAN_APPLICATION_USER = "testsuite-application-user";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -23,9 +23,12 @@ package org.jboss.as.test.clustering.cluster;
 
 import static org.wildfly.common.Assert.checkNotNullArrayParam;
 
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
@@ -103,9 +106,16 @@ public abstract class AbstractClusteringTestCase {
     public static final String INFINISPAN_APPLICATION_USER = "testsuite-application-user";
     public static final String INFINISPAN_APPLICATION_PASSWORD = "testsuite-application-password";
 
-    public static TestRule infinispanServerTestRule() {
+    public static TestRule infinispanServerTestRule()  {
+        // Workaround for "ISPN-13107 ServerRunMode.FORKED yields InvalidPathException with relative server config paths on Windows platform" by using absolute file path which won't get mangled.
+        String absoluteConfigurationFile = null;
+        try {
+            absoluteConfigurationFile = Paths.get(Objects.requireNonNull(AbstractClusteringTestCase.class.getClassLoader().getResource(INFINISPAN_SERVER_PROFILE)).toURI()).toFile().toString();
+        } catch (URISyntaxException ignore) {
+        }
+
         return InfinispanServerRuleBuilder
-                .config(INFINISPAN_SERVER_PROFILE)
+                .config(absoluteConfigurationFile)
                 .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR, INFINISPAN_SERVER_HOME)
                 .property("infinispan.client.rest.auth_username", "testsuite-driver-user")
                 .property("infinispan.client.rest.auth_password", "testsuite-driver-password")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -37,6 +37,7 @@ import org.apache.http.HttpResponse;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.core.TestSystemPropertyNames;
+import org.infinispan.server.test.junit4.InfinispanServerRule;
 import org.infinispan.server.test.junit4.InfinispanServerRuleBuilder;
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
@@ -105,8 +106,9 @@ public abstract class AbstractClusteringTestCase {
     public static final int INFINISPAN_SERVER_PORT = 11222;
     public static final String INFINISPAN_APPLICATION_USER = "testsuite-application-user";
     public static final String INFINISPAN_APPLICATION_PASSWORD = "testsuite-application-password";
+    public static final InfinispanServerRule INFINISPAN_SERVER_RULE;
 
-    public static TestRule infinispanServerTestRule()  {
+    static {
         // Workaround for "ISPN-13107 ServerRunMode.FORKED yields InvalidPathException with relative server config paths on Windows platform" by using absolute file path which won't get mangled.
         String absoluteConfigurationFile = null;
         try {
@@ -114,7 +116,7 @@ public abstract class AbstractClusteringTestCase {
         } catch (URISyntaxException ignore) {
         }
 
-        return InfinispanServerRuleBuilder
+        INFINISPAN_SERVER_RULE = InfinispanServerRuleBuilder
                 .config(absoluteConfigurationFile)
                 .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR, INFINISPAN_SERVER_HOME)
                 .property("infinispan.client.rest.auth_username", "testsuite-driver-user")
@@ -122,6 +124,10 @@ public abstract class AbstractClusteringTestCase {
                 .numServers(1)
                 .runMode(ServerRunMode.FORKED)
                 .build();
+    }
+
+    public static TestRule infinispanServerTestRule() {
+        return INFINISPAN_SERVER_RULE;
     }
 
     // Undertow-based WildFly load-balancer

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -32,8 +32,6 @@ import java.util.stream.Stream;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.infinispan.client.hotrod.ProtocolVersion;
-import org.infinispan.commons.test.skip.OS;
-import org.infinispan.commons.test.skip.SkipJunit;
 import org.infinispan.server.test.core.ServerRunMode;
 import org.infinispan.server.test.core.TestSystemPropertyNames;
 import org.infinispan.server.test.junit4.InfinispanServerRuleBuilder;
@@ -45,7 +43,6 @@ import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.logging.Logger;
-import org.jgroups.util.Util;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.rules.TestRule;
@@ -99,16 +96,19 @@ public abstract class AbstractClusteringTestCase {
 
     // Infinispan Server
     public static final String INFINISPAN_SERVER_HOME = System.getProperty("infinispan.server.home");
-    public static final String INFINISPAN_SERVER_PROFILE = "infinispan-server/infinispan.xml";
+    public static final String INFINISPAN_SERVER_PROFILE = "infinispan.xml";
     public static final String INFINISPAN_SERVER_PROTOCOL_VERSION = ProtocolVersion.DEFAULT_PROTOCOL_VERSION.toString();
     public static final String INFINISPAN_SERVER_ADDRESS = "127.0.0.1";
     public static final int INFINISPAN_SERVER_PORT = 11222;
+    public static final String INFINISPAN_APPLICATION_USER = "testsuite-application-user";
+    public static final String INFINISPAN_APPLICATION_PASSWORD = "testsuite-application-password";
 
     public static TestRule infinispanServerTestRule() {
-        // Disable on Windows until https://issues.redhat.com/browse/ISPN-12041 is fixed
-        return Util.checkForWindows() ? new SkipJunit(OS.WINDOWS) : InfinispanServerRuleBuilder
+        return InfinispanServerRuleBuilder
                 .config(INFINISPAN_SERVER_PROFILE)
-                .property(TestSystemPropertyNames.INFINISPAN_SERVER_HOME, INFINISPAN_SERVER_HOME)
+                .property(TestSystemPropertyNames.INFINISPAN_TEST_SERVER_DIR, INFINISPAN_SERVER_HOME)
+                .property("infinispan.client.rest.auth_username", "testsuite-driver-user")
+                .property("infinispan.client.rest.auth_password", "testsuite-driver-password")
                 .numServers(1)
                 .runMode(ServerRunMode.FORKED)
                 .build();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
@@ -26,7 +26,6 @@ import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.IN
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_USER;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_ADDRESS;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PORT;
-import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PROTOCOL_VERSION;
 
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.shared.CLIServerSetupTask;
@@ -38,7 +37,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
         this.builder.node(AbstractClusteringTestCase.TWO_NODES)
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
-                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, protocol-version=%s)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD, INFINISPAN_SERVER_PROTOCOL_VERSION)
+                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s})", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD)
                 .setup("/subsystem=infinispan/remote-cache-container=sso/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
                 .teardown("/subsystem=infinispan/remote-cache-container=sso:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.clustering.cluster.sso.remote;
 
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_PASSWORD;
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_USER;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_ADDRESS;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PORT;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PROTOCOL_VERSION;
@@ -36,9 +38,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
         this.builder.node(AbstractClusteringTestCase.TWO_NODES)
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
-// Disable infinispan-server security until test driver issues are fixed
-//                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=testsuite-user,infinispan.client.hotrod.auth_password=testsuite-password}, protocol-version=%s)", INFINISPAN_SERVER_PROTOCOL_VERSION)
-                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, protocol-version=%s)", INFINISPAN_SERVER_PROTOCOL_VERSION)
+                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, protocol-version=%s)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD, INFINISPAN_SERVER_PROTOCOL_VERSION)
                 .setup("/subsystem=infinispan/remote-cache-container=sso/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
                 .teardown("/subsystem=infinispan/remote-cache-container=sso:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.clustering.cluster.web.remote;
 
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_PASSWORD;
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_USER;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_ADDRESS;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PORT;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PROTOCOL_VERSION;
@@ -37,9 +39,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
         this.builder.node(AbstractClusteringTestCase.THREE_NODES)
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
-                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, module=org.wildfly.clustering.web.hotrod, protocol-version=%s, statistics-enabled=true)", INFINISPAN_SERVER_PROTOCOL_VERSION)
-// Disable infinispan-server security until test driver issues are fixed
-//                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=testsuite-user, infinispan.client.hotrod.auth_password=testsuite-password}, protocol-version=%s, statistics-enabled=true)", INFINISPAN_SERVER_PROTOCOL_VERSION)
+                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, protocol-version=%s, statistics-enabled=true)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD, INFINISPAN_SERVER_PROTOCOL_VERSION)
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
                 .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -26,7 +26,6 @@ import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.IN
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_USER;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_ADDRESS;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PORT;
-import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PROTOCOL_VERSION;
 
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.shared.CLIServerSetupTask;
@@ -39,7 +38,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
         this.builder.node(AbstractClusteringTestCase.THREE_NODES)
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
-                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, protocol-version=%s, statistics-enabled=true)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD, INFINISPAN_SERVER_PROTOCOL_VERSION)
+                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, module=org.wildfly.clustering.web.hotrod, properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, statistics-enabled=true)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD)
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
                 .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")

--- a/testsuite/integration/clustering/src/test/resources/infinispan-server-overlay/groups.properties
+++ b/testsuite/integration/clustering/src/test/resources/infinispan-server-overlay/groups.properties
@@ -1,0 +1,18 @@
+#
+# Properties declaration of users roles for the realm 'default' which is the default realm.
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# The format of this file is as follows: -
+# username=role1,role2,role3
+#
+# Use the CLI user command to manipulate users
+#
+# The following illustrates how an admin user could be defined.
+#
+#admin=PowerUser,BillingAdmin,
+#guest=guest
+
+testsuite-application-user=testsuite-application-group
+testsuite-driver-user=admin

--- a/testsuite/integration/clustering/src/test/resources/infinispan-server-overlay/users.properties
+++ b/testsuite/integration/clustering/src/test/resources/infinispan-server-overlay/users.properties
@@ -29,4 +29,6 @@
 # username=password
 #
 # Use the CLI to manipulate users
-testsuite-user=testsuite-password
+
+testsuite-application-user=testsuite-application-password
+testsuite-driver-user=testsuite-driver-password

--- a/testsuite/integration/clustering/src/test/resources/infinispan.xml
+++ b/testsuite/integration/clustering/src/test/resources/infinispan.xml
@@ -27,7 +27,17 @@
             xmlns:server="urn:infinispan:server:12.1">
 
     <cache-container name="default" statistics="true">
-        <!--transport cluster="${infinispan.cluster.name:infinispan}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:infinispan-1}"/-->
+        <security>
+            <authorization>
+                <!-- Declare a role mapper that associates a security principal to each role. -->
+                <cluster-role-mapper/>
+                <!-- Specify user roles and corresponding permissions. -->
+                <roles>
+                    <role name="testsuite-application-group" permissions="ALL"/>
+                </roles>
+            </authorization>
+        </security>
+
         <local-cache name="default">
             <expiration interval="1000"/>
         </local-cache>
@@ -50,27 +60,21 @@
         </socket-bindings>
 
         <security>
+            <credential-stores>
+                <credential-store name="credentials" path="credentials.pfx">
+                    <clear-text-credential clear-text="secret"/>
+                </credential-store>
+            </credential-stores>
             <security-realms>
                 <security-realm name="default">
-                    <!-- Uncomment to enable TLS on the realm -->
-                    <!-- server-identities>
-                       <ssl>
-                          <keystore path="application.keystore" relative-to="infinispan.server.config.path"
-                                    keystore-password="password" alias="server" key-password="password"
-                                    generate-self-signed-certificate-host="localhost"/>
-                       </ssl>
-                    </server-identities-->
                     <properties-realm groups-attribute="Roles">
-                        <user-properties path="users.properties" relative-to="infinispan.server.config.path" plain-text="true"/>
-                        <group-properties path="groups.properties" relative-to="infinispan.server.config.path"/>
+                        <user-properties path="users.properties"/>
+                        <group-properties path="groups.properties"/>
                     </properties-realm>
                 </security-realm>
             </security-realms>
         </security>
 
-        <endpoints socket-binding="default">
-            <hotrod-connector name="hotrod"/>
-            <rest-connector name="rest"/>
-        </endpoints>
+        <endpoints socket-binding="default" security-realm="default"/>
     </server>
 </infinispan>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-14902
https://issues.redhat.com/browse/WFLY-13883
https://issues.redhat.com/browse/WFLY-13897

Requires
https://github.com/wildfly/wildfly/pull/14533