### PR TITLE
[WFLY-15516] "ThreadLocal" variables clean up (security)

### DIFF
--- a/security/plugins/src/main/java/org/jboss/as/security/remoting/RemotingContext.java
+++ b/security/plugins/src/main/java/org/jboss/as/security/remoting/RemotingContext.java
@@ -69,7 +69,7 @@ public class RemotingContext {
     public static void clear() {
         checkPermission(CLEAR_CONNECTION);
 
-        connection.set(null);
+        connection.remove();
     }
 
     public static Connection getConnection() {


### PR DESCRIPTION
"ThreadLocal" variables should be cleaned up when no longer used (security)
Fixes https://issues.redhat.com/browse/WFLY-15516
as part of https://issues.redhat.com/browse/WFLY-15513
