### PR TITLE
[WFLY-15776] Remove management identity's default security domain configuration from testsuite

### DIFF
--- a/testsuite/integration/elytron/enable-elytron.cli
+++ b/testsuite/integration/elytron/enable-elytron.cli
@@ -5,6 +5,4 @@ embed-server --admin-only=true --server-config=standalone-full.xml
 /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
 /subsystem=iiop-openjdk:write-attribute(name=security, value=elytron)
 
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
-
 stop-embedded-server

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -8,7 +8,6 @@
         <extension module="org.wildfly.extension.elytron"/>
     </extensions>
     <management>
-        <identity security-domain="ManagementDomain"/>
         <audit-log>
             <formatters>
                 <json-formatter name="json-formatter"/>

--- a/testsuite/shared/enable-elytron-manualmode.cli
+++ b/testsuite/shared/enable-elytron-manualmode.cli
@@ -12,7 +12,6 @@ echo "Configuring standalone.xml"
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
 
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
 /core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
 /core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
 
@@ -33,7 +32,6 @@ echo "Configuring standalone-full.xml"
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
 
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
 /core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
 /core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
 
@@ -53,7 +51,6 @@ echo "Configuring standalone-full-ha.xml"
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
 
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
 /core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
 /core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
 

--- a/testsuite/shared/enable-elytron.cli
+++ b/testsuite/shared/enable-elytron.cli
@@ -5,8 +5,6 @@ embed-server --server-config=standalone.xml
 
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
 
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
-
 stop-embedded-server
 
 
@@ -19,7 +17,5 @@ embed-server --server-config=standalone-full.xml
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
 /subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
 /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
-
-/core-service=management/access=identity:add(security-domain=ManagementDomain)
 
 stop-embedded-server


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15776 