### PR TITLE
[WFLY-15517] "ThreadLocal" variables clean up (jpa)

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/CreatedEntityManagers.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/CreatedEntityManagers.java
@@ -73,6 +73,7 @@ public class CreatedEntityManagers {
             }
         } finally {
             store.clear();
+            deferToPostConstruct.remove();
         }
     }
 


### PR DESCRIPTION
"ThreadLocal" variables should be cleaned up when no longer used (jpa)

Fixes https://issues.redhat.com/browse/WFLY-15517
as part of https://issues.redhat.com/browse/WFLY-15513