### PR TITLE
[WFLY-15514] "ThreadLocal" variables clean up (jsf)

### DIFF
--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesInjectionProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesInjectionProvider.java
@@ -31,9 +31,9 @@ import org.jboss.as.web.common.WebInjectionContainer;
  *
  * @author Dmitrii Tikhomirov dtikhomi@redhat.com (C) 2016 Red Hat Inc.
  */
-public class MyFacesInjectionProvider extends InjectionProvider {
+public class MyFacesInjectionProvider extends InjectionProvider implements AutoCloseable {
 
-    private final WebInjectionContainer injectionContainer;
+    private WebInjectionContainer injectionContainer;
 
     public MyFacesInjectionProvider() {
         this.injectionContainer = StartupContext.getInjectionContainer();
@@ -64,7 +64,13 @@ public class MyFacesInjectionProvider extends InjectionProvider {
 
     @Override
     public boolean isAvailable() {
-        return true;
+        return this.injectionContainer != null;
+    }
+
+    @Override
+    public void close() {
+        StartupContext.removeInjectionContainer();
+        this.injectionContainer = null;
     }
 
 }

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesInjectionProviderFactory.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesInjectionProviderFactory.java
@@ -34,7 +34,7 @@ import javax.faces.context.ExternalContext;
  */
 public class MyFacesInjectionProviderFactory extends InjectionProviderFactory {
 
-    private final InjectionProvider injectionProvider;
+    private InjectionProvider injectionProvider;
 
     public MyFacesInjectionProviderFactory(){
         injectionProvider = new MyFacesInjectionProvider();
@@ -47,7 +47,9 @@ public class MyFacesInjectionProviderFactory extends InjectionProviderFactory {
 
     @Override
     public void release() {
-
+        MyFacesInjectionProvider toClose = (MyFacesInjectionProvider) injectionProvider;
+        injectionProvider = null;
+        toClose.close();
     }
 
 }

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
@@ -37,9 +37,9 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 /**
  * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
  */
-public class MyFacesLifecycleProvider implements LifecycleProvider2 {
+public class MyFacesLifecycleProvider implements LifecycleProvider2, AutoCloseable {
 
-    private final WebInjectionContainer injectionContainer;
+    private WebInjectionContainer injectionContainer;
 
     public MyFacesLifecycleProvider() {
         this.injectionContainer = StartupContext.getInjectionContainer();
@@ -78,4 +78,9 @@ public class MyFacesLifecycleProvider implements LifecycleProvider2 {
         injectionContainer.destroyInstance(obj);
     }
 
+    @Override
+    public void close()  {
+        this.injectionContainer = null;
+        StartupContext.removeInjectionContainer();
+    }
 }

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProviderFactory.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProviderFactory.java
@@ -30,7 +30,7 @@ import org.apache.myfaces.config.annotation.LifecycleProviderFactory;
  */
 public class MyFacesLifecycleProviderFactory extends LifecycleProviderFactory {
 
-    private final LifecycleProvider provider;
+    private LifecycleProvider provider;
 
     public MyFacesLifecycleProviderFactory() {
         provider = new MyFacesLifecycleProvider();
@@ -43,7 +43,9 @@ public class MyFacesLifecycleProviderFactory extends LifecycleProviderFactory {
 
     @Override
     public void release() {
-
+        MyFacesLifecycleProvider toClose = (MyFacesLifecycleProvider) provider;
+        provider = null;
+        toClose.close();
     }
 
 }

--- a/web-common/src/main/java/org/jboss/as/web/common/StartupContext.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/StartupContext.java
@@ -41,4 +41,8 @@ public class StartupContext {
         return INJECTION_CONTAINER.get();
     }
 
+    public static void removeInjectionContainer() {
+        INJECTION_CONTAINER.remove();
+    }
+
 }


### PR DESCRIPTION
"ThreadLocal" variables should be cleaned up when no longer used (jsf)

Fixes https://issues.redhat.com/browse/WFLY-15514
as part of https://issues.redhat.com/browse/WFLY-15513
