### PR TITLE
[WFLY-15316] Update jose4j to 0.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-5</version.org.apache.xalan>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
-        <version.org.bitbucket.jose4j>0.7.2</version.org.bitbucket.jose4j>
+        <version.org.bitbucket.jose4j>0.7.9</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.11.12</version.org.bytebuddy>
         <version.org.cryptacular>1.2.4</version.org.cryptacular>
         <version.org.eclipse.jdt>3.26.0</version.org.eclipse.jdt>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15316

This component upgrade fixes the TokenUtilsEncryptTest.testFailAlgorithm failure that occurs with SE 17