### PR TITLE
RESTEasy Upgrades

### DIFF
--- a/ee-9/common/pom.xml
+++ b/ee-9/common/pom.xml
@@ -526,6 +526,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.resteasy.spring</groupId>
+            <artifactId>resteasy-spring</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-api</artifactId>
             <exclusions>

--- a/ee-9/common/src/main/resources/packages/org.jboss.resteasy.resteasy-spring/pm/wildfly/tasks.xml
+++ b/ee-9/common/src/main/resources/packages/org.jboss.resteasy.resteasy-spring/pm/wildfly/tasks.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+    <copy-artifact artifact="org.jboss.resteasy.spring:resteasy-spring" to-location="modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/bundled/resteasy-spring-jar/"/>
+</tasks>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -925,6 +925,10 @@
                     <groupId>org.jboss.narayana.jts</groupId>
                     <artifactId>narayana-jts-integration</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-spring</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -112,6 +112,7 @@
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
         <version.org.jboss.resteasy.6>6.1.0.Beta2</version.org.jboss.resteasy.6>
         <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.spring>3.0.0.Alpha3</version.org.jboss.resteasy.spring>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
         <version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>
         <version.org.jboss.spec.jakarta.xml.soap.saaj-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_2.0_spec>
@@ -1226,6 +1227,18 @@
                     <exclusion>
                         <artifactId>*</artifactId>
                         <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy.spring</groupId>
+                <artifactId>resteasy-spring</artifactId>
+                <version>${version.org.jboss.resteasy.spring}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -110,7 +110,7 @@
         <version.org.hibernate.validator>8.0.0.Alpha3</version.org.hibernate.validator>
         <version.org.jberet>2.0.4.Final</version.org.jberet>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.resteasy.6>6.1.0.Beta1</version.org.jboss.resteasy.6>
+        <version.org.jboss.resteasy.6>6.1.0.Beta2</version.org.jboss.resteasy.6>
         <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>3.0.0</version.org.jboss.spec.jakarta.el.jboss-el-api_4.0_spec>
         <version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>1.0.1.Final</version.org.jboss.spec.jakarta.xml.ws.api_3.0_spec>


### PR DESCRIPTION
* https://issues.redhat.com/browse/WFLY-16314
* https://issues.redhat.com/browse/WFLY-16315

The first commit simply upgrades RESTEasy. There are minimal changes to this release:
Tag: https://github.com/resteasy/resteasy/releases/tag/6.1.0.Beta2
Diff: https://github.com/resteasy/resteasy/compare/6.1.0.Beta1...6.1.0.Beta2

The second commit migrates WildFly Preview to RESTEasy Spring. This project was created by taking the resteasy-spring module and tests out of RESTEasy and into their own project. Note that this uses Spring 6 which requires Java 17. However, the RESTEasy Spring project is still being compiled down to Java 11.