### PR TITLE
WFLY-15865 Replace deprecated EnumValidator constructors and methods

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
@@ -225,7 +225,7 @@ public class Constants {
             .setRequired(false)
             .setAllowExpression(true)
             .setAllowedValues(Stream.of(FlushStrategy.values()).map(FlushStrategy::toString).filter(Objects::nonNull).toArray(String[]::new))
-            .setValidator(new EnumValidator<FlushStrategy>(FlushStrategy.class, true, true))
+            .setValidator(EnumValidator.create(FlushStrategy.class))
             .setRestartAllServices()
             .build();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
@@ -105,7 +105,7 @@ public class JcaDistributedWorkManagerDefinition extends SimpleResourceDefinitio
                 .setMeasurementUnit(MeasurementUnit.NONE)
                 .setRestartAllServices()
                 .setXmlName(Element.SELECTOR.getLocalName())
-                .setValidator(new EnumValidator<SelectorValue>(SelectorValue.class, true, true))
+                .setValidator(EnumValidator.create(SelectorValue.class))
                 .setDefaultValue(new ModelNode(SelectorValue.PING_TIME.name()))
                 .build()),
         POLICY(SimpleAttributeDefinitionBuilder.create("policy", ModelType.STRING)
@@ -114,7 +114,7 @@ public class JcaDistributedWorkManagerDefinition extends SimpleResourceDefinitio
                 .setMeasurementUnit(MeasurementUnit.NONE)
                 .setRestartAllServices()
                 .setXmlName(Element.POLICY.getLocalName())
-                .setValidator(new EnumValidator<PolicyValue>(PolicyValue.class, true, true))
+                .setValidator(EnumValidator.create(PolicyValue.class))
                 .setDefaultValue(new ModelNode(PolicyValue.WATERMARK.name()))
                 .build()),
         POLICY_OPTIONS(new PropertiesAttributeDefinition.Builder("policy-options", true)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -292,7 +292,7 @@ public class Constants {
     static final SimpleAttributeDefinition TRANSACTION_SUPPORT = new SimpleAttributeDefinitionBuilder(TRANSACTIONSUPPORT_NAME, ModelType.STRING, true)
             .setXmlName(Activation.Tag.TRANSACTION_SUPPORT.getLocalName())
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<TransactionSupportEnum>(TransactionSupportEnum.class, true, true))
+            .setValidator(EnumValidator.create(TransactionSupportEnum.class))
             .setRestartAllServices()
             .build();
 

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
@@ -168,7 +168,7 @@ public class ManagedExecutorServiceResourceDefinition extends SimpleResourceDefi
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(AbstractManagedExecutorService.RejectPolicy.ABORT.toString()))
-                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class, true, true))
+                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class))
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME_AD, CONTEXT_SERVICE_AD, THREAD_FACTORY_AD, THREAD_PRIORITY_AD, HUNG_TASK_TERMINATION_PERIOD_AD, HUNG_TASK_THRESHOLD_AD, LONG_RUNNING_TASKS_AD, CORE_THREADS_AD, MAX_THREADS_AD, KEEPALIVE_TIME_AD, QUEUE_LENGTH_AD, REJECT_POLICY_AD};

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
@@ -148,7 +148,7 @@ public class ManagedScheduledExecutorServiceResourceDefinition extends SimpleRes
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(AbstractManagedExecutorService.RejectPolicy.ABORT.toString()))
-                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class, true, true))
+                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class))
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME_AD, CONTEXT_SERVICE_AD, THREAD_FACTORY_AD, THREAD_PRIORITY_AD, HUNG_TASK_TERMINATION_PERIOD_AD, HUNG_TASK_THRESHOLD_AD, LONG_RUNNING_TASKS_AD, CORE_THREADS_AD, KEEPALIVE_TIME_AD, REJECT_POLICY_AD};

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolResourceDefinition.java
@@ -70,7 +70,7 @@ public class StrictMaxPoolResourceDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DERIVE_SIZE, ModelType.STRING, true)
                     .setAllowExpression(true)
                     // DeriveSize.NONE is no longer legal but if presented we will correct to undefined
-                    .setValidator(EnumValidator.create(DeriveSize.class, true, false, DeriveSize.LEGAL_VALUES))
+                    .setValidator(EnumValidator.create(DeriveSize.class, DeriveSize.LEGAL_VALUES))
                     .setCorrector(((newValue, currentValue) ->
                             (newValue.getType() == ModelType.STRING && DeriveSize.NONE.toString().equalsIgnoreCase(newValue.asString()))
                                     ? new ModelNode() : newValue))
@@ -111,7 +111,7 @@ public class StrictMaxPoolResourceDefinition extends SimpleResourceDefinition {
 
         // All values but NONE are 'legal' for use, although we provide a corrector to allow NONE as well
         // I use this convoluted mechanism to name these to make this more robust in case other values get added
-        private static DeriveSize[] LEGAL_VALUES = EnumSet.complementOf(EnumSet.of(NONE)).toArray(new DeriveSize[2]);
+        private static EnumSet<DeriveSize> LEGAL_VALUES = EnumSet.complementOf(EnumSet.of(NONE));
         private String value;
 
         DeriveSize(String value) {

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -61,7 +61,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
 
     static final ModelNode NONE = new ModelNode("none");
 
-    static final ParameterValidator SSL_CONFIG_VALIDATOR = new EnumValidator<>(SSLConfigValue.class, true, false);
+    static final ParameterValidator SSL_CONFIG_VALIDATOR = EnumValidator.create(SSLConfigValue.class);
 
     static final StringLengthValidator LENGTH_VALIDATOR = new StringLengthValidator(1, Integer.MAX_VALUE, true, false);
 
@@ -71,8 +71,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     static final SensitiveTargetAccessConstraintDefinition IIOP_SECURITY_DEF = new SensitiveTargetAccessConstraintDefinition(
             IIOP_SECURITY);
 
-    static final ParameterValidator VALIDATOR = new EnumValidator<>(IORTransportConfigValues.class,
-            true, true);
+    static final ParameterValidator VALIDATOR = EnumValidator.create(IORTransportConfigValues.class);
 
     //ORB attributes
 
@@ -110,7 +109,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.ORB_INIT_SECURITY, ModelType.STRING, true)
             .setAttributeGroup(Constants.ORB_INIT)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(SecurityAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(SecurityAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).setAllowExpression(true)
             .addAccessConstraint(IIOP_SECURITY_DEF).build();
 
@@ -127,7 +126,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.ORB_INIT_TRANSACTIONS, ModelType.STRING, true)
             .setAttributeGroup(Constants.ORB_INIT)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(TransactionsAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(TransactionsAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).setAllowExpression(true).build();
 
     //Naming attributes
@@ -313,7 +312,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.IOR_TRANSPORT_TRUST_IN_TARGET, ModelType.STRING, true)
             .setAttributeGroup(Constants.IOR_TRANSPORT_CONFIG)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setValidator(new EnumValidator<>(IORTransportConfigValues.class, true, true,
+            .setValidator(new EnumValidator<>(IORTransportConfigValues.class,
                     IORTransportConfigValues.NONE, IORTransportConfigValues.SUPPORTED))
             .setAllowExpression(true)
             .setDeprecated(IIOPExtension.VERSION_1)
@@ -355,7 +354,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             .setAttributeGroup(Constants.IOR_AS_CONTEXT)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(new ModelNode(AuthMethodValues.USERNAME_PASSWORD.toString()))
-            .setValidator(new EnumValidator<>(AuthMethodValues.class, true, true))
+            .setValidator(EnumValidator.create(AuthMethodValues.class))
             .setAllowExpression(true)
             .build();
 
@@ -382,7 +381,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             .setAttributeGroup(Constants.IOR_SAS_CONTEXT)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(CallerPropagationValues.class, true, true))
+            .setValidator(EnumValidator.create(CallerPropagationValues.class))
             .setAllowExpression(true)
             .build();
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -66,7 +66,7 @@ public class JPADefinition extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .setXmlName(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<ExtendedPersistenceInheritance>(ExtendedPersistenceInheritance.class,true,true))
+                    .setValidator(EnumValidator.create(ExtendedPersistenceInheritance.class))
                     .setDefaultValue(new ModelNode(ExtendedPersistenceInheritance.DEEP.toString()))
                     .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
@@ -54,7 +54,7 @@ public class IORASContextDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_AS_CONTEXT_AUTH_METHOD, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(AuthMethodValues.USERNAME_PASSWORD.toString()))
-                    .setValidator(new EnumValidator<AuthMethodValues>(AuthMethodValues.class, true, true))
+                    .setValidator(EnumValidator.create(AuthMethodValues.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
@@ -53,7 +53,7 @@ public class IORSASContextDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_SAS_CONTEXT_CALLER_PROPAGATION, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(CallerPropagationValues.NONE.toString()))
-                    .setValidator(new EnumValidator<CallerPropagationValues>(CallerPropagationValues.class, true, true))
+                    .setValidator(EnumValidator.create(CallerPropagationValues.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
@@ -49,8 +49,7 @@ import org.jboss.dmr.ModelType;
  */
 class IORTransportConfigDefinition extends PersistentResourceDefinition {
 
-    static final ParameterValidator VALIDATOR = new EnumValidator<IORTransportConfigValues>(
-            IORTransportConfigValues.class, true, true);
+    static final ParameterValidator VALIDATOR = EnumValidator.create(IORTransportConfigValues.class);
 
     static final AttributeDefinition INTEGRITY =
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_INTEGRITY, ModelType.STRING, true)
@@ -69,7 +68,7 @@ class IORTransportConfigDefinition extends PersistentResourceDefinition {
     static final AttributeDefinition TRUST_IN_TARGET =
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_TRUST_IN_TARGET, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<IORTransportConfigValues>(IORTransportConfigValues.class, true, true,
+                    .setValidator(new EnumValidator<IORTransportConfigValues>(IORTransportConfigValues.class,
                             IORTransportConfigValues.NONE, IORTransportConfigValues.SUPPORTED))
                     .setAllowExpression(true)
                     .build();

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
@@ -56,11 +56,10 @@ class JacORBSubsystemDefinitions {
 
     static final ModelNode DEFAULT_ENABLED_PROPERTY = new ModelNode("on");
 
-    private static final ParameterValidator SSL_CONFIG_VALIDATOR =
-            new EnumValidator<SSLConfigValue>(SSLConfigValue.class, true, false);
+    private static final ParameterValidator SSL_CONFIG_VALIDATOR = EnumValidator.create(SSLConfigValue.class);
 
     private static final ParameterValidator ON_OFF_VALIDATOR = new EnumValidator<TransactionsAllowedValues>(
-            TransactionsAllowedValues.class, true, false, TransactionsAllowedValues.ON, TransactionsAllowedValues.OFF);
+            TransactionsAllowedValues.class, TransactionsAllowedValues.ON, TransactionsAllowedValues.OFF);
 
     static final SensitivityClassification JACORB_SECURITY =
             new SensitivityClassification(JacORBExtension.SUBSYSTEM_NAME, "jacorb-security", false, false, true);
@@ -206,7 +205,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_INIT_SECURITY = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_SECURITY, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setValidator(new EnumValidator<SecurityAllowedValues>(SecurityAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(SecurityAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .addAccessConstraint(JACORB_SECURITY_DEF)
@@ -215,7 +214,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_INIT_TX = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_TRANSACTIONS, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setValidator(new EnumValidator<TransactionsAllowedValues>(TransactionsAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(TransactionsAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .build();

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
@@ -53,7 +53,7 @@ public class AddressSettingDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition ADDRESS_FULL_MESSAGE_POLICY = create("address-full-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(AddressFullMessagePolicy.PAGE.toString()))
-            .setValidator(new EnumValidator<>(AddressFullMessagePolicy.class, true, false))
+            .setValidator(EnumValidator.create(AddressFullMessagePolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
@@ -146,7 +146,7 @@ public class AddressSettingDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_POLICY = create("slow-consumer-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(SlowConsumerPolicy.NOTIFY.toString()))
-            .setValidator(new EnumValidator<>(SlowConsumerPolicy.class, true, true))
+            .setValidator(EnumValidator.create(SlowConsumerPolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -365,7 +365,7 @@ public interface CommonAttributes {
             .setDefaultValue(new ModelNode(JournalType.ASYNCIO.toString()))
             .setRequired(false)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(JournalType.class, true, true))
+            .setValidator(EnumValidator.create(JournalType.class))
             .setRestartAllServices()
             .build();
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
@@ -78,7 +78,7 @@ public class GroupingHandlerDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(TYPE.class, false, true))
+            .setValidator(EnumValidator.create(TYPE.class))
             .setRestartAllServices()
             .build();
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryType.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryType.java
@@ -48,7 +48,7 @@ public enum ConnectionFactoryType {
         return type;
     }
 
-    public static final ParameterValidator VALIDATOR = new EnumValidator<>(ConnectionFactoryType.class, true, false);
+    public static final ParameterValidator VALIDATOR = EnumValidator.create(ConnectionFactoryType.class);
 
     // copied from HornetQ to avoid import HornetQ artifacts just to define attribute constants and enum validator
     private enum JMSFactoryType

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
@@ -126,7 +126,7 @@ public class JMSBridgeDefinition extends ModelOnlyResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition QUALITY_OF_SERVICE = create("quality-of-service", STRING)
-            .setValidator(new EnumValidator<>(QualityOfServiceMode.class, false, false))
+            .setValidator(EnumValidator.create(QualityOfServiceMode.class))
             .setAllowExpression(true)
             .build();
     public static final SimpleAttributeDefinition FAILURE_RETRY_INTERVAL = create("failure-retry-interval", LONG)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -94,7 +94,7 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition ADDRESS_FULL_MESSAGE_POLICY = create("address-full-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(AddressFullMessagePolicy.PAGE.toString()))
-            .setValidator(new EnumValidator<>(AddressFullMessagePolicy.class, true, false))
+            .setValidator(EnumValidator.create(AddressFullMessagePolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
@@ -187,7 +187,7 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_POLICY = create("slow-consumer-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(SlowConsumerPolicy.NOTIFY.toString()))
-            .setValidator(new EnumValidator<>(SlowConsumerPolicy.class, true, true))
+            .setValidator(EnumValidator.create(SlowConsumerPolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -134,7 +134,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
     // FIXME WFLY-4587 forward-when-no-consumers == true ? STRICT : ON_DEMAND
     public static final SimpleAttributeDefinition MESSAGE_LOAD_BALANCING_TYPE = create("message-load-balancing-type", STRING)
             .setDefaultValue(new ModelNode(MessageLoadBalancingType.ON_DEMAND.toString()))
-            .setValidator(new EnumValidator<>(MessageLoadBalancingType.class, true, true))
+            .setValidator(EnumValidator.create(MessageLoadBalancingType.class))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -89,7 +89,7 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(Type.class, false, true))
+            .setValidator(EnumValidator.create(Type.class))
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -442,7 +442,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setAllowExpression(true)
             // list allowed values explicitly to exclude MAPPED
-            .setValidator(new EnumValidator<>(JournalType.class, true, true))
+            .setValidator(EnumValidator.create(JournalType.class))
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition JOURNAL_MAX_ATTIC_FILES = create("journal-max-attic-files", ModelType.INT)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryType.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryType.java
@@ -56,5 +56,5 @@ public enum ConnectionFactoryType {
         return type;
     }
 
-    public static final ParameterValidator VALIDATOR = new EnumValidator<>(ConnectionFactoryType.class, true, false);
+    public static final ParameterValidator VALIDATOR = EnumValidator.create(ConnectionFactoryType.class);
 }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
@@ -60,7 +60,7 @@ public class NamingBindingResourceDefinition extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition BINDING_TYPE = new SimpleAttributeDefinitionBuilder(NamingSubsystemModel.BINDING_TYPE, ModelType.STRING, false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setValidator(EnumValidator.create(BindingType.class, false, false))
+            .setValidator(EnumValidator.create(BindingType.class))
             .build();
 
     static final SimpleAttributeDefinition VALUE = new SimpleAttributeDefinitionBuilder(NamingSubsystemModel.VALUE, ModelType.STRING, true)

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/handlers/HandlerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/handlers/HandlerResourceDefinition.java
@@ -51,7 +51,7 @@ public class HandlerResourceDefinition extends AbstractFederationResourceDefinit
         .build();
 
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(HandlerTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(HandlerTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/AttributeManagerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/AttributeManagerResourceDefinition.java
@@ -40,7 +40,7 @@ public class AttributeManagerResourceDefinition extends AbstractFederationResour
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<AttributeManagerTypeEnum>(AttributeManagerTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributeManagerTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/RoleGeneratorResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/RoleGeneratorResourceDefinition.java
@@ -40,7 +40,7 @@ public class RoleGeneratorResourceDefinition extends AbstractFederationResourceD
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(RoleGeneratorTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(RoleGeneratorTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/CredentialHandlerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/CredentialHandlerResourceDefinition.java
@@ -44,7 +44,7 @@ public class CredentialHandlerResourceDefinition extends AbstractIDMResourceDefi
        .setAlternatives(ModelElement.COMMON_CODE.getName())
        .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<CredentialTypeEnum>(CredentialTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(CredentialTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/LDAPStoreMappingResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/LDAPStoreMappingResourceDefinition.java
@@ -45,7 +45,7 @@ public class LDAPStoreMappingResourceDefinition extends AbstractIDMResourceDefin
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<AttributedTypeEnum>(AttributedTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributedTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypeResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypeResourceDefinition.java
@@ -46,7 +46,7 @@ public class SupportedTypeResourceDefinition extends AbstractIDMResourceDefiniti
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(AttributedTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributedTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/security/subsystem/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
@@ -43,7 +43,7 @@ public class JASPIMappingModuleDefinition extends MappingModuleDefinition {
 
     private static final SimpleAttributeDefinition FLAG = new SimpleAttributeDefinitionBuilder(Constants.FLAG, ModelType.STRING)
             .setRequired(false)
-            .setValidator(new EnumValidator<ModuleFlag>(ModuleFlag.class, true, true))
+            .setValidator(EnumValidator.create(ModuleFlag.class))
             .setAllowExpression(true)
             .build();
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
@@ -89,7 +89,7 @@ class LegacySupport {
         static {
             final ParametersValidator delegate = new ParametersValidator();
             delegate.registerValidator(CODE, new StringLengthValidator(1));
-            delegate.registerValidator(Constants.FLAG, new EnumValidator<ModuleFlag>(ModuleFlag.class, true, false));
+            delegate.registerValidator(Constants.FLAG, EnumValidator.create(ModuleFlag.class));
             delegate.registerValidator(Constants.MODULE, new StringLengthValidator(1, true));
             delegate.registerValidator(Constants.MODULE_OPTIONS, new ModelTypeValidator(ModelType.OBJECT, true));
             delegate.registerValidator(Constants.LOGIN_MODULE_STACK_REF, new StringLengthValidator(1, true));
@@ -176,7 +176,7 @@ class LegacySupport {
         static {
             final ParametersValidator delegate = new ParametersValidator();
             delegate.registerValidator(CODE, new StringLengthValidator(1));
-            delegate.registerValidator(Constants.FLAG, new EnumValidator<ModuleFlag>(ModuleFlag.class, false, false));
+            delegate.registerValidator(Constants.FLAG, EnumValidator.create(ModuleFlag.class));
             delegate.registerValidator(Constants.MODULE, new StringLengthValidator(1, true));
             delegate.registerValidator(Constants.MODULE_OPTIONS, new ModelTypeValidator(ModelType.OBJECT, true));
             validator = new ParametersOfValidator(delegate);

--- a/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
@@ -50,7 +50,7 @@ public class LoginModuleResourceDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition FLAG = new SimpleAttributeDefinitionBuilder(Constants.FLAG, ModelType.STRING)
             .setRequired(true)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<ModuleFlag>(ModuleFlag.class, false, true))
+            .setValidator(EnumValidator.create(ModuleFlag.class))
             .build();
 
     static final SimpleAttributeDefinition MODULE = new SimpleAttributeDefinitionBuilder(Constants.MODULE, ModelType.STRING)

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
@@ -132,7 +132,7 @@ class LogStoreConstants {
             .setRequired(false)
             .setDefaultValue(new ModelNode())
             .setMeasurementUnit(MeasurementUnit.NONE)
-            .setValidator(new EnumValidator<ParticipantStatus>(ParticipantStatus.class, true, false))
+            .setValidator(EnumValidator.create(ParticipantStatus.class))
             .build();
 
     static SimpleAttributeDefinition PARTICIPANT_JNDI_NAME = (new SimpleAttributeDefinitionBuilder(JNDI_ATTRIBUTE, ModelType.STRING))

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
@@ -75,7 +75,7 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
             .setRequired(false)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(SslClientAuthMode.class, true, true))
+            .setValidator(EnumValidator.create(SslClientAuthMode.class))
             .setDefaultValue(new ModelNode(SslClientAuthMode.NOT_REQUESTED.name()))
             .setDeprecated(ModelVersion.create(4, 0, 0))
             .setAlternatives(Constants.SSL_CONTEXT)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
@@ -70,7 +70,7 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.STACK_TRACE_ON_ERROR, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(ServletStackTraces.LOCAL_ONLY.toString()))
-                    .setValidator(new EnumValidator<>(ServletStackTraces.class, true, true))
+                    .setValidator(EnumValidator.create(ServletStackTraces.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -143,7 +143,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
 
     public static final AttributeDefinition FAILOVER_STRATEGY = new SimpleAttributeDefinitionBuilder(Constants.FAILOVER_STRATEGY, ModelType.STRING)
             .setRequired(false)
-            .setValidator(new EnumValidator<>(FailoverStrategy.class, true, true))
+            .setValidator(EnumValidator.create(FailoverStrategy.class))
             .setRestartAllServices()
             .setDefaultValue(new ModelNode(FailoverStrategy.LOAD_BALANCED.name()))
             .build();

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/Attributes.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/Attributes.java
@@ -60,7 +60,7 @@ interface Attributes {
     SimpleAttributeDefinition WSDL_URI_SCHEME = new SimpleAttributeDefinitionBuilder(Constants.WSDL_URI_SCHEME, ModelType.STRING)
             .setRequired(false)
             .setMinSize(1)
-            .setValidator(new EnumValidator<>(WsdlUriSchema.class, false, false))
+            .setValidator(EnumValidator.create(WsdlUriSchema.class))
             .setAllowExpression(true)
             .build();
     enum WsdlUriSchema {http, https}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15865

Changes made for equivalent results:
Constructors:
```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```
