### PR TITLE
WFLY-15911 Replace deprecated EnumValidator constructors and methods (Security)

### DIFF
--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/handlers/HandlerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/handlers/HandlerResourceDefinition.java
@@ -51,7 +51,7 @@ public class HandlerResourceDefinition extends AbstractFederationResourceDefinit
         .build();
 
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(HandlerTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(HandlerTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/AttributeManagerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/AttributeManagerResourceDefinition.java
@@ -40,7 +40,7 @@ public class AttributeManagerResourceDefinition extends AbstractFederationResour
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<AttributeManagerTypeEnum>(AttributeManagerTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributeManagerTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/RoleGeneratorResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/federation/model/idp/RoleGeneratorResourceDefinition.java
@@ -40,7 +40,7 @@ public class RoleGeneratorResourceDefinition extends AbstractFederationResourceD
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(RoleGeneratorTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(RoleGeneratorTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/CredentialHandlerResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/CredentialHandlerResourceDefinition.java
@@ -44,7 +44,7 @@ public class CredentialHandlerResourceDefinition extends AbstractIDMResourceDefi
        .setAlternatives(ModelElement.COMMON_CODE.getName())
        .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<CredentialTypeEnum>(CredentialTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(CredentialTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/LDAPStoreMappingResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/LDAPStoreMappingResourceDefinition.java
@@ -45,7 +45,7 @@ public class LDAPStoreMappingResourceDefinition extends AbstractIDMResourceDefin
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<AttributedTypeEnum>(AttributedTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributedTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypeResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypeResourceDefinition.java
@@ -46,7 +46,7 @@ public class SupportedTypeResourceDefinition extends AbstractIDMResourceDefiniti
         .setAlternatives(ModelElement.COMMON_CODE.getName())
         .build();
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelElement.COMMON_CODE.getName(), ModelType.STRING, true)
-        .setValidator(new EnumValidator<>(AttributedTypeEnum.class, true, true))
+        .setValidator(EnumValidator.create(AttributedTypeEnum.class))
         .setAllowExpression(true)
         .setAlternatives(ModelElement.COMMON_CLASS_NAME.getName())
         .build();

--- a/security/subsystem/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
@@ -43,7 +43,7 @@ class JASPIMappingModuleDefinition extends MappingModuleDefinition {
 
     private static final SimpleAttributeDefinition FLAG = new SimpleAttributeDefinitionBuilder(Constants.FLAG, ModelType.STRING)
             .setRequired(false)
-            .setValidator(new EnumValidator<ModuleFlag>(ModuleFlag.class, true, true))
+            .setValidator(EnumValidator.create(ModuleFlag.class))
             .setAllowExpression(true)
             .build();
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
@@ -89,7 +89,7 @@ class LegacySupport {
         static {
             final ParametersValidator delegate = new ParametersValidator();
             delegate.registerValidator(CODE, new StringLengthValidator(1));
-            delegate.registerValidator(Constants.FLAG, new EnumValidator<ModuleFlag>(ModuleFlag.class, true, false));
+            delegate.registerValidator(Constants.FLAG, EnumValidator.create(ModuleFlag.class));
             delegate.registerValidator(Constants.MODULE, new StringLengthValidator(1, true));
             delegate.registerValidator(Constants.MODULE_OPTIONS, new ModelTypeValidator(ModelType.OBJECT, true));
             delegate.registerValidator(Constants.LOGIN_MODULE_STACK_REF, new StringLengthValidator(1, true));
@@ -176,7 +176,7 @@ class LegacySupport {
         static {
             final ParametersValidator delegate = new ParametersValidator();
             delegate.registerValidator(CODE, new StringLengthValidator(1));
-            delegate.registerValidator(Constants.FLAG, new EnumValidator<ModuleFlag>(ModuleFlag.class, false, false));
+            delegate.registerValidator(Constants.FLAG, EnumValidator.create(ModuleFlag.class));
             delegate.registerValidator(Constants.MODULE, new StringLengthValidator(1, true));
             delegate.registerValidator(Constants.MODULE_OPTIONS, new ModelTypeValidator(ModelType.OBJECT, true));
             validator = new ParametersOfValidator(delegate);

--- a/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
@@ -50,7 +50,7 @@ class LoginModuleResourceDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition FLAG = new SimpleAttributeDefinitionBuilder(Constants.FLAG, ModelType.STRING)
             .setRequired(true)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<ModuleFlag>(ModuleFlag.class, false, true))
+            .setValidator(EnumValidator.create(ModuleFlag.class))
             .build();
 
     static final SimpleAttributeDefinition MODULE = new SimpleAttributeDefinitionBuilder(Constants.MODULE, ModelType.STRING)


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15911 

Changes made for equivalent results:
Constructors:
```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```