### PR TITLE
[WFLY-15023] Move WildFly Preview to a native jakarta.* namespace variant of JBoss Metadata artifacts that use EE APIs

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -90,7 +90,7 @@
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
         <version.org.jberet>2.0.1.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.4</version.org.jboss.activemq.artemis.integration>
-        <version.org.jboss.metadata>14.0.0.Beta1</version.org.jboss.metadata>
+        <version.org.jboss.metadata>14.0.0.Beta2</version.org.jboss.metadata>
         <version.org.jboss.weld.weld>4.0.2.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>4.0.SP1</version.org.jboss.weld.weld-api>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
@@ -174,12 +174,14 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <escapeString>\</escapeString>
                             <resources>
                                 <resource>
                                     <directory>${servlet.common.resources.directory}</directory>
                                     <excludes>
                                         <exclude>**/org/jboss/as/security/main/module.xml</exclude>
                                     </excludes>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>
@@ -445,6 +447,10 @@
                     <artifactId>jaxb-xjc</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-ejb</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>wildfly-mail</artifactId>
                 </exclusion>
@@ -465,6 +471,12 @@
             <version>${ee.maven.version}</version>
             <type>pom</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -1055,22 +1067,22 @@
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.metadata</groupId>
-            <artifactId>jboss-metadata-common</artifactId>
+            <artifactId>jboss-metadata-common-jakarta</artifactId>
             <version>${version.org.jboss.metadata}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.jboss</groupId>
-                    <artifactId>jboss-common-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1085,18 +1097,22 @@
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.metadata</groupId>
-            <artifactId>jboss-metadata-ejb</artifactId>
+            <artifactId>jboss-metadata-ejb-jakarta</artifactId>
             <version>${version.org.jboss.metadata}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1110,6 +1126,10 @@
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.metadata</groupId>
+                    <artifactId>jboss-metadata-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
+++ b/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
@@ -191,6 +191,28 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.jboss.metadata</groupId>
+      <artifactId>jboss-metadata-common-jakarta</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 only</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.metadata</groupId>
+      <artifactId>jboss-metadata-ejb-jakarta</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 only</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.annotation</groupId>
       <artifactId>jboss-annotations-api_1.3_spec</artifactId>
       <licenses>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.metadata:jboss-metadata-ejb}"/>
+        <artifact name="\${org.jboss.metadata:jboss-metadata-ejb@module.jakarta.suffix@}"/>
     </resources>
 
     <dependencies>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -121,9 +121,11 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <escapeString>\</escapeString>
                             <resources>
                                 <resource>
                                     <directory>${servlet.common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/common/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.metadata:jboss-metadata-common}"/>
+        <artifact name="\${org.jboss.metadata:jboss-metadata-common@module.jakarta.suffix@}"/>
     </resources>
 
     <dependencies>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ear/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/ear/main/module.xml
@@ -34,7 +34,6 @@
     <dependencies>
         <module name="java.xml"/>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.annotation.api"/>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/web/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/metadata/web/main/module.xml
@@ -34,10 +34,7 @@
     <dependencies>
         <module name="java.xml"/>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.annotation.api"/>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
-        <module name="javax.servlet.api" optional="true"/>
-        <module name="javax.servlet.jsp.api" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/servlet-feature-pack/galleon-feature-pack/pom.xml
+++ b/servlet-feature-pack/galleon-feature-pack/pom.xml
@@ -200,9 +200,11 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <escapeString>\</escapeString>
                             <resources>
                                 <resource>
                                     <directory>${common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15023

Also cleans up some unnecessary module.xml dependencies that imply EE APIs were used when they are not

Builds upon #14507 