### PR TITLE
WFLY-15278 Upgrade smallrye-open-api to 2.1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.0.13</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.10</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.1.15</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.6.0</version.io.smallrye.smallrye-common>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15278

Requires wildfly-core 17.0.2.Final.