### PR TITLE
[WFLY-15038] Kerberos authenticated database connections (e.g. to SQL Server) not reusable when using legacy security and remote EJBs

### DIFF
--- a/security/plugins/src/main/java/org/jboss/as/security/remoting/RemotingContext.java
+++ b/security/plugins/src/main/java/org/jboss/as/security/remoting/RemotingContext.java
@@ -23,6 +23,7 @@
 package org.jboss.as.security.remoting;
 
 import java.security.Permission;
+import java.util.Objects;
 
 import javax.net.ssl.SSLSession;
 
@@ -116,6 +117,19 @@ public class RemotingContext {
         @Override
         public SecurityIdentity getSecurityIdentity() {
             return connection.getLocalIdentity();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.connection);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof RemotingRemoteConnection) {
+                return Objects.equals(this.connection, ((RemotingRemoteConnection) obj).connection);
+            }
+            return false;
         }
     }
 

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -2898,6 +2898,7 @@
                                         -->
                                         <exclude>org/jboss/as/test/integration/ejb/container/**/SwitchIdentityTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/**/LdapLegacyTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/PicketboxCacheTestCase</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/**/RunAsPrincipalCustomDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/**/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/**/EJBContextMultipleSDTestCase.java</exclude>
@@ -3647,6 +3648,7 @@
                                         <exclude>org/jboss/as/test/integration/ejb/security/RunAsPrincipalCustomDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/securitydomain/EJBContextMultipleSDTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/cache/PicketboxCacheTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jca/security/DsWithSecurityDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/PicketboxCacheTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/PicketboxCacheTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.ejb.security.cache;
+
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.ejb.security.cache.RemotePicketboxCacheValidator.Result;
+import org.jboss.as.test.integration.ejb.security.cache.RemotePicketboxCacheValidator.Status;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.naming.client.WildFlyInitialContextFactory;
+
+/**
+ * Test for checking the picketbox principal and credential are cacheable under
+ * the same connection. This ensures that cache for security domains will work
+ * as in previous releases.
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class PicketboxCacheTestCase {
+
+    private static final String DEPLOYMENT = PicketboxCacheTestCase.class.getSimpleName();
+    private final String INVOCATION_URL = "remote+http://" +
+            NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "localhost")) + ":8080";
+
+    @BeforeClass
+    public static void beforeClass() {
+        // Test for PicketBox cache - not supported in Elytron
+        AssumeTestGroupUtil.assumeElytronProfileEnabled();
+    }
+
+    @Deployment(testable = false)
+    public static Archive deployment() {
+        return ShrinkWrap.create(JavaArchive.class, DEPLOYMENT + ".jar")
+                .addPackage(PicketboxCacheValidatorBean.class.getPackage())
+                .addAsResource(PermissionUtils.createPermissionsXmlAsset(
+                        new RuntimePermission("org.jboss.security.getSecurityContext"),
+                        new RuntimePermission("org.jboss.security.plugins.JBossSecurityContext.getSubjectInfo")),
+                        "META-INF/jboss-permissions.xml");
+    }
+
+    @Test
+    public void testCacheIsUsed() throws Exception {
+        Properties prop = new Properties();
+        prop.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
+        prop.put(Context.PROVIDER_URL, INVOCATION_URL);
+        prop.put(Context.SECURITY_PRINCIPAL, "user1");
+        prop.put(Context.SECURITY_CREDENTIALS, "password1");
+        InitialContext ctx = null;
+        try {
+            ctx = new InitialContext(prop);
+            String lookupName = "ejb:/" + DEPLOYMENT + "/" + PicketboxCacheValidatorBean.class.getSimpleName() + "!" + RemotePicketboxCacheValidator.class.getName();
+            // first time
+            RemotePicketboxCacheValidator ejb = (RemotePicketboxCacheValidator) ctx.lookup(lookupName);
+            Result result = ejb.check();
+            Assert.assertEquals("The logged user is not new to the cache", Status.NEW, result.getStatus());
+            Assert.assertEquals("Username is not OK", "user1", result.getName());
+            // second time to ensure the cache is used and the credential is the same
+            ejb = (RemotePicketboxCacheValidator) ctx.lookup(lookupName);
+            result = ejb.check();
+            Assert.assertEquals("The logged user is not cached", Status.CACHED, result.getStatus());
+            Assert.assertEquals("Username is not OK", "user1", result.getName());
+        } finally {
+            if (ctx != null) {
+                ctx.close();
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/PicketboxCacheValidatorBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/PicketboxCacheValidatorBean.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.ejb.security.cache;
+
+import java.security.Principal;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.ConcurrencyManagementType;
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+import org.jboss.security.SecurityContext;
+import org.jboss.security.SecurityContextAssociation;
+
+/**
+ * Implementation of the RemotePicketboxCacheValidator using a concurrent hash
+ * map for the cache.
+ *
+ * @author rmartinc
+ */
+@Singleton
+@Remote(RemotePicketboxCacheValidator.class)
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
+public class PicketboxCacheValidatorBean implements RemotePicketboxCacheValidator {
+
+    private final ConcurrentHashMap<Principal, Object> cache;
+
+    public PicketboxCacheValidatorBean() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Result check() {
+        SecurityContext sc = SecurityContextAssociation.getSecurityContext();
+        if (sc == null) {
+            return new Result(Status.ERROR);
+        }
+        Object credential = sc.getUtil().getCredential();
+        Principal principal = sc.getUtil().getUserPrincipal();
+        if (credential == null || principal == null) {
+            return new Result(Status.ERROR);
+        }
+        Object cachedCredential = cache.get(principal);
+        if (cachedCredential == null) {
+            cache.put(principal, credential);
+            return new Result(principal.getName(), Status.NEW);
+        } else if (cachedCredential.equals(credential)) {
+            return new Result(principal.getName(), Status.CACHED);
+        } else {
+            return new Result(principal.getName(), Status.INVALID);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/RemotePicketboxCacheValidator.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/cache/RemotePicketboxCacheValidator.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.ejb.security.cache;
+
+import java.io.Serializable;
+import javax.ejb.Remote;
+
+/**
+ * Interface for an EJB that checks the principal and credential of a picketbox
+ * login is cacheable as before.
+ *
+ * @author rmartinc
+ */
+@Remote
+public interface RemotePicketboxCacheValidator {
+
+    /**
+     * The status of the picketbox principal/credential in the cache.
+     */
+    public enum Status {
+
+        /**
+         * Error obtaining the picketbox principal or credential.
+         */
+        ERROR,
+
+        /**
+         * The principal is new to the cache.
+         */
+        NEW,
+
+        /**
+         * The principal is in the cache and the credential is also the
+         * one stored in it.
+         */
+        CACHED,
+
+        /**
+         * The principal is in the cache but the credential passed is different
+         * to the one cached.
+         */
+        INVALID
+    };
+
+    /**
+     * The result of the check.
+     */
+    public class Result implements Serializable {
+        private String name;
+        private Status status;
+
+        public Result() {
+            this.name = null;
+            this.status = null;
+        }
+
+        public Result(Status status) {
+            this.name = null;
+            this.status = status;
+        }
+
+        public Result(String name, Status status) {
+            this.name = name;
+            this.status = status;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public String toString() {
+            String result = this.status.name();
+            if (this.name != null) {
+                result += "(" + this.name + ")";
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Method that checks if the picketbox logged principal and credential
+     * is inside a cache.
+     * @return The status of the principal in the cache
+     */
+    public Result check();
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-15038

Just adding an equals method to the wrapping `RemotingRemoteConnection` class. This way the picketbox cache for security domains is maintained when the EJB call is using the same connection as before. Indirect test added, not using kerberos, just checking the principal and credential obtained from picketbox are cachable.

@darranl Please do the review when you have time. No hurry, the elytron configuration is working better.
