### PR TITLE
[WFLY-15337] Manual Model microprofile tests fail due to missing stan…

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/microprofile/health/MicroProfileHealthDefaultEmptyReadinessTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/microprofile/health/MicroProfileHealthDefaultEmptyReadinessTestBase.java
@@ -22,6 +22,13 @@
 
 package org.wildfly.test.manual.microprofile.health;
 
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,19 +39,14 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.net.ConnectException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Test that readiness handling with mp.health.disable-default-procedures=true respects the
@@ -92,6 +94,12 @@ public abstract class MicroProfileHealthDefaultEmptyReadinessTestBase {
 
     @ArquillianResource
     private ContainerController containerController;
+
+    @Before
+    public void check() {
+        //Assume we are using the full distribution which contains standalone-microprofile.xml
+        AssumeTestGroupUtil.assumeFullDistribution();
+    }
 
     @Test
     @InSequence(1)

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/microprofile/health/MicroProfileHealthDefaultEmptyStartupTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/microprofile/health/MicroProfileHealthDefaultEmptyStartupTestBase.java
@@ -22,6 +22,13 @@
 
 package org.wildfly.test.manual.microprofile.health;
 
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,19 +39,14 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.net.ConnectException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Test that startup handling with mp.health.disable-default-procedures=true respects the
@@ -92,6 +94,12 @@ public abstract class MicroProfileHealthDefaultEmptyStartupTestBase {
 
     @ArquillianResource
     private ContainerController containerController;
+
+    @Before
+    public void check() {
+        //Assume we are using the full distribution which contains standalone-microprofile.xml
+        AssumeTestGroupUtil.assumeFullDistribution();
+    }
 
     @Test
     @InSequence(1)

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -72,6 +72,17 @@ public class AssumeTestGroupUtil {
 //                () -> getJavaSpecificationVersion() == javaSpecificationVersion);
 //    }
 
+    /**
+     * Assume for test failures when running against a full distribution.
+     * Full distributions are available from build/dist modules. It skips tests in case
+     * {@code '-Dtestsuite.default.build.project.prefix'} Maven argument is used with
+     * a non empty value, e.g. testsuite.default.build.project.prefix=ee- which means we
+     * are using ee-build/ee-dist modules as the source where to find the server under test.
+     */
+    public static void assumeFullDistribution() {
+        assumeCondition("Tests requiring full distribution are disabled", () -> System.getProperty("testsuite.default.build.project.prefix", "").equals(""));
+    }
+
     private static int getJavaSpecificationVersion() {
         String versionString = System.getProperty("java.specification.version");
         versionString = versionString.startsWith("1.") ? versionString.substring(2) : versionString;


### PR DESCRIPTION
…dalone-microprofile.xml

Jira issue: https://issues.redhat.com/browse/WFLY-15337

Right now tests are failing when we are using the ee-galleon-pack distribution, which does not contain MP stuff. 

Instead of doing a considerable refactor of the manualmode pom, here we are disabling the tests when we are not testing a full server distribution. 