### PR TITLE
WFLY-16013 Print more informative failure messages when working with …

### DIFF
--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -882,4 +882,6 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 105, value = "The %s %s is configured to use socket-binding %s, but this socket binding doesn't have the multicast-address or a multicast-port attributes configured.")
     OperationFailedException socketBindingMulticastNotSet(String resourceType, String resourceName, String socketBindingName);
 
+    @Message(id = 106, value = "Either socket-binding or jgroups-cluster attribute is required.")
+    OperationFailedException socketBindingOrJGroupsClusterRequired();
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_BINDING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,9 +69,11 @@ public class BroadcastGroupAdd extends ShallowResourceAdd {
             if (operation.hasDefined(JGROUPS_CLUSTER.getName())) {
                 target = target.append(CommonAttributes.JGROUPS_BROADCAST_GROUP, context.getCurrentAddressValue());
                 addHandler = JGroupsBroadcastGroupAdd.LEGACY_INSTANCE;
-            } else {
+            } else if (operation.hasDefined(SOCKET_BINDING.getName())) {
                 target = target.append(CommonAttributes.SOCKET_BROADCAST_GROUP, context.getCurrentAddressValue());
                 addHandler = SocketBroadcastGroupAdd.LEGACY_INSTANCE;
+            } else {
+                throw MessagingLogger.ROOT_LOGGER.socketBindingOrJGroupsClusterRequired();
             }
             op.get(OP_ADDR).set(target.toModelNode());
             context.addStep(op, addHandler, OperationContext.Stage.MODEL, true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.wildfly.extension.messaging.activemq.shallow.ShallowResourceAdd;
 
 /**
@@ -60,9 +61,11 @@ public class DiscoveryGroupAdd extends ShallowResourceAdd {
             if (operation.hasDefined(JGROUPS_CLUSTER.getName())) {
                 target = target.append(CommonAttributes.JGROUPS_DISCOVERY_GROUP, context.getCurrentAddressValue());
                 addHandler = JGroupsDiscoveryGroupAdd.LEGACY_INSTANCE;
-            } else {
+            } else if (operation.hasDefined(CommonAttributes.SOCKET_BINDING.getName())) {
                 target = target.append(CommonAttributes.SOCKET_DISCOVERY_GROUP, context.getCurrentAddressValue());
                 addHandler = SocketDiscoveryGroupAdd.LEGACY_INSTANCE;
+            } else {
+                throw MessagingLogger.ROOT_LOGGER.socketBindingOrJGroupsClusterRequired();
             }
             op.get(OP_ADDR).set(target.toModelNode());
             context.addStep(op, addHandler, OperationContext.Stage.MODEL, true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/ShallowResourceDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/ShallowResourceDefinition.java
@@ -17,10 +17,14 @@ package org.wildfly.extension.messaging.activemq.shallow;
 
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 
 /**
  *
@@ -60,5 +64,9 @@ public abstract class ShallowResourceDefinition extends PersistentResourceDefini
                 registry.registerReadOnlyAttribute(attr, new TranslatedReadAttributeHandler(this, this));
             }
         }
+    }
+
+    public void validateOperation(OperationContext context, PathAddress targetAddress, ModelNode translatedOperation)
+            throws OperationFailedException {
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/TranslatedWriteAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/TranslatedWriteAttributeHandler.java
@@ -33,19 +33,20 @@ public class TranslatedWriteAttributeHandler implements OperationStepHandler {
 
     private static final Logger LOG = Logger.getLogger(TranslatedWriteAttributeHandler.class);
 
-    private final ShallowResourceDefinition converter;
+    private final ShallowResourceDefinition shallowResource;
 
-    public TranslatedWriteAttributeHandler(ShallowResourceDefinition converter) {
-        this.converter = converter;
+    public TranslatedWriteAttributeHandler(ShallowResourceDefinition shallowResource) {
+        this.shallowResource = shallowResource;
     }
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-        PathAddress targetAddress = converter.convert(context, operation);
+        PathAddress targetAddress = shallowResource.convert(context, operation);
         ModelNode op = operation.clone();
         op.get(OP_ADDR).set(targetAddress.toModelNode());
         String attributeName = op.get(ModelDescriptionConstants.NAME).asString();
-        if (!converter.getIgnoredAttributes(context, op).contains(attributeName)) {
+        if (!shallowResource.getIgnoredAttributes(context, op).contains(attributeName)) {
+            shallowResource.validateOperation(context, targetAddress, op);
             OperationStepHandler writeAttributeHandler = context.getRootResourceRegistration()
                     .getAttributeAccess(targetAddress, attributeName).getWriteHandler();
             context.addStep(op, writeAttributeHandler, context.getCurrentStage(), true);

--- a/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/ShallowResourcesTestCase.java
+++ b/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/ShallowResourcesTestCase.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.messaging.activemq;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.jgroups.spi.JGroupsDefaultRequirement;
+import org.wildfly.clustering.spi.ClusteringDefaultRequirement;
+import org.wildfly.clustering.spi.ClusteringRequirement;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+/**
+ * Verifies that an attempt to undefine socket-binding attr on the socket-discovery-group resource, when performed via
+ * the original discovery-group shallow resource, fails with informative error message.
+ *
+ * The same is tested for the jgroups-cluster attr on the jgroups-discovery-group, and similarly for the *-broadcast-group resources.
+ */
+public class ShallowResourcesTestCase extends AbstractSubsystemTest {
+
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME);
+    private static final PathAddress SERVER_ADDRESS = SUBSYSTEM_ADDRESS.append(CommonAttributes.SERVER, CommonAttributes.DEFAULT);
+
+    private static PathAddress discoveryGroupAddress(String name) {
+        return SUBSYSTEM_ADDRESS.append(CommonAttributes.DISCOVERY_GROUP, name);
+    }
+
+    private static PathAddress broadcastGroupAddress(String name) {
+        return SERVER_ADDRESS.append(CommonAttributes.BROADCAST_GROUP, name);
+    }
+
+    public ShallowResourcesTestCase() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    @Test
+    public void testDiscoveryGroupRequiresSocketBindingOrJGroupsCluster() throws Exception {
+        ModelNode operationTemplate = Util.createAddOperation(discoveryGroupAddress("dg"));
+        testRequiresSocketBindingOrJGroupsCluster(operationTemplate);
+    }
+
+    @Test
+    public void testBroadcastGroupRequiresSocketBindingOrJGroupsCluster() throws Exception {
+        ModelNode operationTemplate = Util.createAddOperation(broadcastGroupAddress("bg"));
+        operationTemplate.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        testRequiresSocketBindingOrJGroupsCluster(operationTemplate);
+    }
+
+    private void testRequiresSocketBindingOrJGroupsCluster(ModelNode addOperationTemplate) throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        // try to add discovery or broadcast group with no socket-binding and no jgroups-cluster attrs -> should fail
+        // with a message saying that one of the two attributes must be set
+        ModelNode op = addOperationTemplate.clone();
+        ModelNode result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.get(FAILURE_DESCRIPTION).asString().contains("WFLYMSGAMQ0107:"));
+
+        // try to add discovery or broadcast group with jgroups-cluster set -> should succeed
+        op = addOperationTemplate.clone();
+        op.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default-cluster");
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(),
+                SUCCESS, result.get(OUTCOME).asString());
+        removeResource(kernelServices, addOperationTemplate.get(ADDRESS));
+
+        // try to add discovery or broadcast group with socket-binding set -> should succeed
+        op = addOperationTemplate.clone();
+        op.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(),
+                SUCCESS, result.get(OUTCOME).asString());
+        removeResource(kernelServices, addOperationTemplate.get(ADDRESS));
+    }
+
+    @Test
+    public void testUndefineDiscoveryGroupAttrs() throws Exception {
+        ModelNode addSocketDiscoveryGroup = Util.createAddOperation(discoveryGroupAddress("socket-group"));
+        addSocketDiscoveryGroup.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+
+        ModelNode addJGroupsDiscoveryGroup = Util.createAddOperation(discoveryGroupAddress("jgroups-group"));
+        addJGroupsDiscoveryGroup.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default");
+
+        testUndefineAttrs(addSocketDiscoveryGroup, addJGroupsDiscoveryGroup);
+    }
+
+    @Test
+    public void testUndefineBroadcastGroupAttrs() throws Exception {
+        ModelNode addSocketBroadcastGroup = Util.createAddOperation(broadcastGroupAddress("socket-group"));
+        addSocketBroadcastGroup.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        addSocketBroadcastGroup.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+
+        ModelNode addJGroupsBroadcastGroup = Util.createAddOperation(broadcastGroupAddress("jgroups-group"));
+        addJGroupsBroadcastGroup.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        addJGroupsBroadcastGroup.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default");
+
+        testUndefineAttrs(addSocketBroadcastGroup, addJGroupsBroadcastGroup);
+    }
+
+    private void testUndefineAttrs(ModelNode addSocketGroupTemplate, ModelNode addJGroupsGroupTemplate) throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        // create socket-*-group to work with
+        ModelNode result = kernelServices.executeOperation(addSocketGroupTemplate);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(), SUCCESS, result.get(OUTCOME).asString());
+
+        // create jgroups-*-group to work with
+        result = kernelServices.executeOperation(addJGroupsGroupTemplate);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(), SUCCESS, result.get(OUTCOME).asString());
+
+        // try to undefine socket-binding from socket-*-group
+        PathAddress socketGroupAddress = PathAddress.pathAddress(addSocketGroupTemplate.get(ADDRESS));
+        ModelNode op = Util.getUndefineAttributeOperation(socketGroupAddress, CommonAttributes.SOCKET_BINDING.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains("WFLYMSGAMQ0106:"));
+
+        // try to undefine jgroups-cluster from jgroups-*-group
+        PathAddress jgroupsGroupAddress = PathAddress.pathAddress(addJGroupsGroupTemplate.get(ADDRESS));
+        op = Util.getUndefineAttributeOperation(jgroupsGroupAddress, CommonAttributes.JGROUPS_CLUSTER.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains("WFLYMSGAMQ0106:"));
+
+        // try to undefine jgroups-cluster attribute in socket-*-group, operation should succeed (it should be ignored)
+        op = Util.getUndefineAttributeOperation(socketGroupAddress, CommonAttributes.JGROUPS_CLUSTER.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+
+        // try to undefine socket-binding attribute in jgroups-*-group, operation should succeed (it should be ignored)
+        op = Util.getUndefineAttributeOperation(jgroupsGroupAddress, CommonAttributes.SOCKET_BINDING.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private KernelServices createKernelServices() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(readResource("subsystem_14_0.xml"))
+                .build();
+        Assert.assertTrue("Subsystem boot failed!", kernelServices.isSuccessfulBoot());
+        return kernelServices;
+    }
+
+    private static void removeResource(KernelServices kernelServices, ModelNode address) {
+        ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(address));
+        ModelNode result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.resolve("ee"),
+                ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName(),
+                JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(),
+                Capabilities.ELYTRON_DOMAIN_CAPABILITY,
+                Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".cs1",
+                Capabilities.DATA_SOURCE_CAPABILITY + ".fooDS",
+                Capabilities.LEGACY_SECURITY_DOMAIN_CAPABILITY.getDynamicName("other"),
+                "org.wildfly.messaging.activemq.connector.external.in-vm",
+                "org.wildfly.messaging.activemq.connector.external.client",
+                "org.wildfly.remoting.http-listener-registry",
+                "org.wildfly.undertow.listener.http-upgrade-registry.default");
+    }
+}


### PR DESCRIPTION
…broadcast/discovery group resources

https://issues.redhat.com/browse/WFLY-16013
https://issues.redhat.com/browse/JBEAP-23159

The broadcast-group and discovery-group resources has been deprecated
and substituted by socket-*-group and jgroups-*-group variants. These
new resources have different validation rules than the original
resources, which may cause confusion for users who are not aware of
these changes.

The changes are:

1) When adding new `discovery-group` resource with `/subsystem=messaging-activemq/discovery-group=new:add()`

Before, the failure description was: `WFLYCTL0155: 'socket-binding' may not be null`
Now, the failure description is: `WFLYMSGAMQ0107: Either socket-binding or jgroups-cluster attribute is required.`

2) When undefining the `socket-binding` attribute on the `discovery-group` resource, operation failed with `WFLYCTL0155: 'socket-binding' may not be null`, even though the attribute is marked as not required in the `discovery-group` resource. In fact this resource is now a "shallow" resource and the undefine operation delegates to the `socket-discovery-group` resource, where the attribute is required. But the deprecation of the `discovery-group` in favor of the new resources is not highlighted anywhere.

The new failure description is: `WFLYMSGAMQ0106: The discovery-group resource has been deprecated and operations on it now delegate to the jgroups-discovery-group or socket-discovery-group resources. It's not possible to undefine socket-bind
ing on socket-discovery-group.`

Equivalent failure description is printed when trying to undefine the `jgroups-cluster` attribute (when it was previously defined, i.e. the resource was `jgroups-discovery-group`).

The same changes has been done to the `broadcat-group` resource.