### PR TITLE
[WFLY-16289]: TestLogHandlerSetupTask should only use UTF-8 logs.

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestLogHandlerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestLogHandlerSetupTask.java
@@ -57,6 +57,7 @@ public abstract class TestLogHandlerSetupTask implements ServerSetupTask {
         ModelNode addTestLogOp = Operations.createAddOperation(handlerAddress);
         addTestLogOp.get("level").set(getLevel());
         addTestLogOp.get("append").set("true");
+        addTestLogOp.get("encoding").set("UTF-8");
         ModelNode file = new ModelNode();
         file.get("relative-to").set("jboss.server.log.dir");
         file.get("path").set(getLogFileName());

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/LoggingUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/LoggingUtil.java
@@ -20,6 +20,7 @@ package org.jboss.as.test.shared.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -99,7 +100,7 @@ public class LoggingUtil {
     @SafeVarargs
     private static boolean isMessageInLogFile(Path logPath, String logMessage, long offset, Predicate<String>... filters) throws Exception{
         boolean found = false;
-        try (BufferedReader fileReader = Files.newBufferedReader(logPath)) {
+        try (BufferedReader fileReader = Files.newBufferedReader(logPath, StandardCharsets.UTF_8)) {
             String line = "";
             long count = 0;
             while ((line = fileReader.readLine()) != null) {
@@ -143,7 +144,7 @@ public class LoggingUtil {
     }
 
     private static void dumpTestLog(Path logPath) throws IOException {
-        try (BufferedReader fileReader = Files.newBufferedReader(logPath)) {
+        try (BufferedReader fileReader = Files.newBufferedReader(logPath, StandardCharsets.UTF_8)) {
             String line = "";
             while ((line = fileReader.readLine()) != null) {
                 System.out.println(line);


### PR DESCRIPTION
* Fixing the file handler to UTF-8.

Jira: https://issues.redhat.com/browse/WFLY-16289