### PR TITLE
[WFLY-16281] Adapt host Controller environment properties and host-sl…

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
@@ -265,7 +265,7 @@ file and setting the `ignore-unused-configuration` attribute:
 <domain-controller>
     <remote authentication-context="hcAuthContext" ignore-unused-configuration="false">
         <discovery-options>
-            <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+            <static-discovery name="primary" protocol="${jboss.domain.primary.protocol:remote}" host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}"/>
         </discovery-options>
     </remote>
 </domain-controller>
@@ -286,7 +286,7 @@ installed on the Domain Controller and on some slaves, but not this one:
             <instance name="org.example.foo"/>
         </ignored-resources>
         <discovery-options>
-            <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+            <static-discovery name="primary" protocol="${jboss.domain.primary.protocol:remote}" host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}"/>
         </discovery-options>
     </remote>
 </domain-controller>

--- a/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
@@ -641,7 +641,7 @@ legacy slave HC's `host.xml`
 <host xmlns="urn:jboss:domain:1.3" name="slave">
 ...
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm">
+       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm">
             <ignored-resources type="profile">
                 <instance name="full-legacy"/>
             </ignored-resources>

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/core-host-slave.xml
@@ -27,10 +27,10 @@
         <feature spec="host.core-service.discovery-options">
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
-                <param name="protocol" value="${jboss.domain.master.protocol:remote+http}"/>
-                <param name="host-feature" value="${jboss.domain.master.address}"/>
+                <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
+                <param name="host-feature" value="${jboss.domain.primary.address}"/>
                 <param name="host" value="slave"/>
-                <param name="port" value="${jboss.domain.master.port:9990}"/>
+                <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>
 

--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-slave.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/servlet-host-slave.xml
@@ -46,8 +46,8 @@
         <feature spec="host.core-service.discovery-options">
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
-                <param name="protocol" value="${jboss.domain.master.protocol:remote+http}"/>
-                <param name="port" value="${jboss.domain.master.port:9990}"/>
+                <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
+                <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>
     </feature>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -58,7 +58,7 @@ public abstract class BuildConfigurationTestBase {
         configuration.setHostControllerManagementAddress(hostAddress);
         configuration.setHostControllerManagementPort(hostPort);
         configuration.setHostControllerManagementProtocol("remote+http");
-        configuration.setHostCommandLineProperties("-Djboss.domain.master.address=" + masterAddress +
+        configuration.setHostCommandLineProperties("-Djboss.domain.primary.address=" + masterAddress +
                 " -Djboss.management.http.port=" + hostPort);
         configuration.setDomainConfigFile(hackFixDomainConfig(new File(CONFIG_DIR, domainXmlName)).getAbsolutePath());
         configuration.setHostConfigFile(hackFixHostConfig(new File(CONFIG_DIR, hostXmlName), hostName, hostAddress).getAbsolutePath());

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-         <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="9990" security-realm="ManagementRealm"/>
+         <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="9990" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <!--

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="ignored"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -56,7 +56,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/>
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -81,7 +81,7 @@
         <!-- Remote domain controller configuration with a host and port -->
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="start-option" host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" />
+                <static-discovery name="start-option" host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" />
             </discovery-options>
         </remote>
     </domain-controller>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -82,7 +82,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -79,7 +79,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -66,7 +66,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" authentication-context="slaveHostAContext">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" authentication-context="slaveHostAContext">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-3.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-3.xml
@@ -33,7 +33,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-2-0.xml
@@ -33,7 +33,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-0-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-0-0.xml
@@ -33,7 +33,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-1-0.xml
@@ -33,7 +33,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-2-0.xml
@@ -55,7 +55,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-3-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-3-0.xml
@@ -55,7 +55,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-4-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-4-0.xml
@@ -55,7 +55,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-0-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-0-0.xml
@@ -56,7 +56,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+        <!-- <remote protocol="remote" host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
     <interfaces>
         <interface name="management">

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
@@ -64,7 +64,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+        <!-- <remote protocol="remote" host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
     <interfaces>
         <interface name="management">

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -40,7 +40,7 @@
     <domain-controller>
        <local/>
        <!-- Alternative remote domain controller configuration with a host and port -->
-       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+       <!-- <remote host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/mixed-domain/src/test/resources/slave-config/host-slave-overlay.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-config/host-slave-overlay.xml
@@ -60,7 +60,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm">
+       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm">
            <!-- The DomainAdjustors used in the test setup delete all the invalid extensions
             <ignored-resources type="extension">
 

--- a/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
@@ -60,7 +60,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm">
+       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm">
            <!-- The DomainAdjustors used in the test setup delete all the invalid extensions
             <ignored-resources type="extension">
 

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/AbstractValidationUnitTest.java
@@ -471,10 +471,10 @@ public class AbstractValidationUnitTest {
         String result = line.replace("${jboss.management.native.port:9999}", "9999");
         result = result.replace("${jboss.management.http.port:9990}", "9990");
         result = result.replace("${jboss.management.https.port:9993}", "9993");
-        result = result.replace("${jboss.domain.master.protocol:remote}", "remote");
-        result = result.replace("${jboss.domain.master.protocol:remote+http}", "remote+http");
-        result = result.replace("${jboss.domain.master.port:9999}", "9999");
-        result = result.replace("${jboss.domain.master.port:9990}", "9990");
+        result = result.replace("${jboss.domain.primary.protocol:remote}", "remote");
+        result = result.replace("${jboss.domain.primary.protocol:remote+http}", "remote+http");
+        result = result.replace("${jboss.domain.primary.port:9999}", "9999");
+        result = result.replace("${jboss.domain.primary.port:9990}", "9990");
         result = result.replace("${jboss.mail.server.host:localhost}", "localhost");
         result = result.replace("${jboss.mail.server.port:25}", "25");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");


### PR DESCRIPTION
…ave.xml configuration variables to primary/secondary nomenclature

Jira issue: https://issues.redhat.com/browse/WFLY-16281

Requires https://github.com/wildfly/wildfly-core/pull/5066

Changes to rename the following environment properties:
jboss.domain.master.protocol, jboss.domain.master.address, jboss.domain.master.port

Integration Jobs available at the wildfly-core counterpart