### PR TITLE
WFLY-16246 Remove redundant "org.wildfly.clustering.ejb.infinispan" package from ejb-local-cache and ejb-dist-cache layers

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -19,10 +19,4 @@
     <!-- Infinispan cache configuration used for distributed SFSB caching -->
     <feature-group name="infinispan-dist-ejb"/>
     <feature-group name="jgroups-all"/>
-    <packages>
-        <!-- The infinispan subsystem doesn't assume ejb3,
-             and ejb3 subysystem doesn't assume clustering, but the
-             combination requires the clustering<->ejb3 integration package -->
-        <package name="org.wildfly.clustering.ejb.infinispan"/>
-    </packages>
 </layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
@@ -11,10 +11,4 @@
     <feature-group name="distributable-ejb-local"/>
     <!-- Infinispan cache configuration used for local SFSB caching -->
     <feature-group name="infinispan-local-ejb"/>
-    <packages>
-        <!-- The infinispan subsystem doesn't assume ejb3,
-             and ejb3 subysystem doesn't assume clustering, but the
-             combination requires the clustering<->ejb3 integration package -->
-        <package name="org.wildfly.clustering.ejb.infinispan"/>
-    </packages>
 </layer-spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16246