### PR TITLE
WFLY-16165 - Remove xerces module dep

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -41,7 +41,6 @@
     <module name="org.jboss.weld.spi"/>
     <module name="org.joda.time"/>
     <module name="org.jsoup"/>
-    <module name="org.apache.xerces" services="import"/>
     <module name="sun.jdk" services="import"/>
     <module name="java.xml"/>
   </dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16165

Remove xerces model dep from the Hibernate Validator module