### PR TITLE
[WFLY-15673] Upgrade jboss-openjdk-orb to 8.1.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
         <version.org.jboss.metadata>14.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.4.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.12.1.Final</version.org.jboss.narayana>
-        <version.org.jboss.openjdk-orb>8.1.5.Final</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>8.1.6.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>4.7.2.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
Upgrade in order to prepare for Jakarta transformation PR + fix of WFLY-15345