### PR TITLE
[WFLY-15925] Upgrade RESTEasy to 6.0.0.Final for WildFly Preview.

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -99,7 +99,7 @@
         <version.org.hibernate.validator>7.0.1.Final</version.org.hibernate.validator>
         <version.org.jberet>2.0.2.Final</version.org.jberet>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.resteasy.ee9>6.0.0.Beta1</version.org.jboss.resteasy.ee9>
+        <version.org.jboss.resteasy.ee9>6.0.0.Final</version.org.jboss.resteasy.ee9>
         <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
         <version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -297,7 +297,7 @@
                 <version.org.eclipse.microprofile.rest.client.api>3.0</version.org.eclipse.microprofile.rest.client.api>
                 <version.org.eclipse.yasson>2.0.3</version.org.eclipse.yasson>
                 <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
-                <version.org.jboss.resteasy.ee9>6.0.0.Beta1</version.org.jboss.resteasy.ee9>
+                <version.org.jboss.resteasy.ee9>6.0.0.Final</version.org.jboss.resteasy.ee9>
                 <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
                 <version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.ws.rs.jboss-jaxrs-api_3.0_spec>
                 <!--


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15925

Tag: https://github.com/resteasy/resteasy/releases/tag/6.0.0.Final
Diff: https://github.com/resteasy/resteasy/compare/6.0.0.Beta1...6.0.0.Final
