### PR TITLE
WFLY-15149 Remove Netty (unused) dependency on javassist

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -38,7 +38,6 @@
         <module name="java.xml"/>
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="sun.jdk"/>
-        <module name="org.javassist" optional="true"/>
         <module name="jdk.sctp"/>
         <module name="jdk.unsupported"/>
     </dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15149

Signed-off-by: Scott Marlow <smarlow@redhat.com>

