### PR TITLE
[WFLY-15696] Start Faces 4 integration

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -42,7 +42,7 @@
         <preview.dist.product.release.version>${full.dist.product.release.version}</preview.dist.product.release.version>
 
         <!-- Version properties for dependency management items -->
-        <version.com.sun.faces>3.0.2.SP01</version.com.sun.faces>
+        <version.com.sun.faces>4.0.0-M6.SP01</version.com.sun.faces>
         <version.com.sun.istack>4.0.1</version.com.sun.istack>
         <version.com.sun.xml.messaging.saaj>2.0.0.SP1</version.com.sun.xml.messaging.saaj>
         <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
@@ -54,7 +54,7 @@
         <version.jakarta.el.jakarta-el-api>5.0.0-RC1</version.jakarta.el.jakarta-el-api>
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>2.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
         <version.jakarta.enterprise>4.0.0-RC2</version.jakarta.enterprise>
-        <version.jakarta.faces.jakarta-faces-api>3.0.0</version.jakarta.faces.jakarta-faces-api>
+        <version.jakarta.faces.jakarta-faces-api>4.0.0-M6</version.jakarta.faces.jakarta-faces-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.jms.jakarta-jms-api>3.0.0</version.jakarta.jms.jakarta-jms-api>

--- a/ee-9/source-transform/jsf/injection/pom.xml
+++ b/ee-9/source-transform/jsf/injection/pom.xml
@@ -26,13 +26,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-ee-9-source-transform-parent</artifactId>
+        <artifactId>wildfly-jsf-parent-jakarta</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>27.0.0.Beta1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <packaging>jar</packaging>
@@ -132,4 +131,40 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <id>delete-old-file</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                def toDelete = [
+                                    "org/jboss/as/jsf/injection/AnnotationMap.java",
+                                    "org/jboss/as/jsf/injection/weld/legacy/"
+                                ]
+                                toDelete.forEach {
+                                    def file = new File(project.build.getDirectory() + "/generated-sources/transformed/" + it)
+                                    if (file.isDirectory()) {
+                                        file.deleteDir()
+                                    } else {
+                                        file.delete()
+                                    }
+                                }
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
 </project>

--- a/ee-9/source-transform/jsf/injection/src/main/java/org/jboss/as/jsf/injection/AnnotationMap.java
+++ b/ee-9/source-transform/jsf/injection/src/main/java/org/jboss/as/jsf/injection/AnnotationMap.java
@@ -1,0 +1,131 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.jboss.as.jsf.injection;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.behavior.FacesBehavior;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.faces.event.NamedEvent;
+import jakarta.faces.render.FacesBehaviorRenderer;
+import jakarta.faces.render.FacesRenderer;
+import jakarta.faces.validator.FacesValidator;
+import jakarta.servlet.ServletContext;
+
+/**
+ * This class retrieves the annotation map from application scope.  This map was placed there by the JSFAnnotationProcessor
+ * in the Jakarta Server Faces subsystem.
+ *
+ * The class also reloads the map if needed.  The reason why the map must be reloaded is because the Jakarta Server Faces
+ * Annotation classes used as the map keys are always loaded by the Jakarta Server Faces subsystem and thus always
+ * correspond to the default Jakarta Server Faces implementation.  If a different Jakarta Server Faces implementation is
+ * used then the Jakarta Server Faces impl will be looking for the wrong version of the map keys.  So, we replace the
+ * default implementations of the Jakarta Server Faces Annotation classes with whatever version the WAR is actually using.
+ *
+ * The reason this works is because we have a "slot" for jsf-injection for each Jakarta Server Faces implementation.
+ * And jsf-injection points to its corresponding Jakarta Server Faces impl/api slots.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class AnnotationMap {
+    /**
+     * @see org.jboss.as.jsf.deployment.JSFAnnotationProcessor#FACES_ANNOTATIONS_SC_ATTR
+     */
+    public static final String FACES_ANNOTATIONS_SC_ATTR =  "org.jboss.as.jsf.FACES_ANNOTATIONS";
+    private static final String ANNOTATION_MAP_CONVERTED = "org.jboss.as.jsf.ANNOTATION_MAP_CONVERTED";
+
+    private static final Map<String, Class<? extends Annotation>> stringToAnnoMap = new HashMap<String, Class<? extends Annotation>>();
+
+    static {
+        // These classes need to be loaded in order!  Some can't be loaded if the Jakarta Server Faces version is too old.
+
+        try { // all of the following classes are available from Faces 2.0 and Faces 2.1
+            stringToAnnoMap.put(FacesComponent.class.getName(), FacesComponent.class);
+            stringToAnnoMap.put(FacesConverter.class.getName(), FacesConverter.class);
+            stringToAnnoMap.put(FacesValidator.class.getName(), FacesValidator.class);
+            stringToAnnoMap.put(FacesRenderer.class.getName(), FacesRenderer.class);
+            stringToAnnoMap.put(NamedEvent.class.getName(), NamedEvent.class);
+            stringToAnnoMap.put(FacesBehavior.class.getName(), FacesBehavior.class);
+            stringToAnnoMap.put(FacesBehaviorRenderer.class.getName(), FacesBehaviorRenderer.class);
+
+            // Put Jakarta Server Faces 2.2+ annotations below this line if any new ones are to be scanned.
+            // Load the class to avoid a NoClassDefFoundError if it is not present in the impl
+            ClassLoader loader = AnnotationMap.class.getClassLoader();
+            addAnnotationIfPresent(loader, "jakarta.faces.view.facelets.FaceletsResourceResolver");
+        } catch (Exception e) {
+            // Ignore.  Whatever classes are available have been loaded into the map.
+        }
+    }
+
+    // don't allow instance
+    private AnnotationMap() {}
+
+    private static void addAnnotationIfPresent(ClassLoader loader, String name) {
+        try {
+            Class clazz = loader.loadClass(name);
+            if (Annotation.class.isAssignableFrom(clazz)) {
+                stringToAnnoMap.put(name, clazz);
+            }
+        } catch(ClassNotFoundException e) {
+            // ignore, annotation not found in the used Jakarta Server Faces version
+        }
+    }
+
+    public static Map<Class<? extends Annotation>, Set<Class<?>>> get(final ExternalContext extContext) {
+        Map<String, Object> appMap = extContext.getApplicationMap();
+        if (appMap.get(ANNOTATION_MAP_CONVERTED) != null) {
+            return (Map<Class<? extends Annotation>, Set<Class<?>>>)appMap.get(FACES_ANNOTATIONS_SC_ATTR);
+        } else {
+            appMap.put(ANNOTATION_MAP_CONVERTED, Boolean.TRUE);
+            return convert((Map<Class<? extends Annotation>, Set<Class<?>>>)appMap.get(FACES_ANNOTATIONS_SC_ATTR));
+        }
+    }
+
+    public static Map<Class<? extends Annotation>, Set<Class<?>>> get(final ServletContext servletContext) {
+        Map<Class<? extends Annotation>, Set<Class<?>>> annotations = (Map<Class<? extends Annotation>, Set<Class<?>>>) servletContext.getAttribute(FACES_ANNOTATIONS_SC_ATTR);
+        if (servletContext.getAttribute(ANNOTATION_MAP_CONVERTED) != null) {
+            return annotations;
+        } else {
+            servletContext.setAttribute(ANNOTATION_MAP_CONVERTED, Boolean.TRUE);
+            return convert(annotations);
+        }
+    }
+
+    private static Map<Class<? extends Annotation>, Set<Class<?>>> convert(Map<Class<? extends Annotation>, Set<Class<?>>> annotations) {
+        final Map<Class<? extends Annotation>, Set<Class<?>>> convertedAnnotatedClasses = new HashMap<Class<? extends Annotation>, Set<Class<?>>>();
+        for (Map.Entry<Class<? extends Annotation>, Set<Class<?>>> entry : annotations.entrySet()) {
+            final Class<? extends Annotation> annotation = entry.getKey();
+            final Set<Class<?>> annotated = entry.getValue();
+            final Class<? extends Annotation> knownAnnotation = stringToAnnoMap.get(annotation.getName());
+            if (knownAnnotation != null) {
+                convertedAnnotatedClasses.put(knownAnnotation, annotated); // put back in the map with the proper version of the class
+            } else {
+                // just copy over the original annotation to annotated classes mapping
+                convertedAnnotatedClasses.put(annotation, annotated);
+            }
+        }
+
+        return convertedAnnotatedClasses;
+    }
+}

--- a/ee-9/source-transform/jsf/pom.xml
+++ b/ee-9/source-transform/jsf/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ee-9-source-transform-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>27.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jsf-parent-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>WildFly: Jakarta Faces integration modules (Jakarta Namespace)</name>
+
+    <modules>
+        <module>subsystem</module>
+        <module>injection</module>
+    </modules>
+</project>

--- a/ee-9/source-transform/jsf/subsystem/pom.xml
+++ b/ee-9/source-transform/jsf/subsystem/pom.xml
@@ -26,13 +26,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-ee-9-source-transform-parent</artifactId>
+        <artifactId>wildfly-jsf-parent-jakarta</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>27.0.0.Beta1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-jsf-jakarta</artifactId>
@@ -163,10 +162,40 @@
                 <configuration>
                     <systemPropertyVariables>
                         <module.path>
+                            ${project.build.directory}${file.separator}generated-test-resources${file.separator}transformed${file.separator}modules${path.separator}${project.build.directory}${file.separator}generated-test-resources${file.separator}transformed${file.separator}modules2
+                        </module.path>
+<!--
+                        <module.path>
                             ${transformer-input-dir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}modules${path.separator}${transformer-input-dir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}modules2
                         </module.path>
+-->
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <id>delete-old-files</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                def toDelete = [
+                                        "org/jboss/as/jsf/deployment/FacesAnnotation.java",
+                                ]
+                                toDelete.forEach {
+                                    new File(project.build.getDirectory() + "/generated-sources/transformed/" + it)
+                                            .delete()
+                                }
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/ee-9/source-transform/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/FacesAnnotation.java
+++ b/ee-9/source-transform/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/FacesAnnotation.java
@@ -1,0 +1,30 @@
+package org.jboss.as.jsf.deployment;
+
+import java.lang.annotation.Annotation;
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.behavior.FacesBehavior;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.faces.event.NamedEvent;
+import jakarta.faces.render.FacesBehaviorRenderer;
+import jakarta.faces.render.FacesRenderer;
+import jakarta.faces.validator.FacesValidator;
+
+import org.jboss.jandex.DotName;
+
+enum FacesAnnotation {
+    FACES_COMPONENT(FacesComponent.class),
+    FACES_CONVERTER(FacesConverter.class),
+    FACES_VALIDATOR(FacesValidator.class),
+    FACES_RENDERER(FacesRenderer.class),
+    NAMED_EVENT(NamedEvent.class),
+    FACES_BEHAVIOR(FacesBehavior.class),
+    FACES_BEHAVIOR_RENDERER(FacesBehaviorRenderer.class);
+
+    final Class<? extends Annotation> annotationClass;
+    final DotName indexName;
+
+    private FacesAnnotation(Class<? extends Annotation> annotationClass) {
+        this.annotationClass = annotationClass;
+        this.indexName = DotName.createSimple(annotationClass.getName());
+    }
+}

--- a/ee-9/source-transform/pom.xml
+++ b/ee-9/source-transform/pom.xml
@@ -58,8 +58,7 @@
         <module>jpa/spi</module>
         <module>jpa/eclipselink</module>
         <module>jpa/subsystem</module>
-        <module>jsf/injection</module>
-        <module>jsf/subsystem</module>
+        <module>jsf</module>
         <module>mail</module>
         <module>microprofile</module>
         <module>mod_cluster/undertow</module>

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/FacesAnnotation.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/FacesAnnotation.java
@@ -1,0 +1,34 @@
+package org.jboss.as.jsf.deployment;
+
+import java.lang.annotation.Annotation;
+import javax.faces.bean.ManagedBean;
+import javax.faces.component.FacesComponent;
+import javax.faces.component.behavior.FacesBehavior;
+import javax.faces.convert.FacesConverter;
+import javax.faces.event.NamedEvent;
+import javax.faces.render.FacesBehaviorRenderer;
+import javax.faces.render.FacesRenderer;
+import javax.faces.validator.FacesValidator;
+import javax.faces.view.facelets.FaceletsResourceResolver;
+
+import org.jboss.jandex.DotName;
+
+enum FacesAnnotation {
+    FACES_COMPONENT(FacesComponent.class),
+    FACES_CONVERTER(FacesConverter.class),
+    FACES_VALIDATOR(FacesValidator.class),
+    FACES_RENDERER(FacesRenderer.class),
+    MANAGED_BEAN(ManagedBean.class),
+    NAMED_EVENT(NamedEvent.class),
+    FACES_BEHAVIOR(FacesBehavior.class),
+    FACES_BEHAVIOR_RENDERER(FacesBehaviorRenderer.class),
+    FACELETS_RESOURCE_RESOLVER(FaceletsResourceResolver.class);
+
+    final Class<? extends Annotation> annotationClass;
+    final DotName indexName;
+
+    private FacesAnnotation(Class<? extends Annotation> annotationClass) {
+        this.annotationClass = annotationClass;
+        this.indexName = DotName.createSimple(annotationClass.getName());
+    }
+}

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFAnnotationProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFAnnotationProcessor.java
@@ -22,6 +22,13 @@
 
 package org.jboss.as.jsf.deployment;
 
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.jboss.as.jsf.logging.JSFLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -37,22 +44,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.modules.Module;
 
-import javax.faces.bean.ManagedBean;
-import javax.faces.component.FacesComponent;
-import javax.faces.component.behavior.FacesBehavior;
-import javax.faces.convert.FacesConverter;
-import javax.faces.event.NamedEvent;
-import javax.faces.render.FacesBehaviorRenderer;
-import javax.faces.render.FacesRenderer;
-import javax.faces.validator.FacesValidator;
-import javax.faces.view.facelets.FaceletsResourceResolver;
-import java.lang.annotation.Annotation;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 /**
  * {@link DeploymentUnitProcessor} implementation responsible for extracting Jakarta Server Faces annotations from a deployment and attaching them
  * to the deployment unit to eventually be added to the {@link javax.servlet.ServletContext}.
@@ -63,26 +54,6 @@ public class JSFAnnotationProcessor implements DeploymentUnitProcessor {
 
     public static final String FACES_ANNOTATIONS_SC_ATTR =  "org.jboss.as.jsf.FACES_ANNOTATIONS";
     private static final String MANAGED_ANNOTATION_PARAMETER = "managed";
-
-    private enum FacesAnnotation {
-        FACES_COMPONENT(FacesComponent.class),
-        FACES_CONVERTER(FacesConverter.class),
-        FACES_VALIDATOR(FacesValidator.class),
-        FACES_RENDERER(FacesRenderer.class),
-        MANAGED_BEAN(ManagedBean.class),
-        NAMED_EVENT(NamedEvent.class),
-        FACES_BEHAVIOR(FacesBehavior.class),
-        FACES_BEHAVIOR_RENDERER(FacesBehaviorRenderer.class),
-        FACELETS_RESOURCE_RESOLVER(FaceletsResourceResolver.class);
-
-        private final Class<? extends Annotation> annotationClass;
-        private final DotName indexName;
-
-        private FacesAnnotation(Class<? extends Annotation> annotationClass) {
-            this.annotationClass = annotationClass;
-            this.indexName = DotName.createSimple(annotationClass.getName());
-        }
-    }
 
 
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/duplicateid/DuplicateIDIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/duplicateid/DuplicateIDIntegrationTestCase.java
@@ -1,5 +1,15 @@
 package org.jboss.as.test.integration.jsf.duplicateid;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
@@ -15,39 +25,37 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.jsf.duplicateid.deployment.IncludeBean;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.LinkedList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 /**
  * Test case based on reproducer for https://issues.jboss.org/browse/JBEAP-10758
- *
+ * <p>
  * Original reproducer: https://github.com/tuner/mojarra-dynamic-include-reproducer
  * Original reproducer author: Kari Lavikka <tuner@bdb.fi>
  *
  * @author Jan Kasik <jkasik@redhat.com>
- *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class DuplicateIDIntegrationTestCase {
+
+    // TODO: Disable this test for now. The inclusion of javax.* strings in static resources is troublesome, but we can
+    // fix that once main is switched to EE 10 and we no longer need to support
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
 
     private static final Logger log = LoggerFactory.getLogger(DuplicateIDIntegrationTestCase.class);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/flash/FlashScopeDistributedSessionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/flash/FlashScopeDistributedSessionTestCase.java
@@ -1,5 +1,7 @@
 package org.jboss.as.test.integration.jsf.flash;
 
+import java.net.URL;
+
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -12,12 +14,11 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -29,19 +30,21 @@ public class FlashScopeDistributedSessionTestCase {
     @Deployment
     public static Archive<?> deploy() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "jsfflashscope.war");
-        war.addAsWebInfResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "web.xml", "web.xml");
-        war.addAsWebInfResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "faces-config.xml", "faces-config.xml");
-        war.addAsWebResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "getvar.xhtml", "getvar.xhtml");
-        war.addAsWebResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "getvar2.xhtml", "getvar2.xhtml");
-        war.addAsWebResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "setvar.xhtml", "setvar.xhtml");
-        war.addAsWebResource(FlashScopeDistributedSessionTestCase.class.getPackage(), "setvar2.xhtml", "setvar2.xhtml");
+        Package pakkage = FlashScopeDistributedSessionTestCase.class.getPackage();
+        war.addAsWebInfResource(pakkage, "web.xml", "web.xml");
+        war.addAsWebInfResource(pakkage, "faces-config.xml", "faces-config.xml");
+        war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        war.addAsWebResource(pakkage, "getvar.xhtml", "getvar.xhtml");
+        war.addAsWebResource(pakkage, "getvar2.xhtml", "getvar2.xhtml");
+        war.addAsWebResource(pakkage, "setvar.xhtml", "setvar.xhtml");
+        war.addAsWebResource(pakkage, "setvar2.xhtml", "setvar2.xhtml");
         return war;
     }
 
     @Test
     public void testSettingAndReadingFlashVar() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
             HttpUriRequest setVarRequest = new HttpGet(url.toExternalForm() + "setvar.jsf");
             HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + "getvar.jsf");
@@ -56,7 +59,7 @@ public class FlashScopeDistributedSessionTestCase {
     @Test
     public void testReadingEmptyFlashVar() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
             HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + "getvar2.jsf");
             try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
@@ -69,7 +72,7 @@ public class FlashScopeDistributedSessionTestCase {
     @Test
     public void testPuttingFlashVarOnNonTransientPage() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
             HttpUriRequest setVarRequest = new HttpGet(url.toExternalForm() + "setvar2.jsf");
             try (CloseableHttpResponse setVarResponse = client.execute(setVarRequest)) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/annotation/AnnotatedManagedBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/annotation/AnnotatedManagedBeanTestCase.java
@@ -23,11 +23,13 @@ package org.jboss.as.test.integration.jsf.managedbean.annotation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +38,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class AnnotatedManagedBeanTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
 
     @Deployment
     public static Archive<?> deploy() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/managedproperty/ManagedPropertyManagedBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/managedproperty/ManagedPropertyManagedBeanTestCase.java
@@ -25,9 +25,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,6 +41,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class ManagedPropertyManagedBeanTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
 
     @Deployment
     public static Archive<?> deploy() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/xml/XmlManagedBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/xml/XmlManagedBeanTestCase.java
@@ -23,11 +23,13 @@ package org.jboss.as.test.integration.jsf.managedbean.xml;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +38,10 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class XmlManagedBeanTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
 
     @Deployment
     public static Archive<?> deploy() {
@@ -49,7 +55,7 @@ public class XmlManagedBeanTestCase {
                 "    xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_1_2.xsd\">\n" +
                 "    <managed-bean eager=\"true\">\n" +
                 "        <managed-bean-name>simpleBean</managed-bean-name>\n" +
-                "        <managed-bean-class>"+SimpleJsfXmlManagedBean.class.getName()+"</managed-bean-class>\n" +
+                "        <managed-bean-class>" + SimpleJsfXmlManagedBean.class.getName() + "</managed-bean-class>\n" +
                 "        <managed-bean-scope>application</managed-bean-scope>\n" +
                 "    </managed-bean>\n" +
                 "</faces-config>"), "faces-config.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/FaceletsResourceResolverTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/resourceResolver/FaceletsResourceResolverTestCase.java
@@ -20,6 +20,7 @@ package org.jboss.as.test.integration.jsf.resourceResolver;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -32,10 +33,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,6 +51,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class FaceletsResourceResolverTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
 
     @ArquillianResource
     URL url;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/unsupportedwar/FaceletsViewMappingsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/unsupportedwar/FaceletsViewMappingsTestCase.java
@@ -16,8 +16,6 @@
 
 package org.jboss.as.test.integration.jsf.unsupportedwar;
 
-import java.net.URL;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
@@ -26,13 +24,19 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,22 +44,34 @@ import org.junit.runner.RunWith;
  * <p>Tests the Jakarta Server Faces deployment failure due to UnsupportedOperationException when
  * <em>javax.faces.FACELETS_VIEW_MAPPINGS</em> is defined with something that
  * does not include <em>*.xhtml</em>.</p>
- *
+ * <p>
  * For details check https://issues.redhat.com/browse/WFLY-13792
  *
  * @author Ranabir Chakraborty <rchakrab@redhat.com>
- *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class FaceletsViewMappingsTestCase {
 
+    public static final String FACELETS_VIEW_MAPPINGS_TEST_CASE = "FaceletsViewMappingsTestCase";
+
+    // TODO: For now...
+    // The runtime behavior seems to have changed with Faces 4, resulting in a failed deployment. To prevent breaking testing from
+    // main, I'm disabling this test for now, and will update it once we make the flip to EE 10.
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeNotWildFlyPreview();
+    }
+
     private static final String DEPLOYMENT = FaceletsViewMappingsTestCase.class.getSimpleName();
 
     @ArquillianResource
-    private URL url;
+    private Deployer deployer;
 
-    @Deployment
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Deployment(name = FACELETS_VIEW_MAPPINGS_TEST_CASE, testable = false, managed = false)
     public static WebArchive deployment() {
         final Package DEPLOYMENT_PACKAGE = HelloBean.class.getPackage();
         WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
@@ -65,17 +81,27 @@ public class FaceletsViewMappingsTestCase {
         return war;
     }
 
+    @Before
+    public void setup() {
+        deployer.deploy(FACELETS_VIEW_MAPPINGS_TEST_CASE);
+    }
+
+    @After
+    public void tearDown() {
+        deployer.undeploy(FACELETS_VIEW_MAPPINGS_TEST_CASE);
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     public void testHelloWorld() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            String Url = url.toExternalForm();
-            HttpGet httpget = new HttpGet(Url);
+            HttpGet httpget = new HttpGet(managementClient.getWebUri() + "/" + DEPLOYMENT);
 
             HttpResponse response = httpclient.execute(httpget);
-            Assert.assertEquals("Jakarta Server Faces deployment failed due to UnsupportedOperationException when javax.faces.FACELETS_VIEW_MAPPINGS valued wrong", HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-            HttpEntity entity = response.getEntity();
-            String result = EntityUtils.toString(entity);
+            String result = EntityUtils.toString(response.getEntity());
+
+            Assert.assertEquals("Jakarta Server Faces deployment failed due to UnsupportedOperationException when javax.faces.FACELETS_VIEW_MAPPINGS valued wrong",
+                    HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
             MatcherAssert.assertThat("Hello World is in place", result, CoreMatchers.containsString("Hello World!"));
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/unsupportedwar/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/unsupportedwar/web.xml
@@ -15,9 +15,9 @@
     limitations under the License.
 -->
 <web-app version="4.0"
-    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+         xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
 
     <context-param>
         <param-name>javax.faces.DEFAULT_SUFFIX</param-name>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -1,10 +1,11 @@
 package org.jboss.as.test.shared.util;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.function.Supplier;
 
-import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.testcontainers.DockerClientFactory;
 
@@ -90,6 +91,12 @@ public class AssumeTestGroupUtil {
         }
     }
 
+    public static void assumeNotWildFlyPreview() {
+        assumeTrue("Some tests are disabled on WildFly Preview",
+                System.getProperty("ts.ee9") == null &&
+                        System.getProperty("ts.bootable.ee9") == null);
+    }
+
     private static int getJavaSpecificationVersion() {
         final String versionString = System.getProperty("java.specification.version");
         return Integer.parseInt(versionString);
@@ -99,7 +106,7 @@ public class AssumeTestGroupUtil {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
             public Void run() {
-                Assume.assumeTrue(message, assumeTrueCondition.get());
+                assumeTrue(message, assumeTrueCondition.get());
                 return null;
             }
         });


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15696

Bump JSF artifact versions
Add parent pom for jsf transform
Fork classes that need manual import changes
Disable some tests in testsuite/integration/basic that are no longer for Faces 4
Extract FacesAnnotation enum
Override enum in source-transform
Delete removed annotation refs from enum in source-transform
