### PR TITLE
WFLY-15908 Replace deprecated EnumValidator constructors and methods (JPA)

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -66,7 +66,7 @@ public class JPADefinition extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .setXmlName(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<ExtendedPersistenceInheritance>(ExtendedPersistenceInheritance.class,true,true))
+                    .setValidator(EnumValidator.create(ExtendedPersistenceInheritance.class))
                     .setDefaultValue(new ModelNode(ExtendedPersistenceInheritance.DEEP.toString()))
                     .build();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15908

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```