### PR TITLE
[WFLY-16089] Upgrade Weld version for EE8 (3.1.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.8.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>3.1.9.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>3.1.SP4</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.3.3.Final</version.org.jboss.ws.common>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16089
A rare case where 26.x was patched first: https://github.com/wildfly/wildfly/commit/92d02eeaafc6212325e1055dfa41cc9b8a64a66c
