### PR TITLE
[WFLY-15046] Add support for connect-timeout in remote cache store (Infinispan)

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -1327,6 +1327,10 @@ public class InfinispanSubsystemXMLReader implements XMLElementReader<List<Model
                     readAttribute(reader, i, operation, RemoteStoreResourceDefinition.Attribute.SOCKET_TIMEOUT);
                     break;
                 }
+                case CONNECT_TIMEOUT: {
+                    readAttribute(reader, i, operation, RemoteStoreResourceDefinition.Attribute.CONNECT_TIMEOUT);
+                    break;
+                }
                 case TCP_NO_DELAY: {
                     readAttribute(reader, i, operation, RemoteStoreResourceDefinition.Attribute.TCP_NO_DELAY);
                     break;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -61,6 +61,7 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         CACHE("cache", ModelType.STRING, null),
         SOCKET_TIMEOUT("socket-timeout", ModelType.LONG, new ModelNode(TimeUnit.MINUTES.toMillis(1))),
+        CONNECT_TIMEOUT("connect-timeout", ModelType.LONG, new ModelNode(TimeUnit.MINUTES.toMillis(1))),
         TCP_NO_DELAY("tcp-no-delay", ModelType.BOOLEAN, ModelNode.TRUE),
         SOCKET_BINDINGS("remote-servers")
         ;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreServiceConfigurator.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.CACHE;
+import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.CONNECT_TIMEOUT;
 import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.SOCKET_BINDINGS;
 import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.SOCKET_TIMEOUT;
 import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.TCP_NO_DELAY;
@@ -55,6 +56,7 @@ public class RemoteStoreServiceConfigurator extends StoreServiceConfigurator<Rem
     private volatile List<SupplierDependency<OutboundSocketBinding>> bindings;
     private volatile String remoteCacheName;
     private volatile long socketTimeout;
+    private volatile long connectTimeout;
     private volatile boolean tcpNoDelay;
 
     public RemoteStoreServiceConfigurator(PathAddress address) {
@@ -73,6 +75,7 @@ public class RemoteStoreServiceConfigurator extends StoreServiceConfigurator<Rem
     public ServiceConfigurator configure(OperationContext context, ModelNode model) throws OperationFailedException {
         this.remoteCacheName = CACHE.resolveModelAttribute(context, model).asString();
         this.socketTimeout = SOCKET_TIMEOUT.resolveModelAttribute(context, model).asLong();
+        this.connectTimeout = CONNECT_TIMEOUT.resolveModelAttribute(context, model).asLong();
         this.tcpNoDelay = TCP_NO_DELAY.resolveModelAttribute(context, model).asBoolean();
         List<String> bindings = StringListAttributeDefinition.unwrapValue(context, SOCKET_BINDINGS.resolveModelAttribute(context, model));
         this.bindings = new ArrayList<>(bindings.size());
@@ -87,6 +90,7 @@ public class RemoteStoreServiceConfigurator extends StoreServiceConfigurator<Rem
         builder.segmented(false)
                 .remoteCacheName(this.remoteCacheName)
                 .socketTimeout(this.socketTimeout)
+                .connectionTimeout(this.connectTimeout)
                 .tcpNoDelay(this.tcpNoDelay)
                 ;
         for (Supplier<OutboundSocketBinding> bindingDependency : this.bindings) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/XMLAttribute.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/XMLAttribute.java
@@ -150,6 +150,7 @@ public enum XMLAttribute {
     MAX_RETRIES(RemoteCacheContainerResourceDefinition.Attribute.MAX_RETRIES),
     PROTOCOL_VERSION(RemoteCacheContainerResourceDefinition.Attribute.PROTOCOL_VERSION),
     SOCKET_TIMEOUT(RemoteCacheContainerResourceDefinition.Attribute.SOCKET_TIMEOUT),
+    CONNECT_TIMEOUT(RemoteCacheContainerResourceDefinition.Attribute.CONNECT_TIMEOUT),
     TCP_NO_DELAY(RemoteCacheContainerResourceDefinition.Attribute.TCP_NO_DELAY),
     TCP_KEEP_ALIVE(RemoteCacheContainerResourceDefinition.Attribute.TCP_KEEP_ALIVE),
     TRANSACTION_TIMEOUT(RemoteCacheContainerResourceDefinition.Attribute.TRANSACTION_TIMEOUT),

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerResourceDefinition.java
@@ -133,6 +133,7 @@ public class RemoteCacheContainerResourceDefinition extends ChildResourceDefinit
             }
         },
         SOCKET_TIMEOUT("socket-timeout", ModelType.INT, new ModelNode(60000)),
+        CONNECT_TIMEOUT("connect-timeout", ModelType.INT, new ModelNode(60000)),
         STATISTICS_ENABLED(ModelDescriptionConstants.STATISTICS_ENABLED, ModelType.BOOLEAN, ModelNode.FALSE),
         TCP_NO_DELAY("tcp-no-delay", ModelType.BOOLEAN, ModelNode.TRUE),
         TCP_KEEP_ALIVE("tcp-keep-alive", ModelType.BOOLEAN, ModelNode.FALSE),

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -433,6 +433,7 @@ infinispan.store.remote.deprecated=Use HotRod store instead.
 infinispan.store.remote.cache=The name of the remote cache to use for this remote store.
 infinispan.store.remote.tcp-no-delay=A TCP_NODELAY value for remote cache communication.
 infinispan.store.remote.socket-timeout=A socket timeout for remote cache communication.
+infinispan.store.remote.connect-timeout=Defines the maximum socket connect timeout before giving up connecting to the server.
 infinispan.store.remote.remote-servers=A list of remote servers for this cache store.
 infinispan.store.remote.remote.servers.remote-server=A remote server, defined by its outbound socket binding.
 infinispan.store.remote.remote-servers.remote-server.outbound-socket-binding=An outbound socket binding for a remote server.


### PR DESCRIPTION
See: https://issues.redhat.com/browse/WFLY-15046
This introduces support for a `connect-timeout` configuration option to the underlying infinispan remote cache.

Previously Wildfly did not support to configure a `connect-timeout` for
caches with a configured remote store, only `socket-timeout` was supported.
However the underlying infinispan remote store model supports `connect-timeout`.

Having support for timeout allows remote cache configurations such as:
```
# See https://docs.jboss.org/infinispan/11.0/configdocs/infinispan-cachestore-remote-config-11.0.html
echo SETUP: Configure Remote Keycloak cache: work
batch
/subsystem=infinispan/cache-container=keycloak/replicated-cache=work:add()
/subsystem=infinispan/cache-container=keycloak/replicated-cache=work/store=remote:add( \
   cache=work, \
   remote-servers=[ispn-remote-1,ispn-remote-2], \
   passivation=false, \
   fetch-state=false, \
   purge=false, \
   preload=false, \
   shared=true, \
   socket-timeout=${env.KEYCLOAK_REMOTE_ISPN_SOCK_TIMEOUT}, \
   connect-timeout=${env.KEYCLOAK_REMOTE_ISPN_CONN_TIMEOUT} \
)
/subsystem=infinispan/cache-container=keycloak/replicated-cache=work/store=remote:write-attribute(name=properties,value={ \
    rawValues=true, \
    marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, \
    infinispan.client.hotrod.auth_username=${env.KEYCLOAK_REMOTE_ISPN_USERNAME:keycloak}, \
    infinispan.client.hotrod.auth_password=${env.KEYCLOAK_REMOTE_ISPN_PASSWORD:password}, \
    infinispan.client.hotrod.auth_realm=${env.KEYCLOAK_REMOTE_ISPN_REALM:default}, \
    infinispan.client.hotrod.auth_server_name=${env.KEYCLOAK_REMOTE_ISPN_SERVER:infinispan}, \
    infinispan.client.hotrod.trust_store_file_name=${env.KEYCLOAK_REMOTE_ISPN_TRUSTSTORE_PATH:/opt/jboss/keycloak/standalone/configuration/ispn-truststore.jks}, \
    infinispan.client.hotrod.trust_store_type=${env.KEYCLOAK_REMOTE_ISPN_TRUSTSTORE_TYPE:JKS}, \
    infinispan.client.hotrod.trust_store_password=${env.KEYCLOAK_REMOTE_ISPN_TRUSTSTORE_PASSWORD:password} \
    })
run-batch
```

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
