### PR TITLE
[WFLY-16737] Upgrade H2 to 2.1.210

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/h2-datasource.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/h2-datasource.xml
@@ -7,7 +7,7 @@
             <param name="use-java-context" value="true"/>
             <param name="jndi-name" value="java:jboss/datasources/ExampleDS"/>
             <param name="data-source" value="ExampleDS"/>
-            <param name="connection-url" value="&quot;jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE&quot;"/>
+            <param name="connection-url" value="&quot;jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=LEGACY&quot;"/>
             <param name="driver-name" value="h2"/>
             <param name="user-name" value="sa"/>
             <param name="password" value="sa"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/h2-datasource.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/h2-datasource.xml
@@ -7,7 +7,7 @@
             <param name="use-java-context" value="true"/>
             <param name="jndi-name" value="java:jboss/datasources/ExampleDS"/>
             <param name="data-source" value="ExampleDS"/>
-            <param name="connection-url" value="&quot;jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=LEGACY&quot;"/>
+            <param name="connection-url" value="&quot;jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}&quot;"/>
             <param name="driver-name" value="h2"/>
             <param name="user-name" value="sa"/>
             <param name="password" value="sa"/>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.j2objc>1.3</version.com.google.j2objc>
         <version.com.google.protobuf>3.19.2</version.com.google.protobuf>
-        <version.com.h2database>1.4.197</version.com.h2database>
+        <version.com.h2database>2.1.210</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
         <version.com.nimbus.jose-jwt>9.23</version.com.nimbus.jose-jwt>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:datasources:7.0">
     <datasources>
         <drivers>
-            <driver name="name" module="com.h2database.h2" major-version="1" minor-version="4">
+            <driver name="name" module="com.h2database.h2" major-version="2" minor-version="1">
                 <driver-class>org.h2.Driver</driver-class>
                 <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
             </driver>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:datasources:7.0">
     <datasources>
         <drivers>
-            <driver name="" module="com.h2database.h2" major-version="1">
+            <driver name="" module="com.h2database.h2" major-version="2" minor-version="1">
                 <driver-class>org.h2.Driver</driver-class>
                 <xa-datasource-class>XaDsClass</xa-datasource-class>
             </driver>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:datasources:7.0">
     <datasources>
         <drivers>
-            <driver module="com.h2database.h2" major-version="1">
+            <driver module="com.h2database.h2" major-version="2" minor-version="1">
                 <driver-class>org.h2.Driver</driver-class>
                 <xa-datasource-class>XaDsClass</xa-datasource-class>
             </driver>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterDatabaseTestUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterDatabaseTestUtil.java
@@ -37,11 +37,11 @@ import org.h2.tools.Server;
 public class ClusterDatabaseTestUtil {
 
     public static void startH2() throws SQLException {
-        Server.createTcpServer("-tcpPort", DB_PORT, "-tcpAllowOthers", "-baseDir", "./target/h2").start();
+        Server.createTcpServer("-tcpPort", DB_PORT, "-tcpAllowOthers", "-ifNotExists", "-tcpPassword", "sa", "-baseDir", "./target/h2").start();
     }
 
     public static void stopH2() throws SQLException {
-        Server.shutdownTcpServer("tcp://localhost:" + DB_PORT, "", true, true);
+        Server.shutdownTcpServer("tcp://localhost:" + DB_PORT, "sa", true, true);
     }
 
     private ClusterDatabaseTestUtil() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/AbstractDatabasePersistenceWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/AbstractDatabasePersistenceWebFailoverTestCase.java
@@ -73,7 +73,7 @@ public abstract class AbstractDatabasePersistenceWebFailoverTestCase extends Abs
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
             this.builder.node(THREE_NODES)
-                    .setup("/subsystem=datasources/data-source=web-sessions-ds:add(jndi-name=\"java:jboss/datasources/web-sessions-ds\", enabled=true, use-java-context=true, connection-url=\"jdbc:h2:tcp://localhost:%s/./web-sessions\", driver-name=h2", DB_PORT)
+                    .setup("/subsystem=datasources/data-source=web-sessions-ds:add(jndi-name=\"java:jboss/datasources/web-sessions-ds\", enabled=true, use-java-context=true, connection-url=\"jdbc:h2:tcp://localhost:%s/./web-sessions;VARIABLE_BINARY=TRUE\", driver-name=h2", DB_PORT)
                     .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence:add")
                     .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/store=jdbc:add(data-source=web-sessions-ds, fetch-state=false, shared=true)")
                     .teardown("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence:remove")

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
@@ -106,7 +106,7 @@ public class StopFromDifferentNodeTestCase {
             if (h2Server == null) {
                 //We need a TCP server that can be shared between the two servers.
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                h2Server = Server.createTcpServer("-tcpAllowOthers").start();
+                h2Server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
             }
 
             if (savedDefaultJobRepository == null) {

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -95,7 +95,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
             if (server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers").start();
+                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
             }
 
             final ModelNode compositeOp = new ModelNode();

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -105,7 +105,7 @@ public class DatabaseTimerServiceMultiNodeTestCase {
             if(server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers").start();
+                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
             }
 
             final ModelNode compositeOp = new ModelNode();

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
@@ -95,7 +95,7 @@ public class DatabaseTimerServiceRefreshTestCase {
             if (server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers").start();
+                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
             }
 
             final ModelNode compositeOp = new ModelNode();


### PR DESCRIPTION
Use the -ifNotExists option with tests that may have 'remote' callers initialize the H2 db
    
H2 2.1.210 defaults to a random management password so set a real one
    
Work around the fact that H2 2.x no longer treats BINARY cols as VARBINARY and defaults to size of 1.
    
    TableResourceDefinition's ColumnAttribute.DATA defaults to BINARY, which will result in a col wherein H2 will only allow a single byte. I suspect the design assumed a more varbinary semantic.
    
    See https://github.com/h2database/h2database/pull/2427
    
    Perhaps the default value of TableResourceDefinition.ColumnAttribute.DATA should be reconsidered.
    
    An alternative fix would be to configure a 'table=string' resource and specify VARBINARY as the col type for 'data'.

https://issues.redhat.com/browse/WFLY-16737

H2 offers different 'compatibility modes' (see http://www.h2database.com/html/features.html#compatibility). For a while this branch was using MODE=LEGACY but that no longer seems to be necessary to pass the testsuite, so my preference is to default to the H2 default of REGULAR.  But I added an expression to the DS URL to make it easy to override, e.g. to LEGACY.