### PR TITLE
[WFLY-15846] Upgrade WildFly Core 19.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15846

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta1
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.0.Final...19.0.0.Beta1

---

<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta1</summary>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5734'>WFCORE-5734</a>] -         Set java.io.tmpdir for surefire
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5601'>WFCORE-5601</a>] -         Update class javadoc for PluggableMBeanServerBuilder
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5746'>WFCORE-5746</a>] -         Bump the kernel management API version to 20.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5752'>WFCORE-5752</a>] -         Add model test controller for EAP XP 4 (using WF 26 as placeholder)
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5745'>WFCORE-5745</a>] -         Upgrade to JBoss VFS 3.2.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5750'>WFCORE-5750</a>] -         Upgrade log4j to 2.16.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5751'>WFCORE-5751</a>] -         Upgrade to wildfly-legacy-test 7.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5754'>WFCORE-5754</a>] -         Upgrade log4j2-jboss-logmanager to 1.1.1.Final
</li>
</ul>
                                                                                                                            
</details>