### PR TITLE
[WFLY-15904] Update test depedency nimbus-jose-jwt from 8.11 to 8.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
-        <version.com.nimbus.jose-jwt>8.11</version.com.nimbus.jose-jwt>
+        <version.com.nimbus.jose-jwt>8.23</version.com.nimbus.jose-jwt>
         <version.com.squareup.okhttp3>3.14.9</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.17.5</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.2</version.com.sun.activation.jakarta.activation>


### PR DESCRIPTION
This it to trigger an update of transitive dep json-smart to 2.4.5 or later to get it off security scanner radar.

The nimbus-jose-jwt project has a number of 9.x releases but I went for the latest release in the same major version, just to improve the odds the upgrade would be suitable.

https://issues.redhat.com/browse/WFLY-15904

Note that this dep is only used in tests; this change has no impact on production code.

@fjuma If this passes CI, please review.