### PR TITLE
[main] [WFLY-15981] Exception thrown when closing WildFlySender

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySender.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/spi/sender/WildFlySender.java
@@ -50,7 +50,12 @@ public class WildFlySender implements Sender {
 
     @Override
     public int close() throws SenderException {
-        return delegate.close();
+        try {
+            return delegate.close();
+        } catch (SenderException ex) {
+            TracingExtensionLogger.ROOT_LOGGER.debugf("Error while flushing %s spans", ex.getDroppedSpanCount(), ex);
+            return 0;
+        }
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15981

Add try/catch to swallow SenderException
