### PR TITLE
WFLY-16111 Increase timeout and count of attempts for starting container in integration tests for OIDC

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
@@ -21,6 +21,8 @@ package org.wildfly.test.integration.elytron.oidc.client;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
+
 /**
  * KeycloakContainer for testing.
  *
@@ -32,6 +34,10 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:latest";
     private static final String SSO_IMAGE = System.getProperty("testsuite.integration.oidc.rhsso.image",KEYCLOAK_IMAGE);
+    private static final int STARTUP_ATTEMPTS = Integer.parseInt(
+            System.getProperty("testsuite.integration.oidc.container.startup.attempts", "5"));
+    private static final Duration ATTEMPT_DURATION = Duration.parse(
+            System.getProperty("testsuite.integration.oidc.container.attempt.duration", "PT30S"));
     private static final int PORT_HTTP = 8080;
     private static final int PORT_HTTPS = 8443;
 
@@ -44,7 +50,8 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public KeycloakContainer(final boolean useHttps) {
         super(SSO_IMAGE);
         this.useHttps = useHttps;
-
+        this.withStartupTimeout(ATTEMPT_DURATION);
+        this.setStartupAttempts(STARTUP_ATTEMPTS);
     }
 
     @Override


### PR DESCRIPTION
new property for count of startup attempts and timeout for one attempt with default vales and possibility change them if needed.

https://issues.redhat.com/browse/WFLY-16111