### PR TITLE
WFLY-15907 Replace deprecated EnumValidator constructors and methods (IIOP)

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -61,7 +61,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
 
     static final ModelNode NONE = new ModelNode("none");
 
-    static final ParameterValidator SSL_CONFIG_VALIDATOR = new EnumValidator<>(SSLConfigValue.class, true, false);
+    static final ParameterValidator SSL_CONFIG_VALIDATOR = EnumValidator.create(SSLConfigValue.class);
 
     static final StringLengthValidator LENGTH_VALIDATOR = new StringLengthValidator(1, Integer.MAX_VALUE, true, false);
 
@@ -71,8 +71,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     static final SensitiveTargetAccessConstraintDefinition IIOP_SECURITY_DEF = new SensitiveTargetAccessConstraintDefinition(
             IIOP_SECURITY);
 
-    static final ParameterValidator VALIDATOR = new EnumValidator<>(IORTransportConfigValues.class,
-            true, true);
+    static final ParameterValidator VALIDATOR = EnumValidator.create(IORTransportConfigValues.class);
 
     //ORB attributes
 
@@ -110,7 +109,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.ORB_INIT_SECURITY, ModelType.STRING, true)
             .setAttributeGroup(Constants.ORB_INIT)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(SecurityAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(SecurityAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).setAllowExpression(true)
             .addAccessConstraint(IIOP_SECURITY_DEF).build();
 
@@ -127,7 +126,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.ORB_INIT_TRANSACTIONS, ModelType.STRING, true)
             .setAttributeGroup(Constants.ORB_INIT)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(TransactionsAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(TransactionsAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).setAllowExpression(true).build();
 
     //Naming attributes
@@ -313,7 +312,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             Constants.IOR_TRANSPORT_TRUST_IN_TARGET, ModelType.STRING, true)
             .setAttributeGroup(Constants.IOR_TRANSPORT_CONFIG)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setValidator(new EnumValidator<>(IORTransportConfigValues.class, true, true,
+            .setValidator(new EnumValidator<>(IORTransportConfigValues.class,
                     IORTransportConfigValues.NONE, IORTransportConfigValues.SUPPORTED))
             .setAllowExpression(true)
             .setDeprecated(IIOPExtension.VERSION_1)
@@ -355,7 +354,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             .setAttributeGroup(Constants.IOR_AS_CONTEXT)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(new ModelNode(AuthMethodValues.USERNAME_PASSWORD.toString()))
-            .setValidator(new EnumValidator<>(AuthMethodValues.class, true, true))
+            .setValidator(EnumValidator.create(AuthMethodValues.class))
             .setAllowExpression(true)
             .build();
 
@@ -382,7 +381,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
             .setAttributeGroup(Constants.IOR_SAS_CONTEXT)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(NONE)
-            .setValidator(new EnumValidator<>(CallerPropagationValues.class, true, true))
+            .setValidator(EnumValidator.create(CallerPropagationValues.class))
             .setAllowExpression(true)
             .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
@@ -54,7 +54,7 @@ public class IORASContextDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_AS_CONTEXT_AUTH_METHOD, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(AuthMethodValues.USERNAME_PASSWORD.toString()))
-                    .setValidator(new EnumValidator<AuthMethodValues>(AuthMethodValues.class, true, true))
+                    .setValidator(EnumValidator.create(AuthMethodValues.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
@@ -53,7 +53,7 @@ public class IORSASContextDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_SAS_CONTEXT_CALLER_PROPAGATION, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(CallerPropagationValues.NONE.toString()))
-                    .setValidator(new EnumValidator<CallerPropagationValues>(CallerPropagationValues.class, true, true))
+                    .setValidator(EnumValidator.create(CallerPropagationValues.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
@@ -49,8 +49,7 @@ import org.jboss.dmr.ModelType;
  */
 class IORTransportConfigDefinition extends PersistentResourceDefinition {
 
-    static final ParameterValidator VALIDATOR = new EnumValidator<IORTransportConfigValues>(
-            IORTransportConfigValues.class, true, true);
+    static final ParameterValidator VALIDATOR = EnumValidator.create(IORTransportConfigValues.class);
 
     static final AttributeDefinition INTEGRITY =
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_INTEGRITY, ModelType.STRING, true)
@@ -69,7 +68,7 @@ class IORTransportConfigDefinition extends PersistentResourceDefinition {
     static final AttributeDefinition TRUST_IN_TARGET =
             new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_TRUST_IN_TARGET, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<IORTransportConfigValues>(IORTransportConfigValues.class, true, true,
+                    .setValidator(new EnumValidator<IORTransportConfigValues>(IORTransportConfigValues.class,
                             IORTransportConfigValues.NONE, IORTransportConfigValues.SUPPORTED))
                     .setAllowExpression(true)
                     .build();

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
@@ -56,11 +56,10 @@ class JacORBSubsystemDefinitions {
 
     static final ModelNode DEFAULT_ENABLED_PROPERTY = new ModelNode("on");
 
-    private static final ParameterValidator SSL_CONFIG_VALIDATOR =
-            new EnumValidator<SSLConfigValue>(SSLConfigValue.class, true, false);
+    private static final ParameterValidator SSL_CONFIG_VALIDATOR = EnumValidator.create(SSLConfigValue.class);
 
     private static final ParameterValidator ON_OFF_VALIDATOR = new EnumValidator<TransactionsAllowedValues>(
-            TransactionsAllowedValues.class, true, false, TransactionsAllowedValues.ON, TransactionsAllowedValues.OFF);
+            TransactionsAllowedValues.class, TransactionsAllowedValues.ON, TransactionsAllowedValues.OFF);
 
     static final SensitivityClassification JACORB_SECURITY =
             new SensitivityClassification(JacORBExtension.SUBSYSTEM_NAME, "jacorb-security", false, false, true);
@@ -206,7 +205,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_INIT_SECURITY = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_SECURITY, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setValidator(new EnumValidator<SecurityAllowedValues>(SecurityAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(SecurityAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .addAccessConstraint(JACORB_SECURITY_DEF)
@@ -215,7 +214,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_INIT_TX = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_TRANSACTIONS, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setValidator(new EnumValidator<TransactionsAllowedValues>(TransactionsAllowedValues.class, true, false))
+            .setValidator(EnumValidator.create(TransactionsAllowedValues.class))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .build();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15907

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```