### PR TITLE
WFLY-16046 MicroProfile Fault Tolerance TCK suite doesn't run with the security manager

### DIFF
--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -21,6 +21,11 @@
  */
 package org.wildfly.extension.microprofile.faulttolerance.tck;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.lang.reflect.ReflectPermission;
+import java.util.PropertyPermission;
+
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
@@ -28,6 +33,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 /**
@@ -57,5 +63,20 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
         if (!applicationArchive.contains("META-INF/beans.xml")) {
             applicationArchive.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
         }
+
+        // Run the TCK with security manager
+        if (applicationArchive instanceof ManifestContainer) {
+            ManifestContainer<?> mc = (ManifestContainer<?>) applicationArchive;
+            mc.addAsManifestResource(createPermissionsXmlAsset(
+                    // Permissions required by test instrumentation - arquillian-core.jar and arquillian-testng.jar
+                    new ReflectPermission("suppressAccessChecks"),
+                    new PropertyPermission("*", "read"),
+                    new RuntimePermission("accessDeclaredMembers"),
+                    // Permissions required by test instrumentation - awaitility.jar
+                    new RuntimePermission("setDefaultUncaughtExceptionHandler"),
+                    new RuntimePermission("modifyThread")
+            ), "permissions.xml");
+        }
     }
+
 }

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
@@ -28,6 +28,7 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16046