### PR TITLE
[WFLY-15984] Increase timeout for MP Rest TCK Tests for Jakarta EE8 variant

### DIFF
--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -441,7 +441,7 @@
                         <jboss.inst>${basedir}/target/wildfly</jboss.inst>
                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
                         <jboss.server.config.file.name>standalone-microprofile.xml</jboss.server.config.file.name>
-                        <microprofile.jvm.args>${microprofile.jvm.args} -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=30 -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</microprofile.jvm.args>
+                        <microprofile.jvm.args>${microprofile.jvm.args} -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=50 -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</microprofile.jvm.args>
                         <test.url>http://localhost:8080</test.url>
                     </systemPropertyVariables>
                 </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15984
