### PR TITLE
WFLY-16039 NonResolvingResourceDescriptionResolver.INSTANCE should be…

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/AppClientExtension.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/AppClientExtension.java
@@ -98,7 +98,7 @@ public class AppClientExtension implements Extension {
     }
 
     public static ResourceDescriptionResolver getResourceDescriptionResolver() {
-        return new NonResolvingResourceDescriptionResolver();
+        return NonResolvingResourceDescriptionResolver.INSTANCE;
     }
 
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -908,7 +908,7 @@ public class Constants {
             .build();
 
     //static final SimpleOperationDefinition INSTALLED_DRIVERS_LIST = new SimpleOperationDefinitionBuilder("installed-drivers-list", DataSourcesExtension.getResourceDescriptionResolver())
-    static final SimpleOperationDefinition INSTALLED_DRIVERS_LIST = new SimpleOperationDefinitionBuilder("installed-drivers-list", new NonResolvingResourceDescriptionResolver())
+    static final SimpleOperationDefinition INSTALLED_DRIVERS_LIST = new SimpleOperationDefinitionBuilder("installed-drivers-list", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setReadOnly()
             .setRuntimeOnly()
             .setReplyType(ModelType.LIST)


### PR DESCRIPTION
… used instead of creating new instances

https://issues.redhat.com/browse/WFLY-16039

Related PR in wildfly-core: https://github.com/wildfly/wildfly-core/pull/4969
