### PR TITLE
[WFLY-16036] GetCallerPrincipal method should return anonymous principal when security not activated

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -81,6 +81,7 @@ import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.requestcontroller.ControlPoint;
+import org.wildfly.security.auth.principal.AnonymousPrincipal;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.authz.Roles;
@@ -281,10 +282,14 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
     public Principal getCallerPrincipal() {
         if (isSecurityDomainKnown()) {
             return getCallerSecurityIdentity().getPrincipal();
-        } else if (WildFlySecurityManager.isChecking()) {
-            return WildFlySecurityManager.doUnchecked(getCaller);
+        } else if (this.serverSecurityManager != null) {
+            if (WildFlySecurityManager.isChecking()) {
+                return WildFlySecurityManager.doUnchecked(getCaller);
+            } else {
+                return this.serverSecurityManager.getCallerPrincipal();
+            }
         } else {
-            return this.serverSecurityManager.getCallerPrincipal();
+            return new AnonymousPrincipal();
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java
@@ -41,7 +41,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -67,7 +66,6 @@ import static org.junit.Assert.fail;
 @RunWith(Arquillian.class)
 @ServerSetup({GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.DisableDefaultSecurityDomainSetupTask.class})
 @Category(CommonCriteria.class)
-@Ignore("[WFLY-15262] Update test case for lack of legacy security.")
 public class GetCallerPrincipalWithNoDefaultSecurityDomainTestCase {
     private static final Logger LOGGER = Logger.getLogger(GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.class);
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-16036
Upstream PRs:  https://github.com/wildfly/wildfly/pull/15219
Related PR: https://github.com/jbossas/jboss-eap7/pull/4253 
