### PR TITLE
[WFLY-15188]: Upgrade artemis-wildfly-integration to 1.0.5 in WildFly Preview.

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -89,7 +89,7 @@
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
         <version.org.jberet>2.0.1.Final</version.org.jberet>
-        <version.org.jboss.activemq.artemis.integration>1.0.4</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>1.0.5</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.weld.weld>4.0.2.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>4.0.SP1</version.org.jboss.weld.weld-api>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
@@ -1388,6 +1388,18 @@
             <artifactId>artemis-tools</artifactId>
             <version>${version.org.apache.activemq.artemis}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.activemq.artemis.integration</groupId>
+            <artifactId>artemis-wildfly-jakarta-integration</artifactId>
+            <version>${version.org.jboss.activemq.artemis.integration}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -30,7 +30,7 @@
 
     <resources>
         <artifact name="${org.wildfly:wildfly-messaging-activemq-subsystem}"/>
-        <artifact name="${org.jboss.activemq.artemis.integration:artemis-wildfly-integration}"/>
+        <artifact name="\${org.jboss.activemq.artemis.integration:artemis-wildfly@module.jakarta.suffix@-integration}"/>
         <resource-root path="META-INF"/>
     </resources>
 


### PR DESCRIPTION
* Upgrade version in preview only as artemis upgrade is required for
  global update
* Use the new jakarta native package

Jira: https://issues.redhat.com/browse/WFLY-15188
