### PR TITLE
[WFLY-15873] Remove Elytron OIDC Client dependencies from WildFly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,6 @@
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.security.elytron>1.17.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>
@@ -9698,24 +9697,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
-                <artifactId>wildfly-elytron-http-oidc</artifactId>
-                <version>${version.org.wildfly.security.elytron}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
-                <artifactId>wildfly-elytron-jose-jwk</artifactId>
-                <version>${version.org.wildfly.security.elytron}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
-                <artifactId>wildfly-elytron-jose-util</artifactId>
-                <version>${version.org.wildfly.security.elytron}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15873

Moving the Elytron OIDC Client related dependencies from WildFly to Core. The modules that actually make use of these dependencies will remain in WildFly.

Depends on https://github.com/wildfly/wildfly-core/pull/4917

