### PR TITLE
WFLY-15914 Replace deprecated EnumValidator constructors and methods (Web Services)

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/Attributes.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/Attributes.java
@@ -60,7 +60,7 @@ interface Attributes {
     SimpleAttributeDefinition WSDL_URI_SCHEME = new SimpleAttributeDefinitionBuilder(Constants.WSDL_URI_SCHEME, ModelType.STRING)
             .setRequired(false)
             .setMinSize(1)
-            .setValidator(new EnumValidator<>(WsdlUriSchema.class, false, false))
+            .setValidator(EnumValidator.create(WsdlUriSchema.class))
             .setAllowExpression(true)
             .build();
     enum WsdlUriSchema {http, https}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15914

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```