### PR TITLE
[WFLY-15965]: ExternalJMSDestinationDefinitionLegacyPrefixMessagingDe…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -3097,6 +3097,8 @@
                                         <exclude>org/jboss/as/test/integration/messaging/jms/definitions/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/xmldeployment/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionMessagingDeploymentTestCase.java</exclude>
                                         <!-- Security is managed at the broker level -->
                                         <exclude>org/jboss/as/test/integration/messaging/security/SecurityTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/security/DeserializationBlackListTestCase.java</exclude>


### PR DESCRIPTION
…ploymentTestCase and ExternalJMSDestinationDefinitionMessagingDeploymentTestCase shouldn't be executed with a remote broker.

* Excluding those test s from 'ejb-remote-broker-layers.surefire'

Jira: https://issues.redhat.com/browse/WFLY-15965
