### PR TITLE
[WFLY-16155] Temporary pin org.bouncycastle 1.69 for elytron int test

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -52,6 +52,9 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
         <security.properties>${project.basedir}/src/test/resources/reenabled_tlsv1.properties</security.properties>
+        <!-- WFLY-16155 temporary pin bouncycastle 1.69 for test only.
+             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests -->
+        <version.org.bouncycastle>1.69</version.org.bouncycastle>
         <version.org.hsqldb.hsqldb>2.5.0</version.org.hsqldb.hsqldb>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>
         <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
@@ -235,24 +238,28 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk15on</artifactId>
+            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
+            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk15on</artifactId>
+            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16155

Shall be reverted when https://issues.redhat.com/browse/WFLY-15867
"Upgrade org.xipki.pki/ocsp-server" including test-rewrite has been resolved.
