### PR TITLE
[WFLY-16274] Remove the dependency on the Geronimo JSON API fork and Apache Johnzon JSON implementation in favor of using the GlassFish

### DIFF
--- a/ee-9/common/src/main/resources/modules/system/layers/base/internal/javax/json/api/ee8/main/module.xml
+++ b/ee-9/common/src/main/resources/modules/system/layers/base/internal/javax/json/api/ee8/main/module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2013, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<module xmlns="urn:jboss:module:1.9" name="internal.javax.json.api.ee8">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.glassfish:jakarta.json}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.logging"/>
+    </dependencies>
+</module>

--- a/ee-9/common/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/ee-9/common/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.logmanager">
+    <resources>
+        <artifact name="${org.jboss.logmanager:jboss-logmanager}"/>
+    </resources>
+
+    <dependencies>
+        <!-- for java.beans -->
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.xml"/>
+        <module name="internal.javax.json.api.ee8"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.wildfly.common"/>
+    </dependencies>
+</module>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -533,6 +533,9 @@
                                 jakarta names are used -->
                                 <exclude>org.apache.logging.log4j:log4j-api\z</exclude>
 
+                                <!-- Uses JSON only for formatting and uses an internal JSON generator -->
+                                <exlude>org.jboss.logmanager:jboss-logmanager\z</exlude>
+
                                 <!-- Don't transform Infinispan modules and its dependents -->
                                 <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
                                 <exclude>org.infinispan:.+\z</exclude>
@@ -561,8 +564,7 @@
                                 <exclude>org.apache.activemq:artemis-core-client\z</exclude>
                                 <exclude>org.apache.activemq:artemis-dto\z</exclude>
                                 <exclude>org.apache.activemq:artemis-server\z</exclude>
-                                <exclude>org.apache.geronimo.specs:geronimo-json_1.1_spec\z</exclude>
-                                <exclude>org.apache.johnzon:johnzon-core\z</exclude>
+                                <exclude>org.glassfish:jakarta.json\z</exclude>
                                 <exclude>activemq-artemis-native\z</exclude>
                                 <exclude>org.jboss.activemq.artemis.integration:artemis-wildfly-jakarta-integration\z</exclude>
                             </jakarta-transform-excluded-artifacts>
@@ -607,10 +609,6 @@
             <exclusions>
                 <!-- Exclude deps that have been replaced with different artifacts in this FP.
                      TODO perhaps put these in a different maven module that we don't pull in -->
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>jakarta.json</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.jboss.invocation</groupId>
                     <artifactId>jboss-invocation</artifactId>

--- a/ee-9/source-transform/messaging-activemq/subsystem/pom.xml
+++ b/ee-9/source-transform/messaging-activemq/subsystem/pom.xml
@@ -175,15 +175,10 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.1_spec</artifactId>
-        </dependency>
 
         <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16274

https://github.com/wildfly/wildfly-core/pull/5052 requires this PR for the integration PR's to successfully pass tests. The second commit adds two modules from core which can be removed once https://github.com/wildfly/wildfly-core/pull/5052 is merged and core is integrated.