### PR TITLE
[26.x][WFLY-16303] Upgrade Apache cxf to 3.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
         <version.org.apache.activemq.artemis>2.19.1</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.10.2</version.org.apache.avro>
-        <version.org.apache.cxf>3.4.5</version.org.apache.cxf>
+        <version.org.apache.cxf>3.4.7</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.3.1</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16303

Upstream (different minor CFX release): https://github.com/wildfly/wildfly/pull/15467