### PR TITLE
[WFLY-15363] Upgrade WildFly Core 17.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Beta7</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15363

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.0.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Beta7...17.0.0.Final

---

<details>

<summary>Release Notes - WildFly Core - Version 17.0.0.Final</summary>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5493'>WFCORE-5493</a>] -         Deployment Transformer not invoked for operation &quot;full-replace-deployment&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5577'>WFCORE-5577</a>] -         Iterator next must check end
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5579'>WFCORE-5579</a>] -         Fix ModelNode AttributeDefinition equal (server)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5582'>WFCORE-5582</a>] -         Fix failing tests on IBM JDK 11
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5587'>WFCORE-5587</a>] -         maximum-cert-path does not work with empty certificate-revocation-list in Elytron trust-manager
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5575'>WFCORE-5575</a>] -         Refactor Boolean parsing and Boolean object usage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5578'>WFCORE-5578</a>] -         Avoid unnecessary number boxing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5589'>WFCORE-5589</a>] -         Remove legacy security phases.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5597'>WFCORE-5597</a>] -         Remove the wildfly-security-integration module.
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5538'>WFCORE-5538</a>] -         Upgrade Apache MINA SSHD to 2.7.0 (fixes CVE-2021-30129), JGit to compatible version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5574'>WFCORE-5574</a>] -         Upgrade JBoss Modules from 1.11.0.Final to 1.12.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5581'>WFCORE-5581</a>] -         Upgrade Jandex to 2.4.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5583'>WFCORE-5583</a>] -         Upgrade galleon-plugins to 5.2.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5585'>WFCORE-5585</a>] -         Upgrade bootable jar to 5.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5593'>WFCORE-5593</a>] -         Upgrade WildFly Elytron to 1.17.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5598'>WFCORE-5598</a>] -         Upgrade Undertow to 2.2.12.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5599'>WFCORE-5599</a>] -         Upgrade undertow to 2.2.12.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5588'>WFCORE-5588</a>] -         Synchronize GNU GPL 2 license name with the name used in Wildfly
</li>
</ul>
                                                                                                                        
</details>