### PR TITLE
[WFLY-15717] Upgrade WildFly Core 18.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>18.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.9.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
WildFly Core 18.0.0.Beta3 is skipped as it introduced failures that were
fixed in https://issues.redhat.com/browse/WFCORE-5715

JIRA: https://issues.redhat.com/browse/WFLY-15717

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.0.0.Beta4
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.0.Beta2...18.0.0.Beta4

---

This supersedes #14905
