### PR TITLE
WFLY-15088 With transactional cache, expiration scheduling reads out of date maxInactiveInterval value changed on non-primary owner

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
@@ -58,10 +58,12 @@ public class SessionExpirationScheduler<MV> implements Scheduler<String, Immutab
 
     @Override
     public void schedule(String sessionId) {
-        MV value = this.metaDataFactory.findValue(sessionId);
-        if (value != null) {
-            ImmutableSessionMetaData metaData = this.metaDataFactory.createImmutableSessionMetaData(sessionId, value);
-            this.schedule(sessionId, metaData);
+        try (Batch batch = this.batcher.createBatch()) {
+            MV value = this.metaDataFactory.findValue(sessionId);
+            if (value != null) {
+                ImmutableSessionMetaData metaData = this.metaDataFactory.createImmutableSessionMetaData(sessionId, value);
+                this.schedule(sessionId, metaData);
+            }
         }
     }
 

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/ImmutableSessionMetaData.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/ImmutableSessionMetaData.java
@@ -67,7 +67,6 @@ public interface ImmutableSessionMetaData {
 
     /**
      * Returns the time interval, using the specified unit, after which this session will expire.
-     * @param unit a time unit
      * @return a time interval
      */
     Duration getMaxInactiveInterval();


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-15088