### PR TITLE
Jakarta JSON Upgrades for Jakarta EE 10

### DIFF
--- a/ee-9/common/pom.xml
+++ b/ee-9/common/pom.xml
@@ -240,6 +240,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <exclusions>
@@ -253,17 +264,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.enterprise.concurrent</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
+++ b/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
@@ -73,6 +73,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <licenses>
+        <license>
+          <name>Eclipse Distribution License, Version 1.0</name>
+          <url>https://repository.jboss.org/licenses/edl-1.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>https://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-iiop-client-jakarta</artifactId>
       <licenses>

--- a/ee-9/common/src/main/resources/modules/system/layers/base/org/eclipse/parsson/main/module.xml
+++ b/ee-9/common/src/main/resources/modules/system/layers/base/org/eclipse/parsson/main/module.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~
-  ~ Copyright 2020 Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags.
+  ~ Copyright 2022 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~   http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,4 +18,17 @@
 <!-- TODO Consider dropping direct dep on core-galleon-pack and instead using
      a source dep, eliminating the need to re-provision this just to get a
      different version. -->
-<module-alias xmlns="urn:jboss:module:1.9" name="org.glassfish.jakarta.json" target-name="org.eclipse.parsson"/>
+<module xmlns="urn:jboss:module:1.9" name="org.eclipse.parsson">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.eclipse.parsson:parsson}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.json.api" />
+    </dependencies>
+</module>

--- a/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
+++ b/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
@@ -38,6 +38,6 @@
             It must also be exported so that modules that depend on the API, e.g. deployments, will be able to see the
             implementation.
         -->
-        <module name="org.glassfish.jakarta.json" export="true"/>
+        <module name="org.eclipse.parsson" export="true" services="export"/>
     </dependencies>
 </module>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -60,7 +60,7 @@
         <version.jakarta.jms.jakarta-jms-api>3.0.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.mail-api>2.1.0</version.jakarta.mail-api>
         <version.jakarta.json.bind.api>2.0.0</version.jakarta.json.bind.api>
-        <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
+        <version.jakarta.json.jakarta-json-api>2.1.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.jws.jakarta-jws-api>3.0.0</version.jakarta.jws.jakarta-jws-api>
         <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.0.0</version.jakarta.resource.jakarta-resource-api>
@@ -76,6 +76,7 @@
         <version.org.apache.myfaces.core>3.0.1</version.org.apache.myfaces.core>
         <version.org.eclipse.angus.angus-activation>1.0.0</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>1.0.0</version.org.eclipse.angus.angus-mail>
+        <version.org.eclipse.parsson>1.1.0</version.org.eclipse.parsson>
         <!--
             Overrides for MP5. Also make sure to update these in testsuite/integration/microprofile-tck/pom.xml
         -->
@@ -101,7 +102,6 @@
         <version.org.eclipselink.version>3.0.2</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>5.0.0-M1</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>2.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
-        <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <!-- WFLY-14723 For XJC we use a jbossorg variant in WF Preview. Use the version expression from the root
 		     pom here so we detect if the base version changes there and we didn't do a -jbossorg of that version -->
         <version.org.glassfish.jaxb.jaxb-xjc>${version.sun.jaxb}-jbossorg-1</version.org.glassfish.jaxb.jaxb-xjc>
@@ -750,6 +750,19 @@
                 </exclusions>
             </dependency>
 
+            <!-- JSON Processing RI -->
+            <dependency>
+                <groupId>org.eclipse.parsson</groupId>
+                <artifactId>parsson</artifactId>
+                <version>${version.org.eclipse.parsson}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
@@ -766,18 +779,6 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.enterprise.concurrent</artifactId>
                 <version>${version.org.glassfish.jakarta.enterprise.concurrent}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.json</artifactId>
-                <version>${version.org.glassfish.jakarta.json}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -59,7 +59,7 @@
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0-RC3</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.jms.jakarta-jms-api>3.0.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.mail-api>2.1.0</version.jakarta.mail-api>
-        <version.jakarta.json.bind.api>2.0.0</version.jakarta.json.bind.api>
+        <version.jakarta.json.bind.api>3.0.0</version.jakarta.json.bind.api>
         <version.jakarta.json.jakarta-json-api>2.1.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.jws.jakarta-jws-api>3.0.0</version.jakarta.jws.jakarta-jws-api>
         <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
@@ -98,7 +98,7 @@
         <version.io.smallrye.smallrye-metrics>4.0.0-RC1</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-opentracing>3.0.0-RC1</version.io.smallrye.smallrye-opentracing>
         <!-- MP5 - END -->
-        <version.org.eclipse.yasson>2.0.3</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>3.0.0-RC1</version.org.eclipse.yasson>
         <version.org.eclipselink.version>3.0.2</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>5.0.0-M1</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>2.0.0</version.org.glassfish.jakarta.enterprise.concurrent>

--- a/ee-9/source-transform/undertow/pom.xml
+++ b/ee-9/source-transform/undertow/pom.xml
@@ -183,8 +183,8 @@
         </dependency>
         <!-- Required implementation for the org.wildfly.core:event-logger which is initialized in the subsystem tests -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* https://issues.redhat.com/browse/WFLY-16263
* https://issues.redhat.com/browse/WFLY-16264
* https://issues.redhat.com/browse/WFLY-16200
* https://issues.redhat.com/browse/WFLY-16262

Upgrade Jakarta JSON Processing to 2.1.0 and migrate to using Eclipse Parsson. Also upgrade Jakarta JSON Binding to 3.0.0 and Yasson to 3.0.0-RC1.
