### PR TITLE
[WFLY-15515] "ThreadLocal" variables clean up (transactions)

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionRollbackSetupAction.java
+++ b/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionRollbackSetupAction.java
@@ -117,7 +117,7 @@ public class TransactionRollbackSetupAction implements SetupAction, Service<Tran
 
         holder.depth += increment;
         if (holder.depth == 0) {
-            depth.set(null);
+            depth.remove();
             return holder.actuallyCleanUp;
         }
         return false;


### PR DESCRIPTION
"ThreadLocal" variables should be cleaned up when no longer used (transactions)

Fixes https://issues.redhat.com/browse/WFLY-15515
as part of https://issues.redhat.com/browse/WFLY-15513