### PR TITLE
[WFLY-16215] Upgrade WildFly HTTP Client to 1.1.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>18.1.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.10.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>2.0.0.Final</version.org.wildfly.transaction.client>
         <version.rhino.js>1.7R2</version.rhino.js>


### PR DESCRIPTION
Jira:  https://issues.redhat.com/browse/WFLY-16215
Main PR: #15402 


        Release Notes - WildFly EJB HTTP Client - Version 1.1.11.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-69'>WEJBHTTP-69</a>] -         Iterate over jndi names not possible with http based access
</li>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-70'>WEJBHTTP-70</a>] -         WildflyClientInputStream.runReadTask invokes wakeupReads
</li>
</ul>
                                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-78'>WEJBHTTP-78</a>] -         Upgrade Undertow to 2.2.17.Final
</li>
</ul>
                                                                                                                                