### PR TITLE
[WFLY-15779] Upgrade WildFly HTTP Client to 1.1.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>18.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.9.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron>1.17.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-15779


        Release Notes - WildFly EJB HTTP Client - Version 1.1.10.Final
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-65'>WEJBHTTP-65</a>] -         PoolAuthenticationContext incompatible with Elytron Web 1.9.2.Final
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-63'>WEJBHTTP-63</a>] -         Add README to WFLY HTTP Client
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-68'>WEJBHTTP-68</a>] -         Upgrade Elytron Web to 1.9.2.Final
</li>
</ul>
                                                                                                                            