### PR TITLE
[WFLY-16033]: Reading a bridge with include-runtime throws WFLYCTL0216.

### DIFF
--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -882,4 +882,7 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 105, value = "The %s %s is configured to use socket-binding %s, but this socket binding doesn't have the multicast-address or a multicast-port attributes configured.")
     OperationFailedException socketBindingMulticastNotSet(String resourceType, String resourceName, String socketBindingName);
 
+    @Message(id = 106, value = "The bridge %s didn't deploy.")
+    OperationFailedException failedBridgeDeployment(String bridgeName);
+
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -85,7 +84,9 @@ public abstract class AbstractActiveMQComponentControlHandler<T extends ActiveMQ
             final String name = operation.require(NAME).asString();
             if (STARTED.getName().equals(name)) {
                 ActiveMQComponentControl control = getActiveMQComponentControl(context, operation, false);
-                context.getResult().set(control.isStarted());
+                if(control != null) {
+                    context.getResult().set(control.isStarted());
+                }
             } else {
                 handleReadAttribute(name, context, operation);
             }
@@ -278,11 +279,6 @@ public abstract class AbstractActiveMQComponentControlHandler<T extends ActiveMQ
         ServiceController<?> artemisService = context.getServiceRegistry(forWrite).getService(artemisServiceName);
         ActiveMQServer server = ActiveMQServer.class.cast(artemisService.getValue());
         PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-         T control = getActiveMQComponentControl(server, address);
-         if (control == null) {
-             throw ControllerLogger.ROOT_LOGGER.managementResourceNotFound(address);
-         }
-         return control;
-
+        return getActiveMQComponentControl(server, address);
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
@@ -60,7 +60,9 @@ public class BroadcastGroupControlHandler extends AbstractActiveMQComponentContr
         if (GET_CONNECTOR_PAIRS_AS_JSON.equals(operationName)) {
             BaseBroadcastGroupControl control = getActiveMQComponentControl(context, operation, false);
             try {
-                context.getResult().set(control.getConnectorPairsAsJSON());
+                if(control != null) {
+                    context.getResult().set(control.getConnectorPairsAsJSON());
+                }
             } catch (Exception e) {
                 context.getFailureDescription().set(e.getLocalizedMessage());
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionControlHandler.java
@@ -59,10 +59,14 @@ public class ClusterConnectionControlHandler extends AbstractActiveMQComponentCo
     protected void handleReadAttribute(String attributeName, OperationContext context, ModelNode operation) throws OperationFailedException {
         if (ClusterConnectionDefinition.NODE_ID.getName().equals(attributeName)) {
             ClusterConnectionControl control = getActiveMQComponentControl(context, operation, false);
-            context.getResult().set(control.getNodeID());
+            if(control != null) {
+                context.getResult().set(control.getNodeID());
+            }
         } else if (ClusterConnectionDefinition.TOPOLOGY.getName().equals(attributeName)) {
             ClusterConnectionControl control = getActiveMQComponentControl(context, operation, false);
-            context.getResult().set(control.getTopology());
+            if(control != null) {
+                context.getResult().set(control.getTopology());
+            }
         } else {
             unsupportedAttribute(attributeName);
         }
@@ -73,11 +77,13 @@ public class ClusterConnectionControlHandler extends AbstractActiveMQComponentCo
         if (ClusterConnectionDefinition.GET_NODES.equals(operationName)) {
             ClusterConnectionControl control = getActiveMQComponentControl(context, operation, false);
             try {
-                Map<String, String> nodes = control.getNodes();
-                final ModelNode result = context.getResult();
-                result.setEmptyObject();
-                for (Map.Entry<String, String> entry : nodes.entrySet()) {
-                    result.get(entry.getKey()).set(entry.getValue());
+                if (control != null) {
+                    Map<String, String> nodes = control.getNodes();
+                    final ModelNode result = context.getResult();
+                    result.setEmptyObject();
+                    for (Map.Entry<String, String> entry : nodes.entrySet()) {
+                        result.get(entry.getKey()).set(entry.getValue());
+                    }
                 }
             } catch (Exception e) {
                 context.getFailureDescription().set(e.getLocalizedMessage());


### PR DESCRIPTION
When a bridge deployment failed, Wildfly wasn't notified and still  provided the resource.
Now it will fail the add operation.

Jira: https://issues.redhat.com/browse/WFLY-16033