### PR TITLE
[WFLY-16264] Minor follow up to the Jakarta JSON Processing upgrading…

### DIFF
--- a/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
+++ b/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/json/api/main/module.xml
@@ -38,6 +38,6 @@
             It must also be exported so that modules that depend on the API, e.g. deployments, will be able to see the
             implementation.
         -->
-        <module name="org.eclipse.parsson" export="true" services="export"/>
+        <module name="org.eclipse.parsson" export="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
…. The implementation module should not export the services to avoid a regression if users include an implementation in their deployment.

Follows up on #15423

https://issues.redhat.com/browse/WFLY-16264

This is a minor update to revert to the previous behavior of relying the API loading the hard-coded default provider. By exporting the services from the implementation it will be found before any implementation provided in the deployment. Whether or not this is the behavior expected, it's how we've done it in the past.