### PR TITLE
WFLY-15909 Replace deprecated EnumValidator constructors and methods (Messaging)

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
@@ -53,7 +53,7 @@ public class AddressSettingDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition ADDRESS_FULL_MESSAGE_POLICY = create("address-full-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(AddressFullMessagePolicy.PAGE.toString()))
-            .setValidator(new EnumValidator<>(AddressFullMessagePolicy.class, true, false))
+            .setValidator(EnumValidator.create(AddressFullMessagePolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
@@ -146,7 +146,7 @@ public class AddressSettingDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_POLICY = create("slow-consumer-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(SlowConsumerPolicy.NOTIFY.toString()))
-            .setValidator(new EnumValidator<>(SlowConsumerPolicy.class, true, true))
+            .setValidator(EnumValidator.create(SlowConsumerPolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -365,7 +365,7 @@ public interface CommonAttributes {
             .setDefaultValue(new ModelNode(JournalType.ASYNCIO.toString()))
             .setRequired(false)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(JournalType.class, true, true))
+            .setValidator(EnumValidator.create(JournalType.class))
             .setRestartAllServices()
             .build();
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
@@ -78,7 +78,7 @@ public class GroupingHandlerDefinition extends ModelOnlyResourceDefinition {
 
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(TYPE.class, false, true))
+            .setValidator(EnumValidator.create(TYPE.class))
             .setRestartAllServices()
             .build();
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryType.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryType.java
@@ -48,7 +48,7 @@ public enum ConnectionFactoryType {
         return type;
     }
 
-    public static final ParameterValidator VALIDATOR = new EnumValidator<>(ConnectionFactoryType.class, true, false);
+    public static final ParameterValidator VALIDATOR = EnumValidator.create(ConnectionFactoryType.class);
 
     // copied from HornetQ to avoid import HornetQ artifacts just to define attribute constants and enum validator
     private enum JMSFactoryType

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
@@ -126,7 +126,7 @@ public class JMSBridgeDefinition extends ModelOnlyResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition QUALITY_OF_SERVICE = create("quality-of-service", STRING)
-            .setValidator(new EnumValidator<>(QualityOfServiceMode.class, false, false))
+            .setValidator(EnumValidator.create(QualityOfServiceMode.class))
             .setAllowExpression(true)
             .build();
     public static final SimpleAttributeDefinition FAILURE_RETRY_INTERVAL = create("failure-retry-interval", LONG)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -94,7 +94,7 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition ADDRESS_FULL_MESSAGE_POLICY = create("address-full-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(AddressFullMessagePolicy.PAGE.toString()))
-            .setValidator(new EnumValidator<>(AddressFullMessagePolicy.class, true, false))
+            .setValidator(EnumValidator.create(AddressFullMessagePolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
@@ -187,7 +187,7 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_POLICY = create("slow-consumer-policy", ModelType.STRING)
             .setDefaultValue(new ModelNode(SlowConsumerPolicy.NOTIFY.toString()))
-            .setValidator(new EnumValidator<>(SlowConsumerPolicy.class, true, true))
+            .setValidator(EnumValidator.create(SlowConsumerPolicy.class))
             .setRequired(false)
             .setAllowExpression(true)
             .build();

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -134,7 +134,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
     // FIXME WFLY-4587 forward-when-no-consumers == true ? STRICT : ON_DEMAND
     public static final SimpleAttributeDefinition MESSAGE_LOAD_BALANCING_TYPE = create("message-load-balancing-type", STRING)
             .setDefaultValue(new ModelNode(MessageLoadBalancingType.ON_DEMAND.toString()))
-            .setValidator(new EnumValidator<>(MessageLoadBalancingType.class, true, true))
+            .setValidator(EnumValidator.create(MessageLoadBalancingType.class))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -89,7 +89,7 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(Type.class, false, true))
+            .setValidator(EnumValidator.create(Type.class))
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -442,7 +442,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setAllowExpression(true)
             // list allowed values explicitly to exclude MAPPED
-            .setValidator(new EnumValidator<>(JournalType.class, true, true))
+            .setValidator(EnumValidator.create(JournalType.class))
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition JOURNAL_MAX_ATTIC_FILES = create("journal-max-attic-files", ModelType.INT)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryType.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryType.java
@@ -56,5 +56,5 @@ public enum ConnectionFactoryType {
         return type;
     }
 
-    public static final ParameterValidator VALIDATOR = new EnumValidator<>(ConnectionFactoryType.class, true, false);
+    public static final ParameterValidator VALIDATOR = EnumValidator.create(ConnectionFactoryType.class);
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15909

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```