### PR TITLE
[WFLY-16025] Switch to org.wildfly.plugins:wildlfy-maven-plugin to provision WildFly

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -66,8 +66,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -76,10 +77,10 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -96,10 +97,10 @@
                                     <version>${full.maven.version}</version>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -86,8 +86,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -96,13 +97,10 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -119,6 +117,9 @@
                                     <version>${full.maven.version}</version>
                                 </feature-pack>
                             </feature-packs>
+                            <galleon-options>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -95,8 +95,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -105,19 +106,19 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${jboss.home}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
+                            <provisioning-dir>wildfly</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${project.version}</version>
-                                    <inherit-configs>false</inherit-configs>
                                     <excluded-packages>
                                         <name>docs</name>
                                         <name>docs.licenses.merge</name>
                                     </excluded-packages>
+                                    <inherit-configs>false</inherit-configs>
                                     <included-configs>
                                         <config>
                                             <model>standalone</model>
@@ -126,9 +127,9 @@
                                     </included-configs>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-9/build/pom.xml
+++ b/ee-9/build/pom.xml
@@ -61,8 +61,9 @@
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -71,10 +72,10 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -85,12 +86,12 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                 <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-9/dist/pom.xml
+++ b/ee-9/dist/pom.xml
@@ -80,8 +80,9 @@
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -90,15 +91,15 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
-                                <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>                               
-                            </plugin-options>
+                                <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/ee-build/pom.xml
+++ b/ee-build/pom.xml
@@ -66,8 +66,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -76,10 +77,10 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -90,10 +91,10 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -85,8 +85,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -95,13 +96,13 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <version.org.wildfly.galleon-plugins>5.2.10.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
-        <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin>3.0.0.Beta1</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>
 

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -64,8 +64,9 @@
         <finalName>${server.output.dir.prefix}-servlet-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -74,10 +75,10 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -88,10 +89,10 @@
                                     </excluded-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -65,8 +65,9 @@
         <finalName>${server.output.dir.prefix}-servlet-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -75,13 +76,13 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1603,8 +1603,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <!-- Provision a cloud-profile server -->
                             <execution>
@@ -1614,15 +1615,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1630,21 +1631,20 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-
                             <!-- Provision a server with JBoss Diagnostic Reporting layer -->
                             <execution>
                                 <id>jdr-provisioning</id>
@@ -1653,15 +1653,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jdr</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jdr</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1669,18 +1669,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                        <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jdr</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jdr</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1692,15 +1692,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-batch</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-batch</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1708,19 +1708,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>batch-jberet</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>batch-jberet</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1732,15 +1732,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jpa</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jpa</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1748,19 +1748,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jpa</layer>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jpa</layer>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1772,15 +1772,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jsonp</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jsonp</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1788,23 +1788,23 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>jsonp</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <!-- Not strictly necessary but it will avoid the provisioning of
-                                                     Jakarta JSON Binding brought in by ee layer. We removes Jakarta JSON Binding to make the tests cleaner -->
-                                                <layer>jsonb</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>jsonp</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <!-- Not strictly necessary but it will avoid the provisioning of
+                                             Jakarta JSON Binding brought in by ee layer. We removes Jakarta JSON Binding to make the tests cleaner -->
+                                        <layer>jsonb</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
 
@@ -1816,15 +1816,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jsonb</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jsonb</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1832,18 +1832,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>jsonb</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>jsonb</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1855,15 +1855,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-microprofile-platform</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-microprofile-platform</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -1871,21 +1871,21 @@
                                             <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-platform</layer>
-                                                <layer>jaxrs-server</layer>
-                                                <!-- Needed by arquillian: protocol and security manager -->
-                                                <layer>jmx-remoting</layer>
-                                                <layer>security-manager</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-platform</layer>
+                                        <layer>jaxrs-server</layer>
+                                        <!-- Needed by arquillian: protocol and security manager -->
+                                        <layer>jmx-remoting</layer>
+                                        <layer>security-manager</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1897,15 +1897,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-ejb-lite</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-ejb-lite</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -1913,21 +1913,22 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>ejb-lite</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>ejb-lite</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
+
                             <!-- Provision a cloud-profile server with ejb -->
                             <execution>
                                 <id>ejb-provisioning</id>
@@ -1936,15 +1937,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-ejb</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-ejb</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${project.groupId}</groupId>
@@ -1952,20 +1953,20 @@
                                             <version>${ee.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>ejb</layer>
-                                                <layer>ejb-elytron-testsuite</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>ejb</layer>
+                                        <layer>ejb-elytron-testsuite</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1977,15 +1978,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-ejb-embedded-broker</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-ejb-embedded-broker</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${project.groupId}</groupId>
@@ -1993,23 +1994,24 @@
                                             <version>${project.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>ejb</layer>
-                                                <layer>embedded-activemq</layer>
-                                                <layer>remote-naming</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>ejb</layer>
+                                        <layer>embedded-activemq</layer>
+                                        <layer>remote-naming</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
+
                             <!-- Provision a cloud-profile server with ejb for remote Artemis broker-->
                             <execution>
                                 <id>ejb-remote-broker-provisioning</id>
@@ -2018,15 +2020,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-ejb-remote-broker</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-ejb-remote-broker</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${project.groupId}</groupId>
@@ -2034,21 +2036,21 @@
                                             <version>${project.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>ejb</layer>
-                                                <layer>remote-activemq-cf</layer>
-                                                <layer>remote-naming</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>ejb</layer>
+                                        <layer>remote-activemq-cf</layer>
+                                        <layer>remote-naming</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2060,15 +2062,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jsf</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jsf</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2076,19 +2078,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>jsf</layer>
-                                                <layer>web-passivation</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>jsf</layer>
+                                        <layer>web-passivation</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2100,15 +2102,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jsf-ejb-lite</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jsf-ejb-lite</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2116,19 +2118,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>jsf</layer>
-                                                <layer>ejb-lite</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>jsf</layer>
+                                        <layer>ejb-lite</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2140,15 +2142,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-legacy-sar</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-legacy-sar</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2156,19 +2158,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>sar</layer>
-                                                <layer>mail</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>sar</layer>
+                                        <layer>mail</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2180,15 +2182,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-mail</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-mail</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2196,18 +2198,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>mail</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>mail</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2219,15 +2221,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-mail-ejb</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-mail-ejb</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2235,19 +2237,19 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>mail</layer>
-                                                <layer>ejb</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>mail</layer>
+                                        <layer>ejb</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2259,15 +2261,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-pojo</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-mail-ejb</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2275,18 +2277,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>pojo</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>pojo</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2298,15 +2300,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-web-console</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-web-console</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2314,18 +2316,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-console</layer>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-console</layer>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2337,15 +2339,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-web-console-cloud</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-web-console-cloud</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -2353,21 +2355,20 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-console</layer>
-                                                <layer>cloud-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-console</layer>
+                                        <layer>cloud-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-
                         </executions>
                     </plugin>
 
@@ -3126,21 +3127,21 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
                                 <id>cloud-profile-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
                             <execution>
                                 <id>jpa-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
@@ -3298,21 +3299,21 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
                                 <id>cloud-profile-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
                             <execution>
                                 <id>jpa-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -110,22 +110,22 @@
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.org.wildfly.plugin}</version>
-                <configuration>
-                    <offline>true</offline>
-                    <jboss-home>${wildfly.dir}</jboss-home>
-                    <stdout>none</stdout>
-                    <java-opts>${modular.jdk.args}</java-opts>
-                    <system-properties>
-                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
-                        <module.path>${jboss.dist}/modules</module.path>
-                    </system-properties>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>execute-commands</goal>
                         </goals>
+                        <configuration>
+                            <offline>true</offline>
+                            <jboss-home>${wildfly.dir}</jboss-home>
+                            <stdout>none</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
+                            <system-properties>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                <module.path>${jboss.dist}/modules</module.path>
+                            </system-properties>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -251,12 +251,6 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <execution>
                                 <id>elytron-oidc-client-provisioning</id>
                                 <goals>
@@ -264,15 +258,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -282,16 +276,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>elytron-oidc-client</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>elytron-oidc-client</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>
@@ -365,12 +353,6 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <execution>
                                 <id>elytron-oidc-client-provisioning</id>
                                 <goals>
@@ -378,17 +360,17 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                         <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -398,16 +380,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>elytron-oidc-client</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>elytron-oidc-client</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>
@@ -571,12 +547,6 @@
                                 </goals>
                                 <phase>none</phase>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
                                 <id>server-provisioning</id>
@@ -663,12 +633,6 @@
                                 </goals>
                                 <phase>none</phase>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
                                 <id>server-provisioning</id>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -467,8 +467,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <id>server-provisioning</id>
@@ -477,10 +478,10 @@
                                 </goals>
                                 <phase>generate-test-resources</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/${wildfly.instance.name}</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
+                                    <provisioning-dir>${wildfly.instance.name}</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -504,10 +505,10 @@
                                             </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <plugin-options>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
+                                    </galleon-options>
                                 </configuration>
                             </execution>
                         </executions>
@@ -566,24 +567,24 @@
                                 <goals>
                                     <goal>execute-commands</goal>
                                 </goals>
+                                <configuration>
+                                    <offline>true</offline>
+                                    <scripts>
+                                        <script>enable-elytron.cli</script>
+                                        <script>modify-elytron-config.cli</script>
+                                    </scripts>
+                                    <jboss-home>${wildfly.dir}</jboss-home>
+                                    <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                                    <java-opts>${modular.jdk.args}</java-opts>
+                                    <system-properties>
+                                        <public.ip>${node0}</public.ip>
+                                        <management.ip>${node0}</management.ip>
+                                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                        <module.path>${wildfly.dir}/modules</module.path>
+                                    </system-properties>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <offline>true</offline>
-                            <scripts>
-                                <script>enable-elytron.cli</script>
-                                <script>modify-elytron-config.cli</script>
-                            </scripts>
-                            <jboss-home>${wildfly.dir}</jboss-home>
-                            <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
-                            <java-opts>${modular.jdk.args}</java-opts>
-                            <system-properties>
-                                <public.ip>${node0}</public.ip>
-                                <management.ip>${node0}</management.ip>
-                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
-                                <module.path>${wildfly.dir}/modules</module.path>
-                            </system-properties>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -616,12 +617,24 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- Instead provision slimmed installations -->
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <!-- FIXME: I'm not sure this is required -->
+                        <!--
+                        <configuration>
+                        -->
+                            <!-- Disable the standard enable-elytron.cli script as it's  already provisioned -->
+                        <!--
+                            <scripts combine.children="override">
+                                <script>modify-elytron-config.cli</script>
+                            </scripts>
+                        </configuration>
+                        -->
                         <executions>
                             <!-- Disable the standard provisioning -->
+                            <!-- Instead provision slimmed installations -->
                             <execution>
                                 <id>server-provisioning</id>
                                 <phase>none</phase>
@@ -634,49 +647,46 @@
                                 </goals>
                                 <phase>generate-test-resources</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/${wildfly.instance.name}</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>${wildfly.instance.name}</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <excluded-packages>
+                                                <name>product.conf</name>
+                                                <name>docs</name>
+                                                <name>docs.licenses.merge</name>
+                                            </excluded-packages>
                                             <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-full.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
-                        <configuration>
-                            <!-- Disable the standard enable-elytron.cli script as it's  already provisioned -->
-                            <scripts combine.children="override">
-                                <script>modify-elytron-config.cli</script>
-                            </scripts>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -773,12 +783,6 @@
                                 </goals>
                                 <phase>none</phase>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
                                 <id>server-provisioning</id>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
@@ -28,7 +28,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -122,6 +122,8 @@
                                     <groupId>${ts.microprofile-tck-provisioning.fp.groupId}</groupId>
                                     <artifactId>${ts.microprofile-tck-provisioning.fp.artifactId}</artifactId>
                                     <version>${ts.microprofile-tck-provisioning.fp.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
                                 </feature-pack>
                             </feature-packs>
                             <layers>
@@ -220,6 +222,8 @@
                             <systemPropertyVariables>
                                 <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
+                                <!-- FIXME? When WildFly is provisioned with wildfly-maven-plugin the config file is always named standalone.xml -->
+                                <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -93,8 +93,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <!-- Provision a server slimmed to only what we want for a particular TCK. -->
                     <execution>
@@ -106,15 +107,15 @@
                              Default is 'none', i.e. disabled. -->
                         <phase>${ts.microprofile-tck-provisioning.phase}</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>wildfly</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <!-- Child modules can set properties to override what feature pack is used -->
@@ -123,21 +124,21 @@
                                     <version>${ts.microprofile-tck-provisioning.fp.version}</version>
                                     <inherit-configs>false</inherit-configs>
                                     <inherit-packages>false</inherit-packages>
+                                    <included-configs>
+                                        <config>
+                                            <model>standalone</model>
+                                            <!-- Call the file standalone-microprofile.xml as that is what
+                                            arquillian.xml says to use for testing in the default maven profile-->
+                                            <name>standalone-microprofile.xml</name>
+                                        </config>
+                                    </included-configs>
                                 </feature-pack>
                             </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <!-- Call the file standalone-microprofile.xml as that is what
-                                         arquillian.xml says to use for testing in the default maven profile-->
-                                    <name>standalone-microprofile.xml</name>
-                                    <layers>
-                                        <!-- Child modules would set properties to drive the desired layers -->
-                                        <layer>${ts.microprofile-tck-provisioning.base.layer}</layer>
-                                        <layer>${ts.microprofile-tck-provisioning.decorator.layer}</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
+                            <layers>
+                                <!-- Child modules would set properties to drive the desired layers -->
+                                <layer>${ts.microprofile-tck-provisioning.base.layer}</layer>
+                                <layer>${ts.microprofile-tck-provisioning.decorator.layer}</layer>
+                            </layers>
                         </configuration>
                     </execution>
                 </executions>
@@ -555,17 +556,17 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <!-- Override the standard tck provisioning to add EE 9 transformation settings -->
                                 <id>microprofile-tck-provisioning</id>
                                 <configuration>
-                                    <plugin-options combine-children="append">
+                                    <galleon-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                         <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
-                                    </plugin-options>
+                                    </galleon-options>
                                 </configuration>
                             </execution>
                         </executions>
@@ -618,10 +619,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
-                            <!-- Provision a server slimmed to only what we want for a particular TCK. -->
                             <execution>
                                 <id>microprofile-tck-provisioning</id>
                                 <phase>none</phase>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -122,16 +122,6 @@
                                     <groupId>${ts.microprofile-tck-provisioning.fp.groupId}</groupId>
                                     <artifactId>${ts.microprofile-tck-provisioning.fp.artifactId}</artifactId>
                                     <version>${ts.microprofile-tck-provisioning.fp.version}</version>
-                                    <inherit-configs>false</inherit-configs>
-                                    <inherit-packages>false</inherit-packages>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <!-- Call the file standalone-microprofile.xml as that is what
-                                            arquillian.xml says to use for testing in the default maven profile-->
-                                            <name>standalone-microprofile.xml</name>
-                                        </config>
-                                    </included-configs>
                                 </feature-pack>
                             </feature-packs>
                             <layers>

--- a/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
@@ -108,6 +108,8 @@
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <!-- FIXME remove once WFMP-146 is fixed -->
+                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/src/test/resources/arquillian.xml
@@ -28,7 +28,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/reactive-streams-operators/pom.xml
+++ b/testsuite/integration/microprofile-tck/reactive-streams-operators/pom.xml
@@ -104,6 +104,8 @@
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <!-- FIXME remove once WFMP-146 is fixed -->
+                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/reactive-streams-operators/src/test/resources/arquillian.xml
@@ -28,7 +28,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8787</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -301,22 +301,8 @@
                                     <groupId>${full.maven.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${full.maven.version}</version>
-                                    <inherit-configs>false</inherit-configs>
-                                    <inherit-packages>false</inherit-packages>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                        </config>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-full.xml</name>
-                                        </config>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-microprofile.xml</name>
-                                        </config>
-                                    </included-configs>
+                                    <inherit-configs>true</inherit-configs>
+                                    <inherit-packages>true</inherit-packages>
                                     <excluded-packages>
                                         <name>docs</name>
                                         <name>docs.licenses.merge</name>
@@ -327,6 +313,10 @@
                     </execution>
                     <execution>
                         <id>microprofile-tck-provisioning</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
                         <!-- Override the inherited feature-pack setting to add a package needed for this TCK -->
                         <configuration>
                             <feature-packs>
@@ -356,6 +346,7 @@
                         <maven.repo.local>${maven.repo.local}</maven.repo.local>
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
                         <beansxml.path>${basedir}/beans.xml</beansxml.path>
+                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                     </system-properties>
                 </configuration>
             </plugin>
@@ -435,7 +426,6 @@
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
                         <jboss.inst>${basedir}/target/wildfly</jboss.inst>
                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
-                        <jboss.server.config.file.name>standalone-microprofile.xml</jboss.server.config.file.name>
                         <microprofile.jvm.args>${microprofile.jvm.args} -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=50 -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</microprofile.jvm.args>
                         <test.url>http://localhost:8080</test.url>
                     </systemPropertyVariables>
@@ -456,6 +446,7 @@
             <properties>
                 <!-- Enable galleon provisioning -->
                 <ts.microprofile-tck-provisioning.phase>compile</ts.microprofile-tck-provisioning.phase>
+                <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
             </properties>
             <build>
                 <plugins>
@@ -469,6 +460,15 @@
                                 <phase>none</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -281,48 +281,28 @@
                             </scripts>
                         </configuration>
                     </execution>
-                </executions>
-                <configuration>
-                    <offline>true</offline>
-                    <jboss-home>${basedir}/target/wildfly</jboss-home>
-                    <stdout>${project.build.directory}/wildfly/standalone/log/wildfly-wiremock.log</stdout>
-                    <java-opts>${modular.jdk.args}</java-opts>
-                    <system-properties>
-                        <maven.repo.local>${maven.repo.local}</maven.repo.local>
-                        <module.path>${project.build.directory}/wildfly/modules</module.path>
-                        <beansxml.path>${basedir}/beans.xml</beansxml.path>
-                    </system-properties>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <executions>
                     <execution>
                         <id>mp-server-provisioning</id>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>provision</goal>
                         </goals>
-                        <phase>generate-resources</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
-                                <jboss-maven-dist />
+                            <provisioning-dir>wildfly</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${full.maven.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${full.maven.version}</version>
-                                    <excluded-packages>
-                                        <name>docs</name>
-                                        <name>docs.licenses.merge</name>
-                                    </excluded-packages>
                                     <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
                                     <included-configs>
                                         <config>
                                             <model>standalone</model>
@@ -337,6 +317,10 @@
                                             <name>standalone-microprofile.xml</name>
                                         </config>
                                     </included-configs>
+                                    <excluded-packages>
+                                        <name>docs</name>
+                                        <name>docs.licenses.merge</name>
+                                    </excluded-packages>
                                 </feature-pack>
                             </feature-packs>
                         </configuration>
@@ -363,6 +347,17 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <offline>true</offline>
+                    <jboss-home>${basedir}/target/wildfly</jboss-home>
+                    <stdout>${project.build.directory}/wildfly/standalone/log/wildfly-wiremock.log</stdout>
+                    <java-opts>${modular.jdk.args}</java-opts>
+                    <system-properties>
+                        <maven.repo.local>${maven.repo.local}</maven.repo.local>
+                        <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <beansxml.path>${basedir}/beans.xml</beansxml.path>
+                    </system-properties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.internetitem</groupId>
@@ -465,8 +460,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <!-- Disable the default provisioning -->
@@ -494,23 +489,17 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <!-- Disable the default provisioning -->
-                                <id>mp-server-provisioning</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <!-- Disable the default module addition -->
                                 <id>add-wiremock-module</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <!-- Disable the default provisioning -->
+                                <id>mp-server-provisioning</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>
@@ -535,23 +524,17 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <!-- Disable the default provisioning -->
-                                <id>mp-server-provisioning</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <!-- Disable the default module addition -->
                                 <id>add-wiremock-module</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <!-- Disable the default provisioning -->
+                                <id>mp-server-provisioning</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>
@@ -587,8 +570,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <!-- Disable the default provisioning -->

--- a/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/microprofile-tck/rest-client/wiremock.cli
+++ b/testsuite/integration/microprofile-tck/rest-client/wiremock.cli
@@ -1,4 +1,4 @@
-embed-server --admin-only=true --server-config=standalone-microprofile.xml
+embed-server --admin-only=true --server-config=${jboss.server.config.file.name:standalone-microprofile.xml}
 
 /subsystem=ee:list-add(name=global-modules,value={name=com.github.tomakehurst.wiremock})
 deployment-overlay add --name=tckOverlay --content=/WEB-INF/lib/*.jar/META-INF/beans.xml=${beansxml.path} --deployments=*.war --redeploy-affected

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -428,12 +428,6 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <execution>
                                 <id>microprofile-provisioning</id>
                                 <goals>
@@ -441,15 +435,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -457,24 +451,24 @@
                                             <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <!-- Call the file standalone-microprofile.xml as that is what
+                                                    arquillian.xml says to use for testing in the default maven profile-->
+                                                    <name>standalone-microprofile.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <!-- Call the file standalone-microprofile.xml as that is what
-                                                 arquillian.xml says to use for testing in the default maven profile-->
-                                            <name>standalone-microprofile.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>microprofile-platform</layer>
-                                                <layer>ejb</layer>
-                                                <!-- Dependencies for reactive specs -->
-                                                <layer>microprofile-reactive-messaging-kafka</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>microprofile-platform</layer>
+                                        <layer>ejb</layer>
+                                        <!-- Dependencies for reactive specs -->
+                                        <layer>microprofile-reactive-messaging-kafka</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>
@@ -548,12 +542,6 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
                             <execution>
                                 <id>microprofile-provisioning</id>
                                 <goals>
@@ -561,17 +549,17 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                         <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -579,24 +567,24 @@
                                             <version>${full.maven.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <!-- Call the file standalone-microprofile.xml as that is what
+                                                    arquillian.xml says to use for testing in the default maven profile-->
+                                                    <name>standalone-microprofile.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <!-- Call the file standalone-microprofile.xml as that is what
-                                                 arquillian.xml says to use for testing in the default maven profile-->
-                                            <name>standalone-microprofile.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>microprofile-platform</layer>
-                                                <layer>ejb</layer>
-                                                <!-- Dependencies for reactive specs -->
-                                                <layer>microprofile-reactive-messaging-kafka</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>microprofile-platform</layer>
+                                        <layer>ejb</layer>
+                                        <!-- Dependencies for reactive specs -->
+                                        <layer>microprofile-reactive-messaging-kafka</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>
@@ -760,17 +748,10 @@
                                 </goals>
                                 <phase>none</phase>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
-                            <!-- Disable the default provisioning -->
                             <execution>
                                 <id>server-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
@@ -852,20 +833,15 @@
                                 </goals>
                                 <phase>none</phase>
                             </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
-                        <executions>
-                            <!-- Disable the default provisioning -->
                             <execution>
+                                <!-- Disable the default provisioning -->
                                 <id>server-provisioning</id>
                                 <goals>
-                                    <goal>provisioning</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
+
                         </executions>
                     </plugin>
                     <plugin>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -301,8 +301,9 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -311,10 +312,10 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <provisioning-dir>wildfly</provisioning-dir>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -325,6 +326,7 @@
                                         <name>docs.licenses.merge</name>
                                     </excluded-packages>
                                     <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>true</inherit-packages>
                                     <included-configs>
                                         <config>
                                             <model>standalone</model>
@@ -341,10 +343,10 @@
                                     </included-configs>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>
@@ -437,9 +439,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <!-- Turn off the standard galleon provisioning -->
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <!-- Turn off the standard provisioning -->
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>server-provisioning</id>
@@ -509,8 +511,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>3.0.0.Beta1</version>
                         <executions>
                             <!-- Provision a cloud-profile server -->
                             <execution>
@@ -520,15 +523,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -536,18 +539,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layer>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layer>
                                 </configuration>
                             </execution>
                             <!-- Provision a cloud-profile server with legacy-security as well -->
@@ -558,15 +561,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-legacy-security</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <provisioning-dir>wildfly-legacy-security</provisioning-dir>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -574,18 +577,18 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layer>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layer>
                                 </configuration>
                             </execution>
 
@@ -597,15 +600,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-legacy-sar</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <provisioning-dir>wildfly-legacy-sar</provisioning-dir>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -613,24 +616,22 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>sar</layer>
-
-                                                <!-- Needed by arquillian: protocol and security manager -->
-                                                <layer>jmx-remoting</layer>
-                                                <layer>security-manager</layer>
-
-                                                <!-- Needed by org.jboss.as.test.smoke.sar.ConfigService -->
-                                                <layer>logging</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layer>
+                                        <layer>sar</layer>
+                                        <!-- Needed by arquillian: protocol and security manager -->
+                                        <layer>jmx-remoting</layer>
+                                        <layer>security-manager</layer>
+                                        <!-- Needed by org.jboss.as.test.smoke.sar.ConfigService -->
+                                        <layer>logging</layer>
+                                    </layer>
                                 </configuration>
                             </execution>
                         </executions>
@@ -757,8 +758,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
@@ -870,8 +871,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <!-- Disable the default provisioning -->
                             <execution>
@@ -955,8 +956,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>server-provisioning</id>
@@ -965,10 +966,10 @@
                                 </goals>
                                 <phase>generate-resources</phase>
                                 <configuration>
-                                    <plugin-options combine.self="append">
+                                    <galleon-options combine.self="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                         <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
-                                    </plugin-options>
+                                    </galleon-options>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -606,12 +606,6 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>
@@ -645,12 +639,6 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>
@@ -685,12 +673,6 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>
@@ -726,12 +708,6 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>
@@ -763,12 +739,6 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -577,10 +577,10 @@
                             </execution>
                         </executions>
                     </plugin>
-
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <!-- Provision a datasources-web-server -->
                             <execution>
@@ -590,15 +590,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -606,23 +606,22 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>datasources</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>datasources</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
-		                    <!-- Provision a datasources-web-server -->
                             <execution>
                                 <id>web-legacy-security-provisioning</id>
                                 <goals>
@@ -630,15 +629,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-legacy-security</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-legacy-security</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -646,20 +645,20 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>datasources</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>datasources</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <!-- Provision a datasources-web-server with support for HTTPS via an autogenerated cert -->
@@ -670,15 +669,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-legacy-https</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-legacy-https</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -686,21 +685,21 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>undertow-https</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>datasources</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>undertow-https</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>datasources</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <!-- Provision a jaxrs-server -->
@@ -711,15 +710,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-jaxrs</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-jaxrs</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -727,17 +726,17 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <!-- Provision a cloud-server -->
@@ -748,15 +747,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-cloud</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-cloud</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -764,22 +763,22 @@
                                             <version>${testsuite.ee.galleon.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
+
                         </executions>
                     </plugin>
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -341,8 +341,9 @@
 
                     <!-- Server provisioning and configuration. -->
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <id>webservices-provisioning</id>
@@ -351,15 +352,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-webservices</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-webservices</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -369,16 +370,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>webservices</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>webservices</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -388,15 +383,15 @@
                                 </goals>
                                 <phase>compile</phase>
                                 <configuration>
-                                    <install-dir>${project.build.directory}/wildfly-webservices-ejb</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>${galleon.offline}</offline>
-                                    <plugin-options>
+                                    <provisioning-dir>wildfly-webservices-ejb</provisioning-dir>
+                                    <record-provisioning-state>false</record-provisioning-state>
+                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                                    <galleon-options>
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
+                                    </galleon-options>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -406,20 +401,14 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>ejb</layer>
-                                                <layer>webservices</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>webservices</layer>
+                                        <layer>ejb</layer>
+                                    </layers>
                                 </configuration>
-                              </execution>
-                           </executions>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -40,13 +40,13 @@
     </dependencies>
     
     <properties>
-        <layers.install.dir>${project.build.directory}/layers-results</layers.install.dir>
+        <layers.install.dir>layers-results</layers.install.dir>
         <!-- Put 'servlet' installations in the same dir as others. Set this to
              a different dir if testing the servlet feature pack. -->
         <servlet.layers.install.dir>${layers.install.dir}</servlet.layers.install.dir>
         <!-- An empty layer for this will disable 'servlet dist' tests which are meant for testing
              the servlet feature pack. -->
-        <servlet.layers.install.root>${project.build.directory}/servlet-layers-results</servlet.layers.install.root>
+        <servlet.layers.install.root>servlet-layers-results</servlet.layers.install.root>
         <layers.delete.installations>true</layers.delete.installations>
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
         
@@ -119,19 +119,20 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <configuration>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                 <jboss-maven-provisioning-repo>${maven.repo.local}</jboss-maven-provisioning-repo>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                         <!--
                             Keep the executions that use Galleon layers defined only in the wildfly-galleon-pack
@@ -145,7 +146,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-server</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-server</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -155,15 +156,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -173,7 +168,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-server-clustered</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-server-clustered</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -183,16 +178,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -202,7 +191,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-server-decorated</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-server-decorated</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -212,17 +201,11 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -232,7 +215,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-server-h2</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-server-h2</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -242,16 +225,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -261,7 +238,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-server-h2</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-server-h2</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -271,20 +248,14 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>jpa-distributed</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>jpa</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>jpa-distributed</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>jpa</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -294,7 +265,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -304,15 +275,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -322,7 +287,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server-clustered</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server-clustered</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -332,16 +297,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -351,7 +310,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server-decorated</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server-decorated</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -361,18 +320,12 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>observability</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>observability</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -382,7 +335,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server-h2</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server-h2</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -392,16 +345,12 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>observability</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -411,7 +360,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server-h2</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server-h2</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -421,17 +370,11 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>jpa-distributed</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>jpa-distributed</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -441,7 +384,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources-web-server-observability</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources-web-server-observability</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -451,16 +394,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>observability</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>observability</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -470,7 +407,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/iiop-openjdk-server</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/iiop-openjdk-server</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -480,15 +417,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>iiop-openjdk</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>iiop-openjdk</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -498,7 +429,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs-server</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs-server</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -508,15 +439,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -526,7 +451,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs-server-clustered</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs-server-clustered</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -536,16 +461,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -555,7 +474,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs-server-decorated</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs-server-decorated</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -565,18 +484,12 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>observability</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>observability</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -586,7 +499,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs-server-h2</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs-server-h2</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -596,16 +509,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -615,7 +522,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs-server-observability</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs-server-observability</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -625,16 +532,10 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>observability</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>observability</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -642,27 +543,21 @@
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
-                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jpa-distributed</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jpa-distributed</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>wildfly-test-galleon-pack</artifactId>
-                                            <version>${ee.maven.version}</version>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
                                             <inherit-configs>false</inherit-configs>
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jpa-distributed</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jpa-distributed</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -672,7 +567,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/web-clustering</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/web-clustering</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -682,15 +577,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-clustering</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -700,7 +589,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/web-passivation</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/web-passivation</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -710,15 +599,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-passivation</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-passivation</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <!-- servlet layers. Most of these we now by default provision
@@ -726,27 +609,20 @@
                             <execution>
                                 <!-- Build the test-standalone-reference from the servlet feature pack.
                                      This is not a layer test. It's a test of the standard standalone.xml
-                                      produced by a feature pack and we have another execution that
-                                      does the same for wildfly-ee. -->
+                                     produced by a feature pack and we have another execution that
+                                     does the same for wildfly-ee. -->
                                 <id>test-standalone-reference-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
                                 <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.root}/test-standalone-reference</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/test-standalone-reference</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.maven.groupId}</groupId>
                                             <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                             <version>${ee.maven.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <included-configs>
-                                                <config>
-                                                    <model>standalone</model>
-                                                    <name>standalone.xml</name>
-                                                </config>
-                                            </included-configs>
                                         </feature-pack>
                                     </feature-packs>
                                 </configuration>
@@ -758,7 +634,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/ee</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/ee</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -768,15 +644,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ee</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ee</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -786,7 +656,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/undertow-https</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/undertow-https</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -796,15 +666,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>undertow-https</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>undertow-https</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -814,7 +678,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/undertow-load-balancer</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/undertow-load-balancer</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -824,15 +688,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>undertow-load-balancer</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>undertow-load-balancer</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -842,7 +700,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/naming</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/naming</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -852,15 +710,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>naming</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>naming</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -870,7 +722,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/undertow</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/undertow</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -880,15 +732,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>undertow</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>undertow</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -898,7 +744,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.dir}/web-server</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/web-server</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${servlet.feature.pack.groupId}</groupId>
@@ -908,15 +754,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-server</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-server</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <!-- Build the test-all-layers from the servlet feature pack.
@@ -929,7 +769,7 @@
                                 </goals>
                                 <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
-                                    <install-dir>${servlet.layers.install.root}/test-all-layers</install-dir>
+                                    <provisioning-dir>${servlet.layers.install.root}/test-all-layers</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.maven.groupId}</groupId>
@@ -939,24 +779,18 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ee</layer>
-                                                <layer>undertow-load-balancer</layer>
-                                                <layer>naming</layer>
-                                                <layer>undertow</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>web-server</layer>
-                                                <!-- core-server, core-tools are from core, 
-                                                required to compare all layers with reference installation -->
-                                                <layer>core-server</layer>
-                                                <layer>core-tools</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ee</layer>
+                                        <layer>undertow-load-balancer</layer>
+                                        <layer>naming</layer>
+                                        <layer>undertow</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>web-server</layer>
+                                        <!-- core-server, core-tools are from core,
+                                        required to compare all layers with reference installation -->
+                                        <layer>core-server</layer>
+                                        <layer>core-tools</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <!-- wildfly layers -->
@@ -967,7 +801,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/batch-jberet</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/batch-jberet</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -977,15 +811,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>batch-jberet</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>batch-jberet</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -995,7 +823,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/bean-validation</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/bean-validation</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1005,15 +833,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>bean-validation</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>bean-validation</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1023,7 +845,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cdi</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cdi</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1033,15 +855,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cdi</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cdi</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1051,7 +867,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/cloud-profile</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/cloud-profile</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1061,15 +877,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-profile</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-profile</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1079,7 +889,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/datasources</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/datasources</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1089,15 +899,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>datasources</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>datasources</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1107,7 +911,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ee</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ee</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1117,15 +921,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ee</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ee</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1135,7 +933,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ee-security</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ee-security</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1145,15 +943,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ee-security</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ee-security</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1163,7 +955,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1173,15 +965,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1191,7 +977,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb-lite</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb-lite</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1201,15 +987,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb-lite</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb-lite</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1219,7 +999,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb-lite-dist-cache</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb-lite-dist-cache</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1229,19 +1009,13 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb-lite</layer>
-                                                <layer>ejb-dist-cache</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>ejb-local-cache</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb-lite</layer>
+                                        <layer>ejb-dist-cache</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>ejb-local-cache</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1251,7 +1025,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb-dist-cache</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb-dist-cache</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1261,15 +1035,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb-dist-cache</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb-dist-cache</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1279,7 +1047,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb-http-invoker</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb-http-invoker</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1289,15 +1057,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb-http-invoker</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb-http-invoker</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1307,7 +1069,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/ejb-local-cache</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/ejb-local-cache</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1317,15 +1079,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>ejb-local-cache</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>ejb-local-cache</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1335,7 +1091,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/h2-datasource</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/h2-datasource</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1345,26 +1101,20 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-profile</layer>
-                                                <layer>h2-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-profile</layer>
+                                        <layer>h2-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-                            <execution>   
+                            <execution>
                                 <id>h2-default-datasource-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/h2-default-datasource</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/h2-default-datasource</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1374,27 +1124,21 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-server</layer>
-                                                <layer>jpa</layer>
-                                                <layer>h2-default-datasource</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-server</layer>
+                                        <layer>jpa</layer>
+                                        <layer>h2-default-datasource</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-                            <execution>   
+                            <execution>
                                 <id>h2-driver-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/h2-driver</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/h2-driver</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1404,17 +1148,11 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-server</layer>
-                                                <layer>jpa</layer>
-                                                <layer>h2-driver</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-server</layer>
+                                        <layer>jpa</layer>
+                                        <layer>h2-driver</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1424,7 +1162,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jaxrs</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jaxrs</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1434,15 +1172,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jaxrs</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jaxrs</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1452,7 +1184,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jdr</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jdr</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1462,15 +1194,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jdr</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jdr</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1480,7 +1206,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jms-activemq</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jms-activemq</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1490,15 +1216,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jms-activemq</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jms-activemq</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1508,7 +1228,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jsonp</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jsonp</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1518,15 +1238,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jsonp</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jsonp</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1536,7 +1250,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jsonb</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jsonb</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1546,15 +1260,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jsonb</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jsonb</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1564,7 +1272,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/remote-activemq</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/remote-activemq</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1574,15 +1282,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>remote-activemq</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>remote-activemq</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1592,7 +1294,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jpa</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jpa</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1602,15 +1304,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jpa</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jpa</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1620,7 +1316,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/jsf</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/jsf</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1630,15 +1326,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>jsf</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>jsf</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1650,7 +1340,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/mail</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/mail</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1660,18 +1350,11 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>mail</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>mail</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-
                             <execution>
                                 <id>messaging-activemq-provisioning</id>
                                 <goals>
@@ -1679,7 +1362,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/messaging-activemq</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/messaging-activemq</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1689,15 +1372,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>messaging-activemq</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>messaging-activemq</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1707,7 +1384,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/observability</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/observability</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1717,15 +1394,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>observability</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>observability</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1735,7 +1406,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/opentelemetry</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/opentelemetry</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1745,15 +1416,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>opentelemetry</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>opentelemetry</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1763,7 +1428,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/pojo</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/pojo</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1773,15 +1438,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>pojo</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>pojo</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1791,7 +1450,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/resource-adapters</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/resource-adapters</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1801,15 +1460,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>resource-adapters</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>resource-adapters</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <!-- SAR provisioning -->
@@ -1820,7 +1473,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/sar</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/sar</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1830,15 +1483,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>sar</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>sar</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1848,7 +1495,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/transactions</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/transactions</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1858,15 +1505,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>transactions</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>transactions</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1876,7 +1517,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/undertow</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/undertow</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1886,15 +1527,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>undertow</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>undertow</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1904,7 +1539,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/web-console</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/web-console</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1914,15 +1549,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>web-console</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>web-console</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1932,7 +1561,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/webservices</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/webservices</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -1942,15 +1571,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>webservices</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>webservices</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -1964,7 +1587,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-platform</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-platform</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -1974,15 +1597,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-platform</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-platform</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1992,7 +1609,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-config</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-config</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2002,15 +1619,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-config</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-config</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2020,7 +1631,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-health</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-health</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2030,15 +1641,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-health</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-health</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2048,7 +1653,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-metrics</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-metrics</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2058,15 +1663,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-metrics</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-metrics</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2076,7 +1675,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-openapi</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-openapi</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2086,15 +1685,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-openapi</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-openapi</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2104,7 +1697,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-fault-tolerance</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-fault-tolerance</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2114,15 +1707,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2132,7 +1719,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-jwt</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-jwt</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2142,15 +1729,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-jwt</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-jwt</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2160,7 +1741,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-standalone</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-standalone</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2170,21 +1751,15 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>web-passivation</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                        <layer>microprofile-jwt</layer>
+                                        <layer>microprofile-openapi</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>web-passivation</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2194,7 +1769,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/microprofile-standalone-ha</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/microprofile-standalone-ha</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2204,25 +1779,19 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>cloud-server</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>jpa-distributed</layer>
-                                                <layer>web-clustering</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>jpa</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                        <layer>microprofile-jwt</layer>
+                                        <layer>microprofile-openapi</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>jpa-distributed</layer>
+                                        <layer>web-clustering</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>jpa</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2232,7 +1801,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/open-tracing</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/open-tracing</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2242,15 +1811,9 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>microprofile-opentracing</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>microprofile-opentracing</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
@@ -2264,7 +1827,7 @@
                                 </goals>
                                 <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/test-all-layers</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/test-all-layers</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2274,86 +1837,80 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>base-server</layer>
-                                                <layer>batch-jberet</layer>
-                                                <layer>bean-validation</layer>
-                                                <layer>cdi</layer>
-                                                <layer>cloud-profile</layer>
-                                                <layer>cloud-server</layer>
-                                                <layer>core-management</layer>
-                                                <layer>core-server</layer>
-                                                <layer>core-tools</layer>
-                                                <layer>datasources</layer>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>deployment-scanner</layer>
-                                                <layer>discovery</layer>
-                                                <layer>ee</layer>
-                                                <layer>ee-security</layer>
-                                                <layer>ejb</layer>
-                                                <layer>ejb-http-invoker</layer>
-                                                <layer>ejb-lite</layer>
-                                                <layer>ejb-local-cache</layer>
-                                                <layer>elytron</layer>
-                                                <layer>h2-datasource</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>h2-driver</layer>
-                                                <layer>iiop-openjdk</layer>
-                                                <layer>io</layer>
-                                                <layer>jaxrs</layer>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>jdr</layer>
-                                                <layer>jms-activemq</layer>
-                                                <layer>jmx</layer>
-                                                <layer>jmx-remoting</layer>
-                                                <layer>jpa</layer>
-                                                <layer>jsf</layer>
-                                                <layer>jsonb</layer>
-                                                <layer>jsonp</layer>
-                                                <layer>logging</layer>
-                                                <layer>mail</layer>
-                                                <layer>management</layer>
-                                                <layer>messaging-activemq</layer>
-                                                <layer>naming</layer>
-                                                <layer>observability</layer>
-                                                <layer>opentelemetry</layer>
-                                                <layer>pojo</layer>
-                                                <layer>remote-activemq</layer>
-                                                <layer>remoting</layer>
-                                                <layer>request-controller</layer>
-                                                <layer>resource-adapters</layer>
-                                                <layer>sar</layer>
-                                                <layer>security-manager</layer>
-                                                <layer>transactions</layer>
-                                                <layer>undertow</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>undertow-load-balancer</layer>
-                                                <layer>web-passivation</layer>
-                                                <layer>web-console</layer>
-                                                <layer>web-server</layer>
-                                                <layer>webservices</layer>
-                                                <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
-                                                 -->
-                                                <layer>microprofile-config</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-health</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-metrics</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>microprofile-opentracing</layer>
-                                                <layer>microprofile-platform</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>base-server</layer>
+                                        <layer>batch-jberet</layer>
+                                        <layer>bean-validation</layer>
+                                        <layer>cdi</layer>
+                                        <layer>cloud-profile</layer>
+                                        <layer>cloud-server</layer>
+                                        <layer>core-management</layer>
+                                        <layer>core-server</layer>
+                                        <layer>core-tools</layer>
+                                        <layer>datasources</layer>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>deployment-scanner</layer>
+                                        <layer>discovery</layer>
+                                        <layer>ee</layer>
+                                        <layer>ee-security</layer>
+                                        <layer>ejb</layer>
+                                        <layer>ejb-http-invoker</layer>
+                                        <layer>ejb-lite</layer>
+                                        <layer>ejb-local-cache</layer>
+                                        <layer>elytron</layer>
+                                        <layer>h2-datasource</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>h2-driver</layer>
+                                        <layer>iiop-openjdk</layer>
+                                        <layer>io</layer>
+                                        <layer>jaxrs</layer>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>jdr</layer>
+                                        <layer>jms-activemq</layer>
+                                        <layer>jmx</layer>
+                                        <layer>jmx-remoting</layer>
+                                        <layer>jpa</layer>
+                                        <layer>jsf</layer>
+                                        <layer>jsonb</layer>
+                                        <layer>jsonp</layer>
+                                        <layer>logging</layer>
+                                        <layer>mail</layer>
+                                        <layer>management</layer>
+                                        <layer>messaging-activemq</layer>
+                                        <layer>naming</layer>
+                                        <layer>observability</layer>
+                                        <layer>opentelemetry</layer>
+                                        <layer>pojo</layer>
+                                        <layer>remote-activemq</layer>
+                                        <layer>remoting</layer>
+                                        <layer>request-controller</layer>
+                                        <layer>resource-adapters</layer>
+                                        <layer>sar</layer>
+                                        <layer>security-manager</layer>
+                                        <layer>transactions</layer>
+                                        <layer>undertow</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>undertow-load-balancer</layer>
+                                        <layer>web-passivation</layer>
+                                        <layer>web-console</layer>
+                                        <layer>web-server</layer>
+                                        <layer>webservices</layer>
+                                        <!--
+                                            Galleon layers defined only in the wildfly-galleon-pack
+                                         -->
+                                        <layer>microprofile-config</layer>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                        <layer>microprofile-health</layer>
+                                        <layer>microprofile-jwt</layer>
+                                        <layer>microprofile-metrics</layer>
+                                        <layer>microprofile-openapi</layer>
+                                        <layer>microprofile-opentracing</layer>
+                                        <layer>microprofile-platform</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
 
-                           <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
+                            <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
                             <execution>
                                 <id>all-layers-jpa-distributed-provisioning-full</id>
                                 <goals>
@@ -2361,7 +1918,7 @@
                                 </goals>
                                 <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/test-all-layers-jpa-distributed</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/test-all-layers-jpa-distributed</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2371,85 +1928,79 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>base-server</layer>
-                                                <layer>batch-jberet</layer>
-                                                <layer>bean-validation</layer>
-                                                <layer>cdi</layer>
-                                                <layer>cloud-profile</layer>
-                                                <layer>cloud-server</layer>
-                                                <layer>core-management</layer>
-                                                <layer>core-server</layer>
-                                                <layer>core-tools</layer>
-                                                <layer>datasources</layer>
-                                                <layer>datasources-web-server</layer>
-                                                <layer>deployment-scanner</layer>
-                                                <layer>discovery</layer>
-                                                <layer>ee</layer>
-                                                <layer>ee-security</layer>
-                                                <layer>ejb</layer>
-                                                <layer>ejb-dist-cache</layer>
-                                                <layer>ejb-http-invoker</layer>
-                                                <layer>ejb-lite</layer>
-                                                <layer>elytron</layer>
-                                                <layer>h2-datasource</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>h2-driver</layer>
-                                                <layer>iiop-openjdk</layer>
-                                                <layer>io</layer>
-                                                <layer>jaxrs</layer>
-                                                <layer>jaxrs-server</layer>
-                                                <layer>jdr</layer>
-                                                <layer>jms-activemq</layer>
-                                                <layer>jmx</layer>
-                                                <layer>jmx-remoting</layer>
-                                                <layer>jpa-distributed</layer>
-                                                <layer>jsf</layer>
-                                                <layer>jsonb</layer>
-                                                <layer>jsonp</layer>
-                                                <layer>logging</layer>
-                                                <layer>mail</layer>
-                                                <layer>management</layer>
-                                                <layer>messaging-activemq</layer>
-                                                <layer>naming</layer>
-                                                <layer>observability</layer>
-                                                <layer>opentelemetry</layer>
-                                                <layer>pojo</layer>
-                                                <layer>remote-activemq</layer>
-                                                <layer>remoting</layer>
-                                                <layer>request-controller</layer>
-                                                <layer>resource-adapters</layer>
-                                                <layer>sar</layer>
-                                                <layer>security-manager</layer>
-                                                <layer>transactions</layer>
-                                                <layer>undertow</layer>
-                                                <layer>undertow-https</layer>
-                                                <layer>undertow-load-balancer</layer>
-                                                <layer>web-clustering</layer>
-                                                <layer>web-console</layer>
-                                                <layer>web-server</layer>
-                                                <layer>webservices</layer>
-                                                <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
-                                                 -->
-                                                <layer>microprofile-config</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-health</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-metrics</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>microprofile-opentracing</layer>
-                                                <layer>microprofile-platform</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>jpa</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>base-server</layer>
+                                        <layer>batch-jberet</layer>
+                                        <layer>bean-validation</layer>
+                                        <layer>cdi</layer>
+                                        <layer>cloud-profile</layer>
+                                        <layer>cloud-server</layer>
+                                        <layer>core-management</layer>
+                                        <layer>core-server</layer>
+                                        <layer>core-tools</layer>
+                                        <layer>datasources</layer>
+                                        <layer>datasources-web-server</layer>
+                                        <layer>deployment-scanner</layer>
+                                        <layer>discovery</layer>
+                                        <layer>ee</layer>
+                                        <layer>ee-security</layer>
+                                        <layer>ejb</layer>
+                                        <layer>ejb-dist-cache</layer>
+                                        <layer>ejb-http-invoker</layer>
+                                        <layer>ejb-lite</layer>
+                                        <layer>elytron</layer>
+                                        <layer>h2-datasource</layer>
+                                        <layer>h2-default-datasource</layer>
+                                        <layer>h2-driver</layer>
+                                        <layer>iiop-openjdk</layer>
+                                        <layer>io</layer>
+                                        <layer>jaxrs</layer>
+                                        <layer>jaxrs-server</layer>
+                                        <layer>jdr</layer>
+                                        <layer>jms-activemq</layer>
+                                        <layer>jmx</layer>
+                                        <layer>jmx-remoting</layer>
+                                        <layer>jpa-distributed</layer>
+                                        <layer>jsf</layer>
+                                        <layer>jsonb</layer>
+                                        <layer>jsonp</layer>
+                                        <layer>logging</layer>
+                                        <layer>mail</layer>
+                                        <layer>management</layer>
+                                        <layer>messaging-activemq</layer>
+                                        <layer>naming</layer>
+                                        <layer>observability</layer>
+                                        <layer>opentelemetry</layer>
+                                        <layer>pojo</layer>
+                                        <layer>remote-activemq</layer>
+                                        <layer>remoting</layer>
+                                        <layer>request-controller</layer>
+                                        <layer>resource-adapters</layer>
+                                        <layer>sar</layer>
+                                        <layer>security-manager</layer>
+                                        <layer>transactions</layer>
+                                        <layer>undertow</layer>
+                                        <layer>undertow-https</layer>
+                                        <layer>undertow-load-balancer</layer>
+                                        <layer>web-clustering</layer>
+                                        <layer>web-console</layer>
+                                        <layer>web-server</layer>
+                                        <layer>webservices</layer>
+                                        <!--
+                                            Galleon layers defined only in the wildfly-galleon-pack
+                                         -->
+                                        <layer>microprofile-config</layer>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                        <layer>microprofile-health</layer>
+                                        <layer>microprofile-jwt</layer>
+                                        <layer>microprofile-metrics</layer>
+                                        <layer>microprofile-openapi</layer>
+                                        <layer>microprofile-opentracing</layer>
+                                        <layer>microprofile-platform</layer>
+                                    </layers>
+                                    <excluded-layers>
+                                        <layer>jpa</layer>
+                                    </excluded-layers>
                                 </configuration>
                             </execution>
                             <!-- Core Layers - These can't be tested in Core as they require Undertow -->
@@ -2460,7 +2011,7 @@
                                 </goals>
                                 <phase>${provisioning.phase}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/remoting</install-dir>
+                                    <provisioning-dir>${layers.install.dir}/remoting</provisioning-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${ee.feature.pack.groupId}</groupId>
@@ -2470,49 +2021,12 @@
                                             <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>remoting</layer>
-                                                <layer>undertow</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
+                                    <layers>
+                                        <layer>remoting</layer>
+                                        <layer>undertow</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
-                            <!-- [WFLY-15001] Legacy security is being incrementally removed.
-                            <execution>
-                                <id>legacy-remoting-provisioning</id>
-                                <goals>
-                                    <goal>provision</goal>
-                                </goals>
-                                <phase>${provisioning.phase.preview.excluded}</phase>
-                                <configuration>
-                                    <install-dir>${layers.install.dir}/legacy-remoting</install-dir>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>legacy-remoting</layer>
-                                                <layer>undertow</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
-                                </configuration>
-                            </execution>
-                            -->
                         </executions>
                     </plugin>
 
@@ -2522,8 +2036,8 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <!-- maven.local.repo is set in parent pom.xml, system property surefire.system.args -->
-                                <servlet.layers.install.root>${servlet.layers.install.root}</servlet.layers.install.root>
-                                <layers.install.root>${layers.install.dir}</layers.install.root>
+                                <servlet.layers.install.root>${project.build.directory}/${servlet.layers.install.root}</servlet.layers.install.root>
+                                <layers.install.root>${project.build.directory}/${layers.install.dir}</layers.install.root>
                                 <jbossas.version>${project.parent.version}</jbossas.version>
                                 <cleanup.tmp>${cleanup.tmp}</cleanup.tmp>
                                 <layers.delete.installations>${layers.delete.installations}</layers.delete.installations>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -61,8 +61,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -71,10 +72,10 @@
                         </goals>
                         <phase>process-test-classes</phase>
                         <configuration>
-                            <install-dir>${wildfly.home}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${server.output.dir.prefix}</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -87,10 +88,10 @@
                                     </excluded-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>
@@ -129,8 +130,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jboss.galleon</groupId>
-                        <artifactId>galleon-maven-plugin</artifactId>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <execution>
                                 <id>server-provisioning</id>
@@ -139,10 +141,10 @@
                                 </goals>
                                 <phase>generate-resources</phase>
                                 <configuration>
-                                    <plugin-options combine.self="append">
+                                    <galleon-options-options combine.self="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
                                         <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
-                                    </plugin-options>
+                                    </galleon-options-options>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This PR bumps wildfly-maven-plugin to 3.x and uses its `provision` goal to provision WildFly instead of using the `galleon-maven-plugin`

JIRA: https://issues.redhat.com/browse/WFLY-16025

---

- [ ] build
- [ ] dist
- [ ] docs
- [ ] ee-9/build
- [ ] ee-9/dist
- [ ] ee-build
- [ ] ee-dist
- [ ] servlet-build
- [ ] servlet-dist
- [ ] testsuite/integration/basic
- [ ] testsuite/integration/elytron-oidc-client
- [ ] testsuite/integration/elytron
- [ ] testsuite/integration/clustering
  - 🔴 not done. It uses the `galleon-maven-plugin` to generate multiple custom configuration based on layers which is out of scope of the `wildfly-maven-plugin` feature set.
- [ ] testsuite/integration/microprofile-tck
  - failures in `reactive-messaging` related to https://issues.redhat.com/browse/WFMP-146 
- [ ] testsuite/integration/microprofile-tck/rest-client
- [ ] testsuite/integration/microprofile
- [ ] testsuite/integration/smoke
- [ ] testsuite/integration/web
- [ ] testsuite/integration/ws
- [ ] testsuite/layers
- [ ] testsuite/scripts

---