### PR TITLE
[WFCORE-5406][WFLY-14793] Adding required --add-opens & --add-exports clauses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10300,8 +10300,10 @@
                     --add-opens=java.base/java.io=ALL-UNNAMED
                     --add-opens=java.base/java.lang=ALL-UNNAMED
                     --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
                     --add-opens=java.base/java.security=ALL-UNNAMED
                     --add-opens=java.base/java.util=ALL-UNNAMED
+                    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
                     --add-opens=java.management/javax.management=ALL-UNNAMED
                     --add-opens=java.naming/javax.naming=ALL-UNNAMED
                 </modular.jdk.args>


### PR DESCRIPTION
to be able to run on both NOT MODULAR and MODULAR JDK types. The analysis why
these modular jdk params are needed is available at WFCORE-5406 JIRA (round 2).

https://issues.redhat.com/browse/WFLY-14793