### PR TITLE
[WFLY-16191] Upgrade WildFly Core 19.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16191

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta6
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta5...19.0.0.Beta6

---

<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta6</summary>
                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4314'>WFCORE-4314</a>] -         Enchance keystore CLI commands
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5530'>WFCORE-5530</a>] -         Add encryption support to FileSystemSecurityRealm
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5594'>WFCORE-5594</a>] -         Restriction of XML External Entity Reference (XXE)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5792'>WFCORE-5792</a>] -         Server configuration allows using files from outside the configuration folder
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5818'>WFCORE-5818</a>] -         !remove might not work properly with some resources
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5827'>WFCORE-5827</a>] -         Wildfly 26.0.1 install with galleon layers installs a broken elytron-tool.sh
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5828'>WFCORE-5828</a>] -         WildFly-Common 1.6 depends on java.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5834'>WFCORE-5834</a>] -         deployent-scanner needs org.wildfly.common
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5837'>WFCORE-5837</a>] -         AttributeMarshallers.SimpleListAttributeMarshaller needs to flag isMarshallableAsElement as true
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5600'>WFCORE-5600</a>] -         Move AcmeMockServerBuilder out of testsuite/shared
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5798'>WFCORE-5798</a>] -         Restore ReloadRedirectTestCase.testReloadwithRedirect
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5817'>WFCORE-5817</a>] -         README.md contains broken link to contributing doc, and incorrect java versioin
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5820'>WFCORE-5820</a>] -         Add version 15.1 of the WildFly Elytron model and schema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5858'>WFCORE-5858</a>] -         Update the Elytron subsystem to use org.wildfly.security.mechanism.gssapi.GSSCredentialSecurityFactory
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5807'>WFCORE-5807</a>] -         Update logback test dependency to 1.2.9 (resolves CVE-2021-42550)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5824'>WFCORE-5824</a>] -         Upgrade log4j2 2.17.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5825'>WFCORE-5825</a>] -         Upgrade slf4j 1.7.36
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5826'>WFCORE-5826</a>] -         Upgrade WildFly Common to 1.6.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5854'>WFCORE-5854</a>] -         Upgrade WildFly Elytron to 1.19.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5760'>WFCORE-5760</a>] -         Replace deprecated EnumValidator constructors and methods
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5811'>WFCORE-5811</a>] -         Improvement to NonResolvingResourceDescriptionResolver.getResourceBundle(Locale locale)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5812'>WFCORE-5812</a>] -         Remove dead code in PathsTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5813'>WFCORE-5813</a>] -         Eliminate unused CapabilityServiceBuilder.addInjection() method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5814'>WFCORE-5814</a>] -         Use EnumMap in place of HashMap for enum keys; code cleanup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5815'>WFCORE-5815</a>] -         StringBuilder op in CommandContextImpl is created and updated but never used
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5821'>WFCORE-5821</a>] -         Fix warnings from deprecated method Assert.assertThat
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5833'>WFCORE-5833</a>] -         Fix warnings from deprecated method Assert.assertEquals(Object[], Object[])
</li>
</ul>
                                                                                                                            

</details>