### PR TITLE
WFLY-15954 getJobInstances, getJobInstanceCount, getRunningExecutions…

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
@@ -84,9 +84,16 @@ abstract class JobRepositoryService implements JobRepository, Service<JobReposit
         return getAndCheckDelegate().getJobNames();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * WildFly JBeret subsystem validates a job name before each batch job operations.
+     * If a job name is invalid, {@code NoSuchJobException} would already have been thrown.
+     * So this method is optimized to always return true.
+     */
     @Override
     public boolean jobExists(final String jobName) {
-        return getAndCheckDelegate().jobExists(jobName);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
… should include jobs that have not been started

https://issues.redhat.com/browse/WFLY-15954

This pull request fixes 2 EE TCK batch test failures.