### PR TITLE
[WFLY-15536] License files need to be filtered by the maven resource …

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -204,6 +204,7 @@
                             <resources>
                                 <resource>
                                     <directory>${mp.galleon.common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                     <excludes>
                                         <exclude>layers/standalone/jaxrs</exclude>
                                     </excludes>
@@ -223,6 +224,7 @@
                             <resources>
                                 <resource>
                                     <directory>${oidc.galleon.common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>
@@ -239,6 +241,7 @@
                             <resources>
                                 <resource>
                                     <directory>${basedir}/src/main/resources</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -203,6 +203,7 @@
                             <resources>
                                 <resource>
                                     <directory>${pruned.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -84,6 +84,7 @@
                             <resources>
                                 <resource>
                                     <directory>${mp.galleon.common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>
@@ -100,6 +101,7 @@
                             <resources>
                                 <resource>
                                     <directory>${oidc.galleon.common.resources.directory}</directory>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>


### PR DESCRIPTION
…plugin

Jira issue: https://issues.redhat.com/browse/WFLY-15536

I wonder if we should move this filtering to the license plugin instead, that would prevent wildfly / wildfly core take care of it and, maybe potentially avoid filtering resources unnecessarily.
