### PR TITLE
[WFLY-15428] Upgrade WildFly Core 18.0.0.Beta1

### DIFF
--- a/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:18.0">
+<server xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:18.0">
+<server xmlns="urn:jboss:domain:19.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>17.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>18.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.8.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0"
+<domain xmlns="urn:jboss:domain:19.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0">
+<domain xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0"
+<domain xmlns="urn:jboss:domain:19.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0">
+<domain xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0">
+<domain xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:18.0" name="master">
+<host xmlns="urn:jboss:domain:19.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:18.0" name="slave">
+<host xmlns="urn:jboss:domain:19.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:18.0"
+<host xmlns="urn:jboss:domain:19.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:18.0">
+<server xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:18.0"
+<domain xmlns="urn:jboss:domain:19.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:18.0">
+<host name="master" xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:18.0">
+<host name="master" xmlns="urn:jboss:domain:19.0">
 
     <extensions>
         <extension module="org.wildfly.extension.elytron"/>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15428

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.0.0.Beta1
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/17.0.1.Final...18.0.0.Beta1

---

<details>
<summary>Release Notes - WildFly Core - Version 18.0.0.Beta1</summary>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5609'>WFCORE-5609</a>] -         AbstractOperationContext#getCurrentOperationName() does not return the name of the operation
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5610'>WFCORE-5610</a>] -         Bump the kernel management API version to 19.0.0 and the xsd to 19.0
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5628'>WFCORE-5628</a>] -         Upgrade WildFly Elytron to 1.17.2.Final
</li>
</ul>
                                                                                                                            
</details>