### PR TITLE
[26.x][WFLY-15075] Add encryption support to FilesystemSecurityRealm

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -127,6 +127,27 @@ _jboss.server.config.dir_.
 If your directory is located outside of _jboss.server.config.dir_, then
 you need to change the _path_ and _relative-to_ values appropriately.
 
+==== Encryption
+
+To enable encryption for a `filesystem-realm`, there are a couple of attributes that can be configured.
+
+* `credential-store`: This attribute specifies the `credential-store` where the secret key used for encrypting and decrypting the realm is stored.
+
+* `secret-key`: This attribute specifies the alias within the `credential-store` that contains the secret key to be used to encrypt and decrypt the realm.
+
+As an example, to create a `credential-store` that is automatically populated with a `SecretKey` under the alias `key`, the following command can be used:
+[source,options="nowrap"]
+----
+/subsystem=elytron/secret-key-credential-store=mycredstore:add(path=propcredstore.cs, relative-to=jboss.server.config.dir, create=true, populate=true)
+----
+
+
+An encrypted `filesystem-realm` that makes use of the `credential-store` could be then created as follows:
+[source,options="nowrap"]
+----
+/subsystem=elytron/filesystem-realm=exampleFsRealm:add(path=fs-realm-users,relative-to=jboss.server.config.dir, credential-store=mycredstore, secret-key=key)
+----
+
 [[add-a-user]]
 ==== Add a user:
 

--- a/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
@@ -13,6 +13,8 @@ Every identity is stored in an XML file where the name of the file is the name o
 * `encoded` When encoding is set to true, the identity names will be BASE32 encoded before they are used as filenames. This is beneficial, because some filesystems are case-insensitive or might restrict set of characters allowed in a filename. Default value is true.
 * `hash-encoding` specifies the string format for the password if it is not stored in plain text. Set to BASE64 bt default, but HEX is also supported.
 * `hash-charset` specifies the character set to use when converting the password string to a byte array. Set to UTF-8 by default.
+* `credential-store` specifies the credential store where the secret key is stored if the filesystem realm is to be encrypted. This attribute is optional.
+* `secret-key` specifies the alias of the secret key that is stored in the previously specified credential store. This attribute is optional.
 
 Filesystem security realm can be added with WildFly management CLI or with Elytron API.
 
@@ -21,9 +23,11 @@ Filesystem security realm can be added with WildFly management CLI or with Elytr
 The following command creates realm with name `fsRealm` that resides in directory `fs-realm-users` inside the base configuration directory defined by `jboss.server.config.dir` property. The levels number is 2 and encoded value is true.
 The charset is UTF-8 and the string encoding is BASE64.
 
+The `credential-store` being referenced is called `mycredstore` and the alias of the `secret-key` in that `credential-store` is `key`. The secret key will be used to encrypt and decrypt the filesystem realm.
+
 [source,options="nowrap"]
 ----
-/subsystem=elytron/filesystem-realm=fsRealm:add(path=fs-realm-users, relative-to=jboss.server.config.dir)
+/subsystem=elytron/filesystem-realm=fsRealm:add(path=fs-realm-users, relative-to=jboss.server.config.dir, credential-store=mycredstore, secret-key=key)
 ----
 
 NOTE: Although identities stored within the same realm can be hashed using different algorithms, they are all
@@ -47,11 +51,19 @@ To delete existing identity from filesystem realm:
 
 When creating filesystem realm with Elytron API, you can specify `name rewriter` in the constructor. The name rewriter will be applied to identity names to transform them from one form to another. It can be used to normalize the case, trim extra whitespaces, map one naming scheme to another, remove realm component from identity name (e.g. "user@realm" to "user") or to perform validation step on the syntax of the name.
 
-Class `org.wildfly.security.auth.realm.FileSystemSecurityRealm` is used to instantiate the realm.
+To enable encryption for a filesystem realm programmatically, you can specify a `SecretKey` when instantiating the realm.
+
+A `org.wildfly.security.auth.realm.FileSystemSecurityRealm` can be instantiated using a `builder()` method as shown in the example below.
 
 [source,options="nowrap"]
 ----
-FileSystemSecurityRealm fsRealm = new FileSystemSecurityRealm(fsRealmPath, NameRewriter.IDENTITY_REWRITER, 2, true);
+FileSystemSecurityRealm fsRealm = FileSystemSecurityRealm.builder()
+    .setRoot(fsRealmPath)
+    .setNameRewriter(IDENTITY_REWRITER)
+    .setLevels(2)
+    .setEncoded(true)
+    .setSecretKey(key)
+    .build();
 ----
 
 `org.wildfly.security.auth.server.NameRewriter.IDENTITY_REWRITER` is a simple identity name rewriter that does no rewriting. You can implement the `NameRewriter` interface and use your own rewriter.
@@ -232,3 +244,16 @@ $JBOSS_HOME/bin/elytron-tool.sh filesystem-realm -u conf/users.properties -r con
 ----
 
 This command creates new filesystem realm with users taken from users.properties file and roles taken from roles.properties file. Script `example-fs-realm.sh` that contains the commands for WildFly CLI is generated as well. The script adds this filesystem realm to the Elytron subsystem and also adds new security domain that uses this filesystem realm as a default realm.
+
+== Converting an unencrypted filesystem realm into an encrypted filesystem realm
+
+It is possible to convert an unencrypted filesystem realm into an encrypted one using the Elytron Tool. In particular, the `filesystem-realm-encrypt` command can be used as shown below:
+
+[source,options="nowrap"]
+----
+$JBOSS_HOME/bin/elytron-tool.sh filesystem-realm-encrypt -i ./standalone/configuration/fs-realm-plain -o ./standalone/configuration/fs-realm-enc -c ./mycredstore.cs
+----
+
+This command creates a new filesystem realm by taking the existing filesystem realm from the specified input location, `./standalone/configuration/fs-realm-plain`, and encrypting its contents using the secret key with alias `key` from the specified credential store, `./mycredstore.cs`. The new filesystem realm is stored in the specified output location, `./standalone/configuration/fs-realm-enc`.
+
+A `.cli` script will also be generated at the root of the filesystem realm. The script contains WildFly CLI commands that can be used to configure a `secret-key-credential-store` resource and a `filesystem-realm` resource in the Elytron subsystem that makes use of the newly encrypted realm content.

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmEncryptedTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmEncryptedTestCase.java
@@ -121,9 +121,6 @@ public class FilesystemRealmEncryptedTestCase {
 
         @Override
         public void setup(ManagementClient managementClient, java.lang.String s) throws Exception {
-            try (CLIWrapper cli = new CLIWrapper(true)) {
-                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=Roles)");
-            }
             setUpTestDomain(DOMAIN_NAME, REALM_NAME, "filesystem", USER, PASSWORD, DEPLOYMENT_ENCRYPTED, CREDENTIAL_STORE, SECRET_KEY, INVALID_CREDENTIAL_STORE);
             SetUpTask.managementClient = managementClient;
             ServerReload.reloadIfRequired(managementClient);
@@ -140,7 +137,7 @@ public class FilesystemRealmEncryptedTestCase {
                         realmName, username, password));
                 cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add-identity-attribute(identity=%s, name=Roles, value=[JBossAdmin])",
                         realmName, username));
-                cli.sendLine(String.format("/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=from-roles-attribute}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
                         domainName, realmName));
                 cli.sendLine(String.format(
                         "/subsystem=undertow/application-security-domain=%s:add(security-domain=%s)",
@@ -162,9 +159,6 @@ public class FilesystemRealmEncryptedTestCase {
         public void tearDown(ManagementClient managementClient, java.lang.String s) throws Exception {
             SetUpTask.managementClient = managementClient;
             tearDownDomain(DEPLOYMENT_ENCRYPTED, DOMAIN_NAME, REALM_NAME, USER, CREDENTIAL_STORE, INVALID_CREDENTIAL_STORE);
-            try (CLIWrapper cli = new CLIWrapper(true)) {
-                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:remove()");
-            }
             ServerReload.reloadIfRequired(managementClient);
         }
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmEncryptedTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmEncryptedTestCase.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.realm;
+
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Full authentication tests for Elytron Encrypted Filesystem Realm.
+ *
+ * @author Ashpan Raskar <araskar@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({FilesystemRealmEncryptedTestCase.SetUpTask.class})
+public class FilesystemRealmEncryptedTestCase {
+
+    private static final String DEPLOYMENT_ENCRYPTED = "filesystemRealmEncrypted";
+    private static final String USER = "plainUser";
+    private static final String PASSWORD = "secretPassword";
+
+
+    @Deployment(name = DEPLOYMENT_ENCRYPTED)
+    public static WebArchive deploymentWithCharsetAndEncoded() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_ENCRYPTED + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(FilesystemRealmEncryptedTestCase.class.getPackage(), "filesystem-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_ENCRYPTED), "jboss-web.xml");
+        return war;
+    }
+
+    /**
+     *
+     * Test Filesystem realm when choosing to encrypt it.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCRYPTED)
+    public void testEncryptionPass(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER, PASSWORD, SC_OK);
+    }
+
+    /**
+     *
+     * Test Filesystem realm when choosing to encrypt it with a bad credential.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCRYPTED)
+    public void testEncryptionCredentialFail(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER+"123", PASSWORD, SC_UNAUTHORIZED);
+    }
+
+    /**
+     *
+     * Test Filesystem realm when choosing to encrypt it with a bad Secret Key.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCRYPTED)
+    public void testEncryptionSecretKeyFail(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        SetUpTask.setUpBadCredentialStore(SetUpTask.REALM_NAME, SetUpTask.INVALID_CREDENTIAL_STORE);
+        Utils.makeCallWithBasicAuthn(url, USER, PASSWORD, SC_INTERNAL_SERVER_ERROR);
+        SetUpTask.tearDownBadCredentialStore(SetUpTask.REALM_NAME, SetUpTask.CREDENTIAL_STORE);
+    }
+
+    private URL prepareURL(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+    }
+
+    static class SetUpTask implements ServerSetupTask {
+
+        private static final String REALM_NAME = "fsRealmEncrypted";
+        private static final String DOMAIN_NAME = "fsDomainEncrypted";
+        private static final String CREDENTIAL_STORE = "mycredstore";
+        private static final String INVALID_CREDENTIAL_STORE = "invalidcredstore";
+        private static final String SECRET_KEY = "key";
+        private static ManagementClient managementClient;
+
+
+        @Override
+        public void setup(ManagementClient managementClient, java.lang.String s) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=Roles)");
+            }
+            setUpTestDomain(DOMAIN_NAME, REALM_NAME, "filesystem", USER, PASSWORD, DEPLOYMENT_ENCRYPTED, CREDENTIAL_STORE, SECRET_KEY, INVALID_CREDENTIAL_STORE);
+            SetUpTask.managementClient = managementClient;
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+        private void setUpTestDomain(String domainName, String realmName, String path, String username, String password, String deployment, String credentialStore, String secretKey, String invalidCredentialStore) throws Exception {
+            try (CLIWrapper cli =  new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/secret-key-credential-store=%1$s:add(path=%1$s.cs, relative-to=jboss.server.config.dir, create=true, populate=true)",
+                        credentialStore));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add(path=%s,relative-to=jboss.server.config.dir, credential-store=%s, secret-key=%s)",
+                        realmName, path, credentialStore, secretKey));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add-identity(identity=%s)", realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%1$s:set-password(identity=%2$s, digest={algorithm=digest-md5, realm=%1$s, password=%3$s})",
+                        realmName, username, password));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add-identity-attribute(identity=%s, name=Roles, value=[JBossAdmin])",
+                        realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=from-roles-attribute}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                        domainName, realmName));
+                cli.sendLine(String.format(
+                        "/subsystem=undertow/application-security-domain=%s:add(security-domain=%s)",
+                        deployment, domainName));
+
+                cli.sendLine(String.format("/subsystem=elytron/secret-key-credential-store=%1$s:add(path=%1$s.cs, relative-to=jboss.server.config.dir, create=true, populate=true)", invalidCredentialStore));
+            }
+        }
+
+        private static void setUpBadCredentialStore(String realmName, String credentialStore) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:write-attribute(name=credential-store, value=%s)",
+                        realmName, credentialStore));
+            }
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, java.lang.String s) throws Exception {
+            SetUpTask.managementClient = managementClient;
+            tearDownDomain(DEPLOYMENT_ENCRYPTED, DOMAIN_NAME, REALM_NAME, USER, CREDENTIAL_STORE, INVALID_CREDENTIAL_STORE);
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:remove()");
+            }
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+        private static void tearDownBadCredentialStore(String realmName, String credentialStore) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:write-attribute(name=credential-store, value=%s)",
+                        realmName, credentialStore));
+            }
+            ServerReload.reloadIfRequired(managementClient);
+        }
+
+
+        private void tearDownDomain(String deployment, String domainName, String realmName, String username, String credentialStore, String invalidCredentialStore) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", deployment));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove-identity(identity=%s)", realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove()", realmName));
+                cli.sendLine(String.format("/subsystem=elytron/secret-key-credential-store=%s:remove()",
+                        credentialStore));
+                cli.sendLine(String.format("/subsystem=elytron/secret-key-credential-store=%s:remove()",
+                        invalidCredentialStore));
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15075
Upstream: https://github.com/wildfly/wildfly/pull/15269

Requires: https://issues.redhat.com/browse/WFCORE-5530
WildFly Core PR with tests: https://github.com/wildfly/wildfly-core/pull/4983