### PR TITLE
WFLY-15041 MDB not working when the bean class does not implement Mes…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationconfig/MDBWithLookupActivationConfigProperties.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationconfig/MDBWithLookupActivationConfigProperties.java
@@ -32,18 +32,20 @@ import javax.jms.Message;
 import javax.jms.MessageListener;
 
 /**
+ * This message-driven bean does not implement MessageListener interface; instead
+ * it is specified with {@code messageListenerInterface} annotation.
  */
-@MessageDriven (activationConfig = {
+@MessageDriven (messageListenerInterface=MessageListener.class,
+        activationConfig = {
         @ActivationConfigProperty(propertyName = "connectionFactoryLookup", propertyValue = "java:/ConnectionFactory"),
         @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = MDBWithLookupActivationConfigProperties.QUEUE_JNDI_NAME),
 })
-public class MDBWithLookupActivationConfigProperties implements MessageListener {
+public class MDBWithLookupActivationConfigProperties {
     public static final String QUEUE_JNDI_NAME = "java:jboss/jms/mdbtest/MDBWithLookupActivationConfigProperties";
 
     @Resource(mappedName = "java:/ConnectionFactory")
     private ConnectionFactory connectionFactory;
 
-    @Override
     public void onMessage(Message message) {
         reply(connectionFactory, message);
     }


### PR DESCRIPTION
…sageListener interface

Change test bean MDBWithLookupActivationConfigProperties to not implement MessageListener interface to expose the problem

https://issues.redhat.com/browse/WFLY-15041

This pull request will be ready to merge after wildfly-core is upgraded to 17.0.0.Beta3 ([WFLY-15042](https://issues.redhat.com/browse/WFLY-15042) Upgrade WildFly Core to 17.0.0.Beta3).  Once the wildfly-core upgrade is in place, we should re-run all checks.  Right now (2021-07-21) the test `MDBActivationConfigTestCase` is failing, as expected.

Update 2021-07-29: all dependency of this pull request has been satisfied and this PR is ready to be reviewed.