### PR TITLE
[26.x] WFLY-16141 Upgrade wildfly-naming-client from 1.0.14.Final to 1.0.15.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version.org.wildfly.core>18.0.4.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
-        <version.org.wildfly.naming-client>1.0.14.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.3-b02</version.sun.jaxb>


### PR DESCRIPTION
…Final

https://issues.redhat.com/browse/WFLY-16141

Port https://github.com/wildfly/wildfly/pull/15316 from main to 26.x branch.