### PR TITLE
[WFLY-15280] Move WildFly Preview to a native jakarta namespace variant of the ee-security subsytem integration module

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -491,6 +491,14 @@
                 </exclusion>
                 <exclusion>
                     <groupId>${project.groupId}</groupId>
+                    <artifactId>wildfly-ee-security</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>wildfly-mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>wildfly-weld-bean-validation</artifactId>
                 </exclusion>
                 <exclusion>
@@ -1479,6 +1487,12 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-ee-jakarta</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-ee-security-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
+++ b/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
@@ -552,6 +552,17 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>wildfly-ee-security-jakarta</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-mail-jakarta</artifactId>
       <licenses>
         <license>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -320,6 +320,18 @@
 
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>wildfly-ee-security-jakarta</artifactId>
+                <version>${ee.maven.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>wildfly-mail-jakarta</artifactId>
                 <version>${project.version}</version>
                 <exclusions>

--- a/ee-9/source-transform/ee-security/pom.xml
+++ b/ee-9/source-transform/ee-security/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2021, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -20,33 +20,42 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-ee-9-source-transform-parent</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>26.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>wildfly-ee-security</artifactId>
+    <artifactId>wildfly-ee-security-jakarta</artifactId>
 
-    <name>WildFly: Jakarta EE Security</name>
+    <name>WildFly: Jakarta EE Security (Jakarta Namespace)</name>
+	
+    <packaging>jar</packaging>
+
+    <properties>
+        <transformer-input-dir>${project.basedir}/../../../ee-security</transformer-input-dir>
+    </properties>
 
     <dependencies>
 
+        <!-- Jakarta-namespace specific deps -->
+
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-ee</artifactId>
+            <artifactId>wildfly-ee-jakarta</artifactId>
         </dependency>
 
+        <!-- Other deps consistent with the javax.* ee-security module -->
+        
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
@@ -76,6 +85,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -87,6 +106,6 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
-    </dependencies>
 
+    </dependencies>
 </project>

--- a/ee-9/source-transform/pom.xml
+++ b/ee-9/source-transform/pom.xml
@@ -47,6 +47,7 @@
     <modules>
         <module>bean-validation</module>
         <module>ee</module>
+        <module>ee-security</module>
         <module>mail</module>
         <module>weld/bean-validation</module>
         <module>weld/common</module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
@@ -33,7 +33,7 @@
     </exports>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-ee-security}"/>
+        <artifact name="\${org.wildfly:wildfly-ee-security@module.jakarta.suffix@}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15280

Builds on #14646