### PR TITLE
WFLY-16256 Make sure Tracer beans are resolved in a manner that doesn…

### DIFF
--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
@@ -28,6 +28,7 @@ import io.smallrye.opentracing.SmallRyeClientTracingFeature;
 import org.eclipse.microprofile.opentracing.ClientTracingRegistrarProvider;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -51,7 +52,11 @@ public class WildFlyClientTracingRegistrarProvider implements ClientTracingRegis
 
     @Override
     public ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService) {
-        Tracer tracer = CDI.current().select(Tracer.class).get();
+        // Create new Instance<Tracer> instead of using CDI.current().select()
+        // this prevents leaks of @Dependent Tracer beans resolved here because the Instance<Tracer> will be GCed
+        // NOTE: instance.destroy(tracer) is deliberately skipped because WFLY uses them as if they were app scoped
+        Instance<Tracer> instance = CDI.current().getBeanManager().createInstance().select(Tracer.class);
+        Tracer tracer = instance.get();
 
         ResteasyClientBuilder resteasyClientBuilder = (ResteasyClientBuilder) clientBuilder;
         return resteasyClientBuilder


### PR DESCRIPTION
…'t cause memory leak.

JIRA - https://issues.redhat.com/browse/WFLY-16256

This PR replaces https://github.com/wildfly/wildfly/pull/15435

I used the reproducer to test this change by monitoring the heap usage after thousands of iterations and it wasn't growing. However, a second pair of eyes if always appreciated :)

CC @jasondlee @ehsavoie @bstansberry