### PR TITLE
WFLY-15552 contention due to the synchronized block in TimerServiceIm…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerState.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerState.java
@@ -21,7 +21,9 @@
  */
 package org.jboss.as.ejb3.timerservice;
 
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Timer states.
@@ -80,6 +82,16 @@ public enum TimerState {
     RETRY_TIMEOUT,
     ;
 
-    public static final EnumSet<TimerState> CREATED_ACTIVE_IN_TIMEOUT_RETRY_TIMEOUT =
-            EnumSet.of(IN_TIMEOUT, RETRY_TIMEOUT, CREATED, ACTIVE);
+    /**
+     * An unmodifiable set that contains timer states {@link #IN_TIMEOUT}, {@link #RETRY_TIMEOUT},
+     * {@link #CREATED} and {@link #ACTIVE}.
+     */
+    public static final Set<TimerState> CREATED_ACTIVE_IN_TIMEOUT_RETRY_TIMEOUT =
+            Collections.unmodifiableSet(EnumSet.of(IN_TIMEOUT, RETRY_TIMEOUT, CREATED, ACTIVE));
+
+    /**
+     * An unmodifiable set that contains timer states {@link #EXPIRED} and {@link #CANCELED}.
+     */
+    public static final Set<TimerState> EXPIRED_CANCELED =
+            Collections.unmodifiableSet(EnumSet.of(EXPIRED, CANCELED));
 }


### PR DESCRIPTION
…pl.getTimers()

https://issues.redhat.com/browse/WFLY-15552

* replacing `HashMap` with `ConcurrentHashMap` for `timers`
* replacing `HashSet` with `ArrayList` inside `getTimers()` method as the impl type to hold the result. The method return type is still `Collection`.
* use `ConcurrentMap.putIfAbsent(...)` inside `registerTimerResource()` method.
* Inside method `getTimers()`, the weakly consistent view of the underlying timers cache should be okay to produce the method return result. With the previously used synchronized block, it was always consistent.
* Previously inside `registerTimerResource()` and ` unregisterTimerResource()`, adding/removing from timers cache and registering/unregistering with management resources are in the same synchronized block. In this PR, the resource management part is no longer in the same critical section.  Registering/unregistering timer resources should not block other access to timers.
* Use `EnumSet` instead of `HashSet` to hold timer states `EXPIRED`, `CANCELED`.