### PR TITLE
WFLY-15897 Messaging BroadcastGroupDefinition & DiscoveryGroupDefinition fixes

### DIFF
--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -879,4 +879,7 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 104, value = "Legacy security is no longer supported.")
     IllegalStateException legacySecurityUnsupported();
 
+    @Message(id = 105, value = "The %s %s is configured to use socket-binding %s, but this socket binding doesn't have the multicast-address or a multicast-port attributes configured.")
+    OperationFailedException socketBindingMulticastNotSet(String resourceType, String resourceName, String socketBindingName);
+
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -67,7 +67,7 @@ import org.wildfly.extension.messaging.activemq.shallow.ShallowResourceDefinitio
  */
 public class BroadcastGroupDefinition extends ShallowResourceDefinition {
     public static final PrimitiveListAttributeDefinition CONNECTOR_REFS = new StringListAttributeDefinition.Builder(CONNECTORS)
-            .setRequired(false)
+            .setRequired(true)
             .setElementValidator(new StringLengthValidator(1))
             .setAttributeParser(AttributeParser.STRING_LIST)
             .setAttributeMarshaller(AttributeMarshaller.STRING_LIST)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupWriteAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupWriteAttributeHandler.java
@@ -49,7 +49,7 @@ public class BroadcastGroupWriteAttributeHandler extends ReloadRequiredWriteAttr
 
     public static final BroadcastGroupWriteAttributeHandler INSTANCE = new BroadcastGroupWriteAttributeHandler(BROADCAST_GROUP_PATH, BroadcastGroupDefinition.ATTRIBUTES);
     public static final BroadcastGroupWriteAttributeHandler JGROUP_INSTANCE = new BroadcastGroupWriteAttributeHandler(JGROUPS_BROADCAST_GROUP_PATH, JGroupsBroadcastGroupDefinition.ATTRIBUTES);
-    public static final BroadcastGroupWriteAttributeHandler SOCKET_INSTANCE = new BroadcastGroupWriteAttributeHandler(SOCKET_BROADCAST_GROUP_PATH, JGroupsBroadcastGroupDefinition.ATTRIBUTES);
+    public static final BroadcastGroupWriteAttributeHandler SOCKET_INSTANCE = new BroadcastGroupWriteAttributeHandler(SOCKET_BROADCAST_GROUP_PATH, SocketBroadcastGroupDefinition.ATTRIBUTES);
 
     private final PathElement path;
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketBroadcastGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketBroadcastGroupAdd.java
@@ -138,6 +138,9 @@ public class SocketBroadcastGroupAdd extends AbstractAddStepHandler {
     static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final String name, final BroadcastGroupConfiguration config, final SocketBinding socketBinding) throws Exception {
 
         final String localAddress = socketBinding.getAddress().getHostAddress();
+        if (socketBinding.getMulticastAddress() == null) {
+            throw MessagingLogger.ROOT_LOGGER.socketBindingMulticastNotSet("socket-broadcast-group", name, socketBinding.getName());
+        }
         final String groupAddress = socketBinding.getMulticastAddress().getHostAddress();
         final int localPort = socketBinding.getPort();
         final int groupPort = socketBinding.getMulticastPort();

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketDiscoveryGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketDiscoveryGroupAdd.java
@@ -45,6 +45,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
  * Handler for adding a discovery group using socket bindings.
@@ -122,6 +123,9 @@ public class SocketDiscoveryGroupAdd extends AbstractAddStepHandler {
    public static DiscoveryGroupConfiguration createDiscoveryGroupConfiguration(final String name, final DiscoveryGroupConfiguration config, final SocketBinding socketBinding) throws Exception {
 
         final String localAddress = socketBinding.getAddress().getHostAddress();
+        if (socketBinding.getMulticastAddress() == null) {
+            throw MessagingLogger.ROOT_LOGGER.socketBindingMulticastNotSet("socket-discovery-group", name, socketBinding.getName());
+        }
         final String groupAddress = socketBinding.getMulticastAddress().getHostAddress();
         final int groupPort = socketBinding.getMulticastPort();
         final long refreshTimeout = config.getRefreshTimeout();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15897
https://issues.redhat.com/browse/JBEAP-23054 (EAP 8)

* Change `BroadcastGroupDefinition#CONNECTOR_REFS` to be required, as both `JGroupsBroadcastGroupDefinition#CONNECTOR_REFS` and `SocketBroadcastGroupDefinition#CONNECTOR_REFS` are required. This is causing the web console not to include the connectors attribute in the Add form.
* `BroadcastGroupWriteAttributeHandler#SOCKET_INSTANCE` references wrong attributes list. Causes NPE when editing resources.
* Avoid NPE in `SocketBroadcastGroupAdd` and `JGroupsBroadcastGroupAdd` when the provided socket binding doesn't have broadcast address defined. Print helpful message instead.
* Make `TranslatedWriteAttributeHandler` not to write into attribute, if the attribute is in the list of ignored attributes for given resource (causes NPE). 