### PR TITLE
[WFLY-16049] Update the OIDC tests so that they can run with Keycloak 17.0.0 and later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
         <version.org.jgroups.kubernetes>1.0.16.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.jvnet.staxex>1.8.3</version.org.jvnet.staxex>
-        <version.org.keycloak>15.0.2</version.org.keycloak>
+        <version.org.keycloak>17.0.0</version.org.keycloak>
         <version.org.kohsuke.metainf-services>1.8</version.org.kohsuke.metainf-services>
         <version.org.opensaml.opensaml>3.4.6</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.2</version.org.ow2.asm>

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
@@ -29,7 +29,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public static final String ADMIN_USER = "admin";
     public static final String ADMIN_PASSWORD = "admin";
-    private static final String AUTH_PATH = "/auth";
 
     private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:latest";
     private static final String SSO_IMAGE = System.getProperty("testsuite.integration.oidc.rhsso.image",KEYCLOAK_IMAGE);
@@ -51,15 +50,18 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     @Override
     protected void configure() {
         withExposedPorts(PORT_HTTP, PORT_HTTPS);
-        waitingFor(Wait.forHttp("/auth").forPort(8080));
-        withEnv("KEYCLOAK_USER", ADMIN_USER);
-        withEnv("KEYCLOAK_PASSWORD", ADMIN_PASSWORD);
+        waitingFor(Wait.forHttp("/").forPort(8080));
+        withEnv("KEYCLOAK_ADMIN", ADMIN_USER);
+        withEnv("KEYCLOAK_ADMIN_PASSWORD", ADMIN_PASSWORD);
         withEnv("SSO_ADMIN_USERNAME", ADMIN_USER);
         withEnv("SSO_ADMIN_PASSWORD", ADMIN_PASSWORD);
         withEnv("SSO_HOSTNAME", "localhost");
+        if (SSO_IMAGE.equals(KEYCLOAK_IMAGE)) {
+            withCommand("start-dev");
+        }
     }
 
     public String getAuthServerUrl() {
-        return String.format("http://%s:%s%s", getContainerIpAddress(), useHttps ? getMappedPort(PORT_HTTPS) : getMappedPort(PORT_HTTP), AUTH_PATH);
+        return String.format("http://%s:%s", getContainerIpAddress(), useHttps ? getMappedPort(PORT_HTTPS) : getMappedPort(PORT_HTTP));
     }
 }

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/deployment/OidcWithDeploymentConfigTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/deployment/OidcWithDeploymentConfigTest.java
@@ -41,7 +41,6 @@ import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration;
@@ -57,7 +56,6 @@ import io.restassured.RestAssured;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ OidcWithDeploymentConfigTest.KeycloakAndSystemPropertySetup.class })
-@Ignore("WFLY-16049")
 public class OidcWithDeploymentConfigTest extends OidcBaseTest {
 
     private static final String OIDC_PROVIDER_URL = "oidc.provider.url";

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/subsystem/OidcWithSubsystemConfigTest.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/subsystem/OidcWithSubsystemConfigTest.java
@@ -42,7 +42,6 @@ import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.elytron.oidc.ElytronOidcExtension;
@@ -59,7 +58,6 @@ import io.restassured.RestAssured;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ OidcWithSubsystemConfigTest.KeycloakAndSubsystemSetup.class })
-@Ignore("WFLY-16049")
 public class OidcWithSubsystemConfigTest extends OidcBaseTest {
 
     private static final String SUBSYSTEM_OVERRIDE_APP = "SubsystemOverrideOidcApp";


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16049
