### PR TITLE
[WFLY-15901] Upgrade WildFly Core 18.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>18.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15901

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.0.2.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.1.Final...18.0.2.Final

---

<details>
<summary>
        Release Notes - WildFly Core - Version 18.0.2.Final</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5764'>WFCORE-5764</a>] -         Can&#39;t write/acquire credentials from a store using the elytron-tool script
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5767'>WFCORE-5767</a>] -         Add Elytron OIDC client related dependencies to Core
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5756'>WFCORE-5756</a>] -         Upgrade bootable jar to 7.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5770'>WFCORE-5770</a>] -         Upgrade log4j 2 to 2.17.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5771'>WFCORE-5771</a>] -         Upgrade jboss-logging to 3.4.3.Final
</li>
</ul>
                                                                                                                                </details>