### PR TITLE
[WFLY-15971] Upgrade WildFly Core 19.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-15971

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta3
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta2...19.0.0.Beta3

---

<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta3</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5490'>WFCORE-5490</a>] -         Elytron Expression Resolution too late to handle system properties.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5765'>WFCORE-5765</a>] -         Unable to check the result containing whitespace with the equals to (==) comparison operator in the &quot;if-else&quot; control flow in JBoss-CLI
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5590'>WFCORE-5590</a>] -         Provide a separate javax.* namespace Jakarta JSON api module and impl module for use by components that use JSON internally
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5769'>WFCORE-5769</a>] -         Adjust chmod to 644 for dev content
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5774'>WFCORE-5774</a>] -         Create SE 11 variants of SE 8 tests against &#39;main&#39;
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5772'>WFCORE-5772</a>] -         Upgrade WildFly Elytron to 1.18.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5776'>WFCORE-5776</a>] -         Upgrade WildFly Elytron to 1.18.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5777'>WFCORE-5777</a>] -         Ugrade to JBoss Modules 2.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5779'>WFCORE-5779</a>] -         Upgrade jandex to 2.4.2.Final
</li>
</ul>
                                                                                                                                

</details>