### PR TITLE
[WFLY-16070] Upgrade WildFly Core 19.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
**Starting with this release, WildFly Core now requires Java 11.**

Version `19.0.0.Beta4` is skipped as its artifacts were not properly released to repository.jboss.org Maven repository.

JIRA: https://issues.redhat.com/browse/WFLY-16070

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta5
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta3...19.0.0.Beta5

---

<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta5</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5805'>WFCORE-5805</a>] -         HostControllerBootOperationsTestCase fails intermittently when Security Manager is enabled
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5802'>WFCORE-5802</a>] -         Restore HTTPSConnectionWithCLITestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5806'>WFCORE-5806</a>] -         Remove the maven.repository.redhat.com repository from the build
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5801'>WFCORE-5801</a>] -         Upgrade Undertow to 2.2.16.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5793'>WFCORE-5793</a>] -         Disable java-class-based resource bundle and disable fallback to default locale
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5808'>WFCORE-5808</a>] -         NonResolvingResourceDescriptionResolver.INSTANCE should be used instead of creating new instances
</li>
</ul>
                                                                                                                            
</details>
<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta4</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5778'>WFCORE-5778</a>] -         Reset java.security.manager default value back to &quot;allow&quot; by default in launcher
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5782'>WFCORE-5782</a>] -         Reset java.security.manager default value back to &quot;allow&quot; by default in WildFly shell scripts
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5555'>WFCORE-5555</a>] -         CLIEmbedServerTestCase.testBuildServerConfig() needs rewriting to use Elytron
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5784'>WFCORE-5784</a>] -         Deprecate the org.apache.log4j module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5788'>WFCORE-5788</a>] -         Migrate to a JDK 11 minimum requirement for the runtime
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5804'>WFCORE-5804</a>] -         Move the log4j:log4j test dep to testbom; switch to reload4j
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5783'>WFCORE-5783</a>] -         Upgrade log4j-jboss-logmanager to 1.3.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5785'>WFCORE-5785</a>] -         Upgrade galleon plugins to 5.2.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5786'>WFCORE-5786</a>] -         Upgrade WildFly OpenSSL to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5787'>WFCORE-5787</a>] -         Upgrade WildFly OpenSSL Natives to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5790'>WFCORE-5790</a>] -         Upgrade JBoss Parent to 39
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5796'>WFCORE-5796</a>] -         Bump netty-codec-http from 4.1.63.Final to 4.1.71.Final in /testbom (resolves  CVE-2021-43797)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5797'>WFCORE-5797</a>] -         Upgrade XNIO to 3.8.6.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5794'>WFCORE-5794</a>] -         Make StandardResourceDescriptionResolver#getVariableBundleKey() protected static to share with subclass
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5800'>WFCORE-5800</a>] -         Remove unused Charset Map Variable and Method in ManagementHttpServer class
</li>
</ul>
                                                                                                                            
</details>
