### PR TITLE
[WFLY-15078] Upgrade WildFly Core 17.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15078

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.0.Beta4
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Beta3...17.0.0.Beta4

---

<details>

<summary>Release Notes - WildFly Core - Version 17.0.0.Beta4</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4171'>WFCORE-4171</a>] -         vault CLI scripts should not be part of core feature-pack
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5516'>WFCORE-5516</a>] -         If JBOSS_BASE_DIR variable is empty -Djboss.server.base.dir is not added in wildfly-init-redhat.sh and wildfly-init-debian.sh scripts.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5528'>WFCORE-5528</a>] -         Missing EAP 7.4 host exclusion as a known release
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5529'>WFCORE-5529</a>] -         Make Elytron transformer tests against EAP 7.4.0 to use the correct controller version
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5347'>WFCORE-5347</a>] -         Replace temporal ModelTestControllerVersion based on WF23 by real 7.4.0.GA
</li>
</ul>
                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5377'>WFCORE-5377</a>] -         Disable use of PicketBox Vault when not supported.
</li>
</ul>
                                                                                                                        


</details>