### PR TITLE
WFLY-15913 Replace deprecated EnumValidator constructors and methods (Undertow)

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
@@ -75,7 +75,7 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
             .setRequired(false)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(SslClientAuthMode.class, true, true))
+            .setValidator(EnumValidator.create(SslClientAuthMode.class))
             .setDefaultValue(new ModelNode(SslClientAuthMode.NOT_REQUESTED.name()))
             .setDeprecated(ModelVersion.create(4, 0, 0))
             .setAlternatives(Constants.SSL_CONTEXT)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
@@ -70,7 +70,7 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.STACK_TRACE_ON_ERROR, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(ServletStackTraces.LOCAL_ONLY.toString()))
-                    .setValidator(new EnumValidator<>(ServletStackTraces.class, true, true))
+                    .setValidator(EnumValidator.create(ServletStackTraces.class))
                     .setAllowExpression(true)
                     .build();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -143,7 +143,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
 
     public static final AttributeDefinition FAILOVER_STRATEGY = new SimpleAttributeDefinitionBuilder(Constants.FAILOVER_STRATEGY, ModelType.STRING)
             .setRequired(false)
-            .setValidator(new EnumValidator<>(FailoverStrategy.class, true, true))
+            .setValidator(EnumValidator.create(FailoverStrategy.class))
             .setRestartAllServices()
             .setDefaultValue(new ModelNode(FailoverStrategy.LOAD_BALANCED.name()))
             .build();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15913

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```