### PR TITLE
[WFLY-15443] Migrate MicroProfile JWT to Jakarta EE 9 Native Components.

### DIFF
--- a/ee-9/common-microprofile/pom.xml
+++ b/ee-9/common-microprofile/pom.xml
@@ -52,6 +52,10 @@
         </dependency>
         <dependency>
             <groupId>${full.maven.groupId}</groupId>
+            <artifactId>wildfly-microprofile-jwt-smallrye-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-openapi-smallrye-jakarta</artifactId>
         </dependency>
         <dependency>

--- a/ee-9/common-microprofile/src/main/resources/license/preview-feature-pack-common-microprofile-licenses.xml
+++ b/ee-9/common-microprofile/src/main/resources/license/preview-feature-pack-common-microprofile-licenses.xml
@@ -25,6 +25,17 @@
         </dependency>
         <dependency>
             <groupId>${full.maven.groupId}</groupId>
+            <artifactId>wildfly-microprofile-jwt-smallrye-jakarta</artifactId>
+            <licenses>
+                <license>
+                    <name>GNU Lesser General Public License v2.1 or later</name>
+                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+                    <distribution>repo</distribution>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-microprofile-openapi-smallrye-jakarta</artifactId>
             <licenses>
                 <license>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -544,6 +544,8 @@
                                 <exclude>org.wildfly:wildfly-clustering-infinispan-extension\z</exclude>
                                 <exclude>org.wildfly:wildfly-clustering-web-infinispan\z</exclude>
 
+                                <exclude>org.wildfly.security:wildfly-elytron-jwt\z</exclude>
+
                                 <exclude>org.hornetq:.+\z</exclude>
                                 <exclude>org.apache.activemq:artemis-jakarta-client\z</exclude>
                                 <exclude>org.apache.activemq:artemis-jakarta-ra\z</exclude>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -544,9 +544,6 @@
                                 <exclude>org.wildfly:wildfly-clustering-infinispan-extension\z</exclude>
                                 <exclude>org.wildfly:wildfly-clustering-web-infinispan\z</exclude>
 
-                                <!-- Contains module names which have been aliased, additional transformation not required. -->
-                                <exclude>org.wildfly:wildfly-microprofile-jwt-smallrye\z</exclude>
-
                                 <exclude>org.hornetq:.+\z</exclude>
                                 <exclude>org.apache.activemq:artemis-jakarta-client\z</exclude>
                                 <exclude>org.apache.activemq:artemis-jakarta-ra\z</exclude>
@@ -681,6 +678,10 @@
                 <exclusion>
                     <groupId>${full.maven.groupId}</groupId>
                     <artifactId>wildfly-microprofile-fault-tolerance-smallrye-extension</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>${full.maven.groupId}</groupId>
+                    <artifactId>wildfly-microprofile-jwt-smallrye</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>${full.maven.groupId}</groupId>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -544,6 +544,7 @@
                                 <exclude>org.wildfly:wildfly-clustering-infinispan-extension\z</exclude>
                                 <exclude>org.wildfly:wildfly-clustering-web-infinispan\z</exclude>
 
+                                <exclude>org.wildfly:wildfly-microprofile-jwt-smallrye\z</exclude>
                                 <exclude>org.wildfly.security:wildfly-elytron-jwt\z</exclude>
 
                                 <exclude>org.hornetq:.+\z</exclude>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -544,8 +544,8 @@
                                 <exclude>org.wildfly:wildfly-clustering-infinispan-extension\z</exclude>
                                 <exclude>org.wildfly:wildfly-clustering-web-infinispan\z</exclude>
 
+                                <!-- Contains module names which have been aliased, additional transformation not required. -->
                                 <exclude>org.wildfly:wildfly-microprofile-jwt-smallrye\z</exclude>
-                                <exclude>org.wildfly.security:wildfly-elytron-jwt\z</exclude>
 
                                 <exclude>org.hornetq:.+\z</exclude>
                                 <exclude>org.apache.activemq:artemis-jakarta-client\z</exclude>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -1542,7 +1542,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>${full.maven.groupId}</groupId>
+                <artifactId>wildfly-microprofile-jwt-smallrye-jakarta</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>
                 <groupId>${full.maven.groupId}</groupId>
                 <artifactId>wildfly-microprofile-openapi-smallrye-jakarta</artifactId>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -119,7 +119,7 @@
         <version.org.jboss.weld.weld-api>5.0.Beta5</version.org.jboss.weld.weld-api>
         <version.org.jvnet.staxex>2.0.1</version.org.jvnet.staxex>
         <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-mp>2.0.0.Beta2</version.org.wildfly.security.elytron-mp>
+        <version.org.wildfly.security.elytron-mp>2.0.0.Beta3</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.security.elytron-web>2.0.0.Beta2</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>2.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>
 

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -95,6 +95,7 @@
         <version.io.smallrye.smallrye-config>3.0.0-RC1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.0-RC1</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-jwt>4.0.0-RC1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>4.0.0-RC1</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-opentracing>3.0.0-RC1</version.io.smallrye.smallrye-opentracing>
         <!-- MP5 - END -->

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -118,6 +118,7 @@
         <version.org.jboss.weld.weld-api>5.0.Beta5</version.org.jboss.weld.weld-api>
         <version.org.jvnet.staxex>2.0.1</version.org.jvnet.staxex>
         <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron-mp>2.0.0.Beta2</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.security.elytron-web>2.0.0.Beta2</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>2.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>
 

--- a/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
+++ b/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
@@ -103,8 +103,12 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-      projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
+++ b/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-microprofile-jakarta</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>27.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-microprofile-jwt-smallrye-jakarta</artifactId>
+
+    <name>WildFly: MicroProfile JWT Extension With SmallRye (Jakarta Namespace)</name>
+
+    <properties>
+        <transformer-input-dir>${project.basedir}/../../../../microprofile/jwt-smallrye</transformer-input-dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>staxmapper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.metadata</groupId>
+            <artifactId>jboss-metadata-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.metadata</groupId>
+            <artifactId>jboss-metadata-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-web-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+      projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectodd.vdx</groupId>
+            <artifactId>vdx-wildfly</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ee-9/source-transform/microprofile/pom.xml
+++ b/ee-9/source-transform/microprofile/pom.xml
@@ -44,6 +44,7 @@
     <modules>
         <module>fault-tolerance-smallrye</module>
         <module>health-smallrye</module>
+        <module>jwt-smallrye</module>
         <module>openapi-smallrye</module>
         <module>reactive-streams-operators-smallrye/cdi-provider</module>
         <module>opentracing-extension</module>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
@@ -25,7 +25,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-microprofile-jwt-smallrye}"/>
+        <artifact name="\${org.wildfly:wildfly-microprofile-jwt-smallrye@module.jakarta.suffix@}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,7 @@
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.security.elytron-mp>1.19.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.transaction.client>2.0.1.Final</version.org.wildfly.transaction.client>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.3-b02</version.sun.jaxb>
@@ -9726,6 +9727,12 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-jwt</artifactId>
+                <version>${version.org.wildfly.security.elytron-mp}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15443

It is not great that we have an Elytron version override for one module in the parent pom of WildFly but this should be short lived once we can drop Jakarta EE 8 from main.