### PR TITLE
 [WFLY-15117] guard potential NPE from service controller 

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ConsoleRedirectService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ConsoleRedirectService.java
@@ -152,7 +152,8 @@ final class ConsoleRedirectService implements Service {
             }
 
             // Host names don't match, use the IP address of the management host if both are loopback
-            if (managementAddress.isLoopbackAddress() && destinationAddress.isLoopbackAddress()) {
+            if (managementAddress.isLoopbackAddress()
+                    && destinationAddress != null && destinationAddress.isLoopbackAddress()) {
                 String hostname = managementAddress.getHostAddress();
                 final int zonePos = hostname.indexOf('%');
                 if (zonePos > 0) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -383,14 +383,14 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
 
         final UndertowDeploymentService deploymentService;
         final ServiceController<?> controller = context.getServiceRegistry(false).getService(UndertowService.deploymentServiceName(server, host, path));
-        if (controller != null && controller.getState() != ServiceController.State.UP) {//check if deployment is active at all
+        if (controller == null || controller.getState() != ServiceController.State.UP) {//check if deployment is active at all
             throw UndertowLogger.ROOT_LOGGER.sessionManagerNotAvailable();
-        } else {
-            deploymentService = (UndertowDeploymentService) controller.getService();
-            if (deploymentService == null || deploymentService.getDeployment() == null) { //we might be in shutdown and it is possible
-                throw UndertowLogger.ROOT_LOGGER.sessionManagerNotAvailable();
-            }
         }
+        deploymentService = (UndertowDeploymentService) controller.getService();
+        if (deploymentService == null || deploymentService.getDeployment() == null) { // we might be in shutdown and it is possible
+            throw UndertowLogger.ROOT_LOGGER.sessionManagerNotAvailable();
+        }
+
         Deployment deployment = deploymentService.getDeployment();
         return deployment.getSessionManager();
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -298,7 +298,7 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
             } else {
                 ModelNode result = new ModelNode();
                 final ServiceController<?> controller = context.getServiceRegistry(false).getService(UndertowService.deploymentServiceName(server, host, path));
-                if (controller != null && controller.getState() != ServiceController.State.UP) {//check if deployment is active at all
+                if (controller == null || controller.getState() != ServiceController.State.UP) {//check if deployment is active at all
                     return;
                 }
                 final UndertowDeploymentService deploymentService = (UndertowDeploymentService) controller.getService();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCService.java
@@ -807,6 +807,9 @@ public class WarJACCService extends JaccService<WarMetaData> {
         }
 
         public boolean equals(Object obj) {
+            if(!(obj instanceof PatternInfo)) {
+                return false;
+            }
             PatternInfo pi = (PatternInfo) obj;
             return pattern.equals(pi.pattern);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-15117 NullPointerException during server startup, when called by monitoring tool

The fist commit actually guards potential NPE from service controller in `DeploymentDefinition.java` mentioned in WFLY-15117.

The second commit (cherry-picked @boris-unckel 's https://github.com/boris-unckel/wildfly/commit/61b593afc61e9003ed6ba9c10f71b7e87c20cdf4 ) avoids some other NPE in undertow subsystem.

@fl4via please review.