### PR TITLE
[WFLY-15661]: ForwardedHandlerTestCase fails on jdk17.

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -140,7 +141,7 @@ public class ForwardedHandlerTestCase {
             final String by = "203.0.113.43:777";
             final InetAddress addr = InetAddress.getByName(url.getHost());
             final String localAddrName = addr.getHostName();
-            final String localAddr = addr.getHostAddress() + ":" + url.getPort();
+            final String localAddr = TestSuiteEnvironment.formatPossibleIpv6Address(addr.getHostAddress()) + ":" + url.getPort();
 
             HttpGet httpget = new HttpGet(url.toExternalForm());
             httpget.addHeader("Forwarded", "for=" + forAddr + ";proto=" + proto + ";by=" + by);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperHandler.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperHandler.java
@@ -21,9 +21,22 @@ public class ForwardedTestHelperHandler implements HttpHandler {
 
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String value = exchange.getSourceAddress() + "|" + exchange.getRequestScheme() + "|"
-                + exchange.getDestinationAddress();
+                + formatPossibleIpv6Address(exchange.getDestinationAddress().toString());
 
         exchange.getResponseHeaders().put(new HttpString(FORWARD_TEST_HEADER), value);
         next.handleRequest(exchange);
+    }
+
+    public static String formatPossibleIpv6Address(String address) {
+        if (address == null) {
+            return address;
+        }
+        if (!address.contains(":")) {
+            return address;
+        }
+        if (address.startsWith("[") && address.endsWith("]")) {
+            return address;
+        }
+        return "[" + address + "]";
     }
 }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperServlet.java
@@ -50,7 +50,7 @@ public class ForwardedTestHelperServlet extends HttpServlet {
         PrintWriter out = resp.getWriter();
 
         out.print(req.getRemoteAddr() + "|" + req.getRemoteHost() + ":" + req.getRemotePort() + "|" + req.getScheme()
-                + "|" + req.getLocalName() + "|" + req.getLocalAddr() + ":" + req.getLocalPort());
+                + "|" + req.getLocalName() + "|" + ForwardedTestHelperHandler.formatPossibleIpv6Address(req.getLocalAddr()) + ":" + req.getLocalPort());
         out.close();
     }
 }


### PR DESCRIPTION
* Updating the test to format all IPv6 addresses.

Jira: https://issues.redhat.com/browse/WFLY-15661