### PR TITLE
[WFLY-16354] Upgrade WildFly Core 19.0.0.Beta9 

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -536,7 +536,8 @@
 
                                 <!-- Uses JSON only for formatting and uses an internal JSON generator -->
                                 <exlude>org.jboss.logmanager:jboss-logmanager\z</exlude>
-
+                                <!-- Uses javax JSON internally -->
+                                <exclude>org.wildfly.core:wildfly-event-logger\z</exclude>
                                 <!-- Don't transform Infinispan modules and its dependents -->
                                 <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
                                 <exclude>org.infinispan:.+\z</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta8</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta9</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16354

Expands on #15531 with a commit to fix the WildFly Preview test failures seen on that PR.