### PR TITLE
[WFLY-14350] Allows DEFAULT_CONTEXT_PROPAGATION to use expressions and sets default value

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
@@ -220,7 +220,7 @@ class XTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
             XtsAsLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s%n", coordinatorURL);
         }
 
-        final boolean isDefaultContextPropagation = DEFAULT_CONTEXT_PROPAGATION.resolveModelAttribute(context, model).asBoolean(false); // TODO WFLY-14350 make the 'false' the default value of DEFAULT_CONTEXT_PROPAGATION
+        final boolean isDefaultContextPropagation = DEFAULT_CONTEXT_PROPAGATION.resolveModelAttribute(context, model).asBoolean(false);
 
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
@@ -62,9 +62,10 @@ public class XTSSubsystemDefinition extends SimpleResourceDefinition {
 
     protected static final SimpleAttributeDefinition DEFAULT_CONTEXT_PROPAGATION =
             new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_CONTEXT_PROPAGATION, ModelType.BOOLEAN, true)
-                    .setAllowExpression(false)
+                    .setAllowExpression(true)
                     .setXmlName(Attribute.ENABLED.getLocalName())
                     .setFlags(AttributeAccess.Flag.RESTART_JVM)
+                    .setDefaultValue(ModelNode.FALSE)
                     .build();
 
     protected static final SimpleAttributeDefinition ASYNC_REGISTRATION =

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
@@ -192,9 +192,6 @@ class XTSSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
             final String value = reader.getAttributeValue(index);
             switch (attribute) {
                 case ENABLED:
-                    if (value == null || (!value.toLowerCase().equals("true") && !value.toLowerCase().equals("false"))) {
-                        throw ParseUtils.invalidAttributeValue(reader, index);
-                    }
                     DEFAULT_CONTEXT_PROPAGATION.parseAndSetParameter(value, subsystem, reader);
                     break;
                 default:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-14350
