### PR TITLE
[26.x][WFLY-16325] Upgrade smallrye-opentracing 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <version.io.reactivex.rxjava3>3.1.4</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
         <version.io.smallrye.open-api>2.1.21</version.io.smallrye.open-api>
-        <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
+        <version.io.smallrye.opentracing>2.1.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.8.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.6.1</version.io.smallrye.smallrye-config>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16325
Upstream https://github.com/wildfly/wildfly/pull/15498