### PR TITLE
[WFLY-15676] The enable-microprofile.xml CLI script fails if dependencies are not already installed

### DIFF
--- a/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
@@ -5,6 +5,20 @@
 
 embed-server --server-config=${config:standalone.xml}
 
+if (outcome != success) of /subsystem=metrics:read-resource
+  /extension=org.wildfly.extension.metrics:add
+  /subsystem=metrics:add
+else
+  echo INFO: wildfly-metrics already in configuration, subsystem not added.
+end-if
+
+if (outcome != success) of /subsystem=health:read-resource
+  /extension=org.wildfly.extension.health:add
+  /subsystem=health:add
+else
+  echo INFO: wildfly-health already in configuration, subsystem not added.
+end-if
+
 if (outcome == success) of /subsystem=iiop-openjdk:read-resource
   /subsystem=iiop-openjdk:write-attribute(name=security, value=elytron)
 else 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15676

Add missing subsystems if needed