### PR TITLE
[WFLY-16100] Correct transformer handling of undefined 'legacy-empty-…

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldTransformers.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldTransformers.java
@@ -27,8 +27,8 @@ public class WeldTransformers implements ExtensionTransformerRegistration {
         // Differences between the current version and 4.0.0
         ResourceTransformationDescriptionBuilder builder400 = chainedBuilder.createBuilder(subsystem.getCurrentSubsystemVersion(), version4_0_0);
         builder400.getAttributeBuilder()
-                // Reject if false or undefined, discard otherwise
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, ModelNode.TRUE),
+                // Discard an explicit 'true' as that's the legacy behavior. Reject otherwise.
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, false, ModelNode.TRUE),
                         WeldResourceDefinition.LEGACY_EMPTY_BEANS_XML_TREATMENT_ATTRIBUTE)
                 .addRejectCheck(RejectAttributeChecker.ALL, WeldResourceDefinition.LEGACY_EMPTY_BEANS_XML_TREATMENT_ATTRIBUTE)
                 .end();

--- a/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -99,11 +99,18 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, parse(getSubsystemXml("subsystem-reject.xml")),
                 new FailedOperationTransformationConfig().addFailedAttribute(PathAddress.pathAddress(WeldExtension.PATH_SUBSYSTEM),
-                        FailedOperationTransformationConfig.ChainedConfig
-                                .createBuilder(WeldResourceDefinition.NON_PORTABLE_MODE_ATTRIBUTE, WeldResourceDefinition.REQUIRE_BEAN_DESCRIPTOR_ATTRIBUTE)
-                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(WeldResourceDefinition.THREAD_POOL_SIZE_ATTRIBUTE))
-                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(WeldResourceDefinition.LEGACY_EMPTY_BEANS_XML_TREATMENT_ATTRIBUTE)).build()
-                ));
+                        new FailedOperationTransformationConfig.NewAttributesConfig(WeldResourceDefinition.LEGACY_EMPTY_BEANS_XML_TREATMENT_ATTRIBUTE) {
+                            @Override
+                            protected boolean checkValue(String attrName, ModelNode attribute, boolean isGeneratedWriteAttribute) {
+                                return !attribute.equals(ModelNode.TRUE);
+                            }
+
+                            @Override
+                            protected ModelNode correctValue(ModelNode attribute, boolean isGeneratedWriteAttribute) {
+                                // if it's 'false' change it to undefined to test handling of undefined as well
+                                return attribute.isDefined() ? ModelNode.TRUE : new ModelNode();
+                            }
+                        }));
     }
 
     private void testTransformer(ModelTestControllerVersion controllerVersion, boolean fixLegacyEmptyXmlTreatment) throws Exception {


### PR DESCRIPTION
…beans-xml-treatment' values.

Also, remove some no longer relevant FailedOperationTransformationConfig setups from WeldSubsystemTestCase as we no longer support transforming to the old versions where those attributes were not understood.

A correction to my transformer handling on https://issues.redhat.com/browse/WFLY-16100

@manovotn Please review.