### PR TITLE
[WFLY-15935]: Artemis Journal module is missing a netty dependency

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -48,6 +48,7 @@
         <module name="io.netty.netty-common"/>
         <module name="io.netty.netty-resolver"/>
         <module name="io.netty.netty-transport"/>
+        <module name="io.netty.netty-handler"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
         <module name="sun.jdk"/>
 


### PR DESCRIPTION
* Adding te missing io.netty.netty-handler dependency to the artemis
  journal module.

Jira: https://issues.redhat.com/browse/WFLY-15935