### PR TITLE
[WFLY-15311] Exclude google guava and opentelemetry artifacts from EE…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -386,6 +386,24 @@
                             <!--<jakarta-transform-verbose>true</jakarta-transform-verbose>-->
                             <jakarta-transform-excluded-artifacts>
                                 <exclude>com.h2database:h2\z</exclude>
+                                <exclude>com.google.guava:guava\z</exclude>
+                                <exclude>io.grpc:grpc-api\z</exclude>
+                                <exclude>io.grpc:grpc-context\z</exclude>
+                                <exclude>io.grpc:grpc-protobuf\z</exclude>
+                                <exclude>io.grpc:grpc-okhttp\z</exclude>
+                                <exclude>io.grpc:grpc-core\z</exclude>
+                                <exclude>io.grpc:grpc-protobuf-lite\z</exclude>
+                                <exclude>io.grpc:grpc-stub\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-api\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-api-metrics\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-context\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-exporter-jaeger\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-exporter-otlp-common\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-exporter-otlp-trace\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-sdk\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-sdk-common\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-sdk-trace\z</exclude>
+                                <exclude>io.opentelemetry:opentelemetry-semconv\z</exclude>
                             </jakarta-transform-excluded-artifacts>
                         </configuration>
                     </execution>


### PR DESCRIPTION
… 9+ transformation as their use of javax.annotation is not about EE APIs

https://issues.redhat.com/browse/WFLY-15311