### PR TITLE
Revert "Revert "WFLY-15278 Upgrade smallrye-open-api to 2.1.15""

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.0.13</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.10</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.1.15</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.6.0</version.io.smallrye.smallrye-common>


### PR DESCRIPTION
This reverts commit 4696c8f668e333cec540e6187d5630a52d4a1821.

The Jandex upgrade needed for WFLY-15278 is now in place, so this can go in.

https://issues.redhat.com/browse/WFLY-15278