### PR TITLE
[WFLY-15396] Override core to roll back to Jandex 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,7 @@
         <version.org.jboss.hal.console>3.3.8.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.5.2.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.jandex>2.3.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
@@ -518,6 +519,13 @@
                 <version>${version.org.wildfly.core}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Override jandex from core -->
+            <dependency>
+                <groupId>org.jboss</groupId>
+                <artifactId>jandex</artifactId>
+                <version>${version.org.jboss.jandex}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.0.13</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.15</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.1.10</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.6.0</version.io.smallrye.smallrye-common>

--- a/servlet-feature-pack/common/pom.xml
+++ b/servlet-feature-pack/common/pom.xml
@@ -68,6 +68,12 @@
             </exclusions>
         </dependency>
 
+        <!-- Override jandex from core -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15396

Unfortunately this reverts the https://issues.redhat.com/browse/WFLY-15278 fix.
