### PR TITLE
WFLY-16100, WFLY-16056 to add build compatible extension support

### DIFF
--- a/ee-9/common/pom.xml
+++ b/ee-9/common/pom.xml
@@ -548,6 +548,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-ejb</artifactId>
             <exclusions>

--- a/ee-9/common/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/ee-9/common/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.weld.core">
+
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
+  <resources>
+    <artifact name="${org.jboss.weld:weld-core-impl}"/>
+    <artifact name="${org.jboss.weld:weld-lite-extension-translator}"/>
+    <artifact name="${org.jboss.weld.module:weld-ejb}"/>
+    <artifact name="${org.jboss.weld.module:weld-jta}"/>
+    <artifact name="${org.jboss.weld.module:weld-web}"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.annotation.api"/>
+    <module name="javax.ejb.api" />
+    <module name="javax.enterprise.api"/>
+    <module name="javax.inject.api"/>
+    <module name="javax.interceptor.api"/>
+    <module name="javax.persistence.api"/>
+    <module name="javax.servlet.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.validation.api"/>
+    <module name="org.glassfish.jakarta.el" />
+    <module name="org.jboss.classfilewriter"/>
+    <module name="org.jboss.weld.api" export="true"/>
+    <module name="org.jboss.weld.spi" export="true"/>
+    <module name="org.jboss.logging" />
+    <module name="jdk.unsupported"/>
+    <module name="java.desktop"/>
+    <module name="java.logging"/>
+    <module name="java.naming"/>
+    <module name="java.xml"/>
+  </dependencies>
+</module>

--- a/ee-9/ee-9-api/pom.xml
+++ b/ee-9/ee-9-api/pom.xml
@@ -83,6 +83,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.lang-model</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>

--- a/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
+++ b/ee-9/ee-9-api/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
@@ -26,6 +26,7 @@
 
     <resources>
         <artifact name="${jakarta.enterprise:jakarta.enterprise.cdi-api}"/>
+        <artifact name="${jakarta.enterprise:jakarta.enterprise.lang-model}"/>
     </resources>
 
     <dependencies>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -53,7 +53,7 @@
         <version.jakarta.ejb.jakarta-ejb-api>4.0.0</version.jakarta.ejb.jakarta-ejb-api>
         <version.jakarta.el.jakarta-el-api>5.0.0-RC1</version.jakarta.el.jakarta-el-api>
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>2.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
-        <version.jakarta.enterprise>4.0.0-RC2</version.jakarta.enterprise>
+        <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
         <version.jakarta.faces.jakarta-faces-api>3.0.0</version.jakarta.faces.jakarta-faces-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
@@ -114,8 +114,8 @@
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
         <version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>
         <version.org.jboss.spec.jakarta.xml.soap.saaj-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_2.0_spec>
-        <version.org.jboss.weld.weld>5.0.0.Beta1</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>5.0.Beta5</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>5.0.0.CR2</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>5.0.CR2</version.org.jboss.weld.weld-api>
         <version.org.jvnet.staxex>2.0.1</version.org.jvnet.staxex>
         <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>2.0.0.Beta2</version.org.wildfly.security.elytron-web>
@@ -436,6 +436,18 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.enterprise}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.lang-model</artifactId>
                 <version>${version.jakarta.enterprise}</version>
                 <exclusions>
                     <exclusion>
@@ -1245,6 +1257,18 @@
                 <artifactId>weld-core-impl</artifactId>
                 <version>${version.org.jboss.weld.weld}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-lite-extension-translator</artifactId>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-9/source-transform/weld/subsystem/pom.xml
+++ b/ee-9/source-transform/weld/subsystem/pom.xml
@@ -169,6 +169,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-ejb</artifactId>
         </dependency>

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
@@ -43,6 +43,7 @@ import org.jboss.as.weld.deployment.CdiAnnotationProcessor;
 import org.jboss.as.weld.deployment.processors.BeanArchiveProcessor;
 import org.jboss.as.weld.deployment.processors.BeanDefiningAnnotationProcessor;
 import org.jboss.as.weld.deployment.processors.BeansXmlProcessor;
+import org.jboss.as.weld.deployment.processors.BuildCompatibleExtensionProcessor;
 import org.jboss.as.weld.deployment.processors.DevelopmentModeProcessor;
 import org.jboss.as.weld.deployment.processors.EarApplicationScopedObserverMethodProcessor;
 import org.jboss.as.weld.deployment.processors.ExternalBeanArchiveProcessor;
@@ -106,6 +107,7 @@ class WeldSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_DEVELOPMENT_MODE, new DevelopmentModeProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_BEAN_ARCHIVE, new BeanArchiveProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_EXTERNAL_BEAN_ARCHIVE, new ExternalBeanArchiveProcessor());
+                processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_PORTABLE_EXTENSIONS, new BuildCompatibleExtensionProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_PORTABLE_EXTENSIONS, new WeldPortableExtensionProcessor());
                 // TODO add processor priority to Phase
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, 0x0F10, new EarApplicationScopedObserverMethodProcessor());

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BuildCompatibleExtensionProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BuildCompatibleExtensionProcessor.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2022, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.weld.deployment.processors;
+
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
+import org.jboss.logging.Logger;
+import org.jboss.modules.Module;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import static org.jboss.as.weld.util.Reflections.loadClass;
+
+/**
+ * This processor adds the Weld LiteExtensionTranslator if CDI Lite BuildCompatibleExtensions are
+ * seen from the root deployment. This uses a static block hack to lookup the
+ * org.jboss.weld.lite.extension.translator.BuildCompatibleExtensionLoader#getBuildCompatibleExtensions
+ * method used to determine if the deployment has BuildCompatibleExtensions. When Weld 5
+ * can be used directly in main this would be replaced with a direct call.
+ */
+public class BuildCompatibleExtensionProcessor implements DeploymentUnitProcessor {
+    private static final Logger log = Logger.getLogger(BuildCompatibleExtensionProcessor.class.getPackage().getName());
+    private static final String BUILD_COMPATIBLE_EXTENSION_LOADER = "org.jboss.weld.lite.extension.translator.BuildCompatibleExtensionLoader";
+    private static final String LITE_EXTENSION_TRANSLATOR = "org.jboss.weld.lite.extension.translator.LiteExtensionTranslator";
+
+    private static final Method getBuildCompatibleExtensions;
+    static {
+        Method method = null;
+        try {
+            // See if the BuildCompatibleExtensionLoader can be loaded (EE10 WFP)
+            @SuppressWarnings("unchecked")
+            Class<?> clazz = BuildCompatibleExtensionProcessor.class.getClassLoader().loadClass(BUILD_COMPATIBLE_EXTENSION_LOADER);
+            method = clazz.getDeclaredMethod("getBuildCompatibleExtensions");
+            log.debugf("Found getBuildCompatibleExtensions for %s", BUILD_COMPATIBLE_EXTENSION_LOADER);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // ignore
+            log.debugf(e, "Cannot find getBuildCompatibleExtensions method in %s", BUILD_COMPATIBLE_EXTENSION_LOADER);
+        }
+        getBuildCompatibleExtensions = method;
+    }
+
+    /**
+     * Reflectively calls the BuildCompatibleExtensionLoader#getBuildCompatibleExtensions to see
+     * if BuildCompatibleExtensions existing in the current deployment. This requies that the
+     * thread context class loader is set to the deployment unit module ClassLoader.
+     * @return true if getBuildCompatibleExtensions returns a list > 0, false otherwise
+     * @throws DeploymentUnitProcessingException - on reflection invocation failure
+     */
+    static boolean hasBuildCompatibleExtensions() throws DeploymentUnitProcessingException {
+        if (getBuildCompatibleExtensions != null) {
+            try {
+                List extensions = (List) getBuildCompatibleExtensions.invoke(null);
+                return extensions.size() > 0;
+            } catch (ReflectiveOperationException e) {
+                throw new DeploymentUnitProcessingException(e);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (deploymentUnit.getParent() != null) {
+            return; // only run for top-level deployments
+        }
+
+        final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);
+        final ClassLoader classLoader = module.getClassLoader();
+        final ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            // Have to set the deployment module class loader as the build compatible extension
+            // loader and translator use the TCCL to search for BuildCompatibleExtensions using
+            // SerivceLoader
+            setContextClassLoader(classLoader);
+            if(hasBuildCompatibleExtensions()) {
+                // there are build compatible extensions visible, register the translator
+                WeldPortableExtensions.getPortableExtensions(deploymentUnit)
+                        .tryRegisterExtension(loadClass(LITE_EXTENSION_TRANSLATOR, classLoader),
+                                              deploymentUnit);
+                log.debugf("Registered %s for %s", LITE_EXTENSION_TRANSLATOR, deploymentUnit.getName());
+            }
+        } finally {
+            setContextClassLoader(currentClassLoader);
+        }
+    }
+
+    private void setContextClassLoader(ClassLoader classLoader) {
+        if (WildFlySecurityManager.isChecking()) {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                public Void run() {
+                    Thread.currentThread().setContextClassLoader(classLoader);
+                    return null;
+                }
+            });
+        } else {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>
More work on https://issues.redhat.com/browse/WFLY-16100 that adds missing build compatible extension integration and dependencies. There is a problem with scanning deployments with BuildCompatibleExtensions as seen in this CDI test failure:

org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.SyntheticBeanWithLookupTest
```
org.jboss.weld.exceptions.AmbiguousResolutionException: WELD-001335: Ambiguous dependencies for type MyDependentBean with qualifiers 
 Possible dependencies: 
  - Managed Bean [class org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.MyDependentBean] with qualifiers [@Any @Default],
  - Managed Bean [class org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.MyDependentBean] with qualifiers [@Any @Default]
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.builtin.InstanceImpl.checkBeanResolved(InstanceImpl.java:254)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.builtin.InstanceImpl.get(InstanceImpl.java:113)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.MyPojoCreator.create(MyPojoCreator.java:16)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.MyPojoCreator.create(MyPojoCreator.java:9)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.lite.extension.translator.LiteExtensionTranslator.lambda$synthesis$0(LiteExtensionTranslator.java:157)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl$CreateCallback.create(BeanConfiguratorImpl.java:372)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bootstrap.events.configurator.BeanConfiguratorImpl$ImmutableBean.create(BeanConfiguratorImpl.java:511)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.contexts.unbound.DependentContextImpl.get(DependentContextImpl.java:64)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.ContextualInstanceStrategy$DefaultContextualInstanceStrategy.get(ContextualInstanceStrategy.java:100)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.ContextualInstance.get(ContextualInstance.java:50)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.manager.BeanManagerImpl.getReference(BeanManagerImpl.java:675)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.builtin.InstanceImpl.getBeanInstance(InstanceImpl.java:262)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.builtin.InstanceImpl.lambda$getHandle$0(InstanceImpl.java:202)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.util.LazyValueHolder$1.computeValue(LazyValueHolder.java:32)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.util.LazyValueHolder.get(LazyValueHolder.java:46)
	at org.jboss.weld.core@5.0.0.CR2//org.jboss.weld.bean.builtin.InstanceImpl$HandlerImpl.get(InstanceImpl.java:380)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.cdi.tck.tests.build.compatible.extensions.syntheticBeanWithLookup.SyntheticBeanWithLookupTest.test(SyntheticBeanWithLookupTest.java:41)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.testng.Arquillian$3.invoke(Arquillian.java:146)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.container.test.impl.execution.LocalTestExecuter.execute(LocalTestExecuter.java:57)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:86)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:103)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:90)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:133)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:105)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventImpl.fire(EventImpl.java:62)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.container.test.impl.execution.ContainerTestExecuter.execute(ContainerTestExecuter.java:36)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:86)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:103)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:90)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.test.impl.TestContextHandler.createTestContext(TestContextHandler.java:116)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:86)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:95)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.test.impl.TestContextHandler.createClassContext(TestContextHandler.java:83)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:86)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:95)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.test.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:69)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:86)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:95)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:133)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.test(EventTestRunnerAdaptor.java:139)
	at deployment.SyntheticBeanWithLookupTest355982c2ff53323b8c1b8eb3ad186685e835f45.war//org.jboss.arquillian.testng.Arquillian.run(Arquillian.java:138)
```

@manovotn it seems like the deployment is being treated as both one to be scanned for annotated classes and beans registered via the BCE. 

