### PR TITLE
WFLY-15915 Replace deprecated EnumValidator constructors and methods (JCA)

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
@@ -225,7 +225,7 @@ public class Constants {
             .setRequired(false)
             .setAllowExpression(true)
             .setAllowedValues(Stream.of(FlushStrategy.values()).map(FlushStrategy::toString).filter(Objects::nonNull).toArray(String[]::new))
-            .setValidator(new EnumValidator<FlushStrategy>(FlushStrategy.class, true, true))
+            .setValidator(EnumValidator.create(FlushStrategy.class))
             .setRestartAllServices()
             .build();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
@@ -105,7 +105,7 @@ public class JcaDistributedWorkManagerDefinition extends SimpleResourceDefinitio
                 .setMeasurementUnit(MeasurementUnit.NONE)
                 .setRestartAllServices()
                 .setXmlName(Element.SELECTOR.getLocalName())
-                .setValidator(new EnumValidator<SelectorValue>(SelectorValue.class, true, true))
+                .setValidator(EnumValidator.create(SelectorValue.class))
                 .setDefaultValue(new ModelNode(SelectorValue.PING_TIME.name()))
                 .build()),
         POLICY(SimpleAttributeDefinitionBuilder.create("policy", ModelType.STRING)
@@ -114,7 +114,7 @@ public class JcaDistributedWorkManagerDefinition extends SimpleResourceDefinitio
                 .setMeasurementUnit(MeasurementUnit.NONE)
                 .setRestartAllServices()
                 .setXmlName(Element.POLICY.getLocalName())
-                .setValidator(new EnumValidator<PolicyValue>(PolicyValue.class, true, true))
+                .setValidator(EnumValidator.create(PolicyValue.class))
                 .setDefaultValue(new ModelNode(PolicyValue.WATERMARK.name()))
                 .build()),
         POLICY_OPTIONS(new PropertiesAttributeDefinition.Builder("policy-options", true)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -292,7 +292,7 @@ public class Constants {
     static final SimpleAttributeDefinition TRANSACTION_SUPPORT = new SimpleAttributeDefinitionBuilder(TRANSACTIONSUPPORT_NAME, ModelType.STRING, true)
             .setXmlName(Activation.Tag.TRANSACTION_SUPPORT.getLocalName())
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<TransactionSupportEnum>(TransactionSupportEnum.class, true, true))
+            .setValidator(EnumValidator.create(TransactionSupportEnum.class))
             .setRestartAllServices()
             .build();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15915 

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```