### PR TITLE
WFLY-15329 Fix intermittent failures in GroupListenerTestCase

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/GroupListenerTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/GroupListenerTestCase.java
@@ -79,7 +79,6 @@ public class GroupListenerTestCase extends AbstractClusteringTestCase {
             assertEquals(topology.getCurrentMembers().toString(), 2, topology.getCurrentMembers().size());
             assertTrue(topology.getCurrentMembers().toString(), topology.getCurrentMembers().contains(NODE_1));
             assertTrue(topology.getCurrentMembers().toString(), topology.getCurrentMembers().contains(NODE_2));
-            assertEquals(topology.getPreviousMembers().toString(), 0, topology.getPreviousMembers().size());
 
             stop(NODE_2);
 


### PR DESCRIPTION
Ignore previous membership during initial state assertions.

https://issues.redhat.com/browse/WFLY-15329