### PR TITLE
[26.x][WFLY-15883] Update protobuf to 3.19.2 (resolves CVE-2021-22569)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <version.com.google.guava>30.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.j2objc>1.3</version.com.google.j2objc>
-        <version.com.google.protobuf>3.15.7</version.com.google.protobuf>
+        <version.com.google.protobuf>3.19.2</version.com.google.protobuf>
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15883
Upstream: #15074

Bump version to 3.19.2
