### PR TITLE
[WFLY-15469] Add missing keyword "abstract" (connector)

### DIFF
--- a/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/AbstractComplexSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/AbstractComplexSubsystemTestCase.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
  *
  * @author <a href="vrastsel@redhat.com">Vladimir Rastseluev</a>
  */
-public class AbstractComplexSubsystemTestCase extends AbstractSubsystemTest {
+public abstract class AbstractComplexSubsystemTestCase extends AbstractSubsystemTest {
 
     public AbstractComplexSubsystemTestCase(final String mainSubsystemName, final Extension mainExtension) {
         super(mainSubsystemName, mainExtension);


### PR DESCRIPTION
AbstractComplexSubsystemTestCase

Fixes https://issues.redhat.com/browse/WFLY-15469
