### PR TITLE
WFLY-16227 Upgrade smallrye-fault-tolerance to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.10.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.9.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>5.3.2</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>5.4.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.4</version.io.smallrye.smallrye-metrics>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -209,7 +209,7 @@
                         </goals>
                         <configuration>
                             <dir>target/classes</dir>
-                            <params>--port=8765</params>
+                            <params>--port=8765 --disable-banner</params>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16227