### PR TITLE
[WFLY-15661]: ForwardedHandlerTestCase fails on jdk17.

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -72,6 +73,7 @@ public class ForwardedHandlerTestCase {
     public static WebArchive deployWithoutUndertowHandlers() {
         return ShrinkWrap.create(WebArchive.class, FORWARDED_HANDLER_NO_UT_HANDLERS + ".war")
                 .addPackage(ForwardedHandlerTestCase.class.getPackage())
+                .addClass(TestSuiteEnvironment.class)
                 .addAsWebInfResource(new StringAsset(JBOSS_WEB_TEXT), "jboss-web.xml")
                 .addAsWebResource(new StringAsset("A file"), "index.html")
                 .addAsManifestResource(
@@ -84,6 +86,7 @@ public class ForwardedHandlerTestCase {
     public static WebArchive deploy_servlet() {
         return ShrinkWrap.create(WebArchive.class, FORWARDED_SERVLET + ".war")
                 .addClass(ForwardedTestHelperServlet.class)
+                .addClass(TestSuiteEnvironment.class)
                 .addAsWebInfResource(new StringAsset(FORWARDER_HANDLER_NAME), "undertow-handlers.conf")
                 .addAsWebResource(new StringAsset("A file"), "index.html");
     }
@@ -92,6 +95,7 @@ public class ForwardedHandlerTestCase {
     public static WebArchive deployWithoutUndertowHandlers_servlet() {
         return ShrinkWrap.create(WebArchive.class, FORWARDED_SERVLET_NO_UT_HANDLERS + ".war")
                 .addClass(ForwardedTestHelperServlet.class)
+                .addClass(TestSuiteEnvironment.class)
                 .addAsWebResource(new StringAsset("A file"), "index.html");
     }
 
@@ -140,7 +144,7 @@ public class ForwardedHandlerTestCase {
             final String by = "203.0.113.43:777";
             final InetAddress addr = InetAddress.getByName(url.getHost());
             final String localAddrName = addr.getHostName();
-            final String localAddr = addr.getHostAddress() + ":" + url.getPort();
+            final String localAddr = TestSuiteEnvironment.formatPossibleIpv6Address(addr.getHostAddress()) + ":" + url.getPort();
 
             HttpGet httpget = new HttpGet(url.toExternalForm());
             httpget.addHeader("Forwarded", "for=" + forAddr + ";proto=" + proto + ";by=" + by);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperHandler.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperHandler.java
@@ -3,6 +3,7 @@ package org.jboss.as.test.integration.web.handlers;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 
 
 /**
@@ -20,8 +21,14 @@ public class ForwardedTestHelperHandler implements HttpHandler {
 
 
     public void handleRequest(HttpServerExchange exchange) throws Exception {
+        String address = exchange.getDestinationAddress().getAddress().toString();
+        if(address.startsWith("/")) {
+            address = "/" + TestSuiteEnvironment.formatPossibleIpv6Address(address.substring(1));
+        } else {
+            address = TestSuiteEnvironment.formatPossibleIpv6Address(address);
+        }
         String value = exchange.getSourceAddress() + "|" + exchange.getRequestScheme() + "|"
-                + exchange.getDestinationAddress();
+                + address + ':' + exchange.getDestinationAddress().getPort();
 
         exchange.getResponseHeaders().put(new HttpString(FORWARD_TEST_HEADER), value);
         next.handleRequest(exchange);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedTestHelperServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 
 
 /**
@@ -48,9 +49,15 @@ public class ForwardedTestHelperServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         PrintWriter out = resp.getWriter();
+        String localAddr = req.getLocalAddr();
+        if(localAddr.startsWith("/")) {
+            localAddr = "/" + TestSuiteEnvironment.formatPossibleIpv6Address(localAddr.substring(1));
+        } else {
+            localAddr = TestSuiteEnvironment.formatPossibleIpv6Address(localAddr);
+        }
 
         out.print(req.getRemoteAddr() + "|" + req.getRemoteHost() + ":" + req.getRemotePort() + "|" + req.getScheme()
-                + "|" + req.getLocalName() + "|" + req.getLocalAddr() + ":" + req.getLocalPort());
+                + "|" + req.getLocalName() + "|" + localAddr + ":" + req.getLocalPort());
         out.close();
     }
 }


### PR DESCRIPTION
* Updating the test to format all IPv6 addresses.

Jira: https://issues.redhat.com/browse/WFLY-15661

Supersedes https://github.com/wildfly/wildfly/pull/14901