### PR TITLE
[WFLY-15336] Correct the list of unused modules for LayersTestCase

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -53,6 +53,8 @@ public class LayersTestCase {
         "javax.validation.api",
         // Un-used
         "javax.activation.api",
+        // Un-used
+        "javax.transaction.api",
         // No patching modules in layers
         "org.jboss.as.patching",
         "org.jboss.as.patching.cli",


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-15336

javax.transaction.api is no longer provisioned when we are creating the servlet distribution by using galleon layers.