### PR TITLE
[WFLY-15307] AppClient o.j.a.a.s.parsing.AppClientXml readServerElement_18

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
@@ -123,7 +123,7 @@ public class AppClientXml extends CommonXml {
                 // Instead of having to list the remaining versions we just check it is actually a valid version.
                 for (Namespace current : Namespace.domainValues()) {
                     if (readerNS.equals(current)) {
-                        readServerElement_1_1(readerNS, reader, address, operationList);
+                        readServerElement_18(readerNS, reader, address, operationList);
                         return;
                     }
                 }


### PR DESCRIPTION
AppClient o.j.a.a.s.parsing.AppClientXml readServerElement_18 not called

Fixes https://issues.redhat.com/browse/WFLY-15307

