### PR TITLE
WFLY-15963 Combine ORDINALS and ORDINAL_TO_WEEK_NUMBER_MAPPING fields…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/attribute/DayOfMonth.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/attribute/DayOfMonth.java
@@ -23,10 +23,8 @@ package org.jboss.as.ejb3.timerservice.schedule.attribute;
 
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -75,7 +73,10 @@ import org.jboss.as.ejb3.timerservice.schedule.value.SingleValue;
  * @version $Revision: $
  */
 public class DayOfMonth extends IntegerBasedExpression {
-
+    /**
+     * Regex pattern for multiple space characters
+     */
+    public static final Pattern REGEX_SPACES = Pattern.compile("\\s+");
     /**
      * The maximum allowed value for the {@link DayOfMonth}
      */
@@ -104,26 +105,15 @@ public class DayOfMonth extends IntegerBasedExpression {
 
     }
 
-    private static final Set<String> ORDINALS = new HashSet<String>();
-
-    private static final Map<String, Integer> ORDINAL_TO_WEEK_NUMBER_MAPPING = new HashMap<String, Integer>();
+    private static final Map<String, Integer> ORDINAL_TO_WEEK_NUMBER_MAPPING = new HashMap<>(8);
 
     static {
-        ORDINALS.add("1st");
-        ORDINALS.add("2nd");
-        ORDINALS.add("3rd");
-        ORDINALS.add("4th");
-        ORDINALS.add("5th");
-        ORDINALS.add("last");
-
         ORDINAL_TO_WEEK_NUMBER_MAPPING.put("1st", 1);
         ORDINAL_TO_WEEK_NUMBER_MAPPING.put("2nd", 2);
         ORDINAL_TO_WEEK_NUMBER_MAPPING.put("3rd", 3);
         ORDINAL_TO_WEEK_NUMBER_MAPPING.put("4th", 4);
         ORDINAL_TO_WEEK_NUMBER_MAPPING.put("5th", 5);
-
     }
-
 
     /**
      * Creates a {@link DayOfMonth} by parsing the passed {@link String} <code>value</code>
@@ -258,32 +248,36 @@ public class DayOfMonth extends IntegerBasedExpression {
         return eligibleDaysOfMonth;
     }
 
-    private int getAbsoluteDayOfMonth(Calendar cal, String relativeDayOfMonth) {
-        if (relativeDayOfMonth == null || relativeDayOfMonth.trim().isEmpty()) {
-            throw EjbLogger.EJB3_TIMER_LOGGER.invalidScheduleValue(DayOfMonth.class.getSimpleName(), relativeDayOfMonth);
+    /**
+     * Gets the absolute day of month.
+     * @param cal the calendar
+     * @param trimmedRelativeDayOfMonth a non-null, trimmed, relative day of month
+     * @return the absolute day of month
+     */
+    private int getAbsoluteDayOfMonth(Calendar cal, String trimmedRelativeDayOfMonth) {
+        if (trimmedRelativeDayOfMonth.isEmpty()) {
+            throw EjbLogger.EJB3_TIMER_LOGGER.invalidScheduleValue(DayOfMonth.class.getSimpleName(), trimmedRelativeDayOfMonth);
         }
-        String trimmedRelativeDayOfMonth = relativeDayOfMonth.trim();
-        if (trimmedRelativeDayOfMonth.equalsIgnoreCase("last")) {
-            int lastDayOfCurrentMonth = CalendarUtil.getLastDateOfMonth(cal);
-            return lastDayOfCurrentMonth;
+        trimmedRelativeDayOfMonth = trimmedRelativeDayOfMonth.toLowerCase(Locale.ROOT);
+        if (trimmedRelativeDayOfMonth.equals("last")) {
+            return CalendarUtil.getLastDateOfMonth(cal);
         }
         if (this.isValidNegativeDayOfMonth(trimmedRelativeDayOfMonth)) {
             Integer negativeRelativeDayOfMonth = Integer.parseInt(trimmedRelativeDayOfMonth);
             int lastDayOfCurrentMonth = CalendarUtil.getLastDateOfMonth(cal);
             return lastDayOfCurrentMonth + negativeRelativeDayOfMonth;
         }
-        if (this.isDayOfWeekBased(trimmedRelativeDayOfMonth)) {
-
-            String[] parts = trimmedRelativeDayOfMonth.split("\\s+");
+        String[] parts = splitDayOfWeekBased(trimmedRelativeDayOfMonth);
+        if (parts != null) {
             String ordinal = parts[0];
             String day = parts[1];
-            int dayOfWeek = DAY_OF_MONTH_ALIAS.get(day.toLowerCase(Locale.ENGLISH));
+            int dayOfWeek = DAY_OF_MONTH_ALIAS.get(day);
 
             Integer date = null;
-            if (ordinal.equalsIgnoreCase("last")) {
+            if (ordinal.equals("last")) {
                 date = CalendarUtil.getDateOfLastDayOfWeekInMonth(cal, dayOfWeek);
             } else {
-                int weekNumber = ORDINAL_TO_WEEK_NUMBER_MAPPING.get(ordinal.toLowerCase(Locale.ENGLISH));
+                int weekNumber = ORDINAL_TO_WEEK_NUMBER_MAPPING.get(ordinal);
                 date = CalendarUtil.getNthDayOfMonth(cal, weekNumber, dayOfWeek);
             }
 
@@ -297,7 +291,7 @@ public class DayOfMonth extends IntegerBasedExpression {
 
             return date;
         }
-        throw EjbLogger.EJB3_TIMER_LOGGER.invalidScheduleValue(DayOfMonth.class.getSimpleName(), relativeDayOfMonth);
+        throw EjbLogger.EJB3_TIMER_LOGGER.invalidScheduleValue(DayOfMonth.class.getSimpleName(), trimmedRelativeDayOfMonth);
     }
 
     private boolean isValidNegativeDayOfMonth(String dayOfMonth) {
@@ -313,45 +307,44 @@ public class DayOfMonth extends IntegerBasedExpression {
 
     }
 
-    private boolean isDayOfWeekBased(String relativeVal) {
-        String trimmedVal = relativeVal.trim();
-        // one or more spaces (which includes tabs and other forms of space)
-        Pattern p = Pattern.compile("\\s+");
-        String[] relativeParts = p.split(trimmedVal);
+    /**
+     * Checks if a relative value is weekOfDay-based, and splits the passed
+     * {@code trimmedLowerCaseRelativeVal} to 2 parts.
+     * @param trimmedLowerCaseRelativeVal must be non-null, trimmed and lower case value
+     * @return 2 parts, or null if {@code trimmedLowerCaseRelativeVal} is not dayOfWeek-based
+     */
+    private String[] splitDayOfWeekBased(String trimmedLowerCaseRelativeVal) {
+        String[] relativeParts = REGEX_SPACES.split(trimmedLowerCaseRelativeVal);
         if (relativeParts == null) {
-            return false;
+            return null;
         }
         if (relativeParts.length != 2) {
-            return false;
+            return null;
         }
-        String ordinal = relativeParts[0];
-        String dayOfWeek = relativeParts[1];
-        if (ordinal == null || dayOfWeek == null) {
-            return false;
+        String lowerCaseOrdinal = relativeParts[0];
+        String lowerCaseDayOfWeek = relativeParts[1];
+        if (lowerCaseOrdinal == null || lowerCaseDayOfWeek == null) {
+            return null;
         }
-        String lowerCaseOrdinal = ordinal.toLowerCase(Locale.ENGLISH);
-        if (ORDINALS.contains(lowerCaseOrdinal) == false) {
-            return false;
+        if (!ORDINAL_TO_WEEK_NUMBER_MAPPING.containsKey(lowerCaseOrdinal) && !lowerCaseOrdinal.equals("last")) {
+            return null;
         }
-        String lowerCaseDayOfWeek = dayOfWeek.toLowerCase(Locale.ENGLISH);
         if (DAY_OF_MONTH_ALIAS.containsKey(lowerCaseDayOfWeek) == false) {
-            return false;
+            return null;
         }
-        return true;
+        return relativeParts;
     }
 
     @Override
     public boolean isRelativeValue(String value) {
-        if (value == null) {
-            throw EjbLogger.EJB3_TIMER_LOGGER.invalidScheduleValue(DayOfMonth.class.getSimpleName(), value);
-        }
-        if (value.equalsIgnoreCase("last")) {
+        String lowerCaseValue = value.toLowerCase(Locale.ROOT);
+        if (lowerCaseValue.equals("last")) {
             return true;
         }
-        if (this.isValidNegativeDayOfMonth(value)) {
+        if (this.isValidNegativeDayOfMonth(lowerCaseValue)) {
             return true;
         }
-        if (this.isDayOfWeekBased(value)) {
+        if (this.splitDayOfWeekBased(lowerCaseValue) != null) {
             return true;
         }
         return false;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/attribute/IntegerBasedExpression.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/attribute/IntegerBasedExpression.java
@@ -210,6 +210,11 @@ public abstract class IntegerBasedExpression {
         }
     }
 
+    /**
+     * Checks if relative value is supported.
+     * @param value non-null value
+     * @return true if relative value is supported
+     */
     public abstract boolean isRelativeValue(String value);
 
 }


### PR DESCRIPTION
… in ejb3 DayOfMonth class

cleanup (improve the use of toLowerCase and equalsIgnoreCase; remove unnecessary null check)

https://issues.redhat.com/browse/WFLY-15963

some notes about changes of code cleanup:

* the regex `Pattern "\\s+"` is moved to the class-level to avoid compiling the pattern for every invocation of the method.
* `isDayOfWeekBased` method is renamed to `splitDayOfWeekBased` and the return type is changed from `boolean` to `String[]`. This method splits the input string to do the checking, and the caller of this method also needs to split the data. To avoid splitting it twice, this method is changed to return the split result: a non-null value is equivalent to previous true return value; a null is equivalent to the previous false return value.