### PR TITLE
[WFLY-16005] Reexport org.jboss.ironjacamar.api module from org.jboss.as.connector module

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
@@ -140,7 +140,7 @@ public class LongRunningThreadsCheckTestCase {
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(LongRunningThreadsCheckTestCase.class,
                 JcaMgmtServerSetupTask.class, JcaMgmtBase.class, JcaTestsUtil.class);
         ja.addPackage(AbstractMgmtTestBase.class.getPackage());
-        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.connector, org.jboss.threads"),
+        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.connector, org.jboss.ironjacamar.api, org.jboss.threads"),
                 "MANIFEST.MF");
 
         ResourceAdapterArchive ra1 = ShrinkWrap.create(ResourceAdapterArchive.class, "wm1.rar");


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16005

Upstream PR: https://github.com/wildfly/wildfly/pull/15192
