### PR TITLE
[26.x][WFLY-16310] Upgrade smallrye-health to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <version.io.smallrye.smallrye-common>1.8.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.6.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>5.2.1</version.io.smallrye.smallrye-fault-tolerance>
-        <version.io.smallrye.smallrye-health>3.1.1</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>3.2.1</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.3</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-mutiny>1.1.2</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16310
Upstream https://github.com/wildfly/wildfly/pull/15480
