### PR TITLE
[WFLY-16048] Temporarily ignore the OIDC tests until we've sorted out issues with the latest Keycloak image

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/deployment/OidcWithDeploymentConfigTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/deployment/OidcWithDeploymentConfigTest.java
@@ -41,6 +41,7 @@ import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
@@ -56,6 +57,7 @@ import io.restassured.RestAssured;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ OidcWithDeploymentConfigTest.KeycloakAndSystemPropertySetup.class })
+@Ignore("WFLY-16049")
 public class OidcWithDeploymentConfigTest extends OidcBaseTest {
 
     private static final String OIDC_PROVIDER_URL = "oidc.provider.url";

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/subsystem/OidcWithSubsystemConfigTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/subsystem/OidcWithSubsystemConfigTest.java
@@ -42,6 +42,7 @@ import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.elytron.oidc.ElytronOidcExtension;
@@ -58,6 +59,7 @@ import io.restassured.RestAssured;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ OidcWithSubsystemConfigTest.KeycloakAndSubsystemSetup.class })
+@Ignore("WFLY-16049")
 public class OidcWithSubsystemConfigTest extends OidcBaseTest {
 
     private static final String SUBSYSTEM_OVERRIDE_APP = "SubsystemOverrideOidcApp";


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16048