### PR TITLE
[WFLY-16233] Upgrade WildFly Core 18.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.1.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>18.1.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16233

Upstream not required

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.1.0.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.1.0.Beta1...18.1.0.Final

---

<details>
<summary>Release Notes - WildFly Core - Version 18.1.0.Final</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5810'>WFCORE-5810</a>] -         Fix license in wildfly-cli jar
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5866'>WFCORE-5866</a>] -         Upgrade Jackson 2.12.6
</li>
</ul>
                                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5563'>WFCORE-5563</a>] -         Use commons-lang3 only, remove common-lang(2) uses.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5777'>WFCORE-5777</a>] -         Ugrade to JBoss Modules 2.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5829'>WFCORE-5829</a>] -         Upgrade JBoss Remoting to 5.0.24.Final
</li>
</ul>
                                                                                                                                

</details>