### PR TITLE
WFLY-13809 Get application name from BatchEnvironment instead of jndi lookup and Upgrade jberet-core from 1.3.9.Final to 1.3.10.Final; from 2.0.0.Final to 2.0.1.Final in ee-9 preview

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/DefaultBatchEnvironment.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/DefaultBatchEnvironment.java
@@ -76,4 +76,9 @@ public class DefaultBatchEnvironment implements BatchEnvironment {
     public Properties getBatchConfigurationProperties() {
         throw BatchLogger.LOGGER.noBatchEnvironmentFound(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
     }
+
+    @Override
+    public String getApplicationName() {
+        throw BatchLogger.LOGGER.noBatchEnvironmentFound(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+    }
 }

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
@@ -224,6 +224,11 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
         }
 
         @Override
+        public String getApplicationName() {
+            return deploymentName;
+        }
+
+        @Override
         public SecurityDomain getSecurityDomain() {
             return batchConfigurationInjector.getValue().getSecurityDomain();
         }

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -86,11 +86,11 @@
         <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
+        <version.org.jberet>2.0.1.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.4</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.metadata>14.0.0.Beta1</version.org.jboss.metadata>
         <version.org.jboss.weld.weld>4.0.2.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>4.0.SP1</version.org.jboss.weld.weld-api>
-        <version.org.jberet>2.0.0.Final</version.org.jberet>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
         <version.org.wildfly.security.jakarta.elytron-ee>2.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
 

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
         <version.org.infinispan.protostream>4.4.1.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.23.2-GA</version.org.javassist>
-        <version.org.jberet>1.3.9.Final</version.org.jberet>
+        <version.org.jberet>1.3.10.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13809

Related Issue: https://issues.redhat.com/browse/WFLY-15059 
https://issues.redhat.com/browse/JBERET-495

This PR also contains a component upgrade.
