### PR TITLE
[WFLY-16185] Upgrade WildFly Core 18.1.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,7 +497,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.0.4.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>18.1.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16185
No upstream required
Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.1.0.Beta1
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.0.4.Final...18.1.0.Beta1

---

<details>
<summary>Release Notes - WildFly Core - Version 18.1.0Beta1</summary>
                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4314'>WFCORE-4314</a>] -         Enchance keystore CLI commands
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5530'>WFCORE-5530</a>] -         Add encryption support to FileSystemSecurityRealm
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5490'>WFCORE-5490</a>] -         Elytron Expression Resolution too late to handle system properties.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5594'>WFCORE-5594</a>] -         Restriction of XML External Entity Reference (XXE)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5765'>WFCORE-5765</a>] -         Unable to check the result containing whitespace with the equals to (==) comparison operator in the &quot;if-else&quot; control flow in JBoss-CLI
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5768'>WFCORE-5768</a>] -         Change default behaviour to resolve jboss parent pom
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5778'>WFCORE-5778</a>] -         Reset java.security.manager default value back to &quot;allow&quot; by default in launcher
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5782'>WFCORE-5782</a>] -         Reset java.security.manager default value back to &quot;allow&quot; by default in WildFly shell scripts
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5805'>WFCORE-5805</a>] -         HostControllerBootOperationsTestCase fails intermittently when Security Manager is enabled
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5818'>WFCORE-5818</a>] -         !remove might not work properly with some resources
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5827'>WFCORE-5827</a>] -         Wildfly 26.0.1 install with galleon layers installs a broken elytron-tool.sh
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5828'>WFCORE-5828</a>] -         WildFly-Common 1.6 depends on java.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5834'>WFCORE-5834</a>] -         deployent-scanner needs org.wildfly.common
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5752'>WFCORE-5752</a>] -         Add model test controller for EAP XP 4 (using WF 26 as placeholder)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5769'>WFCORE-5769</a>] -         Adjust chmod to 644 for dev content
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5784'>WFCORE-5784</a>] -         Deprecate the org.apache.log4j module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5798'>WFCORE-5798</a>] -         Restore ReloadRedirectTestCase.testReloadwithRedirect
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5804'>WFCORE-5804</a>] -         Move the log4j:log4j test dep to testbom; switch to reload4j
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5820'>WFCORE-5820</a>] -         Add version 15.1 of the WildFly Elytron model and schema
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5745'>WFCORE-5745</a>] -         Upgrade to JBoss VFS 3.2.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5751'>WFCORE-5751</a>] -         Upgrade to wildfly-legacy-test 7.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5766'>WFCORE-5766</a>] -         Upgrade to JBoss Modules 2.0.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5779'>WFCORE-5779</a>] -         Upgrade jandex to 2.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5783'>WFCORE-5783</a>] -         Upgrade log4j-jboss-logmanager to 1.3.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5785'>WFCORE-5785</a>] -         Upgrade galleon plugins to 5.2.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5786'>WFCORE-5786</a>] -         Upgrade WildFly OpenSSL to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5787'>WFCORE-5787</a>] -         Upgrade WildFly OpenSSL Natives to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5790'>WFCORE-5790</a>] -         Upgrade JBoss Parent to 39
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5796'>WFCORE-5796</a>] -         Bump netty-codec-http from 4.1.63.Final to 4.1.71.Final in /testbom (resolves  CVE-2021-43797)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5797'>WFCORE-5797</a>] -         Upgrade XNIO to 3.8.6.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5801'>WFCORE-5801</a>] -         Upgrade Undertow to 2.2.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5807'>WFCORE-5807</a>] -         Update logback test dependency to 1.2.9 (resolves CVE-2021-42550)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5824'>WFCORE-5824</a>] -         Upgrade log4j2 2.17.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5825'>WFCORE-5825</a>] -         Upgrade slf4j 1.7.36
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5826'>WFCORE-5826</a>] -         Upgrade WildFly Common to 1.6.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5854'>WFCORE-5854</a>] -         Upgrade WildFly Elytron to 1.19.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4867'>WFCORE-4867</a>] -         Highlight the config name in start message
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5793'>WFCORE-5793</a>] -         Disable java-class-based resource bundle and disable fallback to default locale
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5808'>WFCORE-5808</a>] -         NonResolvingResourceDescriptionResolver.INSTANCE should be used instead of creating new instances
</li>
</ul>
                                                                                                                            

</details>