### PR TITLE
[26.x] [WFLY-15964] OpenTelemetry ratio-based sampler should not accept value bigger than 1.0

### DIFF
--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
@@ -146,7 +146,7 @@ public class OpenTelemetrySubsystemDefinition extends PersistentResourceDefiniti
             .setAttributeGroup(GROUP_SAMPLER)
             .setValidator((parameterName, value) -> {
                 if (value.isDefined() && value.getType() != ModelType.EXPRESSION) {
-                    long val = value.asLong();
+                    double val = value.asDouble();
                     if (val < 0.0 || val > 1.0) {
                         throw new OperationFailedException(OpenTelemetryExtensionLogger.OTEL_LOGGER.invalidRatio());
                     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15964

Port fix from main