### PR TITLE
 [WFLY-15832] Ability to create ConfigSource root directory in MP Config subsystem.

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
@@ -68,7 +68,7 @@ This results in the XML configuration:
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
     <config-source name="file-props">
         <dir path="/etc/config/numbers-app"/>
     </config-source>
@@ -95,6 +95,82 @@ int numMax; // <2>
 This corresponds to the layout used by https://docs.openshift.com/enterprise/3.2/dev_guide/configmaps.html[OpenShift ConfigMaps].
 The `dir` value corresponds to the `mountPath` in the ConfigMap definition in OpenShift or Kubernetes.
 
+==== ConfigSources from Root directory
+You can also point to a root directory by adjusting the examples in the preceding section to include
+`root=true` when defining them. Top level directories within this root directory each become an
+individual `ConfigSource` reading from a directory similar to what we saw earlier in
+<<configsource-from-directory, ConfigSource from Directory>>. Any directories below the top-level
+directories are ignored. Also, any files in the root directory are ignored; only files in the top
+level directories within the root directory will be used for the configuration.
+
+This is especially useful when running on OpenShift where constructs such as `ConfigMap` and
+`ServiceBinding` instances get mapped under
+a common known location. For example if there are two `ConfigMap` instances (for this example,
+we will call them `map-a`, and `map-b`) used by your application pod, they will
+each get mapped under `/etc/config`. So you would have `/etc/config/map-a` and `/etc/config/map-b`
+directories.
+
+Each of these directories will have files where the file name is the name of the property and the file
+content is the value of the property, like we saw earlier.
+
+We can thus simply run the following CLI command to pick up all these child directories as
+a `ConfigSource` each:
+[source,options="nowrap"]
+----
+/subsystem=microprofile-config-smallrye/config-source=config-map-root:add(dir={path=/etc/config, root=true})
+----
+
+This results in the XML configuration:
+
+[source,xml,options="nowrap"]
+----
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
+    <config-source name="config-map-root">
+        <dir path="/etc/config" root="true"/>
+    </config-source>
+</subsystem>
+----
+Assuming the `/etc/config` directory contains the `map-a` and `map-b` directories we are using
+for this example, the above is analogous to doing:
+----
+/subsystem=microprofile-config-smallrye/config-source=file-props:add(dir={path=/etc/config/map-a})
+/subsystem=microprofile-config-smallrye/config-source=file-props:add(dir={path=/etc/config/map-b})
+----
+Specifying the root directory rather than each individual directory removes the need to know the
+exact names of each entry under the common parent directory (this is especially useful in some
+OpenShift scenarios where the names of these directories are auto-generated).
+
+The situation where two `ConfigSource` entries under the same root both contain the same property
+should be avoided. However, to make this situation deterministic, the directories representing each
+`ConfigSource` are sorted by their name according to standard Java sorting rules before doing the
+lookup of values. To make this more concrete, if we have the following entries:
+* `/etc/config/map-a/name` contains `kabir`
+* `/etc/config/map-b/name` contains `jeff`
+
+Since `map-a` will come before `map-b` after sorting, in the following scenario `kabir` (coming from
+`map-a`) will be injected for the following `username` field:
+
+[source,java,options="nowrap"]
+----
+@Inject
+@ConfigProperty(name = "name")
+String username;
+----
+
+
+You may override this default sorting by including a file called `config_ordinal` in a directory. The
+ordinal specified in that file will be used for config values coming from that directory. Building
+on our previous example, if we had:
+* `/etc/config/map-a/config_ordinal` contains `120`
+* `/etc/config/map-b/config_ordinal` contains `140`
+
+Since now `map-b` has a higher ordinal (`140`) than `map-a` (`120`), we will instead inject the value
+`jeff` for the earlier `username` field.
+
+If there is no `config_ordinal` file in a top-level directory under the root directory, the
+ordinal used when specifying the `ConfigSource` will be used for that directory.
+
+
 === ConfigSource from Class
 
 You can create a specific type of `ConfigSource` implementation by creating a `config-source` resource
@@ -111,7 +187,7 @@ This results in the XML configuration:
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
     <config-source name="my-config-source">
         <class name="org.example.MyConfigSource" module="org.example"/>
     </config-source>
@@ -136,7 +212,7 @@ This results in the XML configuration:
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
     <config-source-provider name="my-config-source-provider">
          <class name="org.example.MyConfigSourceProvider" module="org.example"/>
     </config-source-provider>

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ClassConfigSourceRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ClassConfigSourceRegistrationService.java
@@ -48,7 +48,7 @@ class ClassConfigSourceRegistrationService implements Service {
         this.sources = sources;
     }
 
-    static void install(OperationContext context, String name, ConfigSource configSource, Registry registry) {
+    static void install(OperationContext context, String name, ConfigSource configSource, Registry<ConfigSource> registry) {
         ServiceBuilder<?> builder = context.getServiceTarget()
                 .addService(ServiceNames.CONFIG_SOURCE.append(name));
 

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderRegistrationService.java
@@ -18,7 +18,7 @@ public class ConfigSourceProviderRegistrationService implements Service {
         this.sources = sources;
     }
 
-    static void install(OperationContext context, String name, ConfigSourceProvider configSourceProvider, Registry registry) {
+    static void install(OperationContext context, String name, ConfigSourceProvider configSourceProvider, Registry<ConfigSourceProvider> registry) {
         context.getServiceTarget()
                 .addService(ServiceNames.CONFIG_SOURCE_PROVIDER.append(name))
                 .setInstance(new ConfigSourceProviderRegistrationService(name, configSourceProvider, registry))

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceRootRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceRootRegistrationService.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.config.smallrye;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.services.path.AbsolutePathService;
+import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.extension.microprofile.config.smallrye._private.MicroProfileConfigLogger;
+
+import io.smallrye.config.source.file.FileSystemConfigSource;
+
+/**
+ * Service to register a ConfigSourceProvider for a root directory, creating a FileSystemConfigSource for each directory
+ * under the given location.
+ *
+ * @author Kabir Khan
+ */
+class ConfigSourceRootRegistrationService implements Service {
+
+    private final String name;
+    private final String path;
+    /**
+     * Can be null
+     */
+    private final String relativeTo;
+    private final int ordinal;
+    private final Supplier<PathManager> pathManager;
+    private final Registry<ConfigSourceProvider> providerRegistry;
+
+    private ConfigSourceRootRegistrationService(String name, String path, String relativeTo, int ordinal, Supplier<PathManager> pathManager, Registry<ConfigSourceProvider> sources) {
+        this.name = name;
+        this.path = path;
+        this.relativeTo = relativeTo;
+        this.ordinal = ordinal;
+        this.pathManager = pathManager;
+        this.providerRegistry = sources;
+    }
+
+    static void install(OperationContext context, String name, String path, String relativeTo, int ordinal, Registry<ConfigSourceProvider> registry) {
+        ServiceBuilder<?> builder = context.getServiceTarget()
+                .addService(ServiceNames.CONFIG_SOURCE_ROOT.append(name));
+        Supplier<PathManager> pathManager = builder.requires(context.getCapabilityServiceName("org.wildfly.management.path-manager", PathManager.class));
+
+        builder.setInstance(new ConfigSourceRootRegistrationService(name, path, relativeTo, ordinal, pathManager, registry))
+                .install();
+    }
+
+    @Override
+    public void start(StartContext startContext) {
+        String relativeToPath = AbsolutePathService.isAbsoluteUnixOrWindowsPath(path) ? null  : relativeTo;
+        String dirPath = pathManager.get().resolveRelativePathEntry(path, relativeToPath);
+        File dir = new File(dirPath);
+        MicroProfileConfigLogger.ROOT_LOGGER.loadConfigSourceRootFromDir(dir.getAbsolutePath());
+        this.providerRegistry.register(this.name, new RootDirectoryConfigSourceProvider(name, dir, ordinal));
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.providerRegistry.unregister(this.name);
+    }
+
+    private static class RootDirectoryConfigSourceProvider implements ConfigSourceProvider {
+        private final String name;
+        private final File rootDirectory;
+        private int ordinal;
+
+        public RootDirectoryConfigSourceProvider(String name, File rootDirectory, int ordinal) {
+            this.name = name;
+            this.rootDirectory = rootDirectory;
+            this.ordinal = ordinal;
+        }
+
+        @Override
+        public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+            TreeMap<String, ConfigSource> map = new TreeMap<>();
+            File[] files = rootDirectory.listFiles();
+            List<String> configSourceDirs = new ArrayList<>();
+            if (files != null) {
+                // If the directory exist, this will be an empty list
+                for (File file : rootDirectory.listFiles()) {
+                    if (file.isDirectory()) {
+                        map.put(file.getName(), new FileSystemConfigSource(file, ordinal));
+                        configSourceDirs.add(file.getAbsolutePath());
+                    }
+                }
+            }
+            MicroProfileConfigLogger.ROOT_LOGGER.logDirectoriesUnderConfigSourceRoot(name, configSourceDirs);
+            return map.values();
+        }
+    }
+
+}

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigExtension.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigExtension.java
@@ -35,7 +35,9 @@ import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.staxmapper.XMLElementWriter;
 
 
 /**
@@ -56,9 +58,12 @@ public class MicroProfileConfigExtension implements Extension {
 
     protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
     protected static final ModelVersion VERSION_1_1_0 = ModelVersion.create(1, 1, 0);
-    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_1_1_0;
+    protected static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_2_0_0;
 
-    private static final MicroProfileConfigSubsystemParser_1_0 CURRENT_PARSER = new MicroProfileConfigSubsystemParser_1_0();
+    private static final MicroProfileConfigSubsystemParser_1_0 PARSER_1_0 = new MicroProfileConfigSubsystemParser_1_0();
+    private static final MicroProfileConfigSubsystemParser_2_0 PARSER_2_0 = new MicroProfileConfigSubsystemParser_2_0();
+    private static final XMLElementWriter<SubsystemMarshallingContext> CURRENT_WRITER = PARSER_2_0;
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {
         return getResourceDescriptionResolver(true, keyPrefix);
@@ -78,7 +83,7 @@ public class MicroProfileConfigExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
-        subsystem.registerXMLElementWriter(CURRENT_PARSER);
+        subsystem.registerXMLElementWriter(CURRENT_WRITER);
 
         IterableRegistry<ConfigSourceProvider> providers = new IterableRegistry<>();
         IterableRegistry<ConfigSource> sources = new IterableRegistry<>();
@@ -86,13 +91,14 @@ public class MicroProfileConfigExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new MicroProfileSubsystemDefinition(providers, sources));
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        registration.registerSubModel(new ConfigSourceDefinition(sources));
+        registration.registerSubModel(new ConfigSourceDefinition(providers, sources));
         registration.registerSubModel(new ConfigSourceProviderDefinition(providers));
     }
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileConfigSubsystemParser_1_0.NAMESPACE, CURRENT_PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileConfigSubsystemParser_1_0.NAMESPACE, PARSER_1_0);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileConfigSubsystemParser_2_0.NAMESPACE, PARSER_2_0);
     }
 
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemParser_2_0.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemParser_2_0.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2017, Red Hat, Inc., and individual contributors
+ * Copyright 2021, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -27,14 +27,11 @@ import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 
-/**
- * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
- */
-class MicroProfileConfigSubsystemParser_1_0 extends PersistentResourceXMLParser {
+class MicroProfileConfigSubsystemParser_2_0 extends PersistentResourceXMLParser {
     /**
      * The name space used for the {@code subsystem} element
      */
-    public static final String NAMESPACE = "urn:wildfly:microprofile-config-smallrye:1.0";
+    public static final String NAMESPACE = "urn:wildfly:microprofile-config-smallrye:2.0";
 
     private static final PersistentResourceXMLDescription xmlDescription;
 
@@ -45,7 +42,7 @@ class MicroProfileConfigSubsystemParser_1_0 extends PersistentResourceXMLParser 
                                 ConfigSourceDefinition.ORDINAL,
                                 ConfigSourceDefinition.PROPERTIES,
                                 ConfigSourceDefinition.CLASS,
-                                ConfigSourceDefinition.DIR_1_0))
+                                ConfigSourceDefinition.DIR))
                 .addChild(builder(MicroProfileConfigExtension.CONFIG_SOURCE_PROVIDER_PATH)
                         .addAttributes(
                                 ConfigSourceProviderDefinition.CLASS))

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigTransformers.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigTransformers.java
@@ -24,12 +24,20 @@ package org.wildfly.extension.microprofile.config.smallrye;
 
 import static org.jboss.as.controller.transform.description.RejectAttributeChecker.SIMPLE_EXPRESSIONS;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
 import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices
@@ -44,13 +52,38 @@ public class MicroProfileConfigTransformers implements ExtensionTransformerRegis
         ChainedTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
 
         registerTransformers_WildFly_20(builder.createBuilder(MicroProfileConfigExtension.VERSION_1_1_0, MicroProfileConfigExtension.VERSION_1_0_0));
+        registerTransformers_WildFly_26(builder.createBuilder(MicroProfileConfigExtension.VERSION_2_0_0, MicroProfileConfigExtension.VERSION_1_1_0));
 
-        builder.buildAndRegister(registration, new ModelVersion[] { MicroProfileConfigExtension.VERSION_1_0_0});
+        builder.buildAndRegister(registration, new ModelVersion[] { MicroProfileConfigExtension.VERSION_1_1_0, MicroProfileConfigExtension.VERSION_1_0_0});
     }
 
     private void registerTransformers_WildFly_20(ResourceTransformationDescriptionBuilder builder) {
         // reject the ordinal attribute onf a config-source if it holds an expression
        builder.addChildResource(MicroProfileConfigExtension.CONFIG_SOURCE_PATH).getAttributeBuilder()
                 .addRejectCheck(SIMPLE_EXPRESSIONS, ConfigSourceDefinition.ORDINAL);
+    }
+
+    private void registerTransformers_WildFly_26(ResourceTransformationDescriptionBuilder builder) {
+        Map<String, RejectAttributeChecker> checkers = new HashMap<>();
+        checkers.put(ConfigSourceDefinition.ROOT.getName(), new RejectAttributeChecker.SimpleAcceptAttributeChecker(ModelNode.FALSE) {
+            @Override
+            protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
+                if (!attributeValue.hasDefined(ConfigSourceDefinition.ROOT.getName())) {
+                    return false;
+                }
+                return super.rejectAttribute(address, attributeName, attributeValue, context);
+            }
+        });
+
+        builder.addChildResource(MicroProfileConfigExtension.CONFIG_SOURCE_PATH).getAttributeBuilder()
+                .addRejectCheck(new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(checkers), ConfigSourceDefinition.DIR)
+                .setValueConverter(new AttributeConverter.DefaultAttributeConverter() {
+                    @Override
+                    protected void convertAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
+                        if (attributeValue.hasDefined(ConfigSourceDefinition.ROOT.getName())) {
+                            attributeValue.remove(ConfigSourceDefinition.ROOT.getName());
+                        }
+                    }
+                }, ConfigSourceDefinition.DIR);
     }
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ServiceNames.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ServiceNames.java
@@ -35,4 +35,7 @@ public interface ServiceNames {
     ServiceName CONFIG_SOURCE = MICROPROFILE_CONFIG.append("config-source");
 
     ServiceName CONFIG_SOURCE_PROVIDER = MICROPROFILE_CONFIG.append("config-source-provider");
+
+    ServiceName CONFIG_SOURCE_ROOT = MICROPROFILE_CONFIG.append("config-source-root");
+
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/_private/MicroProfileConfigLogger.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/_private/MicroProfileConfigLogger.java
@@ -25,6 +25,8 @@ package org.wildfly.extension.microprofile.config.smallrye._private;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.util.List;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -72,4 +74,11 @@ public interface MicroProfileConfigLogger extends BasicLogger {
     String seeDownstream();
     */
 
+    @LogMessage(level = DEBUG)
+    @Message(id = 9, value = "Use directory for MicroProfile Config Source Root: %s")
+    void loadConfigSourceRootFromDir(String path);
+
+    @LogMessage(level = INFO)
+    @Message(id = 10, value = "The MicroProfile Config Source root directory '%s' contains the following directories which will be used as MicroProfile Config Sources: %s")
+    void logDirectoriesUnderConfigSourceRoot(String name, List<String> directories);
 }

--- a/microprofile/config-smallrye/src/main/resources/org/wildfly/extension/microprofile/config/smallrye/LocalDescriptions.properties
+++ b/microprofile/config-smallrye/src/main/resources/org/wildfly/extension/microprofile/config/smallrye/LocalDescriptions.properties
@@ -1,3 +1,4 @@
+# config-source properties
 config-source=ConfigSource provides a source for configuration values.
 config-source.add=Add a Config Source (the source of the configuration is determined by the attributes of the config-source (class to provide a new ConfigSource implementation, properties to store configuration values in WildFly  management model, etc.)
 config-source.ordinal=Ordinal value for the config source
@@ -5,16 +6,19 @@ config-source.properties=Properties configured for this config source and stored
 config-source.dir=Directory that is scanned to config properties for this config source (file names are key, file content are value)
 config-source.dir.path=The path of the directory to scan. It is treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.
 config-source.dir.relative-to=The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include: jboss.home - the root directory of the JBoss AS distribution, user.home - user's home directory, user.dir - user's current working directory, java.home - java installation directory, jboss.server.base.dir - root directory for an individual server instance, jboss.server.data.dir - directory the server will use for persistent data file storage, jboss.server.log.dir - directory the server will use for log file storage, jboss.server.tmp.dir - directory the server will use for temporary file storage, and jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances.
+config-source.dir.root=Whether the resolved directory is taken to be a root directory where the top level directories under the directory will each result in a directory type Config Source
 config-source.class=Class of the config source to load
 config-source.class.module=Module of the config source to load
 config-source.class.name=Name of the class of the config source to load
 config-source.remove=Remove the Config Source
+# config-source-provider properties
 config-source-provider=Config Source Provider can be used to register new implementation for multiple Config Sources.
 config-source-provider.add=Add a Config Source Provider
 config-source-provider.class=Class of the ConfigSourceProvider to load
 config-source-provider.class.module=Module of the config source provider to load
 config-source-provider.class.name=Name of the class of the config source to load
 config-source-provider.remove=Remove the Config Source Provider
+# Extension properties
 microprofile-config-smallrye=WildFly Extension for MicroProfile Config With SmallRye
 microprofile-config-smallrye.add=Add the subsystem
 microprofile-config-smallrye.remove=Remove the subsystem

--- a/microprofile/config-smallrye/src/main/resources/schema/wildfly-microprofile-config-smallrye_2_0.xsd
+++ b/microprofile/config-smallrye/src/main/resources/schema/wildfly-microprofile-config-smallrye_2_0.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2021, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:wildfly:microprofile-config-smallrye:2.0"
+            xmlns="urn:wildfly:microprofile-config-smallrye:2.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="config-source" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:sequence>
+                                <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="name" type="xs:string" use="required" />
+                                        <xs:attribute name="value" type="xs:string" use="required" />
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:element name="class" type="classType" minOccurs="0" maxOccurs="1" />
+                            <xs:element name="dir" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="path" type="xs:string" use="required" />
+                                    <xs:attribute name="relative-to" type="xs:string" />
+                                    <xs:attribute name="root" type="xs:boolean" default="false"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:choice>
+                        <xs:attribute name="ordinal" type="xs:nonNegativeInteger" use="optional" />
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="config-source-provider" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="class" type="classType" minOccurs="0" maxOccurs="1" />
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="classType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="module" type="xs:string" use="required" />
+    </xs:complexType>
+</xs:schema>

--- a/microprofile/config-smallrye/src/test/java/org/wildfly/extension/microprofile/config/smallrye/MPConfigSubsystemParsingTestCase.java
+++ b/microprofile/config-smallrye/src/test/java/org/wildfly/extension/microprofile/config/smallrye/MPConfigSubsystemParsingTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2017, Red Hat, Inc., and individual contributors
+ * Copyright 2021, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.wildfly.extension.microprofile.config.smallrye.MicroProfileConfigExtension.CONFIG_SOURCE_PATH;
 import static org.wildfly.extension.microprofile.config.smallrye.MicroProfileConfigExtension.SUBSYSTEM_PATH;
 import static org.wildfly.extension.microprofile.config.smallrye.MicroProfileConfigExtension.VERSION_1_0_0;
+import static org.wildfly.extension.microprofile.config.smallrye.MicroProfileConfigExtension.VERSION_1_1_0;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,21 +45,21 @@ import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 
-public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
+public class MPConfigSubsystemParsingTestCase extends AbstractSubsystemBaseTest {
 
-    public Subsystem_1_0_ParsingTestCase() {
+    public MPConfigSubsystemParsingTestCase() {
         super(MicroProfileConfigExtension.SUBSYSTEM_NAME, new MicroProfileConfigExtension());
     }
 
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_1_0.xml");
+        return readResource("subsystem.xml");
     }
 
     @Override
-    protected String getSubsystemXsdPath() throws IOException {
-        return "schema/wildfly-microprofile-config-smallrye_1_0.xsd";
+    protected String getSubsystemXsdPath() {
+        return "schema/wildfly-microprofile-config-smallrye_2_0.xsd";
     }
 
     protected Properties getResolvedProperties() {
@@ -69,6 +70,11 @@ public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testRejectingTransformersEAP_7_3_0() throws Exception {
         testRejectingTransformers(ModelTestControllerVersion.EAP_7_3_0, VERSION_1_0_0);
+    }
+
+    @Test
+    public void testRejectingTransformersEAP_XP4() throws Exception {
+        testRejectingTransformers(ModelTestControllerVersion.EAP_XP_4, VERSION_1_1_0);
     }
 
     private static String getMicroProfileConfigSmallryeGAV(ModelTestControllerVersion version) {
@@ -96,15 +102,52 @@ public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(microprofileConfigVersion).isSuccessfulBoot());
 
-        List<ModelNode> ops = builder.parseXmlResource("subsystem_1_0_reject_transformers.xml");
+        List<ModelNode> ops = builder.parseXmlResource("subsystem_reject_transformers.xml");
+        if (controllerVersion == ModelTestControllerVersion.EAP_7_3_0) {
+            // For 7.3.0 the ConfigSource 'add' operation installs services despite being in admin-only mode,
+            // which causes errors.
+            // Since the transformers are chained the rejection of the 'root' nested attribute installed
+            // by the 'my-config-source-with-root' config source is tested in later legacy controller versions.
+            int remove = -1;
+            for (int i = 0 ; i < ops.size() ; i++) {
+                if (ops.get(i).get("address").asString().contains("my-config-source-with-root")) {
+                    remove = i;
+                }
+            }
+            ops.remove(remove);
+        }
+
         PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM_PATH);
 
         FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
-        if (microprofileConfigVersion.equals(VERSION_1_0_0)) {
+        if (microprofileConfigVersion.compareTo(VERSION_1_0_0) >= 0) {
             config.addFailedAttribute(subsystemAddress.append(CONFIG_SOURCE_PATH.getKey(), "my-config-source-with-ordinal-expression"),
                     new FailedOperationTransformationConfig.NewAttributesConfig(
                             ConfigSourceDefinition.ORDINAL));
         }
+        if (microprofileConfigVersion.compareTo(VERSION_1_1_0) >= 0) {
+            config.addFailedAttribute(subsystemAddress.append(CONFIG_SOURCE_PATH.getKey(), "my-config-source-with-root"), new FailedOperationTransformationConfig.AttributesPathAddressConfig() {
+                @Override
+                protected boolean isAttributeWritable(String attributeName) {
+                    return true;
+                }
+
+                @Override
+                protected boolean checkValue(String attrName, ModelNode attribute, boolean isGeneratedWriteAttribute) {
+                    if (attribute.hasDefined(ConfigSourceDefinition.ROOT.getName())) {
+                        return attribute.get(ConfigSourceDefinition.ROOT.getName()).asString().equals("false");
+                    }
+                    return false;
+                }
+
+                @Override
+                protected ModelNode correctValue(ModelNode toResolve, boolean isGeneratedWriteAttribute) {
+                    toResolve.remove(ConfigSourceDefinition.ROOT.getName());
+                    return toResolve;
+                }
+            });
+        }
+
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, microprofileConfigVersion, ops, config);
     }
 

--- a/microprofile/config-smallrye/src/test/java/org/wildfly/extension/microprofile/config/smallrye/MPConfigSubsystem_1_0_ParsingTestCase.java
+++ b/microprofile/config-smallrye/src/test/java/org/wildfly/extension/microprofile/config/smallrye/MPConfigSubsystem_1_0_ParsingTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.config.smallrye;
+
+import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+
+public class MPConfigSubsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
+
+    public MPConfigSubsystem_1_0_ParsingTestCase() {
+        super(MicroProfileConfigExtension.SUBSYSTEM_NAME, new MicroProfileConfigExtension());
+    }
+
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem_1_0.xml");
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws IOException {
+        return "schema/wildfly-microprofile-config-smallrye_1_0.xsd";
+    }
+
+    protected Properties getResolvedProperties() {
+        return System.getProperties();
+    }
+
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities(
+                WELD_CAPABILITY_NAME);
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        super.compareXml(configId, original, marshalled, true);
+    }
+}

--- a/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem.xml
+++ b/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem.xml
@@ -1,0 +1,24 @@
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
+    <config-source name="myFirstConfigSource"
+                   ordinal="101">
+        <property name="foo" value="123" />
+        <property name="bar" value="yes" />
+    </config-source>
+    <config-source name="mySecondConfigSource"
+                   ordinal="${mySecondConfigSource.ordinal:201}" />
+    <config-source name="configSourceFromClass">
+        <class name="foo.bar.MyConfigSource" module="foo.bar" />
+    </config-source>
+    <config-source name="configSourceFromAbsoluteDir">
+        <dir path="${java.io.tmpdir}" />
+    </config-source>
+    <config-source name="configSourceFromRelativeDir">
+        <dir path="myConfigDir" relative-to="java.io.tmpdir"/>
+    </config-source>
+    <config-source name="configSourceRoot">
+        <dir path="myConfigDir" relative-to="java.io.tmpdir" root="${root.dir:true}"/>
+    </config-source>
+    <config-source-provider name="myConfigSourceProvider">
+        <class name="foo.bar.MyConfigSourceProvider" module="foo.bar" />
+    </config-source-provider>
+</subsystem>

--- a/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem_1_0_reject_transformers.xml
+++ b/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem_1_0_reject_transformers.xml
@@ -1,4 +1,0 @@
-<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
-    <config-source name="my-config-source-with-ordinal-expression"
-                   ordinal="${my.ordinal:201}" />
-</subsystem>

--- a/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem_reject_transformers.xml
+++ b/microprofile/config-smallrye/src/test/resources/org/wildfly/extension/microprofile/config/smallrye/subsystem_reject_transformers.xml
@@ -1,0 +1,7 @@
+<subsystem xmlns="urn:wildfly:microprofile-config-smallrye:2.0">
+    <config-source name="my-config-source-with-ordinal-expression"
+                   ordinal="${my.ordinal:201}" />
+    <config-source name="my-config-source-with-root">
+        <dir path="myConfigDir" relative-to="jboss.home.dir" root="true"/>
+    </config-source>
+</subsystem>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/ConfigSourceFromDirTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/ConfigSourceFromDirTestCase.java
@@ -25,8 +25,11 @@ package org.wildfly.test.integration.microprofile.config.smallrye.management.con
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.SetupTask.A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.SetupTask.B;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.B_OVERRIDES_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.DEFAULT;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.FROM_A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.FROM_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_B;
 
 import java.net.URL;
 
@@ -80,6 +83,8 @@ public class ConfigSourceFromDirTestCase extends AbstractMicroProfileConfigTestC
             AssertUtils.assertTextContainsProperty(text, FROM_A, A);
             AssertUtils.assertTextContainsProperty(text, FROM_B, B);
             AssertUtils.assertTextContainsProperty(text, B_OVERRIDES_A, SetupTask.OVERRIDDEN_B);
+            AssertUtils.assertTextContainsProperty(text, NOT_AVAILABLE_NESTED_DIR_UNDER_A, DEFAULT);
+            AssertUtils.assertTextContainsProperty(text, NOT_AVAILABLE_NESTED_DIR_UNDER_B, DEFAULT);
         }
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/SetupTask.java
@@ -50,6 +50,7 @@ public class SetupTask extends CLIServerSetupTask {
 
     private static final String ADDR_A = "/subsystem=microprofile-config-smallrye/config-source=propsA";
     private static final String ADDR_B = "/subsystem=microprofile-config-smallrye/config-source=propsB";
+    private static final String ADDR_NON_EXISTENT = "/subsystem=microprofile-config-smallrye/config-source=not-there";
 
     static final String A = "val-a";
     static final String B = "val-b";
@@ -58,12 +59,17 @@ public class SetupTask extends CLIServerSetupTask {
     static final String OVERRIDDEN_B = "overridden-b";
 
     private volatile Path rootDir;
+    private volatile Path nonExistent;
 
     @Override
     public void setup(ManagementClient managementClient, String containerId) throws Exception {
         Path target = Paths.get("target").toAbsolutePath().normalize();
         rootDir = Files.createTempDirectory(target, "test");
         Assert.assertTrue(Files.exists(rootDir));
+
+        nonExistent = Files.createTempDirectory(target, "duff");
+        deleteDirectory(nonExistent);
+        Assert.assertFalse(Files.exists(nonExistent));
 
         Path dirA = createPropsDir(rootDir, PROPS_A, FROM_A, A, B_OVERRIDES_A, OVERRIDDEN_A);
         Path dirB = createPropsDir(rootDir, PROPS_B, FROM_B, B, B_OVERRIDES_A, OVERRIDDEN_B);
@@ -74,9 +80,11 @@ public class SetupTask extends CLIServerSetupTask {
         nb.setup(String.format("%s:add(dir={path=\"%s\"})", ADDR_A, escapePath(dirA)));
         nb.setup(String.format("/path=mp-config-test:add(path=\"%s\")", escapePath(dirB.getParent())));
         nb.setup(String.format("%s:add(dir={relative-to=mp-config-test, path=\"%s\"}, ordinal=300)", ADDR_B, dirB.getFileName()));
+        nb.setup(String.format("%s:add(dir={path=\"%s\"})", ADDR_NON_EXISTENT, escapePath(nonExistent)));
 
         nb.teardown(String.format("%s:remove", ADDR_A));
         nb.teardown(String.format("%s:remove", ADDR_B));
+        nb.teardown(String.format("%s:remove", ADDR_NON_EXISTENT));
         nb.teardown("/path=mp-config-test:remove");
 
         super.setup(managementClient, containerId);
@@ -110,6 +118,10 @@ public class SetupTask extends CLIServerSetupTask {
     }
 
     private void deleteDirectory() throws IOException {
+        deleteDirectory(rootDir);
+    }
+
+    private void deleteDirectory(Path rootDir) throws IOException {
         if (rootDir != null && Files.exists(rootDir)) {
             Files.walkFileTree(rootDir, new SimpleFileVisitor<Path>() {
                 @Override

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/SetupTask.java
@@ -25,6 +25,8 @@ package org.wildfly.test.integration.microprofile.config.smallrye.management.con
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.B_OVERRIDES_A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.FROM_A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.FROM_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_B;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -74,12 +76,19 @@ public class SetupTask extends CLIServerSetupTask {
         Path dirA = createPropsDir(rootDir, PROPS_A, FROM_A, A, B_OVERRIDES_A, OVERRIDDEN_A);
         Path dirB = createPropsDir(rootDir, PROPS_B, FROM_B, B, B_OVERRIDES_A, OVERRIDDEN_B);
 
+        // Add some files which will be ignored (since the config sources we are adding here are not roots)
+        // in child directories of the config source directories
+        createPropsDir(dirA, PROPS_A, NOT_AVAILABLE_NESTED_DIR_UNDER_A, "Hello");
+        createPropsDir(dirB, PROPS_B, NOT_AVAILABLE_NESTED_DIR_UNDER_B, "Hello");
+
+
         NodeBuilder nb = builder.node(containerId);
 
 
         nb.setup(String.format("%s:add(dir={path=\"%s\"})", ADDR_A, escapePath(dirA)));
         nb.setup(String.format("/path=mp-config-test:add(path=\"%s\")", escapePath(dirB.getParent())));
-        nb.setup(String.format("%s:add(dir={relative-to=mp-config-test, path=\"%s\"}, ordinal=300)", ADDR_B, dirB.getFileName()));
+        // Make this one explicitly set root=false for test coverage
+        nb.setup(String.format("%s:add(dir={relative-to=mp-config-test, path=\"%s\", root=false}, ordinal=300)", ADDR_B, dirB.getFileName()));
         nb.setup(String.format("%s:add(dir={path=\"%s\"})", ADDR_NON_EXISTENT, escapePath(nonExistent)));
 
         nb.teardown(String.format("%s:remove", ADDR_A));

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/TestApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/TestApplication.java
@@ -41,6 +41,11 @@ public class TestApplication extends Application {
     static final String FROM_B = "from-b";
     static final String B_OVERRIDES_A = "b-overrides-a";
 
+
+    static final String NOT_AVAILABLE_NESTED_DIR_UNDER_A = "not-available-a";
+    static final String NOT_AVAILABLE_NESTED_DIR_UNDER_B = "not-available-b";
+    static final String DEFAULT = "default";
+
     @Path("/test")
     public static class Resource {
 
@@ -56,13 +61,25 @@ public class TestApplication extends Application {
         @ConfigProperty(name = B_OVERRIDES_A)
         String bOverridesA;
 
+        @Inject
+        @ConfigProperty(name = NOT_AVAILABLE_NESTED_DIR_UNDER_A, defaultValue = DEFAULT)
+        String notAvailableA;
+
+        @Inject
+        @ConfigProperty(name = NOT_AVAILABLE_NESTED_DIR_UNDER_B, defaultValue = DEFAULT)
+        String notAvailableB;
+
+
         @GET
         @Produces("text/plain")
         public Response doGet() {
+
             StringBuilder text = new StringBuilder();
             text.append(FROM_A + " = " + fromA + "\n");
             text.append(FROM_B + " = " + fromB + "\n");
-            text.append(B_OVERRIDES_A    + " = " + bOverridesA + "\n");
+            text.append(B_OVERRIDES_A + " = " + bOverridesA + "\n");
+            text.append(NOT_AVAILABLE_NESTED_DIR_UNDER_A + " = " + notAvailableA + "\n");
+            text.append(NOT_AVAILABLE_NESTED_DIR_UNDER_B + " = " + notAvailableB + "\n");
             return Response.ok(text).build();
         }
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir;
+
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.X_D_OVERRIDES_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A1;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A2;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.Y_A_OVERRIDES_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.Z_C_OVERRIDES_A;
+
+import java.net.URL;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.config.smallrye.AbstractMicroProfileConfigTestCase;
+import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
+
+/**
+ * Tests Root directory config sources
+ *
+ * @author Kabir Khan
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(SetupTask.class)
+public class ConfigSourceRootTestCase extends AbstractMicroProfileConfigTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromDirTestCase.war")
+                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testGetWithConfigProperties() throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpResponse response = client.execute(new HttpGet(url + "custom-config-source/test"));
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            String text = EntityUtils.toString(response.getEntity());
+            AssertUtils.assertTextContainsProperty(text, FROM_A1, SetupTask.A1);
+            AssertUtils.assertTextContainsProperty(text, FROM_A2, SetupTask.A2);
+            AssertUtils.assertTextContainsProperty(text, FROM_B, SetupTask.B);
+            AssertUtils.assertTextContainsProperty(text, X_D_OVERRIDES_A, SetupTask.X_FROM_D);
+            AssertUtils.assertTextContainsProperty(text, Y_A_OVERRIDES_B, SetupTask.Y_FROM_A);
+            AssertUtils.assertTextContainsProperty(text, Z_C_OVERRIDES_A, SetupTask.Z_FROM_C);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir;
 
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.DEFAULT;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.NOT_AVAILABLE_ROOT_FILE;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.X_D_OVERRIDES_A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A1;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A2;
@@ -84,6 +87,8 @@ public class ConfigSourceRootTestCase extends AbstractMicroProfileConfigTestCase
             AssertUtils.assertTextContainsProperty(text, X_D_OVERRIDES_A, SetupTask.X_FROM_D);
             AssertUtils.assertTextContainsProperty(text, Y_A_OVERRIDES_B, SetupTask.Y_FROM_A);
             AssertUtils.assertTextContainsProperty(text, Z_C_OVERRIDES_A, SetupTask.Z_FROM_C);
+            AssertUtils.assertTextContainsProperty(text, NOT_AVAILABLE_NESTED_DIR_UNDER_A, DEFAULT);
+            AssertUtils.assertTextContainsProperty(text, NOT_AVAILABLE_ROOT_FILE, DEFAULT);
         }
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/SetupTask.java
@@ -1,0 +1,156 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir;
+
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.Y_A_OVERRIDES_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.X_D_OVERRIDES_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A1;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A2;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_B;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.Z_C_OVERRIDES_A;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.CLIServerSetupTask;
+import org.junit.Assert;
+
+/**
+ * Adds config-source-roots in the microprofile-config subsystem.
+ *
+ * @author Kabir Khan
+ */
+public class SetupTask extends CLIServerSetupTask {
+    private static final String PROPS_A = "propsA";
+    private static final String PROPS_B = "propsB";
+    private static final String PROPS_C = "propsC";
+    private static final String PROPS_D = "propsD";
+
+    private static final String ROOT_A = "/subsystem=microprofile-config-smallrye/config-source=rootA";
+    private static final String ROOT_B = "/subsystem=microprofile-config-smallrye/config-source=rootB";
+    private static final String ROOT_NON_EXISTENT = "/subsystem=microprofile-config-smallrye/config-source=bad-root";
+
+    static final String A1 = "val-a1";
+    static final String A2 = "val-a2";
+    static final String B = "val-b";
+    static final String X_FROM_A = "x-from-a";
+    static final String X_FROM_D = "x-from-d";
+    static final String Y_FROM_A = "y-from-a";
+    static final String Y_FROM_B = "y-from-b";
+    static final String Z_FROM_A = "z-from-a";
+    static final String Z_FROM_C = "z-from-c";
+
+    private volatile Path rootDir1;
+    private volatile Path rootDir2;
+    private volatile Path nonExistent;
+
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        Path target = Paths.get("target").toAbsolutePath().normalize();
+        rootDir1 = Files.createTempDirectory(target, "test1");
+        rootDir2 = Files.createTempDirectory(target, "test2");
+        Assert.assertTrue(Files.exists(rootDir1));
+        Assert.assertTrue(Files.exists(rootDir2));
+
+        nonExistent = Files.createTempDirectory(target, "duff");
+        deleteDirectory(nonExistent);
+        Assert.assertFalse(Files.exists(nonExistent));
+
+        // Since PROPS_A is alphabetically lower than PROPS_B, Y will come from PROPS_A
+        createPropsDir(rootDir1, PROPS_A, FROM_A1, A1, FROM_A2, A2, X_D_OVERRIDES_A, X_FROM_A, Y_A_OVERRIDES_B, Y_FROM_A, Z_C_OVERRIDES_A, Z_FROM_A);
+        createPropsDir(rootDir1, PROPS_B, FROM_B, B, Y_A_OVERRIDES_B, Y_FROM_B);
+        // Since PROPS_C has a higher ordinal, Z will come from PROPS_A
+        createPropsDir(rootDir1, PROPS_C, "config_ordinal", "500", Z_C_OVERRIDES_A, Z_FROM_C);
+
+        // Since this config-source-root has a higher ordinal than rootDir1, X will be used from here
+        createPropsDir(rootDir2, PROPS_D, X_D_OVERRIDES_A, X_FROM_D);
+
+        NodeBuilder nb = builder.node(containerId);
+
+
+        nb.setup(String.format("%s:add(dir={root=true, path=\"%s\"})", ROOT_A, escapePath(rootDir1)));
+        nb.setup(String.format("/path=mp-config-test:add(path=\"%s\")", escapePath(rootDir2.getParent())));
+        nb.setup(String.format("%s:add(dir={root=true, relative-to=mp-config-test, path=\"%s\"}, ordinal=300)", ROOT_B, rootDir2.getFileName()));
+        nb.setup(String.format("%s:add(dir={root=true, path=\"%s\"})", ROOT_NON_EXISTENT, escapePath(nonExistent)));
+
+        nb.teardown(String.format("%s:remove", ROOT_A));
+        nb.teardown(String.format("%s:remove", ROOT_B));
+        nb.teardown(String.format("%s:remove", ROOT_NON_EXISTENT));
+        nb.teardown("/path=mp-config-test:remove");
+
+        super.setup(managementClient, containerId);
+    }
+
+    private String escapePath(Path path) {
+        String s = path.toString();
+        //Avoid problems with paths on Windows
+        s = s.replace('\\', '/');
+        return s;
+    }
+
+    private Path createPropsDir(Path rootDir, String sourceName, String... props) throws IOException {
+        Path sourceDir = rootDir.resolve(sourceName);
+        Files.createDirectory(sourceDir);
+        Assert.assertTrue(Files.exists(sourceDir));
+
+        for (int i = 0 ; i < props.length ; i += 2) {
+            Path file = sourceDir.resolve(props[i]);
+            Files.createFile(file);
+            Assert.assertTrue(Files.exists(file));
+            Files.write(file, Collections.singletonList(props[i + 1]));
+        }
+        return sourceDir.toAbsolutePath().normalize();
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        super.tearDown(managementClient, containerId);
+        deleteDirectory(rootDir1);
+        deleteDirectory(rootDir2);
+    }
+
+    private void deleteDirectory(Path dir) throws IOException {
+        if (dir != null && Files.exists(dir)) {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return super.visitFile(file, attrs);
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return super.postVisitDirectory(dir, exc);
+                }
+            });
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/SetupTask.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir;
 
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.NOT_AVAILABLE_NESTED_DIR_UNDER_A;
+import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.NOT_AVAILABLE_ROOT_FILE;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.Y_A_OVERRIDES_B;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.X_D_OVERRIDES_A;
 import static org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir.TestApplication.FROM_A1;
@@ -84,7 +86,7 @@ public class SetupTask extends CLIServerSetupTask {
         Assert.assertFalse(Files.exists(nonExistent));
 
         // Since PROPS_A is alphabetically lower than PROPS_B, Y will come from PROPS_A
-        createPropsDir(rootDir1, PROPS_A, FROM_A1, A1, FROM_A2, A2, X_D_OVERRIDES_A, X_FROM_A, Y_A_OVERRIDES_B, Y_FROM_A, Z_C_OVERRIDES_A, Z_FROM_A);
+        Path dirA = createPropsDir(rootDir1, PROPS_A, FROM_A1, A1, FROM_A2, A2, X_D_OVERRIDES_A, X_FROM_A, Y_A_OVERRIDES_B, Y_FROM_A, Z_C_OVERRIDES_A, Z_FROM_A);
         createPropsDir(rootDir1, PROPS_B, FROM_B, B, Y_A_OVERRIDES_B, Y_FROM_B);
         // Since PROPS_C has a higher ordinal, Z will come from PROPS_A
         createPropsDir(rootDir1, PROPS_C, "config_ordinal", "500", Z_C_OVERRIDES_A, Z_FROM_C);
@@ -93,6 +95,12 @@ public class SetupTask extends CLIServerSetupTask {
         createPropsDir(rootDir2, PROPS_D, X_D_OVERRIDES_A, X_FROM_D);
 
         NodeBuilder nb = builder.node(containerId);
+
+        //Create some files in locations that should not be considered as properties for a config source root director
+        // 1) in the root directory itself
+        Files.write(rootDir1.resolve(NOT_AVAILABLE_ROOT_FILE), Collections.singletonList("Hello"));
+        // 2) in a nested folder under one of the folders under the root dirctory
+        createPropsDir(dirA, PROPS_A, NOT_AVAILABLE_NESTED_DIR_UNDER_A, "Hello");
 
 
         nb.setup(String.format("%s:add(dir={root=true, path=\"%s\"})", ROOT_A, escapePath(rootDir1)));
@@ -128,6 +136,7 @@ public class SetupTask extends CLIServerSetupTask {
         }
         return sourceDir.toAbsolutePath().normalize();
     }
+
 
     @Override
     public void tearDown(ManagementClient managementClient, String containerId) throws Exception {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/TestApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/TestApplication.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.from_root_dir;
+
+import javax.inject.Inject;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * @author Kabir Khan
+ */
+@ApplicationPath("/custom-config-source")
+public class TestApplication extends Application {
+    static final String FROM_A1 = "from-a1";
+    static final String FROM_A2 = "from-a2";
+    static final String FROM_B = "from-b";
+    static final String X_D_OVERRIDES_A = "x-d-overrides-a";
+    static final String Y_A_OVERRIDES_B = "y-a-overrides-b";
+    static final String Z_C_OVERRIDES_A = "y-c-overrides-a";
+
+    @Path("/test")
+    public static class Resource {
+
+        @Inject
+        @ConfigProperty(name = FROM_A1)
+        String fromA1;
+
+        @Inject
+        @ConfigProperty(name = FROM_A2)
+        String fromA2;
+
+        @Inject
+        @ConfigProperty(name = FROM_B)
+        String fromB;
+
+        @Inject
+        @ConfigProperty(name = X_D_OVERRIDES_A)
+        String xDOverridesA;
+
+        @Inject
+        @ConfigProperty(name = Y_A_OVERRIDES_B)
+        String yAOverridesB;
+
+        @Inject
+        @ConfigProperty(name = Z_C_OVERRIDES_A)
+        String zCOverridesA;
+
+        @GET
+        @Produces("text/plain")
+        public Response doGet() {
+            StringBuilder text = new StringBuilder();
+            text.append(FROM_A1 + " = " + fromA1 + "\n");
+            text.append(FROM_A2 + " = " + fromA2 + "\n");
+            text.append(FROM_B + " = " + fromB + "\n");
+            text.append(X_D_OVERRIDES_A + " = " + xDOverridesA + "\n");
+            text.append(Y_A_OVERRIDES_B + " = " + yAOverridesB + "\n");
+            text.append(Z_C_OVERRIDES_A + " = " + zCOverridesA + "\n");
+            return Response.ok(text).build();
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/TestApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/TestApplication.java
@@ -44,6 +44,11 @@ public class TestApplication extends Application {
     static final String Y_A_OVERRIDES_B = "y-a-overrides-b";
     static final String Z_C_OVERRIDES_A = "y-c-overrides-a";
 
+    static final String NOT_AVAILABLE_NESTED_DIR_UNDER_A = "not-available-a";
+    static final String NOT_AVAILABLE_ROOT_FILE = "not-available-root-file";
+    static final String DEFAULT = "default";
+
+
     @Path("/test")
     public static class Resource {
 
@@ -71,6 +76,16 @@ public class TestApplication extends Application {
         @ConfigProperty(name = Z_C_OVERRIDES_A)
         String zCOverridesA;
 
+        @Inject
+        @ConfigProperty(name = NOT_AVAILABLE_NESTED_DIR_UNDER_A, defaultValue = DEFAULT)
+        String notAvailableA;
+
+        @Inject
+        @ConfigProperty(name = NOT_AVAILABLE_ROOT_FILE, defaultValue = DEFAULT)
+        String notAvailableRootFile;
+
+
+
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -81,6 +96,9 @@ public class TestApplication extends Application {
             text.append(X_D_OVERRIDES_A + " = " + xDOverridesA + "\n");
             text.append(Y_A_OVERRIDES_B + " = " + yAOverridesB + "\n");
             text.append(Z_C_OVERRIDES_A + " = " + zCOverridesA + "\n");
+            text.append(NOT_AVAILABLE_NESTED_DIR_UNDER_A + " = " + notAvailableA + "\n");
+            text.append(NOT_AVAILABLE_ROOT_FILE + " = " + notAvailableRootFile + "\n");
+
             return Response.ok(text).build();
         }
     }


### PR DESCRIPTION
…mallrye

Enhance tests to illustrate that if a directory for a config-source or a
config-source-root does not exist, the config is still valid and will
not give errors.

https://issues.redhat.com/browse/WFLY-15832 / https://github.com/wildfly/wildfly-proposals/pull/450
Needs a core release with https://github.com/wildfly/wildfly-core/pull/4899