### PR TITLE
WFLY-15028 Move WildFly Preview to a native jakarta namespace variant…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -590,6 +590,7 @@
                 <exclusion>
                     <groupId>com.sun.istack</groupId>
                     <artifactId>istack-commons-tools</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.jboss</groupId>
                     <artifactId>jboss-ejb-client</artifactId>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -561,6 +561,10 @@
                     <groupId>${project.groupId}</groupId>
                     <artifactId>wildfly-weld-transactions</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-ejb-client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -961,6 +965,12 @@
         <dependency>
             <groupId>org.jboss.activemq.artemis.integration</groupId>
             <artifactId>artemis-wildfly-jakarta-integration</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client-jakarta</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
+++ b/ee-9/feature-pack/src/main/resources/license/preview-feature-pack-licenses.xml
@@ -209,6 +209,17 @@
     </dependency>
     <dependency>
       <groupId>org.jboss</groupId>
+      <artifactId>jboss-ejb-client-jakarta</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss</groupId>
       <artifactId>jboss-transaction-spi-jakarta</artifactId>
       <licenses>
         <license>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -649,6 +649,18 @@
 
             <dependency>
                 <groupId>org.jboss</groupId>
+                <artifactId>jboss-ejb-client-jakarta</artifactId>
+                <version>${version.org.jboss.ejb-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss</groupId>
                 <artifactId>jboss-transaction-spi-jakarta</artifactId>
                 <version>${version.org.jboss.jboss-transaction-spi}</version>
                 <exclusions>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -23,7 +23,7 @@
 <module xmlns="urn:jboss:module:1.9" name="org.jboss.ejb-client">
 
     <resources>
-        <artifact name="${org.jboss:jboss-ejb-client}"/>
+        <artifact name="\${org.jboss:jboss-ejb-client@module.jakarta.suffix@}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.5</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.43.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.44.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
… of the JBoss EJB Client jar

[WFLY-15028](https://issues.redhat.com/browse/WFLY-15028) Move WildFly Preview to a native jakarta namespace variant of the JBoss EJB Client jar

[WFLY-15626](https://issues.redhat.com/browse/WFLY-15626) Upgrade jboss-ejb-client from 4.0.43.Final to 4.0.44.Final