### PR TITLE
[WFLY-15752] Fix incorrect generation of license files

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -333,32 +333,10 @@
                                 <licensesConfigFile>${basedir}/target/resources/license/servlet-feature-pack-common-licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${basedir}/target/resources/license/ee-feature-pack-common-licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${basedir}/target/resources/license/preview-feature-pack-licenses.xml</licensesConfigFile>
+                                <licensesConfigFile>${basedir}/target/resources/license/elytron-oidc-feature-pack-licenses.xml</licensesConfigFile>
+                                <licensesConfigFile>${basedir}/target/resources/license/microprofile-feature-pack-licenses.xml</licensesConfigFile>
                             </licensesConfigFiles>
-                            <licensesOutputFile>${license.directory}/full-feature-pack-licenses.xml</licensesOutputFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>update-licenses-xml-mp</id>
-                        <goals>
-                            <goal>insert-versions</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
-                            <licensesConfigFile>${basedir}/target/resources/license/microprofile-feature-pack-licenses.xml</licensesConfigFile>
                             <licensesOutputFile>${license.directory}/microprofile-feature-pack-licenses.xml</licensesOutputFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>update-licenses-xml-oidc</id>
-                        <goals>
-                            <goal>insert-versions</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
-                            <licensesConfigFile>${basedir}/target/resources/license/elytron-oidc-client-feature-pack-licenses.xml</licensesConfigFile>
-                            <licensesOutputFile>${license.directory}/elytron-oidc-client-feature-pack-licenses.xml</licensesOutputFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -162,20 +162,8 @@
                         <configuration>
                             <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                             <licensesConfigFile>${feature-pack.license.directory}/microprofile-feature-pack-licenses.xml</licensesConfigFile>
+                            <licensesConfigFile>${oidc.feature-pack.license.directory}/elytron-oidc-feature-pack-licenses.xml</licensesConfigFile>
                             <licensesOutputFile>${license.directory}/microprofile-feature-pack-licenses.xml</licensesOutputFile>
-                            <excludedArtifacts>wildfly-ee-galleon-pack|wildfly-feature-pack-galleon-content</excludedArtifacts>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>update-licenses-xml-oidc</id>
-                        <goals>
-                            <goal>insert-versions</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
-                            <licensesConfigFile>${oidc.feature-pack.license.directory}/elytron-oidc-client-feature-pack-licenses.xml</licensesConfigFile>
-                            <licensesOutputFile>${license.directory}/elytron-oidc-client-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedArtifacts>wildfly-ee-galleon-pack|wildfly-feature-pack-galleon-content</excludedArtifacts>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-15752

Per Jira discussions, this PR does:
* Ensure we have only one license plugin execution to insert the license versions per feature fack.
* For Galleon Pack, OIDC license entries are now combined with the MicroProfile to produce `microprofile-feature-pack-licenses.xml`
* For WildFly preview, we no longer produce a `full-feature-pack-licenses.xml`
