### PR TITLE
[WFLY-16127] Upgrade jboss-iiop-client to 1.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.5.11.Final</version.org.jboss.hal.console>
-        <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
+        <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.5.5.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16127

PR because of Jakarta migration 