### PR TITLE
[WFLY-15640]: Upgrade WildFly Galleon plugins to 5.2.5.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>5.2.4.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.2.5.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>5.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>

--- a/servlet-feature-pack/common/pom.xml
+++ b/servlet-feature-pack/common/pom.xml
@@ -300,6 +300,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+            <classifier>client</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <exclusions>


### PR DESCRIPTION
* Upgrading the galleon plugins to 5.2.5.Final
* fixing the feature pack to define the version of the cli artefact
with the classifier 'client'.

Jira: https://issues.redhat.com/browse/WFLY-15640