### PR TITLE
[WFLY-15375] Fix unstable test

### DIFF
--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -324,6 +324,7 @@
                         <microprofile.server.jvm.args>${microprofile.server.jvm.args}</microprofile.server.jvm.args>
                         <arquillian.launch>manual-mode</arquillian.launch>
                         <jboss.config.file.name>standalone-ha.xml</jboss.config.file.name>
+                        <ryuk.container.timeout>60</ryuk.container.timeout>
                         <!-- needed for SSLEJBRemoteClientTestCase only, however setting them from within the test itself isn't possible -->
                         <javax.net.ssl.trustStore>${basedir}/target/test-classes/ejb3/ssl/jbossClient.truststore</javax.net.ssl.trustStore>
                         <javax.net.ssl.keyStore>${basedir}/target/test-classes/ejb3/ssl/jbossClient.keystore</javax.net.ssl.keyStore>

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/observability/opentelemetry/JaegerContainer.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/observability/opentelemetry/JaegerContainer.java
@@ -1,0 +1,35 @@
+package org.wildfly.test.manual.observability.opentelemetry;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+
+public class JaegerContainer extends GenericContainer<JaegerContainer> {
+    private static final String JAEGER_IMAGE = "jaegertracing/all-in-one:latest";
+
+    public JaegerContainer() {
+        super(JAEGER_IMAGE);
+    }
+
+    @Override
+    protected void configure() {
+        final List<Integer> udp = Arrays.asList(5775, 6831, 6832);
+        final List<Integer> tcp = Arrays.asList(5778, 9411, 14250, 14268, 16686);
+
+        udp.forEach(p -> addFixedExposedPort(p, p, InternetProtocol.UDP));
+        tcp.forEach(p -> addFixedExposedPort(p, p));
+
+        withEnv("COLLECTOR_ZIPKIN_HOST_PORT", "9411");
+        waitingFor(new HostPortWaitStrategy() {
+            @Override
+            protected Set<Integer> getLivenessCheckPorts() {
+                return new HashSet<>(tcp);
+            }
+        });
+    }
+}

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -164,6 +164,12 @@
             <artifactId>wildfly-elytron-x500-cert</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -5,6 +5,8 @@ import java.security.PrivilegedAction;
 import java.util.function.Supplier;
 
 import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.testcontainers.DockerClientFactory;
 
 /**
  * Helper methods which help to skip tests for feature which is not yet fully working. Put the call of the method directly into
@@ -86,6 +88,14 @@ public class AssumeTestGroupUtil {
      */
     public static void assumeFullDistribution() {
         assumeCondition("Tests requiring full distribution are disabled", () -> System.getProperty("testsuite.default.build.project.prefix", "").equals(""));
+    }
+
+    public static void assumeDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+        } catch (Throwable ex) {
+            throw new AssumptionViolatedException("Docker is not available.");
+        }
     }
 
     private static int getJavaSpecificationVersion() {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15375

Increase ryuk timeout
Modify assume() to check for Docker in setup
Remove "always pull" image policy
Move test container setup to separate class
