### PR TITLE
[WFLY-15309] Re-enable some tests in -Dts.ee9 profile that couldn't work due to their use of legacy security

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -3649,12 +3649,6 @@
                                         <exclude>org/jboss/as/test/integration/ejb/security/RunAsPrincipalCustomDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/securitydomain/EJBContextMultipleSDTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/DsWithSecurityDomainTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMSecurityDomainWorkManagerTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/api/security/SecurityDomainDotNameTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/web/security/runas/WebSecurityRunAsTestCase.java</exclude>
                                         <!-- Requires JSR77 -->
@@ -3665,7 +3659,6 @@
                                         <exclude>org/jboss/as/test/integration/ejb/security/In*Ann*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/security/SaslLegacyMechanismConfigurationTestCase.java</exclude><!-- wants legacy security but the EE9 remoting config is probably wrong too -->
                                         <exclude>org/jboss/as/test/integration/ejb/security/SingleMethodsAnn*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jmx/full/JMXFilterTestCase.java</exclude><!-- Uses jsr77 subsystem as test subject -->
                                         <exclude>org/jboss/as/test/integration/management/cli/DeploymentOverlayCLITestCase.java</exclude><!-- use of unmanaged (exploded) deployments?? -->
                                         <exclude>org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java</exclude><!-- Problem is probably MDB use -->
@@ -3729,13 +3722,6 @@
                                         <!-- Requires legacy security -->
                                         <exclude>org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/anno/*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/basic/*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/ijdeployment/*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/metrics/RaCfgMetricUnitTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jca/statistics/ResourceAdapterStatisticsTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/api/security/SecurityDomainDotNameTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/api/security/SecurityDomainTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/aselytron/SecurityDomainAsElytronSecurityRealmTestCase.java</exclude>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -2387,13 +2387,10 @@
                                         <exclude>${test-group}/**/byteman/*TestCase.java</exclude>
                                         <exclude>%regex[${test-group}/(${ts.surefire.clustering.ha.additionalExcludes})/.*TestCase.class]</exclude>
 
-                                        <!-- Requires legacy security subsystem -->
-                                        <exclude>${test-group}/web/authentication/*TestCase.java</exclude>
                                         <!-- TODO see why these aren't working and fix or exclude with a clear explanation -->
                                         <exclude>${test-group}/ejb/remote/GlobalAuthContextRemoteStatelessEJBFailoverTestCase.java</exclude>
                                         <exclude>${test-group}/ejb/remote/ThreadAuthContextRemoteStatelessEJBFailoverTestCase.java</exclude>
                                         <exclude>${test-group}/jsf/JSFFailoverTestCase.java</exclude> <!-- test hard-codes javax package; need to parameterize -->
-                                        <exclude>${test-group}/sso/*TestCase.java</exclude><!-- Perhaps ElytronSSOServerSetupTask needs to deal with the EJB application-security-domain too? -->
                                     </excludes>
                                 </configuration>
                             </execution>
@@ -2404,16 +2401,6 @@
                                     <excludes>
                                         <!-- Requires the /subsystem=messaging-activemq/server=default to exist for it's setup tasks -->
                                         <exclude>${test-group}/jms/ClusteredMessagingTestCase.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>ts.surefire.clustering.ha-infinispan-server</id>
-                                <!--<phase>none</phase>-->
-                                <configuration>
-                                    <excludes>
-                                        <!-- TODO see why these aren't working and fix or exclude with a clear explanation -->
-                                        <exclude>${test-group}/sso/remote/*TestCase.java</exclude><!-- Perhaps ElytronSSOServerSetupTask needs to deal with the EJB application-security-domain too? -->
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -99,10 +99,6 @@
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
                                     </environmentVariables>
-                                    <excludes>
-                                        <!-- Requires legacy security -->
-                                        <exclude>org/jboss/as/testsuite/integration/secman/PBStaticMethodsTestCase.java</exclude>
-                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -931,8 +931,6 @@
                                         <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <excludes>
-                                        <!-- Requires legacy security for some methods -->
-                                        <exclude>org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java</exclude>
                                         <!-- Requires messaging -->
                                         <exclude>org/jboss/as/test/smoke/jms/**/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/smoke/jms/**/*Test.java</exclude>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -1406,11 +1406,6 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <excludes>
-                                        <!-- requires legacy-security -->
-                                        <exclude>org/jboss/as/test/integration/web/security/WebSecurity*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/web/security/external/WebSecurity*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/web/security/form/WebSecuritySimpleRoleMappingTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/web/security/jaspi/WebSecurity*TestCase.java</exclude>
                                         <!-- TODO rework these to handle EE 9 -->
                                         <exclude>org/jboss/as/test/integration/web/annotationsmodule/WebModuleDeploymentTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/web/jsp/taglib/external/ExternalTagLibTestCase.java</exclude>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -543,18 +543,6 @@
                                 <id>default-test</id>
                                 <phase>none</phase>
                             </execution>
-                            <execution>
-                                <id>ws-integration-default.surefire</id>
-                                <configuration>
-                                    <excludes>
-                                        <!-- Other security issues -->
-                                        <exclude>org/jboss/as/test/integration/ws/authentication/*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/ws/authentication/policy/*TestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15309

Builds on #14679 
