### PR TITLE
[26.x] WFLY-15921 WFLY-15954 WFLY-16112 JobOperator.getJobNames() does only return Names of Jobs t…

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
@@ -29,7 +29,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -38,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-
 import javax.batch.operations.JobExecutionAlreadyCompleteException;
 import javax.batch.operations.JobExecutionIsRunningException;
 import javax.batch.operations.JobExecutionNotMostRecentException;
@@ -163,13 +161,9 @@ public class JobOperatorService extends AbstractJobOperator implements WildFlyJo
     @Override
     public Set<String> getJobNames() throws JobSecurityException {
         checkState();
-        Set<String> set = new HashSet<>();
-        for (String s : super.getJobNames()) {
-            if (resolver.isValidJobName(s)) {
-                set.add(s);
-            }
-        }
-        return set;
+        // job repository does not know a job if it has not been started.
+        // So we rely on the resolver to provide complete job names for the deployment.
+        return resolver.getJobNames();
     }
 
     @Override

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JobRepositoryService.java
@@ -84,9 +84,16 @@ abstract class JobRepositoryService implements JobRepository, Service<JobReposit
         return getAndCheckDelegate().getJobNames();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * WildFly JBeret subsystem validates a job name before each batch job operations.
+     * If a job name is invalid, {@code NoSuchJobException} would already have been thrown.
+     * So this method is optimized to always return true.
+     */
     @Override
     public boolean jobExists(final String jobName) {
-        return getAndCheckDelegate().jobExists(jobName);
+        return true;
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/inactive-job.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/inactive-job.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2022 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<job id="inactive-job" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="inactive-job.step1">
+        <batchlet ref="simpleCounterBatchlet">
+        </batchlet>
+    </step>
+</job>


### PR DESCRIPTION
…hat have already been executed since server start

WFLY-15954 getJobInstances, getJobInstanceCount, getRunningExecutions should include jobs that have not been started
WFLY-16112 Batch JobOperatorService should look for only active job names to stop during suspend

https://issues.redhat.com/browse/WFLY-15921
https://issues.redhat.com/browse/WFLY-15954
https://issues.redhat.com/browse/WFLY-16112

Port the fixes from main branch to 26.x.