### PR TITLE
Remove duplicate declaration of picketbox version property and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,6 @@
         <version.org.jboss.mod_cluster>1.4.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.12.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.5.Final</version.org.jboss.openjdk-orb>
-        <version.org.picketbox>5.0.3.Final-redhat-00007</version.org.picketbox>
         <version.org.jboss.resteasy>4.7.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
@@ -520,50 +519,6 @@
                 <version>${version.org.wildfly.core}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- Override WildFly Core's picketbox version -->
-            <dependency>
-                <groupId>org.picketbox</groupId>
-                <artifactId>picketbox</artifactId>
-                <version>${version.org.picketbox}</version>
-                <exclusions>
-                    <exclusion>
-                         <groupId>org.picketbox</groupId>
-                         <artifactId>jboss-security-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                         <groupId>org.picketbox</groupId>
-                         <artifactId>jbosssx</artifactId>
-                    </exclusion>
-                    <exclusion>
-                         <groupId>org.picketbox</groupId>
-                         <artifactId>picketbox-bare</artifactId>
-                    </exclusion>
-                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.picketbox</groupId>
-                <artifactId>picketbox-infinispan</artifactId>
-                <version>${version.org.picketbox}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.picketbox</groupId>
-                        <artifactId>picketbox-spi-bare</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketbox</groupId>
-                        <artifactId>jbosssx-bare</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.logging</groupId>
-                        <artifactId>jboss-logging-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.infinispan</groupId>
-                        <artifactId>infinispan-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes the following warning when building:
~~~~
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.wildfly:wildfly-appclient:jar:25.0.0.Final-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.picketbox:picketbox:jar -> duplicate declaration of version ${version.org.picketbox} @ org.wildfly:wildfly-parent:25.0.0.Final-SNAPSHOT, /home/paul/wildfly/main/wildfly/pom.xml, line 9288, column 25
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.picketbox:picketbox-infinispan:jar -> duplicate declaration of version ${version.org.picketbox} @ org.wildfly:wildfly-parent:25.0.0.Final-SNAPSHOT, /home/paul/wildfly/main/wildfly/pom.xml, line 9307, column 25
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.wildfly:wildfly-parent:pom:25.0.0.Final-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.picketbox:picketbox:jar -> duplicate declaration of version ${version.org.picketbox} @ line 9288, column 25
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.picketbox:picketbox-infinispan:jar -> duplicate declaration of version ${version.org.picketbox} @ line 9307, column 25
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
~~~~