### PR TITLE
WFLY-16169 Upgrade jakarta batch api from 2.0.0 to 2.1.0-M2

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -49,7 +49,7 @@
         <version.jakarta.annotation.jakarta-annotation-api>2.1.0-B1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authentication.jakarta-authentication-api>2.0.0</version.jakarta.authentication.jakarta-authentication-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0</version.jakarta.authorization.jakarta-authorization-api>
-        <version.jakarta.batch.jakarta.batch-api>2.0.0</version.jakarta.batch.jakarta.batch-api>
+        <version.jakarta.batch.jakarta.batch-api>2.1.0-M2</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.0</version.jakarta.ejb.jakarta-ejb-api>
         <version.jakarta.el.jakarta-el-api>5.0.0-RC1</version.jakarta.el.jakarta-el-api>
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>2.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16169

Upgrades jakarta batch api to 2.1.0-M2 for EE10 preview. The batch api version in WildFly proper is not changed.