### PR TITLE
[WFLY-15055] Use javax module alias instead of the jakarta modules on…

### DIFF
--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -32,8 +32,8 @@
     <dependencies>
         <!-- Required for the IBM J9 1.8 -->
         <module name="java.se"/>
-        <module name="jakarta.mail.api" optional="true"/>
-        <module name="jakarta.activation.api" optional="true"/>
+        <module name="javax.mail.api" optional="true"/>
+        <module name="javax.activation.api" optional="true"/>
         <module name="org.bouncycastle.bcpkix"/>
         <module name="org.bouncycastle.bcprov"/>
         <module name="org.bouncycastle.bcutil"/>


### PR DESCRIPTION
… the Bouncy Castle Jakarta Mail module

Jira issue: https://issues.redhat.com/browse/WFLY-15055
