### PR TITLE
[26.x][WFLY-16323] Upgrade net.bytebuddy to 1.12.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
         <version.org.apache.xerces>2.12.0.SP03</version.org.apache.xerces>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.bitbucket.jose4j>0.7.9</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.11.12</version.org.bytebuddy>
+        <version.org.bytebuddy>1.12.9</version.org.bytebuddy>
         <version.org.cryptacular>1.2.4</version.org.cryptacular>
         <version.org.eclipse.jdt>3.26.0</version.org.eclipse.jdt>
         <!-- Required by the Wiremock used in the MicroProfile REST Client TCK -->


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16323
