### PR TITLE
[WFLY-15670] Upgrade WildFly Core 18.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>18.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.9.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15670

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.0.0.Beta3
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.0.Beta2...18.0.0.Beta3

---

<details>
<summary>Release Notes - WildFly Core - Version 18.0.0.Beta3</summary>
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5645'>WFCORE-5645</a>] -         Assertion arguments should be passed in the correct order (testsuite)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5646'>WFCORE-5646</a>] -         Assertion arguments should be passed in the correct order (protocol)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5647'>WFCORE-5647</a>] -         Assertion arguments should be passed in the correct order (elytron)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5648'>WFCORE-5648</a>] -         Assertion arguments should be passed in the correct order (controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5656'>WFCORE-5656</a>] -         Test preparation errors shall cause failure (testsuite)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5657'>WFCORE-5657</a>] -         Test preparation errors shall cause failure (patching)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5658'>WFCORE-5658</a>] -         Test preparation errors shall cause failure (jmx)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5659'>WFCORE-5659</a>] -         Test preparation errors shall cause failure (host-controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5662'>WFCORE-5662</a>] -         Check emptiness with Collection.isEmpty() (controller-client)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5663'>WFCORE-5663</a>] -         Check emptiness with Collection.isEmpty() (elytron)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5664'>WFCORE-5664</a>] -         Check emptiness with Collection.isEmpty() (host-controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5665'>WFCORE-5665</a>] -         Check emptiness with Collection.isEmpty() (jmx)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5666'>WFCORE-5666</a>] -         Check emptiness with Collection.isEmpty() (model-test)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5667'>WFCORE-5667</a>] -         Check emptiness with Collection.isEmpty() (patching)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5668'>WFCORE-5668</a>] -         Check emptiness with Collection.isEmpty() (process-controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5669'>WFCORE-5669</a>] -         Check emptiness with Collection.isEmpty() (remoting)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5670'>WFCORE-5670</a>] -         Check emptiness with Collection.isEmpty() (security-manager)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5671'>WFCORE-5671</a>] -         Check emptiness with Collection.isEmpty() (server)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5672'>WFCORE-5672</a>] -         Check emptiness with Collection.isEmpty() (subsystem-test)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5699'>WFCORE-5699</a>] -         &quot;StandardCharsets&quot; constants should be preferred (controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5700'>WFCORE-5700</a>] -         &quot;StandardCharsets&quot; constants should be preferred (host-controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5701'>WFCORE-5701</a>] -         &quot;StandardCharsets&quot; constants should be preferred (process-controller)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5702'>WFCORE-5702</a>] -         &quot;StandardCharsets&quot; constants should be preferred (server)
</li>
</ul>
                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5497'>WFCORE-5497</a>] -         Multiple syntax issues with &#39;wildfly-init-debian.sh&#39;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5630'>WFCORE-5630</a>] -         Use of maven-resource-plugin filtering during feature pack generation is picking up binary files
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5636'>WFCORE-5636</a>] -         Nested attributes do not show deprecated status
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5637'>WFCORE-5637</a>] -         SystemPropertiesParsingTest fails on SE 17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5638'>WFCORE-5638</a>] -         ClientCompatibilityUnitTestCase hangs on SE 17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5650'>WFCORE-5650</a>] -         Adding management user newly requires reload
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5655'>WFCORE-5655</a>] -         Test preparation errors shall cause failure
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5660'>WFCORE-5660</a>] -         Assertion type must match (elytron)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5682'>WFCORE-5682</a>] -         SE 17 tests fail when byteman is used
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5694'>WFCORE-5694</a>] -         RealmsTestCase fails on Mac
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5695'>WFCORE-5695</a>] -         The stdout and stderr streams are not wrapped in a logger for the bootable JAR
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5661'>WFCORE-5661</a>] -         Check emptiness with Collection.isEmpty()
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5675'>WFCORE-5675</a>] -         OperationTransformationTestCase fails when SE 17 is used
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5698'>WFCORE-5698</a>] -         &quot;StandardCharsets&quot; constants should be preferred
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5703'>WFCORE-5703</a>] -         Remove deprecated org.jboss.as.server.deployment.Attachments keys
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5677'>WFCORE-5677</a>] -         Upgrade Elytron Web to 1.10.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5692'>WFCORE-5692</a>] -         Upgrade WildFly Galleon plugins to 5.2.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5704'>WFCORE-5704</a>] -         Upgrade galleon plugins to 5.2.6.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5688'>WFCORE-5688</a>] -         Replace usages of getParameterTypes().length with getParameterCount()
</li>
</ul>
                                                                                                                        
</details>