### PR TITLE
[WFLY-16312] Upgrade WildFly Core 19.0.0.Beta8

### DIFF
--- a/ee-9/common/pom.xml
+++ b/ee-9/common/pom.xml
@@ -197,7 +197,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcjmail-jdk15on</artifactId>
+            <artifactId>bcjmail-jdk18on</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
+++ b/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcjmail-jdk15on</artifactId>
+      <artifactId>bcjmail-jdk18on</artifactId>
       <licenses>
         <license>
           <name>MIT License</name>

--- a/ee-9/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-9/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -26,7 +26,7 @@
 
     <resources>
         <!-- bcjmail is the Jakarta version of bcmail -->
-        <artifact name="${org.bouncycastle:bcjmail-jdk15on}"/>
+        <artifact name="${org.bouncycastle:bcjmail-jdk18on}"/>
     </resources>
 
     <dependencies>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -1789,7 +1789,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk15on</artifactId>
+      <artifactId>bcmail-jdk18on</artifactId>
       <licenses>
         <license>
           <name>MIT License</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -29,7 +29,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.bouncycastle:bcmail-jdk15on}"/>
+        <artifact name="${org.bouncycastle:bcmail-jdk18on}"/>
     </resources>
 
     <dependencies>

--- a/ee-feature-pack/pruned/pom.xml
+++ b/ee-feature-pack/pruned/pom.xml
@@ -171,7 +171,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
+            <artifactId>bcmail-jdk18on</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/pruned/src/main/resources/license/ee-feature-pack-legacy-licenses.xml
+++ b/ee-feature-pack/pruned/src/main/resources/license/ee-feature-pack-legacy-licenses.xml
@@ -151,7 +151,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk15on</artifactId>
+      <artifactId>bcmail-jdk18on</artifactId>
       <licenses>
         <license>
           <name>MIT License</name>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -29,7 +29,7 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.DeploymentUtils;
-import org.jboss.as.server.deployment.module.DelegatingClassFileTransformer;
+import org.jboss.as.server.deployment.module.DelegatingClassTransformer;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 
@@ -56,8 +56,8 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
         // to use ClassTransformers.  Providers that need class transformers will add them
         // during the call to CreateContainerEntityManagerFactory.
 
-        DelegatingClassFileTransformer transformer = deploymentUnit.getAttachment(DelegatingClassFileTransformer.ATTACHMENT_KEY);
-
+        DelegatingClassTransformer transformer = deploymentUnit.getAttachment(DelegatingClassTransformer.ATTACHMENT_KEY);
+        boolean appContainsPersistenceProviderJars = false;  // remove when we revert WFLY-10520
         if ( transformer != null) {
 
             for (ResourceRoot resourceRoot : DeploymentUtils.allResourceRoots(deploymentUnit)) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
@@ -24,7 +24,6 @@ package org.jboss.as.jpa.processor;
 
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
-import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.nio.ByteBuffer;
 import java.security.AccessControlContext;
@@ -33,25 +32,22 @@ import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 
 import org.jboss.as.jpa.messages.JpaLogger;
+import org.jboss.modules.ClassTransformer;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.security.manager.action.GetAccessControlContextAction;
 
+
 /**
- * Helps implement PersistenceUnitInfo.addClassTransformer() by using DelegatingClassFileTransformer
+ * Helps implement PersistenceUnitInfo.addClassTransformer() by using DelegatingClassTransformer
  *
  * @author Scott Marlow
  */
-class JPADelegatingClassFileTransformer implements ClassFileTransformer, org.jboss.modules.ClassTransformer {
+class JPADelegatingClassFileTransformer implements ClassTransformer {
     private final PersistenceUnitMetadata persistenceUnitMetadata;
 
     public JPADelegatingClassFileTransformer(PersistenceUnitMetadata pu) {
         persistenceUnitMetadata = pu;
-    }
-
-    @Override
-    public byte[] transform(ClassLoader classLoader, String className, Class<?> aClass, ProtectionDomain protectionDomain, byte[] originalBuffer) {
-        return getBytes(transform(classLoader, className, protectionDomain, ByteBuffer.wrap(originalBuffer)));
     }
 
     @Override

--- a/picketlink/pom.xml
+++ b/picketlink/pom.xml
@@ -86,6 +86,16 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-wildfly-subsystem</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta7</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta8</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -10261,6 +10261,11 @@
                                             <exclude>org.apache.geronimo.specs:geronimo-stax-api_1.0_spec</exclude>
                                             <exclude>org.apache.xalan:serializer</exclude>
                                             <exclude>org.apache.xalan:xalan</exclude>
+                                            <!-- replaced by org.bouncycastle:*-jdk18on -->
+                                            <exclude>org.bouncycastle:bcpg-jdk15on</exclude>
+                                            <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                            <exclude>org.bouncycastle:bcpkix-jdk15on</exclude>
+                                            <exclude>org.bouncycastle:bcutil-jdk15on</exclude>
                                             <exclude>org.codehaus.jackson:jackson-core-asl</exclude>
                                             <exclude>org.codehaus.jackson:jackson-jaxrs</exclude>
                                             <exclude>org.codehaus.jackson:jackson-mapper-asl</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transformer/DummyClassFileTransformer1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transformer/DummyClassFileTransformer1.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.test.integration.deployment.classloading.transformer;
 
-import java.lang.instrument.ClassFileTransformer;
-import java.lang.instrument.IllegalClassFormatException;
+import org.jboss.modules.ClassTransformer;
+import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -31,14 +31,14 @@ import java.util.concurrent.ConcurrentSkipListSet;
 /**
  * @author Marius Bogoevici
  */
-public class DummyClassFileTransformer1 implements ClassFileTransformer {
+public class DummyClassFileTransformer1 implements ClassTransformer {
 
     public static boolean wasActive = false;
 
     public static Set<String> transformedClassNames = new ConcurrentSkipListSet<String>();
 
     @Override
-    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+    public ByteBuffer transform(ClassLoader loader, String className, ProtectionDomain protectionDomain, ByteBuffer classfileBuffer) throws IllegalArgumentException {
         transformedClassNames.add(className);
         wasActive = true;
         return classfileBuffer;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transformer/DummyClassFileTransformer2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transformer/DummyClassFileTransformer2.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.test.integration.deployment.classloading.transformer;
 
-import java.lang.instrument.ClassFileTransformer;
-import java.lang.instrument.IllegalClassFormatException;
+import org.jboss.modules.ClassTransformer;
+import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -31,14 +31,14 @@ import java.util.concurrent.ConcurrentSkipListSet;
 /**
  * @author Marius Bogoevici
  */
-public class DummyClassFileTransformer2 implements ClassFileTransformer {
+public class DummyClassFileTransformer2 implements ClassTransformer {
 
     public static boolean wasActive = false;
 
     public static Set<String> transformedClassNames = new ConcurrentSkipListSet<String> ();
 
     @Override
-    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+    public ByteBuffer transform(ClassLoader loader, String className, ProtectionDomain protectionDomain, ByteBuffer classfileBuffer) throws IllegalArgumentException {
         transformedClassNames.add(className);
         wasActive = true;
         return classfileBuffer;

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -53,7 +53,8 @@
         <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
         <security.properties>${project.basedir}/src/test/resources/reenabled_tlsv1.properties</security.properties>
         <!-- WFLY-16155 temporary pin bouncycastle 1.69 for test only.
-             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests -->
+             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests
+             and change to org.bouncycastle:*-jdk18on -->
         <version.org.bouncycastle>1.69</version.org.bouncycastle>
         <version.org.hsqldb.hsqldb>2.5.0</version.org.hsqldb.hsqldb>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>
@@ -234,6 +235,9 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- WFLY-16155 temporary pin bouncycastle 1.69 for test only.
+             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests
+             and change to org.bouncycastle:*-jdk18on -->
         <!-- crl and ocsp -->
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16312
JIRA: https://issues.jboss.org/browse/WFLY-15288
JIRA: https://issues.jboss.org/browse/WFLY-16267

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

This PR also includes commits from #14661 and #15429 that were required to build WildFly with this version of WildFly Core.
I added an additional commit to #15429 for WFLY-16267 as I was getting banned dependencies through `org.keycloak:keycloak-saml-wildfly-subsystem` test dependency.

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta8
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta7...19.0.0.Beta8

---

<details>
<summary>
        Release Notes - WildFly Core - Version 19.0.0.Beta8</summary>
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5880'>WFCORE-5880</a>] -         BootableJarCommandBuilder sets modular options
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5882'>WFCORE-5882</a>] -         Fix cleanup method org.jboss.as.jmx.ModelControllerMBeanTestCase#cleanup
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5799'>WFCORE-5799</a>] -         Restore ReloadRedirectTestCase.testRedirectWithSecurityCommands and CLIAuthenticationTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5840'>WFCORE-5840</a>] -         [primary/secondary] Adapt domain.sh script arguments and its documentation
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5875'>WFCORE-5875</a>] -         Change the dependency on the log managers JSON formatter
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5876'>WFCORE-5876</a>] -         Migrate the internal.javax.json.api.ee8 to use GlassFish Jakarta JSON
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5881'>WFCORE-5881</a>] -         Use JPMS properties from launcher optionally
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5874'>WFCORE-5874</a>] -         Upgrade bouncycastle to 1.71
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5887'>WFCORE-5887</a>] -         Upgrade XNIO to 3.8.7.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5888'>WFCORE-5888</a>] -         Upgrade httpcore to 4.4.15
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3685'>WFCORE-3685</a>] -         Use org.jboss.modules.ClassTransformer for transformation DUPs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5862'>WFCORE-5862</a>] -         Excessive output regarding downloads when project built
</li>
</ul>
                                                                                                                            
</summary>
</details>
