### PR TITLE
[26.x][WFLY-16305] Upgrade cryptacular to 1.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.bitbucket.jose4j>0.7.9</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.11.12</version.org.bytebuddy>
-        <version.org.cryptacular>1.2.4</version.org.cryptacular>
+        <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.eclipse.jdt>3.26.0</version.org.eclipse.jdt>
         <!-- Required by the Wiremock used in the MicroProfile REST Client TCK -->
         <version.org.eclipse.jetty>9.2.30.v20200428</version.org.eclipse.jetty>
@@ -6567,6 +6567,12 @@
                 <groupId>org.cryptacular</groupId>
                 <artifactId>cryptacular</artifactId>
                 <version>${version.org.cryptacular}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk18on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16305
Upstream https://github.com/wildfly/wildfly/pull/15472