### PR TITLE
[WFLY-16158]: Deployment submodel should be runtime

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemRootDefinition.java
@@ -48,7 +48,8 @@ public class DataSourcesSubsystemRootDefinition extends SimpleResourceDefinition
         super(new Parameters(PATH_SUBSYSTEM, DataSourcesExtension.getResourceDescriptionResolver())
                 .setAddHandler(deployed ? null : DataSourcesSubsystemAdd.INSTANCE)
                 .setRemoveHandler(deployed ? null : ReloadRequiredRemoveStepHandler.INSTANCE)
-                .setFeature(!deployed));
+                .setFeature(!deployed)
+                .setRuntime(deployed));
         this.registerRuntimeOnly = registerRuntimeOnly;
         this.deployed = deployed;
     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
@@ -78,7 +78,8 @@ public class ResourceAdaptersExtension implements Extension {
                     new SimpleResourceDefinition.Parameters(SUBSYSTEM_PATH,
                             new StandardResourceDescriptionResolver(Constants.STATISTICS_NAME,
                                     CommonAttributes.RESOURCE_NAME, CommonAttributes.class.getClassLoader()))
-                            .setFeature(false)));
+                            .setFeature(false)
+                            .setRuntime()));
             deployments.registerSubModel(new IronJacamarResourceDefinition());
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
@@ -90,7 +90,7 @@ public class EJB3Extension implements Extension {
 
         if (registerRuntimeOnly) {
             ResourceDefinition deploymentsDef = new SimpleResourceDefinition(new Parameters(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME),
-                    getResourceDescriptionResolver("deployed")).setFeature(false));
+                    getResourceDescriptionResolver("deployed")).setFeature(false).setRuntime());
             final ManagementResourceRegistration deploymentsRegistration = subsystem.registerDeploymentModel(deploymentsDef);
             deploymentsRegistration.registerSubModel(MessageDrivenBeanResourceDefinition.INSTANCE);
             deploymentsRegistration.registerSubModel(SingletonBeanDeploymentResourceDefinition.INSTANCE);

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
@@ -76,7 +76,7 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
             = new ObjectTypeAttributeDefinition.Builder("jaxrs-resource", CLASSNAME, PATH, METHODS).setStorageRuntime().build();
 
     private JaxrsDeploymentDefinition() {
-          super(new Parameters(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver()).setFeature(false));
+          super(new Parameters(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver()).setFeature(false).setRuntime(true));
     }
 
     @Override

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -80,7 +80,7 @@ public class JPADefinition extends SimpleResourceDefinition {
     private static Parameters getParameters(boolean feature) {
         Parameters result = new Parameters(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME),
                 JPAExtension.getResourceDescriptionResolver())
-                .setFeature(feature);
+                .setFeature(feature).setRuntime(!feature);
         if (feature) {
             result = result.setCapabilities(JPA_CAPABILITY);
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -391,13 +391,13 @@ public class MessagingExtension implements Extension {
 
         if (registerRuntimeOnly) {
             final ManagementResourceRegistration deployment = subsystemRegistration.registerDeploymentModel(new SimpleResourceDefinition(
-                    new Parameters(SUBSYSTEM_PATH, getResourceDescriptionResolver("deployed")).setFeature(false)));
+                    new Parameters(SUBSYSTEM_PATH, getResourceDescriptionResolver("deployed")).setFeature(false).setRuntime()));
             deployment.registerSubModel(new ExternalConnectionFactoryDefinition(registerRuntimeOnly));
             deployment.registerSubModel(ExternalPooledConnectionFactoryDefinition.DEPLOYMENT_INSTANCE);
             deployment.registerSubModel(new ExternalJMSQueueDefinition(registerRuntimeOnly));
             deployment.registerSubModel(new ExternalJMSTopicDefinition(registerRuntimeOnly));
             final ManagementResourceRegistration deployedServer = deployment.registerSubModel(new SimpleResourceDefinition(
-                    new Parameters(SERVER_PATH, getResourceDescriptionResolver(SERVER)).setFeature(false)));
+                    new Parameters(SERVER_PATH, getResourceDescriptionResolver(SERVER)).setFeature(false).setRuntime()));
             deployedServer.registerSubModel(new JMSQueueDefinition(true, registerRuntimeOnly));
             deployedServer.registerSubModel(new JMSTopicDefinition(true, registerRuntimeOnly));
             deployedServer.registerSubModel(PooledConnectionFactoryDefinition.DEPLOYMENT_INSTANCE);

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDeploymentDefinition.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDeploymentDefinition.java
@@ -41,7 +41,7 @@ public class TracingDeploymentDefinition extends SimpleResourceDefinition {
 
     private TracingDeploymentDefinition() {
           super(new Parameters(SubsystemExtension.SUBSYSTEM_PATH, SubsystemExtension.getResourceDescriptionResolver())
-                  .setFeature(false));
+                  .setFeature(false).setRuntime());
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDeploymentTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.jca.ijdeployment;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
@@ -91,6 +92,7 @@ public class IronJacamarDeploymentTestCase extends ContainerResourceMgmtTestBase
         operation.get(OP).set("read-resource");
         operation.get(OP_ADDR).set(address);
         operation.get(RECURSIVE).set(true);
+        operation.get(INCLUDE_RUNTIME).set(true);
         ModelNode result = executeOperation(operation);
 
         assertEquals("Bootstrap-context value is wrong", result.get("bootstrap-context").asString(), "default");

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -145,7 +145,7 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
 
     private DeploymentDefinition() {
         super(new Parameters(PathElement.pathElement(SUBSYSTEM, UndertowExtension.SUBSYSTEM_NAME), DEFAULT_RESOLVER)
-                .setFeature(false));
+                .setFeature(false).setRuntime());
     }
 
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
@@ -165,6 +165,7 @@ public final class WSExtension implements Extension {
         if (registerRuntimeOnly) {
             subsystem.registerDeploymentModel(ResourceBuilder.Factory.create(SUBSYSTEM_PATH, getResourceDescriptionResolver("deployment"))
                     .noFeature()
+                    .setRuntime()
                     .pushChild(ENDPOINT_PATH)
                     .addMetrics(WSEndpointMetrics.INSTANCE, WSEndpointMetrics.ATTRIBUTES)
                     .addReadOnlyAttribute(ENDPOINT_CLASS)


### PR DESCRIPTION
* setting runtime on deployment submodels for Messaging, Webservices,
  Resource adapters, datasources, jpa jaxrs, jpa, ejb3, undertow

Jira: https://issues.redhat.com/browse/WFLY-16158