### PR TITLE
[26.x] WFLY-16142 Upgrade WildFly Common from 1.5.2.Final to 1.6.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
         <version.org.jboss.galleon>4.2.8.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.galleon-plugins>5.2.7.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16142

Port https://github.com/wildfly/wildfly/pull/15317 from main to 26.x branch.