### PR TITLE
[WFLY-14919] Make credential store expression resolution usable for d…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/metadata/property/FunctionalResolverProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/property/FunctionalResolverProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.ee.metadata.property;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.metadata.property.CompositePropertyResolver;
+import org.jboss.metadata.property.SimpleExpressionResolver;
+
+/**
+ * Integrates any {@code Function<String, String>} instances
+ * {@link org.jboss.as.server.deployment.Attachments#DEPLOYMENT_EXPRESSION_RESOLVERS attached to the deployment unit}
+ * into the list used to compose the final deployment property replacer.
+ */
+public class FunctionalResolverProcessor implements DeploymentUnitProcessor {
+
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final List<Function<String, String>> functions = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.DEPLOYMENT_EXPRESSION_RESOLVERS);
+        if (functions != null) {
+            SimpleExpressionResolver[] sers = new SimpleExpressionResolver[functions.size()];
+            for (int i = 0; i < functions.size(); i++) {
+                Function<String, String> funct = functions.get(i);
+                sers[i] = expressionContent -> {
+                    String input = "${" + expressionContent + "}";
+                    String resolved = funct.apply(input);
+                    return resolved == null ? null : new SimpleExpressionResolver.ResolutionResult(resolved, false);
+                };
+            }
+            deploymentUnit.addToAttachmentList(Attachments.DEPLOYMENT_PROPERTY_RESOLVERS, new CompositePropertyResolver(sers));
+        }
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
@@ -63,6 +63,7 @@ import org.jboss.as.ee.managedbean.processors.ManagedBeanAnnotationProcessor;
 import org.jboss.as.ee.managedbean.processors.ManagedBeanSubDeploymentMarkingProcessor;
 import org.jboss.as.ee.metadata.property.DeploymentPropertiesProcessor;
 import org.jboss.as.ee.metadata.property.DeploymentPropertyResolverProcessor;
+import org.jboss.as.ee.metadata.property.FunctionalResolverProcessor;
 import org.jboss.as.ee.metadata.property.PropertyResolverProcessor;
 import org.jboss.as.ee.metadata.property.SystemPropertyResolverProcessor;
 import org.jboss.as.ee.naming.ApplicationContextProcessor;
@@ -163,8 +164,7 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_DEPLOYMENT_PROPERTIES, new DeploymentPropertiesProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_DEPLOYMENT_PROPERTY_RESOLVER, new DeploymentPropertyResolverProcessor());
-                // TODO - WFLY-14919 Add an encrypted expression resolver.
-                //processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_VAULT_PROPERTY_RESOLVER, new VaultPropertyResolverProcessor());
+                processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_FUNCTIONAL_RESOLVERS, new FunctionalResolverProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_SYSTEM_PROPERTY_RESOLVER, new SystemPropertyResolverProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_PROPERTY_RESOLVER, new PropertyResolverProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_REGISTER_JBOSS_ALL_EE_APP, new JBossAllXmlParserRegisteringProcessor<JBossAppMetaData>(AppJBossAllParser.ROOT_ELEMENT, AppJBossAllParser.ATTACHMENT_KEY, new AppJBossAllParser()));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/vaultedproperties/MDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/vaultedproperties/MDB.java
@@ -35,7 +35,7 @@ import javax.jms.TextMessage;
   * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
  */
 @MessageDriven(activationConfig = {
-        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = MDBWithVaultedPropertiesTestCase.CLEAR_TEXT_DESTINATION_LOOKUP)
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = MDBWithVaultedPropertiesTestCase.DEPLOYMENT_PROP_EXPRESSION)
 })
 public class MDB implements MessageListener {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/VaultedMessageProducer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/VaultedMessageProducer.java
@@ -39,7 +39,7 @@ public class VaultedMessageProducer {
 
     @Inject
     @JMSConnectionFactory("java:jboss/exported/jms/RemoteConnectionFactory")
-    @JMSPasswordCredential(userName = "guest", password = "guest")
+    @JMSPasswordCredential(userName = "${test.userName}", password = "${test.password}")
     private JMSContext context;
 
     public void sendToDestination(Destination destination, String text) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
@@ -92,8 +92,8 @@ import javax.jms.TopicConnectionFactory;
                 @JMSConnectionFactoryDefinition(
                         name="java:comp/env/myFactory5",
                         interfaceName = "javax.jms.QueueConnectionFactory",
-                        user = "guest",
-                        password = "guest"
+                        user = "${test.userName}",
+                        password = "${test.password}"
                 )
         }
 )

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
@@ -47,8 +47,8 @@
             </jms-connection-factory>
             <jms-connection-factory>
                 <name>java:app/myFactory6</name>
-                <user>guest</user>
-                <password>guest</password>
+                <user>${test.userName}</user>
+                <password>${test.password}</password>
             </jms-connection-factory>
             <jms-destination>
                 <description></description>

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/SecureExpressionUtil.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/SecureExpressionUtil.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+public final class SecureExpressionUtil {
+
+    public static final class SecureExpressionData extends org.jboss.as.test.shared.SecureExpressionUtil.SecureExpressionData {
+        private final String property;
+
+        public SecureExpressionData(String clearText, String property) {
+            super(clearText);
+            this.property = property;
+        }
+    }
+
+    public static void setupCredentialStoreExpressions(String storeName,
+                                                       SecureExpressionData... toConfigure) throws Exception {
+        org.jboss.as.test.shared.SecureExpressionUtil.setupCredentialStoreExpressions(storeName, toConfigure);
+    }
+
+    public static void setupCredentialStore(ManagementClient arquillianClient, String storeName, String storeLocation) throws Exception {
+        org.wildfly.core.testrunner.ManagementClient client = getCoreManagmentClient(arquillianClient);
+        org.jboss.as.test.shared.SecureExpressionUtil.setupCredentialStore(client, storeName, storeLocation);
+    }
+
+    public static void teardownCredentialStore(ManagementClient arquillianClient, String storeName, String storeLocation) throws Exception {
+
+        org.wildfly.core.testrunner.ManagementClient client = getCoreManagmentClient(arquillianClient);
+        org.jboss.as.test.shared.SecureExpressionUtil.teardownCredentialStore(client, storeName, storeLocation);
+    }
+
+    public static Asset getDeploymentPropertiesAsset(SecureExpressionData... expressions) {
+        StringBuilder builder = new StringBuilder("# Conversion of well known static properties to dynamic secure " +
+                "expressions calculated by " + SecureExpressionUtil.class.getSimpleName() + " during test setup\n");
+        if (expressions != null) {
+            for (SecureExpressionData expressionData : expressions) {
+                if (expressionData.property != null && !expressionData.property.isEmpty()) {
+                    builder.append(expressionData.property);
+                    builder.append('=');
+                    builder.append(expressionData.getExpression());
+                    builder.append('\n');
+                }
+            }
+        }
+        return new StringAsset(builder.toString());
+    }
+
+    public static Class[] getDeploymentClasses() {
+        return new Class[] { SecureExpressionUtil.class,
+                SecureExpressionData.class,
+                org.jboss.as.test.shared.SecureExpressionUtil.class,
+                org.jboss.as.test.shared.SecureExpressionUtil.SecureExpressionData.class
+        };
+    }
+
+    private static org.wildfly.core.testrunner.ManagementClient getCoreManagmentClient(ManagementClient arquillianClient) {
+        return new org.wildfly.core.testrunner.ManagementClient(arquillianClient.getControllerClient(), arquillianClient.getMgmtAddress(), arquillianClient.getMgmtPort(), arquillianClient.getMgmtProtocol());
+    }
+}


### PR DESCRIPTION
…eployment descriptors and annotations.

Restore use of expressions to deployment resources used by tests that formerly tested vault expressions. Use deployment property expressions, but have those deployment properties resolve to credential store expressions, which then recursively resolve to the clear text. This indirection via deployment property expressions avoids the need for the test dev to generate the needed secret keys and expressions when writing the test; they can be generated and added to the deployment's META-INF/jboss-properties as part of test setup during text execution.

https://issues.redhat.com/browse/WFLY-14919

Requires https://github.com/wildfly/wildfly-core/pull/4865 merged and integrated into full WildFly.