### PR TITLE
WFLY-15372 Remove the use of TimerHandle in ejb timer management oper…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.ejb.ConcurrentAccessTimeoutException;
 import javax.ejb.EJBAccessException;
 import javax.ejb.EJBException;
@@ -54,7 +53,6 @@ import javax.ejb.NoSuchObjectLocalException;
 import javax.ejb.RemoveException;
 import javax.ejb.ScheduleExpression;
 import javax.ejb.Timer;
-import javax.ejb.TimerHandle;
 import javax.ejb.TransactionAttributeType;
 import javax.interceptor.InvocationContext;
 import javax.naming.Context;
@@ -2319,12 +2317,12 @@ public interface EjbLogger extends BasicLogger {
     EJBException timerServiceWithIdNotRegistered(String timedObjectId);
 
     /**
-     * Creates an exception indicating the timer for handle is not active"
+     * Creates an exception indicating the timer for the handle is not active.
      *
      * @return an {@link NoSuchObjectLocalException} for the error.
      */
-    @Message(id = 339, value = "Timer for handle: %s is not active")
-    NoSuchObjectLocalException timerHandleIsNotActive(TimerHandle timerHandle);
+    @Message(id = 339, value = "Timer for handle with timer id: %s, timedObjectId: %s is not active")
+    NoSuchObjectLocalException timerHandleIsNotActive(String timerId, String timedObjectId);
 
 //    /**
 //     * Creates an exception indicating it could not find timeout method

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerResourceDefinition.java
@@ -23,10 +23,8 @@
 package org.jboss.as.ejb3.subsystem.deployment;
 
 import java.util.Date;
-
 import javax.ejb.NoMoreTimeoutsException;
 import javax.ejb.ScheduleExpression;
-import javax.ejb.TimerHandle;
 
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -47,7 +45,6 @@ import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.subsystem.EJB3Extension;
 import org.jboss.as.ejb3.subsystem.EJB3SubsystemModel;
-import org.jboss.as.ejb3.timerservice.TimerHandleImpl;
 import org.jboss.as.ejb3.timerservice.TimerImpl;
 import org.jboss.as.ejb3.timerservice.TimerServiceImpl;
 import org.jboss.dmr.ModelNode;
@@ -377,10 +374,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
             final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
             final String timerId = address.getLastElement().getValue();
             final String timedInvokerObjectId = timerService.getTimedObjectInvoker().getValue().getTimedObjectId();
-            final TimerHandle handle = new TimerHandleImpl(timerId, timedInvokerObjectId, timerService);
-            TimerImpl timer = null;
+            TimerImpl timer;
             try {
-                timer = timerService.getTimer(handle);
+                timer = timerService.getTimer(timerId, timedInvokerObjectId);
             } catch (Exception e) {
                 throw new OperationFailedException(e, null);
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerHandleImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerHandleImpl.java
@@ -98,9 +98,9 @@ public class TimerHandleImpl implements TimerHandle {
                 throw EjbLogger.EJB3_TIMER_LOGGER.timerServiceWithIdNotRegistered(timedObjectId);
             }
         }
-        final TimerImpl timer = this.service.getTimer(this);
+        final TimerImpl timer = this.service.getTimer(id, timedObjectId);
         if (timer == null || !timer.isActive()) {
-            throw EjbLogger.EJB3_TIMER_LOGGER.timerHandleIsNotActive(this);
+            throw EjbLogger.EJB3_TIMER_LOGGER.timerHandleIsNotActive(id, timedObjectId);
         }
         return timer;
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
@@ -76,12 +76,6 @@ public class TimerImpl implements Timer {
     protected final boolean persistent;
 
     /**
-     * A {@link javax.ejb.TimerHandle} for this timer, not assigned till
-     * {@code getHandle()} is called.
-     */
-    protected TimerHandleImpl handle;
-
-    /**
      * The initial (first) expiry date of this timer
      */
     protected final Date initialExpiration;
@@ -197,13 +191,7 @@ public class TimerImpl implements Timer {
         if (!persistent) {
             throw EjbLogger.EJB3_TIMER_LOGGER.invalidTimerHandlersForPersistentTimers("Enterprise Beans 3.1 Spec 18.2.6");
         }
-
-        synchronized (this) {
-            if (handle == null) {
-                handle = new TimerHandleImpl(id, timedObjectId, timerService);
-            }
-        }
-        return handle;
+        return new TimerHandleImpl(id, timedObjectId, timerService);
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -44,7 +44,6 @@ import javax.ejb.EJBException;
 import javax.ejb.ScheduleExpression;
 import javax.ejb.Timer;
 import javax.ejb.TimerConfig;
-import javax.ejb.TimerHandle;
 import javax.ejb.TimerService;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
@@ -585,27 +584,28 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
     }
 
     /**
-     * Returns the {@link javax.ejb.Timer} corresponding to the passed {@link javax.ejb.TimerHandle}
+     * Returns the timer corresponding to the passed timer id and timed object id.
      *
-     * @param handle The {@link javax.ejb.TimerHandle} for which the {@link javax.ejb.Timer} is being looked for
+     * @param timerId timer id
+     * @param timedObjectId timed object id
+     * @return the {@code TimerImpl} corresponding to the passed timer id and timed object id
      */
-    public TimerImpl getTimer(TimerHandle handle) {
-        TimerHandleImpl timerHandle = (TimerHandleImpl) handle;
+    public TimerImpl getTimer(final String timerId, final String timedObjectId) {
         TimerImpl timer;
         synchronized (this.timers) {
-            timer = this.timers.get(timerHandle.getId());
+            timer = this.timers.get(timerId);
         }
         if (timer != null) {
             return timer;
         }
-        timer = getWaitingOnTxCompletionTimers().get(timerHandle.getId());
+        timer = getWaitingOnTxCompletionTimers().get(timerId);
         if (timer != null) {
             return timer;
         }
         final TimerPersistence persistence = timerPersistence.getOptionalValue();
         if (persistence instanceof DatabaseTimerPersistence) {
             timer = ((DatabaseTimerPersistence) persistence).loadTimer(
-                    timerHandle.getTimedObjectId(), timerHandle.getId(), this);
+                    timedObjectId, timerId, this);
         }
         return timer;
     }


### PR DESCRIPTION
…ations

https://issues.redhat.com/browse/WFLY-15372

This PR removes the use of `TimerHandle` from ejb timer management operations. It also removes the `timerHandle` field from `TimerImpl` class and modifies its `getHandle()` method to return a new instance of `TimerHandleImpl` for every call, since it's not worthwhile to save it as an instance variable.

~~Any conflict with https://github.com/wildfly/wildfly/pull/14723 should be manually resolved.~~ (conflict resolved)
