### PR TITLE
[WFLY-15799] Upgrade to Kafka client 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.4</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.4</version.org.apache.james.apache-mime4j>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
-        <version.org.apache.kafka>3.0.0</version.org.apache.kafka>
+        <version.org.apache.kafka>3.1.0</version.org.apache.kafka>
         <version.org.apache.lucene>5.5.5</version.org.apache.lucene>
         <version.org.apache.myfaces.core>2.3.8</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
@@ -492,15 +492,8 @@
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <!--
-            Temporary downgrade of Kafka for the embedded setup (the main bundled Kafka client is still defined
-            above in version.org.apache.kafka) to avoid problems on Windows until
-            https://github.com/apache/kafka/commit/145392b8c66cf5c351d11bc659a3fc80fc6b602a makes it into
-            a 3.0.1 or 3.1.0 release.
-            Tracked in https://issues.redhat.com/browse/WFLY-15799
-        -->
-        <version.org.apache.kafka.for.test>2.8.1</version.org.apache.kafka.for.test>
-        <version.org.springframework.kafka>2.7.3</version.org.springframework.kafka>
+        <!-- Test dependency -->
+        <version.org.springframework.kafka>2.8.2</version.org.springframework.kafka>
         <version.org.testcontainers.testcontainers>1.16.0</version.org.testcontainers.testcontainers>
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -49,13 +49,6 @@
         <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
         <!-- properties to enable plugins shared by various bootable jar executions -->
         <bootable-jar-packaging.phase>none</bootable-jar-packaging.phase>
-        <!--
-            Temporarily downgrade embedded Kafka until until
-            https://github.com/apache/kafka/commit/145392b8c66cf5c351d11bc659a3fc80fc6b602a makes it into
-            a 3.0.1 or 3.1.0 release of the Kafka client.
-            Tracked in https://issues.redhat.com/browse/WFLY-15799
-        -->
-        <version.org.apache.kafka>${version.org.apache.kafka.for.test}</version.org.apache.kafka>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15799

As mentioned in the Jira, this allows us to remove the temporary downgrade of the embedded Kafka version for testing