### PR TITLE
WFLY-15198 Avoid unneeded TimerImpl instances during db refresh

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -1197,6 +1197,22 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         return !timer.persistent || timerPersistence.getValue().shouldRun(timer);
     }
 
+    /**
+     * Safely closes some resource without throwing an exception.
+     * Any exception will be logged at TRACE level.
+     *
+     * @param resource the resource to close
+     */
+    public static void safeClose(final AutoCloseable resource) {
+        if (resource != null) {
+            try {
+                resource.close();
+            } catch (Throwable t) {
+                EjbLogger.EJB3_TIMER_LOGGER.tracef(t, "Closing resource failed");
+            }
+        }
+    }
+
     private class TimerCreationTransactionSynchronization implements Synchronization {
         /**
          * The timer being managed in the transaction

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerState.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerState.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.ejb3.timerservice;
 
+import java.util.EnumSet;
+
 /**
  * Timer states.
  * <p/>
@@ -77,4 +79,7 @@ public enum TimerState {
      */
     RETRY_TIMEOUT,
     ;
+
+    public static final EnumSet<TimerState> CREATED_ACTIVE_IN_TIMEOUT_RETRY_TIMEOUT =
+            EnumSet.of(IN_TIMEOUT, RETRY_TIMEOUT, CREATED, ACTIVE);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
@@ -21,6 +21,37 @@
  */
 package org.jboss.as.ejb3.timerservice.persistence.filestore;
 
+import static java.security.AccessController.doPrivileged;
+import static org.jboss.as.ejb3.logging.EjbLogger.EJB3_TIMER_LOGGER;
+import static org.jboss.as.ejb3.timerservice.TimerServiceImpl.safeClose;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.ejb3.component.stateful.CurrentSynchronizationCallback;
 import org.jboss.as.ejb3.timerservice.TimerImpl;
@@ -40,36 +71,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.jboss.staxmapper.XMLMapper;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
-
-import javax.transaction.Status;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FilePermission;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import static java.security.AccessController.doPrivileged;
-import static org.jboss.as.ejb3.logging.EjbLogger.EJB3_TIMER_LOGGER;
 
 /**
  * File based persistent timer store.
@@ -523,16 +524,6 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
     private void setIfSupported(final XMLInputFactory inputFactory, final String property, final Object value) {
         if (inputFactory.isPropertySupported(property)) {
             inputFactory.setProperty(property, value);
-        }
-    }
-
-    private static void safeClose(final Closeable closeable) {
-        if (closeable != null) {
-            try {
-                closeable.close();
-            } catch (IOException e) {
-                // ignore
-            }
         }
     }
 


### PR DESCRIPTION
and some general code cleanup.

https://issues.redhat.com/browse/WFLY-15198 

The most important changes are:
 * DatabaseTimerPersistence.java line 557, add 2 params to `timerFromResult` method: (timerId, timerState). These 2 values are in most cases already retrieved from the `ResultSet` by the caller already. So just pass them in, instead of calling `getString()` inside the method again, to avoid getting the same column multiple times.
 * DatabaseTimerPersistence.java line 835, optimize the logic to reconcile potential difference between in-memory and db timer state, and delay the call to `timerFromResult` to avoid unneeded `TimerImpl` instantiation. First check in-memory timer state, then check db timer state, and only if there is a mismatch, then call `timerFromResult`.