### PR TITLE
[WFLY-15757] Finish updating JCA Smoke / Basic tests to use Elytron c…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
@@ -64,7 +64,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -75,7 +74,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(NoRaAnnoTestCase.NoRaAnnoTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class NoRaAnnoTestCase {
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
@@ -63,7 +63,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,7 +73,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(RaAnnoTestCase.NoRaAnnoTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class RaAnnoTestCase {
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment10TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment10TestCase.java
@@ -40,7 +40,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,7 +50,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment10TestCase.BasicDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDeployment10TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment15TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment15TestCase.java
@@ -41,7 +41,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment15TestCase.BasicDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDeployment15TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment16TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment16TestCase.java
@@ -41,7 +41,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment16TestCase.BasicDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDeployment16TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
@@ -41,7 +41,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment17TestCase.BasicDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDeployment17TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeployment16TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeployment16TestCase.java
@@ -41,7 +41,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeployment16TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDoubleDeployment16TestCase {
 
     // deployment archive name must match "archive" element.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_1TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_1TestCase.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeploymentFail16_1TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDoubleDeploymentFail16_1TestCase {
 
     // deployment archive name must match "archive" element.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_2TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_2TestCase.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeploymentFail16_2TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update for lack of legacy security.")
 public class BasicDoubleDeploymentFail16_2TestCase {
 
     // deployment archive name must match "archive" element.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
@@ -71,7 +71,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -83,7 +82,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(ResourceAdapterCapacityPoliciesTestCase.ResourceAdapterCapacityPoliciesServerSetupTask.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class ResourceAdapterCapacityPoliciesTestCase extends JcaMgmtBase {
     private static final String RA_NAME = "capacity-policies-test.rar";
     private static final ModelNode RA_ADDRESS = new ModelNode().add(SUBSYSTEM, "resource-adapters")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/RaCfgMetricUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/RaCfgMetricUnitTestCase.java
@@ -36,7 +36,6 @@ import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,7 +46,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class RaCfgMetricUnitTestCase extends JCAMetrictsTestBase {
 
     public static void setBaseAddress(String rar) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicFlatTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class BasicFlatTestCase extends AbstractModuleDeploymentTestCase {
 
     private final String cf = "java:/testMeRA";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicJarTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.jca.moduledeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
-//import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class BasicJarTestCase extends BasicFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationFlatTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultiActivationFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class MultiActivationFlatTestCase extends
         AbstractModuleDeploymentTestCase {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationJarTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.jca.moduledeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
-//import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultiActivationJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class MultiActivationJarTestCase extends MultiActivationFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationFlatTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultiObjectActivationFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class MultiObjectActivationFlatTestCase extends
         AbstractModuleDeploymentTestCase {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationJarTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.jca.moduledeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
-//import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultiObjectActivationJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class MultiObjectActivationJarTestCase extends MultiObjectActivationFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationFlatTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PartialObjectActivationFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class PartialObjectActivationFlatTestCase extends
         AbstractModuleDeploymentTestCase {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationJarTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.jca.moduledeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
-//import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PartialObjectActivationJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class PartialObjectActivationJarTestCase extends PartialObjectActivationFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureFlatTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PureFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class PureFlatTestCase extends AbstractModuleDeploymentTestCase {
 
     private final String cf = "java:/testMeRA";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureJarTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.jca.moduledeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
-//import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 
@@ -46,7 +45,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PureJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class PureJarTestCase extends PureFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,7 +54,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(TwoModulesFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class TwoModulesFlatTestCase extends TwoRaFlatTestCase {
 
     static class ModuleAcDeploymentTestCaseSetup extends AbstractModuleDeploymentTestCaseSetup {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(TwoModulesJarTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class TwoModulesJarTestCase extends TwoModulesFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(TwoModulesOfDifferentTypeTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class TwoModulesOfDifferentTypeTestCase extends TwoModulesFlatTestCase {
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaFlatTestCase.java
@@ -34,7 +34,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,7 +59,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(TwoRaFlatTestCase.ModuleAcDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class TwoRaFlatTestCase extends AbstractModuleDeploymentTestCase {
 
     protected final String cf = "java:/testMeRA";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaJarTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.dmr.ModelNode;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(TwoRaJarTestCase.ModuleAcDeploymentTestCaseSetup1.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class TwoRaJarTestCase extends TwoRaFlatTestCase {
 
     static class ModuleAcDeploymentTestCaseSetup1 extends AbstractModuleDeploymentTestCaseSetup {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -69,7 +69,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -80,7 +79,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(ResourceAdapterPoolAttributesTestCase.ResourceAdapterCapacityPoliciesServerSetupTask.class)
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
     private static final String RA_NAME = "pool-attributes-test.rar";
     private static final ModelNode RA_ADDRESS = new ModelNode().add(SUBSYSTEM, "resource-adapters")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Assert;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
@@ -63,7 +62,6 @@ import org.wildfly.test.security.common.elytron.SimpleAuthContext;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({WildFlyActivationRaWithElytronAuthContextTestCase.ElytronSetup.class, WildFlyActivationRaWithElytronAuthContextTestCase.RaSetup.class})
-//@Ignore("[WFLY-15249] Deployment failure needs correcting once legacy security is removed.")
 public class WildFlyActivationRaWithElytronAuthContextTestCase {
 
     private static final String AUTH_CONFIG = "MyAuthConfig";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ResourceAdapterStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ResourceAdapterStatisticsTestCase.java
@@ -39,7 +39,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.After;
 import org.junit.AfterClass;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,7 +49,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//@Ignore("[WFLY-15249] Deployments need to handle lack of legacy security.")
 public class ResourceAdapterStatisticsTestCase extends JcaStatisticsBase {
 
     static int jndiCount = 0;

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/afterresourcecreation/AfterResourceCreationDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/afterresourcecreation/AfterResourceCreationDeploymentTestCase.java
@@ -45,7 +45,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +56,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(AfterResourceCreationDeploymentTestCase.AfterResourceCreationDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class AfterResourceCreationDeploymentTestCase extends ContainerResourceMgmtTestBase {
 
     static String deploymentName = "basic-after.rar";

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,7 +53,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(ConfigPropertyTestCase.ConfigPropertyTestClassSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class ConfigPropertyTestCase {
 
     /**

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,7 +52,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(EarPackagedDeploymentTestCase.EarPackagedDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class EarPackagedDeploymentTestCase {
 
     static class EarPackagedDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
@@ -44,7 +44,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,7 +54,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleActivationTestCase.MultipleActivationTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class MultipleActivationTestCase {
 
     static class MultipleActivationTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
@@ -45,7 +45,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,7 +55,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleObjectActivationTestCase.MultipleObjectActivationTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class MultipleObjectActivationTestCase {
 
     static class MultipleObjectActivationTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,7 +53,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleObjectPartialActivationTestCase.MultipleObjectPartialActivationTestCaseSetup.class)
-@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class MultipleObjectPartialActivationTestCase {
 
     static class MultipleObjectPartialActivationTestCaseSetup extends AbstractMgmtServerSetupTask {

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,7 +53,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(RaTestConnectionTestCase.RaTestConnectionTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class RaTestConnectionTestCase extends ContainerResourceMgmtTestBase {
     private static ModelNode address;
     private static String deploymentName = "testcon_mult.rar";

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
@@ -47,7 +47,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-//import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,7 +58,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(ReDeploymentTestCase.ReDeploymentTestCaseSetup.class)
-//@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class ReDeploymentTestCase extends ContainerResourceMgmtTestBase {
 
     static String deploymentName = "re-deployment.rar";

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java
@@ -52,7 +52,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -64,7 +63,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("[WFLY-15249] Update test to use an Elytron configuration.")
 public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmtTestBase {
     private static final Deque<ModelNode> REMOVE_ADDRESSES = new LinkedList<>();
 
@@ -116,11 +114,6 @@ public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmt
     }
 
     @Test
-    public void addComplexResourceAdapterWithAppSecurity_SecurityDomainRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.APPLICATION, ConnectionSecurityType.SECURITY_DOMAIN);
-    }
-
-    @Test
     public void addComplexResourceAdapterWithAppSecurity_ElytronRecovery() throws Exception {
         complexResourceAdapterAddTest(ConnectionSecurityType.APPLICATION, ConnectionSecurityType.ELYTRON);
     }
@@ -128,60 +121,6 @@ public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmt
     @Test
     public void addComplexResourceAdapterWithAppSecurity_ElytronAuthCtxtRecovery() throws Exception {
         complexResourceAdapterAddTest(ConnectionSecurityType.APPLICATION, ConnectionSecurityType.ELYTRON_AUTHENTICATION_CONTEXT);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomain() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN, ConnectionSecurityType.SECURITY_DOMAIN);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomain_NoRecoverySec() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN, null);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomain_UserPassRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN, ConnectionSecurityType.USER_PASSWORD);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomain_ElytronRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN, ConnectionSecurityType.ELYTRON);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomain_ElytronAuthCtxtRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN, ConnectionSecurityType.ELYTRON_AUTHENTICATION_CONTEXT);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomainAndApp() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN_AND_APPLICATION, null);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomainAndApp_UserPassRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN_AND_APPLICATION,
-                ConnectionSecurityType.USER_PASSWORD);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomainAndApp_SecurityDomainRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN_AND_APPLICATION,
-                ConnectionSecurityType.SECURITY_DOMAIN);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomainAndApp_ElytronRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN_AND_APPLICATION,
-                ConnectionSecurityType.ELYTRON);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithSecurityDomainAndApp_ElytronAuthCtxtRecovery() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.SECURITY_DOMAIN_AND_APPLICATION,
-                ConnectionSecurityType.ELYTRON_AUTHENTICATION_CONTEXT);
     }
 
     @Test
@@ -197,11 +136,6 @@ public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmt
     @Test
     public void addComplexResourceAdapterWithElytron_UserPassRecoverySec() throws Exception {
         complexResourceAdapterAddTest(ConnectionSecurityType.ELYTRON, ConnectionSecurityType.USER_PASSWORD);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithElytron_SecurityDomainRecoverySec() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.ELYTRON, ConnectionSecurityType.SECURITY_DOMAIN);
     }
 
     @Test
@@ -223,11 +157,6 @@ public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmt
     @Test
     public void addComplexResourceAdapterWithElytronAuthCtxt_UserPassRecoverySec() throws Exception {
         complexResourceAdapterAddTest(ConnectionSecurityType.ELYTRON_AUTHENTICATION_CONTEXT, ConnectionSecurityType.USER_PASSWORD);
-    }
-
-    @Test
-    public void addComplexResourceAdapterWithElytronAuthCtxt_SecurityDomainRecoverySec() throws Exception {
-        complexResourceAdapterAddTest(ConnectionSecurityType.ELYTRON_AUTHENTICATION_CONTEXT, ConnectionSecurityType.SECURITY_DOMAIN);
     }
 
     @Test
@@ -376,11 +305,10 @@ public class ResourceAdapterOperationsUnitTestCase extends ContainerResourceMgmt
         execute(client, op);
     }
 
-    private static ModelNode execute(final ModelControllerClient client, final ModelNode op) throws IOException {
+    private static void execute(final ModelControllerClient client, final ModelNode op) throws IOException {
         final ModelNode result = client.execute(op);
         if (!Operations.isSuccessfulOutcome(result)) {
             throw new RuntimeException(Operations.getFailureDescription(result).asString());
         }
-        return result;
     }
 }


### PR DESCRIPTION
…onfiguration

Remove ResourceAdapterOperationsUnitTestCase test methods that are testing permutations involving no-longer supported connection security types

Remove unneeded @Ignore from MultipleObjectPartialActivationTestCase

Remove commented out @Ignore statements that reference WFLY-15249

https://issues.redhat.com/browse/WFLY-15757