### PR TITLE
[WFLY-16280] Upgrade WildFly Core 19.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16280

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta7
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta6...19.0.0.Beta7

---

<details>
<summary>Release Notes - WildFly Core - Version 19.0.0.Beta7</summary>
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5849'>WFCORE-5849</a>] -         Null pointers should not be dereferenced (cli)
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5810'>WFCORE-5810</a>] -         Fix license in wildfly-cli jar
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5861'>WFCORE-5861</a>] -         InaccessibleObjectException with OpenJDK17 and embed-server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5866'>WFCORE-5866</a>] -         Upgrade Jackson 2.12.6
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5871'>WFCORE-5871</a>] -         Invalid operator error launching the server in dash
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5878'>WFCORE-5878</a>] -         Typo in message WFLYSRV0115.
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5839'>WFCORE-5839</a>] -         [primary/secondary] Find and replace occurrences used by management model attribute descriptions (e.g. LocalDescriptions.properties)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5865'>WFCORE-5865</a>] -         Add gitleaks.toml file with allowlist
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5870'>WFCORE-5870</a>] -         Create new constant for git branch and update in org.jboss.as.server.Main.java
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5563'>WFCORE-5563</a>] -         Use commons-lang3 only, remove common-lang(2) uses.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5759'>WFCORE-5759</a>] -         Upgrade bouncycastle from 1.69 to 1.70
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5829'>WFCORE-5829</a>] -         Upgrade JBoss Remoting to 5.0.24.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5867'>WFCORE-5867</a>] -         Upgrade Undertow to 2.2.17.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5877'>WFCORE-5877</a>] -         Upgrade galleon plugins to 5.2.11.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5863'>WFCORE-5863</a>] -         LdapSecurityRealmBuilder should warn that direct verification and user password mapper are incompatible
</li>
</ul>
                                                                                                                            

</details>