### PR TITLE
[WFLY-15402] Upgrade WildFly Core 17.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>17.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,6 @@
         <version.org.jboss.hal.console>3.3.8.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.5.2.Final</version.org.jboss.ironjacamar>
-        <version.org.jboss.jandex>2.3.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
@@ -519,13 +518,6 @@
                 <version>${version.org.wildfly.core}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- Override jandex from core -->
-            <dependency>
-                <groupId>org.jboss</groupId>
-                <artifactId>jandex</artifactId>
-                <version>${version.org.jboss.jandex}</version>
             </dependency>
 
             <dependency>

--- a/servlet-feature-pack/common/pom.xml
+++ b/servlet-feature-pack/common/pom.xml
@@ -68,12 +68,6 @@
             </exclusions>
         </dependency>
 
-        <!-- Override jandex from core -->
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jandex</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15402

This PR also reverts the temporary workaround in https://github.com/wildfly/wildfly/commit/570b2691f97058f0f4de827c82a82eb29a1a3d04

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/17.0.1.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.0.Final...17.0.1.Final

---

<details>
<summary>Release Notes - WildFly Core - Version 17.0.1.Final</summary>
                                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5603'>WFCORE-5603</a>] -         Downgrade Jandex to 2.3.1.Final
</li>
</ul>
</details>