### PR TITLE
[WFLY-16354] Upgrade WildFly Core 19.0.0.Beta9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta8</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta9</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-16354

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta9
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta8...19.0.0.Beta9

---

<details>
  <summary>Release Notes - WildFly Core - Version 19.0.0.Beta9</summary>
          
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5649'>WFCORE-5649</a>] -         Assertion arguments should be passed in the correct order (cli)
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3407'>WFCORE-3407</a>] -         Logging deployments that contain a logging configuration file do not clear the log context
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5892'>WFCORE-5892</a>] -         IndexOutOfBoundsException in RequirementRegistration.getOldestRegistrationPoint() during sequence of resource removals
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5893'>WFCORE-5893</a>] -         Testsuite uses 1024 RSA keys - they are disabled in newer JDKs by default
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5894'>WFCORE-5894</a>] -         The test UndertowService is missing required permissions
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5680'>WFCORE-5680</a>] -         Move WildFly Preview to a native Jakarta namespace variant of the elytron subsystem module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5713'>WFCORE-5713</a>] -         wildfly-event-logger - Move WildFly Preview to a native jakarta namespace variant
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5883'>WFCORE-5883</a>] -         Remove dependency management of wildfly-elytron-jwt
</li>
</ul>
                                                                                                            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5885'>WFCORE-5885</a>] -         Add a transformation of the Elytron subsystem to EE9+
</li>
</ul>

</details>
                                                                                                                            