### PR TITLE
[26.x] [WFLY-15997]: Upgrade Apache Artemis to 2.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
         <version.jsoup>1.14.2</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.3.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.19.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.19.1</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.4.5</version.org.apache.cxf>


### PR DESCRIPTION
* Upgrading Apache Artemis

 Jira: https://issues.redhat.com/browse/WFLY-15997