### PR TITLE
[WFLY-15509] Getters and setters should be synced in pairs (undertow)

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
@@ -134,7 +134,7 @@ public abstract class ListenerService implements Service<UndertowListener>, Unde
         return this.serverService.get();
     }
 
-    public boolean isEnabled() {
+    public synchronized boolean isEnabled() {
         return enabled;
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowService.java
@@ -261,7 +261,7 @@ public class UndertowService implements Service<UndertowService> {
         return obfuscateSessionRoute;
     }
 
-    public boolean isStatisticsEnabled() {
+    public synchronized boolean isStatisticsEnabled() {
         return statisticsEnabled;
     }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-15509
as part of https://issues.redhat.com/browse/WFLY-15507