### PR TITLE
WFLY-15905 Replace deprecated EnumValidator constructors and methods (EE)

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
@@ -168,7 +168,7 @@ public class ManagedExecutorServiceResourceDefinition extends SimpleResourceDefi
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(AbstractManagedExecutorService.RejectPolicy.ABORT.toString()))
-                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class, true, true))
+                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class))
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME_AD, CONTEXT_SERVICE_AD, THREAD_FACTORY_AD, THREAD_PRIORITY_AD, HUNG_TASK_TERMINATION_PERIOD_AD, HUNG_TASK_THRESHOLD_AD, LONG_RUNNING_TASKS_AD, CORE_THREADS_AD, MAX_THREADS_AD, KEEPALIVE_TIME_AD, QUEUE_LENGTH_AD, REJECT_POLICY_AD};

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
@@ -148,7 +148,7 @@ public class ManagedScheduledExecutorServiceResourceDefinition extends SimpleRes
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(AbstractManagedExecutorService.RejectPolicy.ABORT.toString()))
-                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class, true, true))
+                    .setValidator(EnumValidator.create(AbstractManagedExecutorService.RejectPolicy.class))
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME_AD, CONTEXT_SERVICE_AD, THREAD_FACTORY_AD, THREAD_PRIORITY_AD, HUNG_TASK_TERMINATION_PERIOD_AD, HUNG_TASK_THRESHOLD_AD, LONG_RUNNING_TASKS_AD, CORE_THREADS_AD, KEEPALIVE_TIME_AD, REJECT_POLICY_AD};


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15905

Changes made for equivalent results:
Constructors:

```java
EnumValidator(Class, boolean, E...) --> EnumValidator(Class, E...)
EnumValidator(Class, boolean, boolean) --> create(Class, E...)
EnumValidator(Class, boolean, boolean, E...) --> EnumValidator(Class, E...)
```

Methods:
```java
create(Class, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, E...)
create(Class, boolean, boolean, E...) --> create(Class, EnumSet)
```