### PR TITLE
[WFLY-15210] Remove MP extensions and subsystem from default configur…

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
@@ -22,9 +22,7 @@
 
 package org.jboss.as.test.integration.domain.mixed.eap740;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.controller.operations.common.Util.createRemoveOperation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,18 +41,11 @@ import org.jboss.dmr.ModelNode;
 public class DomainAdjuster740 extends DomainAdjuster {
 
     @Override
-    protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress, boolean withMasterServers) throws Exception {
+    protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress, boolean withMasterServers) {
         final List<ModelNode> ops = new ArrayList<>();
 
         adjustRemoting(ops, profileAddress.append(SUBSYSTEM, "remoting"));
         adjustUndertow(ops, profileAddress.append(SUBSYSTEM, "undertow"));
-        // Mixed Domain tests always uses the complete build instead of alternating with ee-dist. We need to remove here
-
-        // the pre-configured microprofile extensions to adjust the current domain to work with a node running EAP 7.4.0
-        // which only uses the ee-dist
-        removeSubsystemExtension(ops, profileAddress.append(SUBSYSTEM, "microprofile-opentracing-smallrye"), PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.microprofile.opentracing-smallrye"));
-        removeSubsystemExtension(ops, profileAddress.append(SUBSYSTEM, "microprofile-jwt-smallrye"), PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.microprofile.jwt-smallrye"));
-        removeSubsystemExtension(ops, profileAddress.append(SUBSYSTEM, "microprofile-config-smallrye"), PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.microprofile.config-smallrye"));
 
         return ops;
     }
@@ -66,11 +57,6 @@ public class DomainAdjuster740 extends DomainAdjuster {
         final PathAddress httpRemotingConnector = subsystem
                 .append("http-connector", "http-remoting-connector");
         ops.add(Util.getUndefineAttributeOperation(httpRemotingConnector, "sasl-authentication-factory"));
-    }
-
-    private void removeSubsystemExtension(List<ModelNode> ops, PathAddress subsystem, PathAddress extension) {
-        ops.add(createRemoveOperation(subsystem));
-        ops.add(createRemoveOperation(extension));
     }
 
     private static void adjustUndertow(final List<ModelNode> ops, final PathAddress subsystem) {


### PR DESCRIPTION
…ation for the Mixed Domain tests

Jira issue: https://issues.redhat.com/browse/WFLY-15210

The initial idea described in the Jira was to detect whether we are running a product as the Domain Controller for the mixed domain tests, however, since right now this is only used to bypass a difference about shipping MP extensions in the default config, I found easier to remove them if they exist, allowing the code to work also for the product.
