### PR TITLE
WFLY-15088 With transactional cache, expiration scheduling reads out of date maxInactiveInterval value changed on non-primary owner

### DIFF
--- a/clustering/ee/infinispan/pom.xml
+++ b/clustering/ee/infinispan/pom.xml
@@ -84,5 +84,26 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-security-manager</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-spi</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
     </dependencies>
 </project>

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithMetaDataCommand.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithMetaDataCommand.java
@@ -22,35 +22,28 @@
 
 package org.wildfly.clustering.ee.infinispan.scheduler;
 
-import org.wildfly.clustering.dispatcher.Command;
-
 /**
- * Command that scheduled an element.
+ * Command that schedules an item, where its meta data is persisted.
  * @author Paul Ferraro
  */
-public interface ScheduleCommand<I, M> extends Command<Void, Scheduler<I, M>> {
+public class ScheduleWithMetaDataCommand<I, M> implements ScheduleCommand<I, M> {
+    private static final long serialVersionUID = 2116021502509126945L;
 
-    /**
-     * Returns the identifier of the element to be scheduled.
-     * @return the identifier of the element to be scheduled.
-     */
-    I getId();
+    private final I id;
+    private final M metaData;
 
-    /**
-     * Returns the meta data of the element to be scheduled.
-     * @return the meta data of the element to be scheduled.
-     */
-    M getMetaData();
+    public ScheduleWithMetaDataCommand(I id, M metaData) {
+        this.id = id;
+        this.metaData = metaData;
+    }
 
     @Override
-    default Void execute(Scheduler<I, M> scheduler) throws Exception {
-        I id = this.getId();
-        M metaData = this.getMetaData();
-        if (metaData != null) {
-            scheduler.schedule(id, metaData);
-        } else {
-            scheduler.schedule(id);
-        }
-        return null;
+    public I getId() {
+        return this.id;
+    }
+
+    @Override
+    public M getMetaData() {
+        return this.metaData;
     }
 }

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithMetaDataCommandMarshaller.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithMetaDataCommandMarshaller.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ee.infinispan.scheduler;
+
+import java.io.IOException;
+
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for a {@link ScheduleWithMetaDataCommand}.
+ * @author Paul Ferraro
+ */
+public class ScheduleWithMetaDataCommandMarshaller<I, M> implements ProtoStreamMarshaller<ScheduleWithMetaDataCommand<I, M>> {
+
+    private static final byte ID_INDEX = 1;
+    private static final byte META_DATA_INDEX = 2;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<? extends ScheduleWithMetaDataCommand<I, M>> getJavaClass() {
+        return (Class<ScheduleWithMetaDataCommand<I, M>>) (Class<?>) ScheduleWithMetaDataCommand.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ScheduleWithMetaDataCommand<I, M> readFrom(ProtoStreamReader reader) throws IOException {
+        I id = null;
+        M metaData = null;
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case ID_INDEX:
+                    id = (I) reader.readAny();
+                    break;
+                case META_DATA_INDEX:
+                    metaData = (M) reader.readAny();
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new ScheduleWithMetaDataCommand<>(id, metaData);
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ScheduleWithMetaDataCommand<I, M> command) throws IOException {
+        I id = command.getId();
+        if (id != null) {
+            writer.writeAny(ID_INDEX, id);
+        }
+        M metaData = command.getMetaData();
+        if (metaData != null) {
+            writer.writeAny(META_DATA_INDEX, metaData);
+        }
+    }
+}

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithTransientMetaDataCommand.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/ScheduleWithTransientMetaDataCommand.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2021, Red Hat, Inc., and individual contributors
+ * Copyright 2019, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,35 +22,32 @@
 
 package org.wildfly.clustering.ee.infinispan.scheduler;
 
-import org.wildfly.clustering.dispatcher.Command;
-
 /**
- * Command that scheduled an element.
+ * Command that scheduled an item.
  * @author Paul Ferraro
  */
-public interface ScheduleCommand<I, M> extends Command<Void, Scheduler<I, M>> {
+public class ScheduleWithTransientMetaDataCommand<I, M> implements ScheduleCommand<I, M> {
+    private static final long serialVersionUID = 6254782388444864112L;
 
-    /**
-     * Returns the identifier of the element to be scheduled.
-     * @return the identifier of the element to be scheduled.
-     */
-    I getId();
+    private final I id;
+    private final transient M metaData;
 
-    /**
-     * Returns the meta data of the element to be scheduled.
-     * @return the meta data of the element to be scheduled.
-     */
-    M getMetaData();
+    public ScheduleWithTransientMetaDataCommand(I id, M metaData) {
+        this.id = id;
+        this.metaData = metaData;
+    }
+
+    ScheduleWithTransientMetaDataCommand(I id) {
+        this(id, null);
+    }
 
     @Override
-    default Void execute(Scheduler<I, M> scheduler) throws Exception {
-        I id = this.getId();
-        M metaData = this.getMetaData();
-        if (metaData != null) {
-            scheduler.schedule(id, metaData);
-        } else {
-            scheduler.schedule(id);
-        }
-        return null;
+    public I getId() {
+        return this.id;
+    }
+
+    @Override
+    public M getMetaData() {
+        return this.metaData;
     }
 }

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/SchedulerSerializationContextInitializer.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/SchedulerSerializationContextInitializer.java
@@ -38,6 +38,7 @@ public class SchedulerSerializationContextInitializer extends AbstractSerializat
     @Override
     public void registerMarshallers(SerializationContext context) {
         context.registerMarshaller(new FunctionalScalarMarshaller<>(CancelCommand.class, Scalar.ANY, CancelCommand::getId, CancelCommand::new));
-        context.registerMarshaller(new FunctionalScalarMarshaller<>(ScheduleCommand.class, Scalar.ANY, ScheduleCommand::getId, ScheduleCommand::new));
+        context.registerMarshaller(new FunctionalScalarMarshaller<>(ScheduleWithTransientMetaDataCommand.class, Scalar.ANY, ScheduleWithTransientMetaDataCommand::getId, ScheduleWithTransientMetaDataCommand::new));
+        context.registerMarshaller(new ScheduleWithMetaDataCommandMarshaller<>());
     }
 }

--- a/clustering/ee/infinispan/src/main/resources/org.wildfly.clustering.ee.infinispan.scheduler.proto
+++ b/clustering/ee/infinispan/src/main/resources/org.wildfly.clustering.ee.infinispan.scheduler.proto
@@ -6,12 +6,20 @@ package org.wildfly.clustering.ee.infinispan.scheduler;
  * @TypeId(180)
  */
 message CancelCommand {
-	required	bytes	id	= 1;
+	optional	bytes	id	 = 1;
 }
 
 /**
  * @TypeId(181)
  */
-message ScheduleCommand {
-	required	bytes	id	= 1;
+message ScheduleWithTransientMetaDataCommand {
+	optional	bytes	id	 = 1;
+}
+
+/**
+ * @TypeId(182)
+ */
+message ScheduleWithMetaDataCommand {
+	optional	bytes	id	 = 1;
+	optional	bytes	metaData	 = 2;
 }

--- a/clustering/ee/infinispan/src/test/java/org/wildfly/clustering/ee/infinispan/scheduler/CommandMarshallerTestCase.java
+++ b/clustering/ee/infinispan/src/test/java/org/wildfly/clustering/ee/infinispan/scheduler/CommandMarshallerTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ee.infinispan.scheduler;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.MarshallingTesterFactory;
+import org.wildfly.clustering.marshalling.Tester;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamTesterFactory;
+
+/**
+ * Unit test for marshalling scheduler commands.
+ * @author Paul Ferraro
+ */
+public class CommandMarshallerTestCase {
+
+    private final MarshallingTesterFactory factory = ProtoStreamTesterFactory.INSTANCE;
+
+    @Test
+    public void testScheduleWithLocalMetaDataCommand() throws IOException {
+        Tester<ScheduleWithTransientMetaDataCommand<String, String>> tester = this.factory.createTester();
+
+        tester.test(new ScheduleWithTransientMetaDataCommand<>("foo"), this::assertEquals);
+        tester.test(new ScheduleWithTransientMetaDataCommand<>("foo", "bar"), this::assertEquals);
+    }
+
+    <I, M> void assertEquals(ScheduleWithTransientMetaDataCommand<I, M> expected, ScheduleWithTransientMetaDataCommand<I, M> actual) {
+        Assert.assertEquals(expected.getId(), actual.getId());
+        Assert.assertNull(actual.getMetaData());
+    }
+
+    @Test
+    public void testCancelCommand() throws IOException {
+        Tester<CancelCommand<String, Object>> tester = this.factory.createTester();
+
+        tester.test(new CancelCommand<>("foo"), this::assertEquals);
+    }
+
+    <I, M> void assertEquals(CancelCommand<I, M> expected, CancelCommand<I, M> actual) {
+        Assert.assertEquals(expected.getId(), actual.getId());
+    }
+
+    @Test
+    public void testScheduleWithMetaDataCommand() throws IOException {
+        Tester<ScheduleWithMetaDataCommand<String, String>> tester = this.factory.createTester();
+
+        tester.test(new ScheduleWithMetaDataCommand<>("foo", "bar"), this::assertEquals);
+    }
+
+    <I, M> void assertEquals(ScheduleWithMetaDataCommand<I, M> expected, ScheduleWithMetaDataCommand<I, M> actual) {
+        Assert.assertEquals(expected.getId(), actual.getId());
+        Assert.assertEquals(expected.getMetaData(), actual.getMetaData());
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -59,6 +59,7 @@ import org.wildfly.clustering.web.session.ImmutableSession;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
 import org.wildfly.clustering.web.session.SessionManager;
 
 /**
@@ -79,7 +80,7 @@ public class InfinispanSessionManager<SC, MV, AV, LC> implements SessionManager<
     private final CacheProperties properties;
     private final SessionFactory<SC, MV, AV, LC> factory;
     private final IdentifierFactory<String> identifierFactory;
-    private final Scheduler<String, ImmutableSessionMetaData> expirationScheduler;
+    private final Scheduler<String, SessionExpirationMetaData> expirationScheduler;
     private final Recordable<ImmutableSessionMetaData> recorder;
     private final SC context;
     private final Runnable startTask;
@@ -107,7 +108,7 @@ public class InfinispanSessionManager<SC, MV, AV, LC> implements SessionManager<
             @Override
             public void accept(ImmutableSession session) {
                 if (session.isValid()) {
-                    configuration.getExpirationScheduler().schedule(session.getId(), session.getMetaData());
+                    configuration.getExpirationScheduler().schedule(session.getId(), new SimpleSessionExpirationMetaData(session.getMetaData()));
                 }
             }
         };

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerConfiguration.java
@@ -34,6 +34,7 @@ import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.web.IdentifierFactory;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 import org.wildfly.clustering.web.session.SessionExpirationListener;
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
 import org.wildfly.clustering.web.session.SessionManager;
 
 /**
@@ -49,7 +50,7 @@ public interface InfinispanSessionManagerConfiguration<SC, LC> {
     CacheProperties getProperties();
     IdentifierFactory<String> getIdentifierFactory();
     Batcher<TransactionBatch> getBatcher();
-    Scheduler<String, ImmutableSessionMetaData> getExpirationScheduler();
+    Scheduler<String, SessionExpirationMetaData> getExpirationScheduler();
     Recordable<ImmutableSessionMetaData> getInactiveSessionRecorder();
     Registrar<SessionExpirationListener> getExpirationRegistar();
     Runnable getStartTask();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
@@ -36,13 +36,14 @@ import org.wildfly.clustering.infinispan.spi.distribution.Locality;
 import org.wildfly.clustering.web.cache.session.ImmutableSessionMetaDataFactory;
 import org.wildfly.clustering.web.infinispan.logging.InfinispanWebLogger;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
 
 /**
  * Session expiration scheduler that eagerly expires sessions as soon as they are eligible.
  * If/When Infinispan implements expiration notifications (ISPN-694), this will be obsolete.
  * @author Paul Ferraro
  */
-public class SessionExpirationScheduler<MV> implements Scheduler<String, ImmutableSessionMetaData>, Predicate<String> {
+public class SessionExpirationScheduler<MV> implements Scheduler<String, SessionExpirationMetaData>, Predicate<String> {
 
     private final LocalScheduler<String> scheduler;
     private final Batcher<TransactionBatch> batcher;
@@ -66,7 +67,7 @@ public class SessionExpirationScheduler<MV> implements Scheduler<String, Immutab
     }
 
     @Override
-    public void schedule(String sessionId, ImmutableSessionMetaData metaData) {
+    public void schedule(String sessionId, SessionExpirationMetaData metaData) {
         Duration maxInactiveInterval = metaData.getMaxInactiveInterval();
         if (!maxInactiveInterval.isZero()) {
             this.scheduler.schedule(sessionId, metaData.getLastAccessEndTime().plus(maxInactiveInterval));

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionSerializationContextInitializer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionSerializationContextInitializer.java
@@ -40,5 +40,6 @@ public class SessionSerializationContextInitializer extends AbstractSerializatio
         context.registerMarshaller(new SessionKeyMarshaller<>(SessionCreationMetaDataKey.class, SessionCreationMetaDataKey::new));
         context.registerMarshaller(new SessionKeyMarshaller<>(SessionAccessMetaDataKey.class, SessionAccessMetaDataKey::new));
         context.registerMarshaller(new EnumMarshaller<>(SessionCreationMetaDataKeyFilter.class));
+        context.registerMarshaller(new SimpleSessionExpirationMetaDataMarshaller());
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaData.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaData.java
@@ -20,37 +20,38 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.ee.infinispan.scheduler;
+package org.wildfly.clustering.web.infinispan.session;
 
-import org.wildfly.clustering.dispatcher.Command;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
 
 /**
- * Command that scheduled an element.
+ * Immutable view of the expiration metadata for a session.
  * @author Paul Ferraro
  */
-public interface ScheduleCommand<I, M> extends Command<Void, Scheduler<I, M>> {
+public class SimpleSessionExpirationMetaData implements SessionExpirationMetaData {
 
-    /**
-     * Returns the identifier of the element to be scheduled.
-     * @return the identifier of the element to be scheduled.
-     */
-    I getId();
+    private final Instant lastAccessEndTime;
+    private final Duration maxInactiveInterval;
 
-    /**
-     * Returns the meta data of the element to be scheduled.
-     * @return the meta data of the element to be scheduled.
-     */
-    M getMetaData();
+    public SimpleSessionExpirationMetaData(SessionExpirationMetaData metaData) {
+        this(metaData.getMaxInactiveInterval(), metaData.getLastAccessEndTime());
+    }
+
+    SimpleSessionExpirationMetaData(Duration maxInactiveInterval, Instant lastAccessEndTime) {
+        this.maxInactiveInterval = maxInactiveInterval;
+        this.lastAccessEndTime = lastAccessEndTime;
+    }
 
     @Override
-    default Void execute(Scheduler<I, M> scheduler) throws Exception {
-        I id = this.getId();
-        M metaData = this.getMetaData();
-        if (metaData != null) {
-            scheduler.schedule(id, metaData);
-        } else {
-            scheduler.schedule(id);
-        }
-        return null;
+    public Instant getLastAccessEndTime() {
+        return this.lastAccessEndTime;
+    }
+
+    @Override
+    public Duration getMaxInactiveInterval() {
+        return this.maxInactiveInterval;
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaDataMarshaller.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaDataMarshaller.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for a {@link SimpleSessionExpirationMetaData}.
+ * @author Paul Ferraro
+ */
+public class SimpleSessionExpirationMetaDataMarshaller implements ProtoStreamMarshaller<SimpleSessionExpirationMetaData> {
+
+    private static final byte MAX_INACTIVE_INTERVAL_INDEX = 1;
+    private static final byte LAST_ACCESS_END_TIME_INDEX = 2;
+
+    // Optimize for specification default
+    private static final Duration DEFAULT_MAX_INACTIVE_INTERVAL = Duration.ofMinutes(30L);
+    private static final Instant DEFAULT_LAST_ACCESS_END_TIME = Instant.EPOCH;
+
+    @Override
+    public Class<? extends SimpleSessionExpirationMetaData> getJavaClass() {
+        return SimpleSessionExpirationMetaData.class;
+    }
+
+    @Override
+    public SimpleSessionExpirationMetaData readFrom(ProtoStreamReader reader) throws IOException {
+        Duration maxInactiveInterval = DEFAULT_MAX_INACTIVE_INTERVAL;
+        Instant lastAccessEndTime = DEFAULT_LAST_ACCESS_END_TIME;
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case MAX_INACTIVE_INTERVAL_INDEX:
+                    maxInactiveInterval = reader.readObject(Duration.class);
+                    break;
+                case LAST_ACCESS_END_TIME_INDEX:
+                    lastAccessEndTime = reader.readObject(Instant.class);
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new SimpleSessionExpirationMetaData(maxInactiveInterval, lastAccessEndTime);
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, SimpleSessionExpirationMetaData metaData) throws IOException {
+        Duration maxInactiveInterval = metaData.getMaxInactiveInterval();
+        if (!maxInactiveInterval.equals(DEFAULT_MAX_INACTIVE_INTERVAL)) {
+            writer.writeObject(MAX_INACTIVE_INTERVAL_INDEX, maxInactiveInterval);
+        }
+        Instant lastAccessEndTime = metaData.getLastAccessEndTime();
+        if (!lastAccessEndTime.equals(DEFAULT_LAST_ACCESS_END_TIME)) {
+            writer.writeObject(LAST_ACCESS_END_TIME_INDEX, lastAccessEndTime);
+        }
+    }
+}

--- a/clustering/web/infinispan/src/main/resources/org.wildfly.clustering.web.infinispan.session.proto
+++ b/clustering/web/infinispan/src/main/resources/org.wildfly.clustering.web.infinispan.session.proto
@@ -1,5 +1,7 @@
 package org.wildfly.clustering.web.infinispan.session;
 
+import "java.time.proto";
+
 // IDs: 200 - 204
 
 /**
@@ -21,4 +23,12 @@ message SessionAccessMetaDataKey {
  */
 enum SessionCreationMetaDataKeyFilter {
 	INSTANCE	= 0;
+}
+
+/**
+ * @TypeId(203)
+ */
+message SimpleSessionExpirationMetaData {
+	optional	java.time.Duration	maxInactiveInterval	 = 1;
+	optional	java.time.Instant	lastAccessEndTime	 = 2;
 }

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationSchedulerTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationSchedulerTestCase.java
@@ -37,6 +37,7 @@ import org.wildfly.clustering.ee.Scheduler;
 import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.web.cache.session.ImmutableSessionMetaDataFactory;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
 
 /**
  * Unit test for {@link SessionExpirationScheduler}.
@@ -68,7 +69,7 @@ public class SessionExpirationSchedulerTestCase {
         when(canceledSessionMetaData.getLastAccessEndTime()).thenReturn(now);
         when(remover.remove(expiringSessionId)).thenReturn(true);
 
-        try (Scheduler<String, ImmutableSessionMetaData> scheduler = new SessionExpirationScheduler<>(batcher, metaDataFactory, remover, Duration.ZERO)) {
+        try (Scheduler<String, SessionExpirationMetaData> scheduler = new SessionExpirationScheduler<>(batcher, metaDataFactory, remover, Duration.ZERO)) {
             scheduler.schedule(immortalSessionId, immortalSessionMetaData);
             scheduler.schedule(canceledSessionId, canceledSessionMetaData);
             scheduler.schedule(expiringSessionId, expiringSessionMetaData);

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaDataMarshallerTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionExpirationMetaDataMarshallerTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.Tester;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamTesterFactory;
+import org.wildfly.clustering.web.session.SessionExpirationMetaData;
+
+/**
+ * Marshaller test for {@link SimpleSessionExpirationMetaData}.
+ * @author Paul Ferraro
+ */
+public class SimpleSessionExpirationMetaDataMarshallerTestCase {
+
+    @Test
+    public void test() throws IOException {
+        Tester<SessionExpirationMetaData> tester = ProtoStreamTesterFactory.INSTANCE.createTester();
+
+        tester.test(new SimpleSessionExpirationMetaData(Duration.ofMinutes(30), Instant.EPOCH), this::assertEquals);
+        tester.test(new SimpleSessionExpirationMetaData(Duration.ofSeconds(600), Instant.now()), this::assertEquals);
+    }
+
+    private void assertEquals(SessionExpirationMetaData expected, SessionExpirationMetaData actual) {
+        Assert.assertEquals(expected.getMaxInactiveInterval(), actual.getMaxInactiveInterval());
+        Assert.assertEquals(expected.getLastAccessEndTime(), actual.getLastAccessEndTime());
+    }
+}

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionExpirationMetaData.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionExpirationMetaData.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2021, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,33 +19,36 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.clustering.web.session;
 
+import java.time.Duration;
 import java.time.Instant;
 
 /**
- * Abstraction for immutable meta information about a web session.
+ * Session meta data that governs expiration.
  * @author Paul Ferraro
  */
-public interface ImmutableSessionMetaData extends SessionExpirationMetaData {
+public interface SessionExpirationMetaData {
 
     /**
-     * Indicates whether or not this session was created by the current thread.
-     * @return true, if this session is new, false otherwise
+     * Indicates whether or not this session was previously idle for longer than the maximum inactive interval.
+     * @return true, if this session is expired, false otherwise
      */
-    default boolean isNew() {
-        return this.getCreationTime().equals(this.getLastAccessStartTime());
+    default boolean isExpired() {
+        Duration maxInactiveInterval = this.getMaxInactiveInterval();
+        return !maxInactiveInterval.isZero() ? this.getLastAccessEndTime().plus(maxInactiveInterval).isBefore(Instant.now()) : false;
     }
 
     /**
-     * Returns the time this session was created.
-     * @return the time this session was created
+     * Returns the end time of the last request to access this session.
+     * @return the end time of the last request to access this session.
      */
-    Instant getCreationTime();
+    Instant getLastAccessEndTime();
 
     /**
-     * Returns the start time of the last request to access this session.
-     * @return the start time of the last request to access this session.
+     * Returns the time interval since {@link #getLastAccessEndTime()} after which this session will expire.
+     * @return a time interval
      */
-    Instant getLastAccessStartTime();
+    Duration getMaxInactiveInterval();
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15088