### PR TITLE
[WFLY-15115] Upgrade WildFly Core 17.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15115

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.0.Beta5
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Beta4...17.0.0.Beta5

---

<details>

<summary>Release Notes - WildFly Core - Version 17.0.0.Beta5</summary>
                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5464'>WFCORE-5464</a>] -         Add environment variables as a source for model expression resolution
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4035'>WFCORE-4035</a>] -         operation-requires-reload message is missing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5406'>WFCORE-5406</a>] -         For JDK 16+ server requires --add-opens to allow reflective access to JDK classes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5521'>WFCORE-5521</a>] -         Close resource - potential resource leak
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5524'>WFCORE-5524</a>] -         *ConfigurationChangesHistoryTestCase fails on Windows
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5536'>WFCORE-5536</a>] -         list-snapshots() doesn&#39;t include snapshot file with a custom name
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5540'>WFCORE-5540</a>] -         Patch file entries should be validated before being used
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5545'>WFCORE-5545</a>] -         CompositeIndexProcessor does not make Jandex indices built via static module class scanning available to WarAnnotationDeploymentProcessor
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5546'>WFCORE-5546</a>] -         &quot;JAVA_OPTS&quot; is not correctly set in standalone.bat
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5556'>WFCORE-5556</a>] -         Add back setAllowNull, required by Keycloak SAML adapter
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5558'>WFCORE-5558</a>] -         Wildlfy app not starting: cause: ApplicationRealm is not getting intailized throwing : FIPS mode: only SunJSSE TrustManagers may be used
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5566'>WFCORE-5566</a>] -         Fix FIPS detection so that it also works with Java 17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5568'>WFCORE-5568</a>] -         Clean up after JandexIndexCachingTestCase
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5502'>WFCORE-5502</a>] -         Fix deprecated constructors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5547'>WFCORE-5547</a>] -         DistributableWebDeploymentProcessor should run before ModuleSpecProcessor
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5550'>WFCORE-5550</a>] -         Deprecate ModelTestControllerVersion-s older than EAP_7_4_0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5552'>WFCORE-5552</a>] -         Manage the -jakartaee9 artifacts from undertow
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5534'>WFCORE-5534</a>] -         Update wildfly-galleon-plugin to 5.2.2.Beta2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5535'>WFCORE-5535</a>] -         Upgrade to JBoss Invocation 1.6.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5541'>WFCORE-5541</a>] -         Upgrade Undertow to 2.2.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5562'>WFCORE-5562</a>] -         Upgrade JBoss DMR 1.6.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5565'>WFCORE-5565</a>] -         Upgrade slf4j 1.7.32
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5543'>WFCORE-5543</a>] -         Operation-scoped caching of static module Jandex indices
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5570'>WFCORE-5570</a>] -         Add a profile to disable compilation to facilitate testing with a different JDKs
</li>
</ul>
                                                                                                                        

</details>