### PR TITLE
[WFLY-15042] Upgrade WildFly Core 17.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15042

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.0.Beta3
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Beta2...17.0.0.Beta3

---

<details>

<summary>Release Notes - WildFly Core - Version 17.0.0.Beta3</summary>
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5466'>WFCORE-5466</a>] -         Remove Vault support entirely from WildFly Core
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-1934'>WFCORE-1934</a>] -         Make number of thread size for ServerService Thread Pool configurable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2592'>WFCORE-2592</a>] -         wildfly-service.exe and jbosspass wrong with # inside
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5353'>WFCORE-5353</a>] -         Multiple syntax issues with &#39;wildfly-init-redhat.sh&#39;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5482'>WFCORE-5482</a>] -         Bouncyclastle bcpkix module requires a dependency on java.logging and java.naming
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5499'>WFCORE-5499</a>] -         domain.ps1 doesn&#39;t add --add-exports JVM options as expected for JDK &gt; 9
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5511'>WFCORE-5511</a>] -         CVE-2021-3644 wildfly-core: Invalid Sensitivity Classification of Vault Expression
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5485'>WFCORE-5485</a>] -         Bump the CLI configuration schema to version 4.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5501'>WFCORE-5501</a>] -         Remove legacy feature pack and the build and dist produced from it
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5503'>WFCORE-5503</a>] -         Get rid of maven warning importing the testbom dependencies 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5504'>WFCORE-5504</a>] -         Check emptiness with Collection.isEmpty()
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5506'>WFCORE-5506</a>] -         Make Bouncy Castle bcutil-jdk15on license to use explicitly the MIT license file shipped with the server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5513'>WFCORE-5513</a>] -         Manage the BouncyCastle Jakarta Mail dependency with WildFly Core
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5509'>WFCORE-5509</a>] -         Upgrade to Byteman 4.0.16
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5510'>WFCORE-5510</a>] -         Upgrade WildFly Elytron to 1.16.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5515'>WFCORE-5515</a>] -         Upgrade log4j-jboss-logmanager to 1.2.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5517'>WFCORE-5517</a>] -         Upgrade Undertow to 2.2.9.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5518'>WFCORE-5518</a>] -         Upgrade jboss-invocation from 1.6.1.Final to 1.6.2.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5376'>WFCORE-5376</a>] -         Disable use of legacy security realms when not supported.
</li>
</ul>
                                                                                                                        
</details>