### PR TITLE
WFLY-16040 Upgrade jberet-core from 1.3.10.Final to 1.3.10.SP1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
         <version.org.infinispan.protostream>4.4.1.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.27.0-GA</version.org.javassist>
-        <version.org.jberet>1.3.10.Final</version.org.jberet>
+        <version.org.jberet>1.3.10.SP1</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.6</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16040

This PR is to get the bug fix for [JBERET-537](https://issues.redhat.com/browse/JBERET-537) into WildFly before porting to downstream. It competes with https://github.com/wildfly/wildfly/pull/14952, which will upgrade jberet-core to a newer version (jberet-core 1.3.11.Final). It will be good for this PR to be considered first.