### PR TITLE
[26.x][WFLY-16321] Upgrade eclipselink to 2.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <version.org.eclipse.microprofile.reactive-streams-operators.api>2.0</version.org.eclipse.microprofile.reactive-streams-operators.api>
         <version.org.eclipse.microprofile.rest.client.api>2.0</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.10</version.org.eclipse.yasson>
-        <version.org.eclipselink.version>2.7.9</version.org.eclipselink.version>
+        <version.org.eclipselink.version>2.7.10</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>3.0.3.jbossorg-4</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16321
Upstream https://github.com/wildfly/wildfly/pull/15494
