### PR TITLE
WFLY-15910 Replace deprecated EnumValidator constructors and methods (Naming)

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
@@ -60,7 +60,7 @@ public class NamingBindingResourceDefinition extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition BINDING_TYPE = new SimpleAttributeDefinitionBuilder(NamingSubsystemModel.BINDING_TYPE, ModelType.STRING, false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setValidator(EnumValidator.create(BindingType.class, false, false))
+            .setValidator(EnumValidator.create(BindingType.class))
             .build();
 
     static final SimpleAttributeDefinition VALUE = new SimpleAttributeDefinitionBuilder(NamingSubsystemModel.VALUE, ModelType.STRING, true)


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15910

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```