### PR TITLE
[26.x][WFLY-15903] Remove Jaeger dep from OpenTelemetry module

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/trace/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/trace/main/module.xml
@@ -40,7 +40,6 @@
         <module name="io.opentelemetry.context"/>
         <module name="com.squareup.okhttp3"/>
         <module name="org.slf4j"/>
-        <module name="io.jaegertracing"/>
         <module name="io.grpc"/>
         <module name="com.google.guava" />
         <module name="com.google.code.gson"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15903

Remove module dep

Upstream PR: https://github.com/wildfly/wildfly/pull/15094