### PR TITLE
[26.x][WFLY-16028] Fix missing AD for attributes in EJB subsystem.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -344,7 +344,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         final EJBDefaultMissingMethodPermissionsWriteHandler defaultMissingMethodPermissionsWriteHandler = new EJBDefaultMissingMethodPermissionsWriteHandler(DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS, missingMethodPermissionsDenyAccessMergingProcessor);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS, null, defaultMissingMethodPermissionsWriteHandler);
 
-        resourceRegistration.registerReadWriteAttribute(DISABLE_DEFAULT_EJB_PERMISSIONS, null, new AbstractWriteAttributeHandler<Void>() {
+        resourceRegistration.registerReadWriteAttribute(DISABLE_DEFAULT_EJB_PERMISSIONS, null, new AbstractWriteAttributeHandler<Void>(DISABLE_DEFAULT_EJB_PERMISSIONS) {
             protected boolean applyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final HandbackHolder<Void> handbackHolder) throws OperationFailedException {
                 if (resolvedValue.asBoolean()) {
                     throw EjbLogger.ROOT_LOGGER.disableDefaultEjbPermissionsCannotBeTrue();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
@@ -65,7 +65,7 @@ public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(ACTIVE, null,
-                new AbstractWriteAttributeHandler<Void>() {
+                new AbstractWriteAttributeHandler<Void>(ACTIVE) {
                     @Override
                     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation,
                                                            String attributeName, ModelNode resolvedValue, ModelNode currentValue,


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16028

Port https://github.com/wildfly/wildfly/pull/15212 from main to 26.x branch.