### PR TITLE
[WFLY-14987] Use Elytron SSLContext from MP Reactive Messaging Kafka Connector

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Messsaging_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Messsaging_SmallRye.adoc
@@ -176,7 +176,31 @@ Next we will briefly discuss each of these entries. Remember the `to` channel is
 
 In addition to the above, Apache Kafka, and SmallRye Reactive Messaging's Kafka connector understand a lot more properties. These can be found in the SmallRye Reactive Messaging Kafka connector https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/{smallrye-reactive-messaging-version}/kafka/kafka.html[documentation], and in the Apache Kafka documentation for the https://kafka.apache.org/documentation/#producerconfigs[producers] and the https://kafka.apache.org/documentation/#consumerconfigs[consumers].
 
-The prefixes discussed above are stripped off before passing the property to Kafka.
+The prefixes discussed above are stripped off before passing the property to Kafka. The same happens for other configuration properties. See the Kafka documentation for more details about how to configure Kafka consumers and producers.
+
+
+===== Connecting to secure Kafka
+If connecting to a Kafka instance secured with SSL and SASL, the following example 'microprofile-config.properties' will help you get started. There are a few new properties. We are showing them on the connector level but they could equally well be defined on the channel level (i.e. with the `mp.messaging.outgoing.to-kafka.` and `mp.messaging.incoming.from-kafka.` prefixes from the previous examples rather than the connector-wide `mp.messaging.connector.smallrye-kafka` prefix).
+
+[source]
+----
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=localhost:9092
+mp.messaging.connector.smallrye-kafka.sasl.mechanism=PLAIN
+mp.messaging.connector.smallrye-kafka.security.protocol=SASL_SSL
+mp.messaging.connector.smallrye-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+  username="${USER}" \
+  password="${PASSWORD}";
+mp.messaging.connector.smallrye-kafka.wildfly.elytron.ssl.context=test
+
+# Channel configuration would follow here, but is left out for brevity
+----
+Each of these lines has the following meaning:
+
+* `mp.messaging.connector.smallrye-kafka.bootstrap.servers=localhost:9092` - specifies the Kafka servers to connect to. This is the same as in the previous examples
+* `mp.messaging.connector.smallrye-kafka.sasl.mechanism=PLAIN` - specifies the SASL mechanism to use. See `sasl.mechanism` in the Kafka documentation for other choices.
+* `mp.messaging.connector.smallrye-kafka.security.protocol` - specifies the protocol mechanism to use. See `security.protocol` in the Kafka documentation for other choices. In this case we are using `SASL_SSL` which means that communication is over SSL, and that SASL is used to authenticate
+* `mp.messaging.connector.smallrye-kafka.sasl.jaas.config=...` - specifies how we will authenticate with Kafka. In order to not hardcode the credentials in our `microprofile-config.properties file` we are using the property substitution feature of MicroProfile Config. In this case, if you have defined the `USER` and `PASSWORD` environment variables they will be passed in as part of the configuration
+* `mp.messaging.connector.smallrye-kafka.wildfly.elytron.ssl.context=test` - this is not needed if Kafka is secured with a CA signed certificate. If you are using self-signed certificates, you will need to specify a truststore in the Elytron subsystem, and create an `SSLContext` referencing that. The value of this property is used to look up the `SSLContext` in the Elytron subsystem under `/subsystem=elytron/client-ssl-context=*` in the WildFly management model. In this case the property value is `test`, so we look up the `SSLContext` defined by `/subsystem=elytron/client-ssl-context=test` and use that configure the truststore to use for the connection to Kafka.
 
 ===== Kafka User API
 In order to be able to get more information about messages received from Kafka, and to be able to influence how Kafka handles messages, there is a user API for Kafka. This API lives in the https://github.com/smallrye/smallrye-reactive-messaging/tree/{smallrye-reactive-messaging-tag}/smallrye-reactive-messaging-kafka-api/src/main/java/io/smallrye/reactive/messaging/kafka/api[`io/smallrye/reactive/messaging/kafka/api`] package.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/util/EjbValidationsUtil.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/util/EjbValidationsUtil.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -165,7 +166,7 @@ public final class EjbValidationsUtil {
 
     private static boolean hasSameSignature(Method left, Method right) {
         return (left.getName().equals(right.getName()) && left.getReturnType().equals(right.getReturnType())
-                && left.getParameterCount() == right.getParameterCount() && left.getParameters().equals(right.getParameters()));
+                && left.getParameterCount() == right.getParameterCount() && Arrays.equals(left.getParameters(), right.getParameters()));
     }
 
     private static Map<String, List<Method>> indexAllMethodsFromInterfaces(Class<?>[] classes) {

--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -713,7 +713,29 @@
 
         <dependency>
             <groupId>${full.maven.groupId}</groupId>
+            <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-reactive-messaging-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
+            <artifactId>wildfly-microprofile-reactive-messaging-kafka</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
@@ -27,5 +27,6 @@
 
     <packages>
         <package name="io.smallrye.reactive.messaging.connector.kafka"/>
+        <package name="org.wildfly.reactive.messaging.kafka"/>
     </packages>
 </layer-spec>

--- a/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
@@ -822,7 +822,29 @@
     </dependency>
     <dependency>
       <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
       <artifactId>wildfly-microprofile-reactive-messaging-config</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${full.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-reactive-messaging-kafka</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 or later</name>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/reactive/messaging/connector/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/reactive/messaging/connector/main/module.xml
@@ -30,8 +30,9 @@
         <module name="io.smallrye.reactive.messaging.connector.amqp" optional="true" export="true" services="export"/>
 
         <module name="io.smallrye.reactive.messaging.connector.kafka" optional="true" export="true" services="export"/>
-        <!-- Add the kafka API module here so that it will be added to the deployment classpath by the DUP -->
+        <!-- Add the kafka API module and a few other central ones so that it will be added to the deployment classpath by the DUP -->
         <module name="io.smallrye.reactive.messaging.connector.kafka.api" optional="true" export="true" services="export"/>
+        <module name="org.wildfly.reactive.messaging.kafka" optional="true" export="true" services="export"/>
 
         <module name="io.smallrye.reactive.messaging.connector.mqtt" optional="true" export="true" services="export"/>
     </dependencies>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
@@ -34,12 +34,15 @@
         <!-- Needed to initialise the netty logger if the module is present -->
         <module name="io.netty" optional="true"/>
 
+        <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
+        <module name="org.wildfly.reactive.messaging.common"/>
+        <module name="org.wildfly.reactive.messaging.kafka" optional="true" services="export"/>
         <module name="org.wildfly.security.manager"/>
 
         <!--

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/reactive/messaging/common/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/reactive/messaging/common/main/module.xml
@@ -21,29 +21,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-microprofile</artifactId>
-        <!--
-        Maintain separation between the artifact id and the version to help prevent
-        merge conflicts between commits changing the GA and those changing the V.
-        -->
-        <version>25.0.0.Beta1-SNAPSHOT</version>
-    </parent>
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.reactive.messaging.common">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
+    <resources>
+        <artifact name="${org.wildfly:wildfly-microprofile-reactive-messaging-common}"/>
+    </resources>
 
-    <artifactId>wildfly-microprofile-reactive-messaging-parent</artifactId>
-    <name>WildFly: MicroProfile Reactive Messaging Parent</name>
-    <packaging>pom</packaging>
-
-    <modules>
-        <module>common</module>
-        <module>extension</module>
-        <module>config</module>
-        <module>kafka</module>
-    </modules>
-</project>
+    <dependencies>
+        <module name="org.jboss.as.server"/>
+    </dependencies>
+</module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/reactive/messaging/kafka/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/reactive/messaging/kafka/main/module.xml
@@ -21,29 +21,23 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-microprofile</artifactId>
-        <!--
-        Maintain separation between the artifact id and the version to help prevent
-        merge conflicts between commits changing the GA and those changing the V.
-        -->
-        <version>25.0.0.Beta1-SNAPSHOT</version>
-    </parent>
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.reactive.messaging.kafka">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
+    <resources>
+        <artifact name="${org.wildfly:wildfly-microprofile-reactive-messaging-kafka}"/>
+    </resources>
 
-    <artifactId>wildfly-microprofile-reactive-messaging-parent</artifactId>
-    <name>WildFly: MicroProfile Reactive Messaging Parent</name>
-    <packaging>pom</packaging>
-
-    <modules>
-        <module>common</module>
-        <module>extension</module>
-        <module>config</module>
-        <module>kafka</module>
-    </modules>
-</project>
+    <dependencies>
+        <module name="org.apache.kafka.client"/>
+        <module name="org.eclipse.microprofile.config.api"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.wildfly.reactive.messaging.common"/>
+        <module name="org.wildfly.reactive.messaging.config"/>
+    </dependencies>
+</module>

--- a/microprofile/reactive-messaging-smallrye/common/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2021, Red Hat, Inc., and individual contributors
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -25,9 +25,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
+    </dependencies>
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-microprofile</artifactId>
+        <artifactId>wildfly-microprofile-reactive-messaging-parent</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
@@ -36,14 +42,7 @@
     </parent>
 
 
-    <artifactId>wildfly-microprofile-reactive-messaging-parent</artifactId>
-    <name>WildFly: MicroProfile Reactive Messaging Parent</name>
-    <packaging>pom</packaging>
+    <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
+    <name>WildFly: MicroProfile Reactive Messaging Common</name>
 
-    <modules>
-        <module>common</module>
-        <module>extension</module>
-        <module>config</module>
-        <module>kafka</module>
-    </modules>
 </project>

--- a/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/DynamicDeploymentProcessorAdder.java
+++ b/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/DynamicDeploymentProcessorAdder.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.common;
+
+import org.jboss.as.server.DeploymentProcessorTarget;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public interface DynamicDeploymentProcessorAdder {
+    void addDeploymentProcessor(DeploymentProcessorTarget target, String subsystemName);
+}

--- a/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/ReactiveMessagingAttachments.java
+++ b/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/ReactiveMessagingAttachments.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.common;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class ReactiveMessagingAttachments {
+    public static AttachmentKey<Boolean> IS_REACTIVE_MESSAGING_DEPLOYMENT = AttachmentKey.create(Boolean.class);
+}

--- a/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/deployment/ReactiveMessagingDependencyProcessor.java
+++ b/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/deployment/ReactiveMessagingDependencyProcessor.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.microprofile.reactive.messaging.deployment;
 
+import static org.wildfly.microprofile.reactive.messaging.common.ReactiveMessagingAttachments.IS_REACTIVE_MESSAGING_DEPLOYMENT;
+
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,6 +91,7 @@ public class ReactiveMessagingDependencyProcessor implements DeploymentUnitProce
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         if (isReactiveMessagingDeployment(deploymentUnit)) {
             addModuleDependencies(deploymentUnit);
+            deploymentUnit.putAttachment(IS_REACTIVE_MESSAGING_DEPLOYMENT, true);
         }
     }
 

--- a/microprofile/reactive-messaging-smallrye/kafka/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/kafka/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2020, Red Hat, Inc., and individual contributors
+  ~ Copyright 2021, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -36,13 +36,13 @@
     </parent>
 
 
-    <artifactId>wildfly-microprofile-reactive-messaging</artifactId>
-    <name>WildFly: MicroProfile Reactive Messaging Extension With SmallRye</name>
+    <artifactId>wildfly-microprofile-reactive-messaging-kafka</artifactId>
+    <name>WildFly: MicroProfile Reactive Messaging Kakfa</name>
 
     <dependencies>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
@@ -63,35 +63,20 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller</artifactId>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-microprofile-reactive-messaging-kafka</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-subsystem-test</artifactId>
-            <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron-security-manager</artifactId>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-microprofile-reactive-messaging-config</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ElytronSSLContextRegistry.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ElytronSSLContextRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class ElytronSSLContextRegistry {
+
+    private static final ElytronSSLContextRegistry INSTANCE = new ElytronSSLContextRegistry();
+    private static final ServiceName BASE_CLIENT_SSL_CONTEXT_NAME = ServiceName.of("org", "wildfly", "security", "ssl-context");
+
+    private volatile ServiceRegistry serviceRegistry;
+
+    private ElytronSSLContextRegistry() {
+    }
+
+    public static void setServiceRegistry(ServiceRegistry serviceRegistry) {
+        INSTANCE.serviceRegistry = serviceRegistry;
+    }
+
+    static SSLContext getInstalledSSLContext(String name) {
+        ServiceController<SSLContext> controller = (ServiceController<SSLContext>)INSTANCE.serviceRegistry
+                .getService(getSSLContextName(name));
+        return controller.getValue();
+    }
+
+    static ServiceName getSSLContextName(String name) {
+        return BASE_CLIENT_SSL_CONTEXT_NAME.append(name);
+    }
+
+}

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ElytronSSLContextRegistry.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ElytronSSLContextRegistry.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context;
 
+import static org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context._private.MicroProfileReactiveMessagingKafkaLogger.LOGGER;
+
 import javax.net.ssl.SSLContext;
 
 import org.jboss.msc.service.ServiceController;
@@ -45,10 +47,20 @@ public class ElytronSSLContextRegistry {
         INSTANCE.serviceRegistry = serviceRegistry;
     }
 
+    static boolean isSSLContextInstalled(String name) {
+        return INSTANCE.getSSLContextController(name) != null;
+    }
+
     static SSLContext getInstalledSSLContext(String name) {
-        ServiceController<SSLContext> controller = (ServiceController<SSLContext>)INSTANCE.serviceRegistry
-                .getService(getSSLContextName(name));
+        ServiceController<SSLContext> controller = INSTANCE.getSSLContextController(name);
+        if (controller == null) {
+            throw LOGGER.noElytronClientSSLContext(name);
+        }
         return controller.getValue();
+    }
+
+    private ServiceController<SSLContext> getSSLContextController(String name) {
+        return (ServiceController<SSLContext>)INSTANCE.serviceRegistry.getService(getSSLContextName(name));
     }
 
     static ServiceName getSSLContextName(String name) {

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/KafkaDynamicDeploymentProcessorAdder.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/KafkaDynamicDeploymentProcessorAdder.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context;
+
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.server.deployment.Phase;
+import org.wildfly.microprofile.reactive.messaging.common.DynamicDeploymentProcessorAdder;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class KafkaDynamicDeploymentProcessorAdder implements DynamicDeploymentProcessorAdder {
+    @Override
+    public void addDeploymentProcessor(DeploymentProcessorTarget target, String subsystemName) {
+
+        final int POST_MODULE_MICROPROFILE_REACTIVE_MESSAGING = 0x3828;
+
+        target.addDeploymentProcessor(subsystemName,
+                Phase.POST_MODULE,
+                POST_MODULE_MICROPROFILE_REACTIVE_MESSAGING,
+                new ReactiveMessagingSslConfigProcessor());
+    }
+}

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ReactiveMessagingSslConfigProcessor.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ReactiveMessagingSslConfigProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context;
+
+import static org.wildfly.microprofile.reactive.messaging.common.ReactiveMessagingAttachments.IS_REACTIVE_MESSAGING_DEPLOYMENT;
+import static org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context._private.MicroProfileReactiveMessagingKafkaLogger.LOGGER;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.SSLContext;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.modules.Module;
+import org.jboss.msc.service.ServiceName;
+import org.wildfly.microprofile.reactive.messaging.config.ReactiveMessagingConfigSource;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+class ReactiveMessagingSslConfigProcessor implements DeploymentUnitProcessor {
+
+    private static final String RM_KAFKA_GLOBAL_PROPERTY_PREFIX = "mp.messaging.connector.smallrye-kafka.";
+    private static final String RM_INCOMING_PROPERTY_PREFIX = "mp.messaging.outgoing.";
+    private static final String RM_OUTGOING_PROPERTY_PREFIX = "mp.messaging.incoming.";
+    static final String SSL_CONTEXT_PROPERTY_SUFFIX = "wildfly.elytron.ssl.context";
+
+    private static final String SSL_ENGINE_FACTORY_CLASS = "ssl.engine.factory.class";
+
+    private static final AttachmentKey<Object> DEPLOYMENT_ATTACHMENT_KEY = AttachmentKey.create(Object.class);
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (!isReactiveMessagingDeployment(deploymentUnit)) {
+            return;
+        }
+        Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+
+        Config config = ConfigProviderResolver.instance().getConfig(module.getClassLoader());
+
+        Map<String, String> addedProperties = new HashMap<>();
+
+        Set<ServiceName> mscDependencies = new HashSet<>();
+        for (String propertyName : config.getPropertyNames()) {
+            if (propertyName.endsWith(SSL_CONTEXT_PROPERTY_SUFFIX)) {
+                String propertyValue = config.getValue(propertyName, String.class);
+                String prefix = null;
+                if (propertyName.equals(RM_KAFKA_GLOBAL_PROPERTY_PREFIX + SSL_CONTEXT_PROPERTY_SUFFIX)) {
+                    prefix = RM_KAFKA_GLOBAL_PROPERTY_PREFIX;
+                } else if (propertyName.startsWith(RM_INCOMING_PROPERTY_PREFIX) ||
+                        propertyName.startsWith(RM_OUTGOING_PROPERTY_PREFIX)) {
+                    prefix = propertyName.substring(0, propertyName.indexOf(SSL_CONTEXT_PROPERTY_SUFFIX));
+                }
+                if (prefix != null) {
+                    LOGGER.foundPropertyUsingElytronClientSSLContext(propertyName, propertyValue);
+                    SSLContext ctx = ElytronSSLContextRegistry.getInstalledSSLContext(propertyValue);
+                    if (ctx == null) {
+                        throw LOGGER.noElytronClientSSLContext(propertyValue);
+                    }
+                    mscDependencies.add(ElytronSSLContextRegistry.getSSLContextName(propertyValue));
+                    addedProperties.put(prefix + SSL_ENGINE_FACTORY_CLASS, WildFlyKafkaSSLEngineFactory.class.getName());
+                }
+            }
+            if (addedProperties.size() > 0) {
+                ReactiveMessagingConfigSource.addProperties(config, addedProperties);
+                for (ServiceName svcName : mscDependencies) {
+                    phaseContext.addDeploymentDependency(svcName, DEPLOYMENT_ATTACHMENT_KEY);
+                }
+            }
+        }
+        if (addedProperties.size() > 0) {
+            ReactiveMessagingConfigSource.addProperties(config, addedProperties);
+            for (ServiceName svcName : mscDependencies) {
+                phaseContext.addDeploymentDependency(svcName, DEPLOYMENT_ATTACHMENT_KEY);
+            }
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit deploymentUnit) {
+
+    }
+
+    private boolean isReactiveMessagingDeployment(DeploymentUnit deploymentUnit) {
+        if (deploymentUnit.hasAttachment(IS_REACTIVE_MESSAGING_DEPLOYMENT)) {
+            Boolean isRm = deploymentUnit.getAttachment(IS_REACTIVE_MESSAGING_DEPLOYMENT);
+            return isRm;
+        }
+        return false;
+    }
+}

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ReactiveMessagingSslConfigProcessor.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/ReactiveMessagingSslConfigProcessor.java
@@ -30,8 +30,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.net.ssl.SSLContext;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.as.server.deployment.AttachmentKey;
@@ -83,18 +81,11 @@ class ReactiveMessagingSslConfigProcessor implements DeploymentUnitProcessor {
                 }
                 if (prefix != null) {
                     LOGGER.foundPropertyUsingElytronClientSSLContext(propertyName, propertyValue);
-                    SSLContext ctx = ElytronSSLContextRegistry.getInstalledSSLContext(propertyValue);
-                    if (ctx == null) {
+                    if (!ElytronSSLContextRegistry.isSSLContextInstalled(propertyValue)) {
                         throw LOGGER.noElytronClientSSLContext(propertyValue);
                     }
                     mscDependencies.add(ElytronSSLContextRegistry.getSSLContextName(propertyValue));
                     addedProperties.put(prefix + SSL_ENGINE_FACTORY_CLASS, WildFlyKafkaSSLEngineFactory.class.getName());
-                }
-            }
-            if (addedProperties.size() > 0) {
-                ReactiveMessagingConfigSource.addProperties(config, addedProperties);
-                for (ServiceName svcName : mscDependencies) {
-                    phaseContext.addDeploymentDependency(svcName, DEPLOYMENT_ATTACHMENT_KEY);
                 }
             }
         }

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/WildFlyKafkaSSLEngineFactory.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/WildFlyKafkaSSLEngineFactory.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context;
+
+import static org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context.ReactiveMessagingSslConfigProcessor.SSL_CONTEXT_PROPERTY_SUFFIX;
+import static org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context._private.MicroProfileReactiveMessagingKafkaLogger.LOGGER;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class WildFlyKafkaSSLEngineFactory implements org.apache.kafka.common.security.auth.SslEngineFactory {
+    private volatile SSLContext sslContext;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        SSLContext context = ElytronSSLContextRegistry.getInstalledSSLContext((String) configs.get(SSL_CONTEXT_PROPERTY_SUFFIX));
+        if (context == null) {
+            throw LOGGER.noElytronClientSSLContext((String) configs.get(SSL_CONTEXT_PROPERTY_SUFFIX));
+        }
+        sslContext = context;
+    }
+
+    @Override
+    public SSLEngine createClientSslEngine(String peerHost, int peerPort, String endpointIdentification) {
+        // Code copied and adjusted from Kafka
+        SSLEngine sslEngine = sslContext.createSSLEngine(peerHost, peerPort);
+
+        sslEngine.setUseClientMode(true);
+        SSLParameters sslParams = sslEngine.getSSLParameters();
+        // SSLParameters#setEndpointIdentificationAlgorithm enables endpoint validation
+        // only in client mode. Hence, validation is enabled only for clients.
+
+        // Hard code this to https for now
+        // This is the default value for SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG
+        // which is documented as setting it to an empty string if we don't want host name verification.
+        // There is a 'Host name verification' subsection under https://kafka.apache.org/documentation/#security_ssl
+        // which explains it in more detail
+        sslParams.setEndpointIdentificationAlgorithm("https");
+        sslEngine.setSSLParameters(sslParams);
+        return sslEngine;
+    }
+
+    @Override
+    public SSLEngine createServerSslEngine(String peerHost, int peerPort) {
+        // We are only dealing with clients
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean shouldBeRebuilt(Map<String, Object> nextConfigs) {
+        return false;
+    }
+
+    @Override
+    public Set<String> reconfigurableConfigs() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public KeyStore keystore() {
+        // We are only dealing with clients
+        // This only comes into play during reconfiguration. Returning null is ok
+        return null;
+    }
+
+    @Override
+    public KeyStore truststore() {
+        // This only comes into play during reconfiguration. Returning null is ok
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.sslContext = null;
+    }
+
+}

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/_private/MicroProfileReactiveMessagingKafkaLogger.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/_private/MicroProfileReactiveMessagingKafkaLogger.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context._private;
+
+import static org.jboss.logging.Logger.Level.INFO;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Log messages for WildFly microprofile-reactive-messaging-smallrye Extension.
+ *
+ * @author <a href="kkhan@redhat.com">Kabir Khan</a>
+ */
+@MessageLogger(projectCode = "WFLYRXMKAF", length = 4)
+public interface MicroProfileReactiveMessagingKafkaLogger extends BasicLogger {
+
+    MicroProfileReactiveMessagingKafkaLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveMessagingKafkaLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
+
+    /**
+     * Logs an informational message indicating the subsystem is being activated.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 1, value = "Found property %s, will use the Elytron client-ssl-context: %s")
+    void foundPropertyUsingElytronClientSSLContext(String prop, String ctx);
+
+    @Message(id = 2, value = "Could not find an Elytron client-ssl-context called: %s")
+    IllegalStateException noElytronClientSSLContext(String ctx);
+
+}

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/resources/META-INF/services/org.wildfly.microprofile.reactive.messaging.common.DynamicDeploymentProcessorAdder
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/resources/META-INF/services/org.wildfly.microprofile.reactive.messaging.common.DynamicDeploymentProcessorAdder
@@ -1,0 +1,23 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2021, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context.KafkaDynamicDeploymentProcessorAdder

--- a/pom.xml
+++ b/pom.xml
@@ -1253,7 +1253,31 @@
 
             <dependency>
                 <groupId>${full.maven.groupId}</groupId>
+                <artifactId>wildfly-microprofile-reactive-messaging-common</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>${full.maven.groupId}</groupId>
                 <artifactId>wildfly-microprofile-reactive-messaging-config</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>${full.maven.groupId}</groupId>
+                <artifactId>wildfly-microprofile-reactive-messaging-kafka</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14987 /  https://github.com/wildfly/wildfly-proposals/pull/411

Requires: #14618 (we currently contain the WFLY-14798 commits which are NOT part of this PR)
This has previously been reviewed in #14475

#14618, #14619 and #14620 (this PR) split up the original #14475 which had all the related work bundled together