### PR TITLE
WFLY-15291 Upgrade jberet-core from 2.0.1.Final to 2.0.2.Final in ee-…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -89,7 +89,7 @@
         <version.org.glassfish.jakarta.enterprise.concurrent>2.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
-        <version.org.jberet>2.0.1.Final</version.org.jberet>
+        <version.org.jberet>2.0.2.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.5</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
         <version.org.jboss.weld.weld>4.0.2.Final</version.org.jboss.weld.weld>


### PR DESCRIPTION
…9 preview

https://issues.redhat.com/browse/WFLY-15291

In jberet-core 2.0.2.Final, the reference to javax transaction api has been removed, and so jberet-core.jar need not be transformed any more.

diff between jberet-core 2.0.1.Final and 2.0.2.Final: https://github.com/jberet/jsr352/compare/2.0.1.Final...2.0.2.Final
