### PR TITLE
Revert "[WFLY-11566] EJB: make a bean class a superclass to a proxy"

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
@@ -23,7 +23,6 @@
 package org.jboss.as.ee.component;
 
 import java.io.Serializable;
-import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.as.ee.logging.EeLogger;
@@ -91,14 +90,7 @@ class DefaultComponentViewConfigurator extends AbstractComponentConfigurator imp
 
             //we define it in the modules class loader to prevent permgen leaks
             if (viewClass.isInterface()) {
-                final Class<?> componentClass = configuration.getComponentClass();
-                Constructor<?> defaultConstructor = null;
-                try {
-                    defaultConstructor = componentClass.getConstructor();
-                } catch (Exception e) {
-                    //ignore
-                }
-                proxyConfiguration.setSuperClass(defaultConstructor == null ? Object.class : componentClass);
+                proxyConfiguration.setSuperClass(Object.class);
                 proxyConfiguration.addAdditionalInterface(viewClass);
                 viewConfiguration = view.createViewConfiguration(viewClass, configuration, new ProxyFactory(proxyConfiguration));
             } else {


### PR DESCRIPTION
I'm reverting the recent commit because of TCK failures. Because the fix was related to support case I'm working on alternative currently.