### PR TITLE
[WFLY-15045] Tests if the default servlet serves content from any directories starting with WEB-INF or META-INF

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultServletTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultServletTestCase.java
@@ -3,14 +3,18 @@ package org.jboss.as.test.integration.web.response;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,6 +35,7 @@ public class DefaultServletTestCase {
 
     private static final String WEB_APP_CONTEXT = "default-servlet-test";
     private static final String APP_XHTML_FILE_NAME = "app.xhtml";
+    private static final String INFDIRS_DEPLOYMENT = "infdirectories";
     private static final Logger logger = Logger.getLogger(DefaultServletTestCase.class);
 
     @ArquillianResource
@@ -38,10 +43,18 @@ public class DefaultServletTestCase {
 
     private HttpClient httpclient;
 
-    @Deployment
+    @Deployment(name = WEB_APP_CONTEXT)
     public static WebArchive deployment() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_CONTEXT + ".war");
         war.addAsWebResource(DefaultServletTestCase.class.getPackage(), APP_XHTML_FILE_NAME, APP_XHTML_FILE_NAME);
+        return war;
+    }
+
+    @Deployment(name = INFDIRS_DEPLOYMENT)
+    public static Archive<?> createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, INFDIRS_DEPLOYMENT + ".war");
+        war.add(new StringAsset("Welcome in WEB-INFOOBAR"), "WEB-INFOOBAR/test.html");
+        war.add(new StringAsset("Welcome in META-INFOOBAR"), "META-INFOOBAR/test.html");
         return war;
     }
 
@@ -56,6 +69,7 @@ public class DefaultServletTestCase {
      * @throws Exception
      * @see https://developer.jboss.org/thread/266805 for more details
      */
+    @OperateOnDeployment(WEB_APP_CONTEXT)
     @Test
     public void testForbidSourceFileAccess() throws Exception {
         // first try accessing the valid URL and expect it to serve the right content
@@ -72,5 +86,24 @@ public class DefaultServletTestCase {
         final HttpGet httpGetNonExistentURL = new HttpGet(nonExistentURL);
         final HttpResponse responseForNonExistentURL = this.httpclient.execute(httpGetNonExistentURL);
         Assert.assertEquals("Unexpected response code for URL " + nonExistentURL, HttpServletResponse.SC_NOT_FOUND, responseForNonExistentURL.getStatusLine().getStatusCode());
+    }
+
+    /**
+     * Tests if the default servlet serves content from any directories starting with WEB-INF or META-INF
+     *
+     * [WFLY-15045]
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @OperateOnDeployment(INFDIRS_DEPLOYMENT)
+    @Test
+    public void testInfDirectories(@ArquillianResource URL webAppURL) throws Exception {
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        HttpResponse httpResponse = httpClient.execute(new HttpGet(webAppURL.toURI() + "WEB-INFOOBAR/test.html"));
+        Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+        EntityUtils.consumeQuietly(httpResponse.getEntity());
+        httpResponse = httpClient.execute(new HttpGet(webAppURL.toURI() + "META-INFOOBAR/test.html"));
+        Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
     }
 }


### PR DESCRIPTION
[WFLY-15045](https://issues.redhat.com/browse/WFLY-15045)

Although WEB-INF and META-INF directories of the war archive may not be visible by http request as mentioned in the related [customer case](https://access.redhat.com/support/cases/#/case/02952259) there might be a need to have directories starting as WEB-INF or META-INF in the war. The test checks if content of such a directory is served by the DefaultServlet.