### PR TITLE
[WFLY-16211] Fix AbstractJMSContextTestCase.java charset to UTF-8

### DIFF
--- a/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
+++ b/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
@@ -42,7 +42,7 @@ import org.mockito.stubbing.Answer;
 /**
  * Test class for AbstractJMSContextTes.
  *
- * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brand„o</a> (c) 2021 Red Hat inc.
+ * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brand√£o</a> (c) 2021 Red Hat inc.
  */
 public class AbstractJMSContextTestCase {
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16211

Difference is visible in local git:
```
diff --git a/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java b/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
index 2ff83ae35c..09900a0c32 100644
--- a/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
+++ b/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
@@ -42,7 +42,7 @@ import org.mockito.stubbing.Answer;
 /**
  * Test class for AbstractJMSContextTes.
  *
- * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brand<E3>o</a> (c) 2021 Red Hat inc.
+ * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brandão</a> (c) 2021 Red Hat inc.
  */
```