### PR TITLE
WFLY-15906 Replace deprecated EnumValidator constructors and methods (EJB)

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolResourceDefinition.java
@@ -70,7 +70,7 @@ public class StrictMaxPoolResourceDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DERIVE_SIZE, ModelType.STRING, true)
                     .setAllowExpression(true)
                     // DeriveSize.NONE is no longer legal but if presented we will correct to undefined
-                    .setValidator(EnumValidator.create(DeriveSize.class, true, false, DeriveSize.LEGAL_VALUES))
+                    .setValidator(EnumValidator.create(DeriveSize.class, DeriveSize.LEGAL_VALUES))
                     .setCorrector(((newValue, currentValue) ->
                             (newValue.getType() == ModelType.STRING && DeriveSize.NONE.toString().equalsIgnoreCase(newValue.asString()))
                                     ? new ModelNode() : newValue))
@@ -111,7 +111,7 @@ public class StrictMaxPoolResourceDefinition extends SimpleResourceDefinition {
 
         // All values but NONE are 'legal' for use, although we provide a corrector to allow NONE as well
         // I use this convoluted mechanism to name these to make this more robust in case other values get added
-        private static DeriveSize[] LEGAL_VALUES = EnumSet.complementOf(EnumSet.of(NONE)).toArray(new DeriveSize[2]);
+        private static EnumSet<DeriveSize> LEGAL_VALUES = EnumSet.complementOf(EnumSet.of(NONE));
         private String value;
 
         DeriveSize(String value) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15906 

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```