### PR TITLE
[WFLY-11566] EJB: make a bean class a superclass to a proxy

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ee.component;
 
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.as.ee.logging.EeLogger;
@@ -90,7 +91,14 @@ class DefaultComponentViewConfigurator extends AbstractComponentConfigurator imp
 
             //we define it in the modules class loader to prevent permgen leaks
             if (viewClass.isInterface()) {
-                proxyConfiguration.setSuperClass(Object.class);
+                final Class<?> componentClass = configuration.getComponentClass();
+                Constructor<?> defaultConstructor = null;
+                try {
+                    defaultConstructor = componentClass.getConstructor();
+                } catch (Exception e) {
+                    //ignore
+                }
+                proxyConfiguration.setSuperClass(!view.requiresSuperclassInProxy() || defaultConstructor == null ? Object.class : componentClass);
                 proxyConfiguration.addAdditionalInterface(viewClass);
                 viewConfiguration = view.createViewConfiguration(viewClass, configuration, new ProxyFactory(proxyConfiguration));
             } else {

--- a/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
@@ -314,4 +314,8 @@ public class ViewDescription {
     public String getMarkupClassName() {
         return markupClassName;
     }
+
+    public boolean requiresSuperclassInProxy() {
+        return true;
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
@@ -153,4 +153,8 @@ public class EJBViewDescription extends ViewDescription {
         return ejb2xView;
     }
 
+    @Override
+    public boolean requiresSuperclassInProxy() {
+        return !(isEjb2xView() || methodIntf == MethodIntf.HOME);
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/session/SessionBeanObjectViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/session/SessionBeanObjectViewConfigurator.java
@@ -115,7 +115,7 @@ public abstract class SessionBeanObjectViewConfigurator implements ViewConfigura
 
                 if (componentMethod != null) {
                     if(!Modifier.isPublic(componentMethod.getModifiers())) {
-                        throw EjbLogger.ROOT_LOGGER.ejbBusinessMethodMustBePublic(componentMethod);
+                        EjbLogger.ROOT_LOGGER.ejbBusinessMethodMustBePublic(componentMethod);
                     }
 
                     configuration.addViewInterceptor(method, new ImmediateInterceptorFactory(new ComponentDispatcherInterceptor(componentMethod)), InterceptorOrder.View.COMPONENT_DISPATCHER);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -24,6 +24,7 @@
 
 package org.jboss.as.ejb3.logging;
 
+import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
@@ -407,7 +408,6 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 37, value = "Dynamic stub creation failed for class %s")
     void dynamicStubCreationFailed(String clazz, @Cause Throwable t);
-
 
 //    /**
 //     */
@@ -2935,8 +2935,8 @@ public interface EjbLogger extends BasicLogger {
 //    @Message(id = 440, value = "%s method %s must be public")
 //    DeploymentUnitProcessingException ejbMethodMustBePublic(final String type, final Method method);
 
-    @Message(id = 441, value = "Jakarta Enterprise Beans business method %s must be public")
-    DeploymentUnitProcessingException ejbBusinessMethodMustBePublic(final Method method);
+//    @Message(id = 441, value = "Jakarta Enterprise Beans business method %s must be public")
+//    DeploymentUnitProcessingException ejbBusinessMethodMustBePublic(final Method method);
 
     @Message(id = 442, value = "Unexpected Error")
     @Signature(String.class)
@@ -3244,4 +3244,8 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 527, value = "Remoting connector (address %s, port %s) is not correctly configured for EJB client invocations, the connector must be listed in <remote/> 'connectors' attribute to receive EJB client invocations")
     void connectorNotConfiguredForEJBClientInvocations(String address, int port);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 528, value = "Jakarta Enterprise Beans business method %s must be public")
+    void ejbBusinessMethodMustBePublic(final Method method);
 }


### PR DESCRIPTION
This PR restores setting proxy superclass to component class for EJB views. This setting was done as a part of https://issues.redhat.com/browse/WFLY-11566 but have to be reverted because of failing TCK tests. With additional fixes below the TCK 9.1 testsuite passes on my laptop. EE-8 testsuite interop tests (which were removed from 9.1+) pass without csiv2 tests https://wildflycts-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/jakartaee-ee8/job/runner/135713/console but I have checked that those tests fail with wildfly:main as well when run with the same method.

@chengfang  could you please review?
