### PR TITLE
WFLY-15232 Persisted AutoTimer doesn't pick up TimerConfig.info change

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -766,9 +767,11 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
                     if (doesTimeoutMethodMatch(calendarTimer.getTimeoutMethod(), methodName, params)) {
 
                         //the timers have the same method.
-                        //now lets make sure the schedule is the same
+                        //now lets make sure the schedule is the same, info is the same,
                         // and the timer does not change the persistence
-                        if (this.doesScheduleMatch(calendarTimer.getScheduleExpression(), timer.getScheduleExpression()) && timer.getTimerConfig().isPersistent()) {
+                        if (this.doesScheduleMatch(calendarTimer.getScheduleExpression(), timer.getScheduleExpression())
+                                && Objects.equals(calendarTimer.info, timer.getTimerConfig().getInfo())
+                                && timer.getTimerConfig().isPersistent()) {
                             it.remove();
                             found = true;
                             break;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15232

This PR fix the above issue by including the info field of the timer schedule when matching a new timer against an existing timer. When the timer info has changed, it's considered a new timer that the application wants to create.