### PR TITLE
minor change to add dom4j + javassist dependencies to pom.xml in testsuite/integration/basic pom

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -120,6 +120,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-core-client</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

^ is to allow:
```
cd testsuite/integration/basic/
mvn install -Dts.ee9 -Dtest=org.jboss.as.test.integration.jpa.packaging.PersistenceUnitPackagingTestCase
```
