### PR TITLE
[WFLY-15807] Upgrade to WildFly Core 18.0.0.Final

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -51,7 +51,6 @@
         <!-- WildFly Preview vs standard WildFly GAV expression properties. -->
         <module.jakarta.classifier>::jakarta</module.jakarta.classifier>
         <module.jakarta.suffix>-jakarta</module.jakarta.suffix>
-        <version.io.undertow>2.2.14.Final</version.io.undertow> <!-- TODO: eliminate this line when proper Undertow version will be available via WildFly Core upgrade -->
     </properties>
 
     <build>
@@ -902,14 +901,12 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet-jakarta</artifactId>
-            <version>${version.io.undertow}</version> <!-- TODO: eliminate this line when proper Undertow version will be available via WildFly Core upgrade -->
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-websockets-jsr-jakarta</artifactId>
-            <version>${version.io.undertow}</version> <!-- TODO: eliminate this line when proper Undertow version will be available via WildFly Core upgrade -->
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>18.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
* in ee-9/feature-pack/pom.xml, reverted the temporary overriding of
  Undertow from WFLY-15786 & WFLY-15787

JIRA: https://issues.redhat.com/browse/WFLY-15807

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.0.0.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.0.Beta5...18.0.0.Final

---

<details>
<summary>
        Release Notes - WildFly Core - Version 18.0.0.Final</summary>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5651'>WFCORE-5651</a>] -         Wrong identity returned for whoami operation
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5726'>WFCORE-5726</a>] -         CLI client shaded JAR doesn&#39;t aggregate services
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5732'>WFCORE-5732</a>] -         Missing modular options in bootable JAR manifest
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5708'>WFCORE-5708</a>] -         Add a new module for the Elytron stateful BASIC mechanism.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5712'>WFCORE-5712</a>] -         Update elytron-tool scripts to make use of jboss-modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5720'>WFCORE-5720</a>] -         Add org.apache.commons.cli and org.apache.commons.lang3 modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5730'>WFCORE-5730</a>] -         Un-ignore org.wildfly.scripts.test.ElytronToolScriptTestCase
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5731'>WFCORE-5731</a>] -         Upgrade Elytron Web to 1.10.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5733'>WFCORE-5733</a>] -         Upgrade to Undertow 2.2.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5741'>WFCORE-5741</a>] -         Upgrade WildFly Elytron to 1.18.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5742'>WFCORE-5742</a>] -         Upgrade WildFly Galleon Plugins to 5.2.7.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5743'>WFCORE-5743</a>] -         Upgrade log4j to 2.15.0
</li>
</ul>
                                                                                                                            
</details>