### PR TITLE
[WFLY-15855] MP Health subsytem property empty-startup-checks-status …

### DIFF
--- a/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
@@ -32,5 +32,6 @@
         <param name="security-enabled" value="false"/>
         <param name="empty-liveness-checks-status" value="${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}" />
         <param name="empty-readiness-checks-status" value="${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}" />
+        <param name="empty-startup-checks-status" value="${env.MP_HEALTH_EMPTY_STARTUP_CHECKS_STATUS:UP}" />
     </feature>
 </layer-spec>

--- a/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
@@ -49,7 +49,7 @@ end-if
 
 if (outcome != success) of /subsystem=microprofile-health-smallrye:read-resource
   /extension=org.wildfly.extension.microprofile.health-smallrye:add
-  /subsystem=microprofile-health-smallrye:add(security-enabled=false, empty-liveness-checks-status="${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}", empty-readiness-checks-status="${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}")
+  /subsystem=microprofile-health-smallrye:add(security-enabled=false, empty-liveness-checks-status="${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}", empty-readiness-checks-status="${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}", empty-startup-checks-status="${env.MP_HEALTH_EMPTY_STARTUP_CHECKS_STATUS:UP}")
 else
   echo INFO: microprofile-health-smallrye already in configuration, subsystem not added.
 end-if

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
@@ -493,6 +493,7 @@ public class AbstractValidationUnitTest {
         result = result.replace("${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
         result = result.replace("${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}", "UP");
         result = result.replace("${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}", "UP");
+        result = result.replace("${env.MP_HEALTH_EMPTY_STARTUP_CHECKS_STATUS:UP}", "UP");
         result = result.replace("${jboss.messaging.connector.host:localhost}", "localhost");
         result = result.replace("${jboss.messaging.connector.port:61616}", "61616");
         return result;


### PR DESCRIPTION
…is not included in default configuration

https://issues.redhat.com/browse/WFLY-15855
