### PR TITLE
WFLY-15851 Weld - fix UrlScanner to correctly reference child file instead of parent directory

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/UrlScanner.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/UrlScanner.java
@@ -172,7 +172,7 @@ class UrlScanner {
             if (child.isDirectory()) {
                 handleDirectory(child, newPath);
             } else {
-                handleFile(newPath, () -> file.toURL().openStream());
+                handleFile(newPath, () -> child.toURL().openStream());
             }
         }
     }


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-15851

Reported via JIRA; this seems like a small oversight that nobody bumped into up until now.