### PR TITLE
[WFLY-16147] Produce new [primary/secondary]-host.xml configuration files and replace the default name for the primary host controller 

### DIFF
--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -38,13 +38,13 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     }
 
     @Test
-    public void testHostSlave() throws Exception {
-        parseXml("domain/configuration/host-slave.xml");
+    public void testHostSecondary() throws Exception {
+        parseXml("domain/configuration/host-secondary.xml");
     }
 
     @Test
-    public void testHostMaster() throws Exception {
-        parseXml("domain/configuration/host-master.xml");
+    public void testHostPrimary() throws Exception {
+        parseXml("domain/configuration/host-primary.xml");
     }
 
     @Test

--- a/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
@@ -197,14 +197,14 @@ standard variants:
 
 [cols=",",options="header"]
 |=======================================================================
-|host-master.xml |A configuration that specifies the Host Controller
-should become the master, aka the Domain Controller. No servers will be
-started by this Host Controller, which is a recommended setup for a
-production master.
+|host-primary.xml |A configuration that specifies the Host Controller
+should become the primary Host Controller, aka the Domain Controller.
+No servers will be started by this Host Controller, which is a recommended
+setup for a production Domain Controller.
 
-|host-slave.xml |A configuration that specifies the Host Controller
-should not become master and instead should register with a remote
-master and be controlled by it. This configuration launches servers,
+|host-secondary.xml |A configuration that specifies the Host Controller
+should not become the primary Host Controller and instead should register with a remote
+primary Host Controller and be controlled by it. This configuration launches servers,
 although a user will likely wish to modify how many servers are launched
 and what server groups they belong to.
 
@@ -219,7 +219,7 @@ the _ _--host-config__ command line argument:
 
 [source,options="nowrap"]
 ----
-$ bin/domain.sh --host-config=host-master.xml
+$ bin/domain.sh --host-config=host-primary.xml
 ----
 
 [[domain-wide-configuration-domain.xml]]

--- a/ee-9/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/ee-9/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -38,13 +38,13 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     }
 
     @Test
-    public void testHostSlave() throws Exception {
-        parseXml("domain/configuration/host-slave.xml");
+    public void testHostSecondary() throws Exception {
+        parseXml("domain/configuration/host-secondary.xml");
     }
 
     @Test
-    public void testHostMaster() throws Exception {
-        parseXml("domain/configuration/host-master.xml");
+    public void testHostPrimary() throws Exception {
+        parseXml("domain/configuration/host-primary.xml");
     }
 
     @Test

--- a/ee-9/feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-9/feature-pack/wildfly-feature-pack-build.xml
@@ -39,8 +39,8 @@
     <config name="standalone-microprofile-ha.xml" model="standalone"/>
     <config name="domain.xml" model="domain"/>
     <config name="host.xml" model="host"/>
-    <config name="host-master.xml" model="host"/>
-    <config name="host-slave.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/ee-dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/ee-dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -38,13 +38,13 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     }
 
     @Test
-    public void testHostSlave() throws Exception {
-        parseXml("domain/configuration/host-slave.xml");
+    public void testHostSecondary() throws Exception {
+        parseXml("domain/configuration/host-secondary.xml");
     }
 
     @Test
-    public void testHostMaster() throws Exception {
-        parseXml("domain/configuration/host-master.xml");
+    public void testHostPrimary() throws Exception {
+        parseXml("domain/configuration/host-primary.xml");
     }
 
     @Test

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host-master.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host-master.xml
@@ -2,7 +2,7 @@
 <feature-group-spec name="host-master" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature-group name="servlet-host-master"/>
     <feature spec="host">
-        <param name="host" value="master"/>
+        <param name="host" value="primary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host-slave.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host-slave.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="host-slave" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature-group name="servlet-host-slave">
-        <exclude feature-id="host.interface:host=slave,interface=unsecure"/>
-        <exclude feature-id="host.interface:host=slave,interface=private"/>
+        <exclude feature-id="host.interface:host=secondary,interface=unsecure"/>
+        <exclude feature-id="host.interface:host=secondary,interface=private"/>
     </feature-group>
     <feature spec="host">
-        <param name="host" value="slave"/>
+        <param name="host" value="secondary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/host.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="host" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature-group name="servlet-host">
-        <exclude feature-id="host.interface:host=master,interface=unsecure"/>
-        <exclude feature-id="host.interface:host=master,interface=private"/>
+        <exclude feature-id="host.interface:host=primary,interface=unsecure"/>
+        <exclude feature-id="host.interface:host=primary,interface=private"/>
     </feature-group>
     <feature spec="host">
-        <param name="host" value="master"/>
+        <param name="host" value="primary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>

--- a/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-master.xml/config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-master.xml/config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-
-<config xmlns="urn:jboss:galleon:config:1.0" name="host-master.xml" model="host">
-    <feature-group name="host-master"/>
-</config>

--- a/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-primary.xml/config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-primary.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-primary.xml" model="host">
+    <feature-group name="host-master"/>
+</config>

--- a/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-secondary.xml/config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-secondary.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-secondary.xml" model="host">
+    <feature-group name="host-slave"/>
+</config>

--- a/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-slave.xml/config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/configs/host/host-slave.xml/config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-
-<config xmlns="urn:jboss:galleon:config:1.0" name="host-slave.xml" model="host">
-    <feature-group name="host-slave"/>
-</config>

--- a/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -43,8 +43,8 @@
     <config name="standalone-load-balancer.xml" model="standalone"/>
     <config name="domain.xml" model="domain"/>
     <config name="host.xml" model="host"/>
-    <config name="host-master.xml" model="host"/>
-    <config name="host-slave.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -35,8 +35,8 @@
             </packages>
             <default-configs inherit="false">
                 <include name="host.xml" model="host"/>
-                <include name="host-master.xml" model="host"/>
-                <include name="host-slave.xml" model="host"/>
+                <include name="host-primary.xml" model="host"/>
+                <include name="host-secondary.xml" model="host"/>
                 <include name="standalone-load-balancer.xml" model="standalone"/>
             </default-configs>
         </dependency>
@@ -59,8 +59,8 @@
     <config name="standalone-microprofile-ha.xml" model="standalone"/>
     <config name="domain.xml" model="domain"/>
     <config name="host.xml" model="host"/>
-    <config name="host-master.xml" model="host"/>
-    <config name="host-slave.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-master.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-master.xml
@@ -2,7 +2,7 @@
 <feature-group-spec name="core-host-master" xmlns="urn:jboss:galleon:feature-group:1.0">
     <!-- TODO Temporary fork to remove security realms. -->
     <feature spec="host">
-        <param name="host" value="master"/>
+        <param name="host" value="primary"/>
         <param name="persist-name" value="true"/>
 
         <feature spec="core-service.management"/>

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="core-host-slave" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="host">
-        <param name="host" value="slave"/>
+        <param name="host" value="secondary"/>
         <param name="persist-name" value="false"/>
 
         <feature spec="core-service.management"/>
@@ -29,7 +29,7 @@
                 <param name="static-discovery" value="primary"/>
                 <param name="protocol" value="${jboss.domain.master.protocol:remote+http}"/>
                 <param name="host-feature" value="${jboss.domain.master.address}"/>
-                <param name="host" value="slave"/>
+                <param name="host" value="secondary"/>
                 <param name="port" value="${jboss.domain.master.port:9990}"/>
             </feature>
         </feature>

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-master.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-master.xml
@@ -24,7 +24,7 @@
     <feature-group name="core-host-master"/>
 
     <feature spec="host">
-        <param name="host" value="master"/>
+        <param name="host" value="primary"/>
 
         <!-- TODO Track back and check why this override is needed. --> 
         <feature spec="host.core-service.management.management-interface.http-interface">

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-slave.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-slave.xml
@@ -4,7 +4,7 @@
 
     <feature-group name="core-host-slave">
         <exclude spec="host.core-service.management.management-interface.http-interface"/>
-        <include feature-id="host:host=slave">
+        <include feature-id="host:host=secondary">
             <feature spec="host.jvm">
                 <param name="jvm" value="default"/>
                 <param name="heap-size" value="64m"/>
@@ -16,7 +16,7 @@
     </feature-group>
 
     <feature spec="host">
-        <param name="host" value="slave"/>
+        <param name="host" value="secondary"/>
         
         <!-- TODO Add an authentication client example.
 

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host.xml
@@ -24,7 +24,7 @@
     <feature-group name="core-host"/>
 
     <feature spec="host">
-        <param name="host" value="master"/>
+        <param name="host" value="primary"/>
         <feature spec="host.interface">
             <param name="interface" value="private"/>
             <param name="inet-address" value="${jboss.bind.address.private:127.0.0.1}"/>

--- a/servlet-feature-pack/galleon-common/src/main/resources/packages/servlet.misc.domain/pm/wildfly/host
+++ b/servlet-feature-pack/galleon-common/src/main/resources/packages/servlet.misc.domain/pm/wildfly/host
@@ -1,3 +1,3 @@
-/host=${host:master}/core-service=management/management-interface=native-interface:add(security-realm="ManagementRealm",interface="management",port="\${jboss.management.native.port:9999}")
+/host=${host:primary}/core-service=management/management-interface=native-interface:add(security-realm="ManagementRealm",interface="management",port="\${jboss.management.native.port:9999}")
 
-/host=${host:master}/core-service=management/security-realm=ApplicationRealm/server-identity=ssl:add(keystore-path="application.keystore",keystore-relative-to="jboss.domain.config.dir",keystore-password="password",alias="server",key-password="password",generate-self-signed-certificate-host="localhost")
+/host=${host:primary}/core-service=management/security-realm=ApplicationRealm/server-identity=ssl:add(keystore-path="application.keystore",keystore-relative-to="jboss.domain.config.dir",keystore-password="password",alias="server",key-password="password",generate-self-signed-certificate-host="localhost")

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-master.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-master.xml/config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-
-<config xmlns="urn:jboss:galleon:config:1.0" name="host-master.xml" model="host">
-    <feature-group name="host-master"/>
-</config>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-primary.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-primary.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-primary.xml" model="host">
+    <feature-group name="host-master"/>
+</config>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-secondary.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-secondary.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-secondary.xml" model="host">
+    <feature-group name="host-slave"/>
+</config>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-slave.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/host/host-slave.xml/config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-
-<config xmlns="urn:jboss:galleon:config:1.0" name="host-slave.xml" model="host">
-    <feature-group name="host-slave"/>
-</config>

--- a/servlet-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/servlet-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -37,8 +37,8 @@
     <config name="standalone-load-balancer.xml" model="standalone"/>
     <config name="domain.xml" model="domain"/>
     <config name="host.xml" model="host"/>
-    <config name="host-master.xml" model="host"/>
-    <config name="host-slave.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -47,7 +47,7 @@ public abstract class BuildConfigurationTestBase {
     static final File CONFIG_DIR = new File("target/wildfly/domain/configuration/");
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName, final String testConfiguration) {
-        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "master", masterAddress, 9990);
+        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "primary", masterAddress, 9990);
     }
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
@@ -77,10 +77,10 @@ public class DefaultConfigSmokeTestCase extends BuildConfigurationTestBase {
 
     @Test
     public void testMasterAndSlave() throws Exception {
-        final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
+        final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-primary.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
-        final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19990);
+        final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-secondary.xml", getClass().getSimpleName(),
+                "secondary", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
@@ -120,7 +120,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         addTestResources();
 
         Map<PathAddress, Map<String, ModelNode>> expectedValues = new HashMap<PathAddress, Map<String, ModelNode>>();
-        setExpressions(PathAddress.EMPTY_ADDRESS, "master", expectedValues);
+        setExpressions(PathAddress.EMPTY_ADDRESS, "primary", expectedValues);
 
         LOGGER.trace("Update statistics:");
         LOGGER.trace("==================");
@@ -139,7 +139,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
 
         // restart back to normal mode
         ModelNode op = new ModelNode();
-        op.get(OP_ADDR).add(HOST, "master");
+        op.get(OP_ADDR).add(HOST, "primary");
         op.get(OP).set("reload");
         op.get("admin-only").set(false);
         domainMasterLifecycleUtil.executeAwaitConnectionClosed(op);
@@ -150,7 +150,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         // check that the servers are up
         domainMasterLifecycleUtil.awaitServers(System.currentTimeMillis());
 
-        validateExpectedValues(PathAddress.EMPTY_ADDRESS, expectedValues, "master");
+        validateExpectedValues(PathAddress.EMPTY_ADDRESS, expectedValues, "primary");
     }
 
     @Before
@@ -187,7 +187,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         op.get(BOOT_TIME).set(true);
         executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
 
-        PathAddress hostSpAddr = PathAddress.pathAddress(PathElement.pathElement(HOST, "master"), PathElement.pathElement(SYSTEM_PROPERTY, "host-test"));
+        PathAddress hostSpAddr = PathAddress.pathAddress(PathElement.pathElement(HOST, "primary"), PathElement.pathElement(SYSTEM_PROPERTY, "host-test"));
         op.get(OP_ADDR).set(hostSpAddr.toModelNode());
         executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
 
@@ -197,7 +197,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         op.get(PATH).set("test");
         executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
 
-        PathAddress hostPathAddr = PathAddress.pathAddress(PathElement.pathElement(HOST, "master"), PathElement.pathElement(PATH, "host-path-test"));
+        PathAddress hostPathAddr = PathAddress.pathAddress(PathElement.pathElement(HOST, "primary"), PathElement.pathElement(PATH, "host-path-test"));
         op.get(OP_ADDR).set(hostPathAddr.toModelNode());
         executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -297,7 +297,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
 
     @BeforeClass
     public static void setUp() throws IOException {
-        masterConfig = createConfiguration("domain.xml", "host-master.xml", HostExcludesTestCase.class.getSimpleName());
+        masterConfig = createConfiguration("domain.xml", "host-primary.xml", HostExcludesTestCase.class.getSimpleName());
         masterUtils = new DomainLifecycleUtil(masterConfig);
         masterUtils.start();
         masterClient = masterUtils.getDomainClient();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -59,10 +59,10 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
 
     @Test
     public void testOrderedChildResources() throws Exception {
-        final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
+        final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-primary.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
-        final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19990);
+        final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-secondary.xml", getClass().getSimpleName(),
+                "secondary", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();


### PR DESCRIPTION
Requires https://github.com/wildfly/wildfly-core/pull/5061

Jira issue: https://issues.redhat.com/browse/WFLY-16147

Included tasks:

- Changes to produce new host-primary.xml / host-secondary.xml
- Replace "master" with "primary" for the default primary host controller name
- Rename Galleon config names to produce the new files
- Modify default values for Galleon feature groups
- Fix affected tests

Once approved, I'll squash the commits.
Integration Jobs are available on the wildfly-core counterpart.