### PR TITLE
[WFLY-16231] replace unsupported git://github.com format with git@github.com

### DIFF
--- a/docs/src/main/asciidoc/_hacking/github_setup.adoc
+++ b/docs/src/main/asciidoc/_hacking/github_setup.adoc
@@ -52,7 +52,7 @@ Add a remote ref to upstream, for pulling future updates
 
 [source,options="nowrap"]
 ----
-git remote add upstream git://github.com/wildfly/wildfly.git
+git remote add upstream git@github.com:wildfly/wildfly.git
 ----
 [[safety]]
 == Safety
@@ -72,7 +72,7 @@ Pulling later updates from upstream
 ----
 $ git checkout -f main
 $ git pull --rebase upstream main
-From git://github.com/wildfly/wildfly
+From github.com:wildfly/wildfly
  * branch            main     -> FETCH_HEAD
 Updating 3382570..1fa25df
 Fast-forward

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -273,7 +273,7 @@ We can use git command to fetch a copy of the demo:
 
 [source,options="nowrap"]
 ----
-git clone git://github.com/liweinan/cluster-demo.git
+git clone git@github.com:liweinan/cluster-demo.git
 ----
 
 In this demo project we have a very simple web application. In web.xml


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16231 replace unsupported git://github.com format with git@github.com