### PR TITLE
[WFLY-14992] Upgrade PicketBox from 5.0.3.Final-redhat-00007 to 5.0.3.Final-redhat-00008

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
         <version.org.opensaml.opensaml>3.4.6</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.1</version.org.ow2.asm>
         <!-- WildFly overrides the picketbox version from core to use MRRC variants -->
-        <version.org.picketbox>5.0.3.Final-redhat-00007</version.org.picketbox>
+        <version.org.picketbox>5.0.3.Final-redhat-00008</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14992

PicketBox upgrade in EAP 7.4.1: https://issues.redhat.com/browse/JBEAP-22084 (WF Core PR is not needed because the dependency has been removed)

Diff: https://github.com/jbossas/redhat-picketbox/compare/5.0.3.Final-20-ga35786ce...5.0.2.Final-28-ga6fb32f2