### PR TITLE
[WFLY-15985]: Upgrade artemis-wildfly-integration to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.27.0-GA</version.org.javassist>
         <version.org.jberet>1.3.10.Final</version.org.jberet>
-        <version.org.jboss.activemq.artemis.integration>1.0.5</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>1.0.6</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>4.0.44.Final</version.org.jboss.ejb-client>


### PR DESCRIPTION
 * upgrading artemis-wildfly-integration to 1.0.6
 * Don't use cluster topology on recovery if the initial cf was configured not to use it.
 * Prepare for SSLcontext injection

Jira: https://issues.redhat.com/browse/WFLY-15985