### PR TITLE
WFLY-15912 Replace deprecated EnumValidator constructors and methods (Transactions)

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
@@ -132,7 +132,7 @@ class LogStoreConstants {
             .setRequired(false)
             .setDefaultValue(new ModelNode())
             .setMeasurementUnit(MeasurementUnit.NONE)
-            .setValidator(new EnumValidator<ParticipantStatus>(ParticipantStatus.class, true, false))
+            .setValidator(EnumValidator.create(ParticipantStatus.class))
             .build();
 
     static SimpleAttributeDefinition PARTICIPANT_JNDI_NAME = (new SimpleAttributeDefinitionBuilder(JNDI_ATTRIBUTE, ModelType.STRING))


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15912 

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```