### PR TITLE
[WFLY-15254] Remove unneeded javax.transaction.api dependency from or…

### DIFF
--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/common/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/common/main/module.xml
@@ -34,7 +34,6 @@
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.jboss.xnio" />
         <module name="org.wildfly.client.config"/>
-        <module name="javax.transaction.api"/>
         <module name="io.undertow.core" />
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling" />

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/http-client/naming/main/module.xml
@@ -33,7 +33,6 @@
         <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="org.wildfly.http-client.common"/>
         <module name="org.wildfly.client.config"/>
-        <module name="javax.transaction.api"/>
         <module name="io.undertow.core" />
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling" />


### PR DESCRIPTION
…g.wildfly.http-client.common and org.wildfly.http-client.naming modules

https://issues.redhat.com/browse/WFLY-15254