### PR TITLE
WFLY-16245 org.wildfly.clustering.ejb.client is missing dependency on org.wildfly.clustering.marshalling.spi

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/client/main/module.xml
@@ -36,6 +36,7 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.ejb-client"/>
         <module name="org.wildfly.clustering.marshalling.api"/>
+        <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.common"/>
     </dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16245