### PR TITLE
[WFLY-15830] Update HostExcludesTestCase configuration to work with WF27

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -87,7 +87,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
     private static final  BiFunction<Set<String>, Set<String>, Set<String>> diff = (a, b) -> a.stream().filter(e -> !b.contains(e)).collect(Collectors.toSet());
     private final boolean isEeGalleonPack = "ee-".equals(System.getProperty("testsuite.default.build.project.prefix"));
 
-    private static final String MAJOR = "26.";
+    private static final String MAJOR = "27.";
 
     /**
      * Maintains the list of expected extensions for each host-exclude name for previous releases.
@@ -191,13 +191,14 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.wildfly.extension.elytron-oidc-client",
                 "org.wildfly.extension.opentelemetry"
         )),
-        // If an extension is added to this enum, also check if it is supplied only by wildfly-galleon-pack. If so, add it also
-        // to the internal mpExtensions Set defined on this class.
-        CURRENT(MAJOR, WILDFLY_25_0, null, Arrays.asList(
+        WILDFLY_26_0("WildFly26.0", WILDFLY_25_0, null, Arrays.asList(
                 "org.jboss.as.cmp",
                 "org.jboss.as.jaxr",
                 "org.jboss.as.configadmin"
-        ));
+        )),
+        // If an extension is added to this enum, also check if it is supplied only by wildfly-galleon-pack. If so, add it also
+        // to the internal mpExtensions Set defined on this class.
+        CURRENT(MAJOR, WILDFLY_26_0);
 
         private final String name;
         private final Set<String> extensions = new HashSet<>();


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-15830

Hello @bstansberry / @darranl 

We have removed some extensions during the WF26 development cycle, the `HostExcludesTestCase` tracks those forcing us to re-create an additional enum in the test case itself when we move forward to the next release. 

This commit will be necessary after creating the WF26 release, so I'm adding it here in case you want to cherry-pick it as soon as you open the main branch to WF27 development, then you can immediately close this PR. Otherwise, I'll rebase this and convert it to a real PR once we get the main branch open to WF27 development.