### PR TITLE
[WFLY-15739] Set java.security.manager system property value to "allow" on JDK18+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10317,6 +10317,17 @@
             </properties>
         </profile>
         <profile>
+            <id>jdk18</id>
+            <activation>
+                <jdk>[18,)</jdk>
+            </activation>
+            <properties>
+                <modular.jdk.props>
+                    -Djava.security.manager=allow
+                </modular.jdk.props>
+            </properties>
+        </profile>
+        <profile>
             <id>docs</id>
             <activation>
                 <property>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15739

This PR replaces https://github.com/wildfly/wildfly/pull/14938 as the property is activated iff JDK18 and above is detected.