### PR TITLE
[WFLY-16077] Upgrade Jakarta Annotation EE10 API from 2.1.0-B1 to 2.1.0

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -46,7 +46,7 @@
         <version.com.sun.istack>4.0.1</version.com.sun.istack>
         <version.com.sun.xml.messaging.saaj>2.0.0.SP1</version.com.sun.xml.messaging.saaj>
         <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
-        <version.jakarta.annotation.jakarta-annotation-api>2.1.0-B1</version.jakarta.annotation.jakarta-annotation-api>
+        <version.jakarta.annotation.jakarta-annotation-api>2.1.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authentication.jakarta-authentication-api>2.0.0</version.jakarta.authentication.jakarta-authentication-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0</version.jakarta.authorization.jakarta-authorization-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.0-M2</version.jakarta.batch.jakarta.batch-api>


### PR DESCRIPTION

Jira issue: https://issues.redhat.com/browse/WFLY-16077
