### PR TITLE
Fix for WFLY-15742, Upgrade bootable jar to 6.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.galleon-plugins>5.2.6.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.jar.plugin>5.0.2.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>6.1.1.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-15742
Upgrade diff: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/5.0.2.Final...6.1.1.Final
