### PR TITLE
Upgrade reactive messaging to 3.15.0

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -88,7 +88,7 @@
         <version.org.eclipse.microprofile.rest.client.api>3.0</version.org.eclipse.microprofile.rest.client.api>
         <!-- Implementations -->
         <version.io.smallrye.open-api>3.0.0-RC1</version.io.smallrye.open-api>
-        <version.io.smallrye.smallrye-common>2.0.0-RC1</version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>2.0.0-RC2</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.0.0-RC1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC1</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.0-RC1</version.io.smallrye.smallrye-health>

--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -312,6 +312,17 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-vertx-context</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
             <exclusions>

--- a/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
@@ -354,6 +354,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.common</groupId>
+      <artifactId>smallrye-common-vertx-context</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
       <licenses>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/common/vertx-context/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/common/vertx-context/main/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.common.vertx-context">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${io.smallrye.common:smallrye-common-vertx-context}"/>
+    </resources>
+
+    <dependencies>
+        <module name="io.smallrye.common.constraint"/>
+        <module name="io.vertx.core"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+
+</module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/reactive/messaging/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/io/smallrye/reactive/messaging/main/module.xml
@@ -37,6 +37,7 @@
 
     <dependencies>
         <module name="io.reactivex.rxjava2.rxjava"/>
+        <module name="io.smallrye.common.vertx-context"/>
         <module name="io.smallrye.config" services="import"/>
         <module name="io.smallrye.reactive.converters.api"/>
         <module name="io.smallrye.reactive.messaging.connector"/>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.8.0</version.io.smallrye.smallrye-common>
-        <version.io.smallrye.smallrye-config>2.6.1</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>2.9.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>5.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
         <version.io.smallrye.smallrye-fault-tolerance>5.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
-        <version.io.smallrye.smallrye-metrics>3.0.3</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>3.0.4</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-mutiny>1.1.2</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>2.15.1</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-reactive-messaging>3.13.0</version.io.smallrye.smallrye-reactive-messaging>

--- a/pom.xml
+++ b/pom.xml
@@ -355,17 +355,17 @@
         <version.io.smallrye.open-api>2.1.17</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
-        <version.io.smallrye.smallrye-common>1.8.0</version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>1.10.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.9.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>5.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.4</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-mutiny>1.1.2</version.io.smallrye.smallrye-mutiny>
-        <version.io.smallrye.smallrye-mutiny-vertx>2.15.1</version.io.smallrye.smallrye-mutiny-vertx>
-        <version.io.smallrye.smallrye-reactive-messaging>3.13.0</version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.smallrye.smallrye-mutiny-vertx>2.16.2</version.io.smallrye.smallrye-mutiny-vertx>
+        <version.io.smallrye.smallrye-reactive-messaging>3.15.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.0.10.Final</version.io.undertow.jastow>
-        <version.io.vertx.vertx>4.2.1</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.2.5</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>${version.io.vertx.vertx}</version.io.vertx.vertx-kafka-client>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
@@ -2624,6 +2624,12 @@
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-function</artifactId>
+                <version>${version.io.smallrye.smallrye-common}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-vertx-context</artifactId>
                 <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16136

This also includes upgrades to other SmallRye components I saw we have old versions of when looking at the smallrye pom:
https://issues.redhat.com/browse/WFLY-16134 (SR Config)
https://issues.redhat.com/browse/WFLY-16135 (SR Metrics)
