### PR TITLE
Temporarily ignore DataSourceMultipleConnStatsTestCase.testClearedDat…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceMultipleConnStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceMultipleConnStatsTestCase.java
@@ -41,6 +41,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -144,6 +145,10 @@ public class DataSourceMultipleConnStatsTestCase {
     @InSequence(2)
     @Test
     public void testClearedDataSourceStatistics() throws Exception {
+
+        // Disable for now on Windows until WFLY-15336 is sorted
+        Assume.assumeTrue("WFLY-15336", System.getProperty("os.name").equalsIgnoreCase("Linux"));
+
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
         this.setConnectionPool();


### PR DESCRIPTION
…aSourceStatistics() in non-Linux environments


