### PR TITLE
[WFLY-15824] Remove unnecessary resteasy-client-microprofile dependen…

### DIFF
--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -624,12 +624,6 @@
                     <scope>system</scope>
                     <systemPath>${project.basedir}/../../../../ee-9/dist/target/wildfly-preview-${project.version}/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/microprofile-rest-client-base-${version.org.jboss.resteasy.microprofile}-ee9.jar</systemPath>
                 </dependency>
-                <dependency>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-client-microprofile</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${project.basedir}/../../../../ee-9/dist/target/wildfly-preview-${project.version}/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/microprofile-rest-client-${version.org.jboss.resteasy.microprofile}.jar</systemPath>
-                </dependency>
             </dependencies>
         </profile>
 


### PR DESCRIPTION
…cy from rest-client TCK EE9 execution

https://issues.redhat.com/browse/WFLY-15824