### PR TITLE
[WFLY-16294] javax.orb.api module must explicitly define its dependency on jdk.unsupported module

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/orb/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/javax/orb/api/main/module.xml
@@ -32,6 +32,7 @@
         <module name="org.jboss.jts.integration"/>
         <module name="javax.transaction.api"/>
         <module name="org.jboss.iiop-client"/>
+        <module name="jdk.unsupported"/>
 
         <!-- These dependencies are required only if the
              iiop-openjdk or jacorb subsystems are present.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16294