### PR TITLE
[26.x] [WFLY-15943]: Can't create an external connection factory using a discovery group with socket binding.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQResourceAdapter.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQResourceAdapter.java
@@ -21,7 +21,6 @@
  */
 package org.wildfly.extension.messaging.activemq;
 
-import static org.wildfly.extension.messaging.activemq.MessagingServices.JBOSS_MESSAGING_ACTIVEMQ;
 
 import java.security.AccessController;
 import javax.resource.spi.work.ExecutionContext;
@@ -76,7 +75,7 @@ public class ActiveMQResourceAdapter extends org.apache.activemq.artemis.ra.Acti
                 return new CommandDispatcherBroadcastEndpointFactory(service.getCommandDispatcherFactory(key), clusterName);
             }
             assert pcf != null;
-            ExternalPooledConnectionFactoryService service = (ExternalPooledConnectionFactoryService) currentServiceContainer().getService(JMSServices.getPooledConnectionFactoryBaseServiceName(JBOSS_MESSAGING_ACTIVEMQ).append(pcf)).getService();
+            ExternalPooledConnectionFactoryService service = (ExternalPooledConnectionFactoryService) currentServiceContainer().getService(JMSServices.getPooledConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName()).append(pcf)).getService();
             return new CommandDispatcherBroadcastEndpointFactory(service.getCommandDispatcherFactory(key), clusterName);
         }
         return super.createBroadcastEndpointFactory(overrideProperties);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -40,7 +40,7 @@ public class MessagingServices {
     /**
      * The service name is "jboss.messaging-activemq"
      */
-    static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
+    private static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
     public static final ServiceName ACTIVEMQ_CLIENT_THREAD_POOL = JBOSS_MESSAGING_ACTIVEMQ.append("client-thread-pool");
     private static final ServiceName COMMAND_DISPATCHER_FACTORY = JBOSS_MESSAGING_ACTIVEMQ.append("command-dispatcher-factory");
 
@@ -71,6 +71,10 @@ public class MessagingServices {
        }
        return PathAddress.EMPTY_ADDRESS;
    }
+
+    public static ServiceName getActiveMQServiceName() {
+        return JBOSS_MESSAGING_ACTIVEMQ;
+    }
 
    public static ServiceName getActiveMQServiceName(String serverName) {
        if(serverName == null || serverName.isEmpty()) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -411,13 +411,13 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
             return false;
         }
         //let's look into the external-pooled-connection-factory
-        ServiceName pcfName = JMSServices.getPooledConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName("")).append(resourceAdapter);
+        ServiceName pcfName = JMSServices.getPooledConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName()).append(resourceAdapter);
         return serviceRegistry.getServiceNames().contains(pcfName);
     }
 
     private static ExternalPooledConnectionFactoryService getExternalPooledConnectionFactory(String resourceAdapter, ServiceRegistry serviceRegistry) {
         //let's look into the external-pooled-connection-factory
-        ServiceName pcfName = JMSServices.getPooledConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName("")).append(resourceAdapter);
+        ServiceName pcfName = JMSServices.getPooledConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName()).append(resourceAdapter);
         return (ExternalPooledConnectionFactoryService) serviceRegistry.getService(pcfName).getValue();
     }
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
@@ -158,7 +158,7 @@ public class JMSDestinationDefinitionInjectionSource extends ResourceDefinitionI
         try {
             ServiceName serviceName;
             if(external) {
-                serviceName = MessagingServices.getActiveMQServiceName("");
+                serviceName = MessagingServices.getActiveMQServiceName();
             } else {
                 serviceName = MessagingServices.getActiveMQServiceName(getActiveMQServerName(properties));
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryRemove.java
@@ -46,7 +46,7 @@ public class ConnectionFactoryRemove extends AbstractRemoveStepHandler {
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         ServiceName serviceName;
         if(isSubsystemResource(context)) {
-            serviceName = MessagingServices.getActiveMQServiceName("");
+            serviceName = MessagingServices.getActiveMQServiceName();
         } else {
             serviceName = MessagingServices.getActiveMQServiceName(context.getCurrentAddress());
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
@@ -82,7 +82,7 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
         List<String> connectorNames = Common.CONNECTORS.unwrap(context, model);
         ServiceBuilder<?> builder = context.getServiceTarget()
                 .addService(serviceName)
-                .addAliases(MessagingServices.getActiveMQServiceName(name));
+                .addAliases(JMSServices.getConnectionFactoryBaseServiceName(MessagingServices.getActiveMQServiceName()).append(name));
         ExternalConnectionFactoryService service;
         if (discoveryGroupName.isDefined()) {
             // mapping between the {discovery}-groups and the cluster names they use
@@ -106,7 +106,7 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
                 String clusterName = JGROUPS_CLUSTER.resolveModelAttribute(context, discoveryGroupModel).asString();
                 clusterNames.put(key, clusterName);
             } else {
-                final ServiceName groupBinding = GroupBindingService.getDiscoveryBaseServiceName(JBOSS_MESSAGING_ACTIVEMQ).append(name);
+                final ServiceName groupBinding = GroupBindingService.getDiscoveryBaseServiceName(JBOSS_MESSAGING_ACTIVEMQ).append(dgname);
                 Supplier<SocketBinding> groupBindingSupplier = builder.requires(groupBinding);
                 groupBindings.put(key, groupBindingSupplier);
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryRemove.java
@@ -39,7 +39,7 @@ public class ExternalPooledConnectionFactoryRemove extends PooledConnectionFacto
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        ServiceName serviceName = MessagingServices.getActiveMQServiceName("");
+        ServiceName serviceName = MessagingServices.getActiveMQServiceName();
         context.removeService(JMSServices.getPooledConnectionFactoryBaseServiceName(serviceName).append(context.getCurrentAddressValue()));
         removeJNDIAliases(context, model.require(ENTRIES.getName()).asList());
     }


### PR DESCRIPTION

 * Fixing the way the service name is created.
 * Simplifying the way to get a ServiceName for 'external' resources.

Jira: https://issues.redhat.com/browse/WFLY-15943
