### PR TITLE
[WFLY-16358] add missing AttributeDefinition to ReloadRequiredWriteAt…

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ProxyConfigurationResourceDefinition.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ProxyConfigurationResourceDefinition.java
@@ -356,7 +356,7 @@ public class ProxyConfigurationResourceDefinition extends ChildResourceDefinitio
                 .addCapabilities(Capability.class)
                 ;
 
-        registration.registerReadWriteAttribute(Attribute.SSL_CONTEXT.getDefinition(), null, new ReloadRequiredWriteAttributeHandler() {
+        registration.registerReadWriteAttribute(Attribute.SSL_CONTEXT.getDefinition(), null, new ReloadRequiredWriteAttributeHandler(Attribute.SSL_CONTEXT.getDefinition()) {
             @Override
             protected void validateUpdatedModel(OperationContext context, Resource model) {
                 context.addStep(new OperationStepHandler() {

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/SSLResourceDefinition.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/SSLResourceDefinition.java
@@ -113,7 +113,7 @@ class SSLResourceDefinition extends ChildResourceDefinition<ManagementResourceRe
                 ;
 
         for (Attribute attribute : Attribute.values()) {
-            registration.registerReadWriteAttribute(attribute.getDefinition(), null, new ReloadRequiredWriteAttributeHandler() {
+            registration.registerReadWriteAttribute(attribute.getDefinition(), null, new ReloadRequiredWriteAttributeHandler(attribute.getDefinition()) {
                 @Override
                 protected void validateUpdatedModel(OperationContext context, Resource model) {
                     context.addStep(new OperationStepHandler() {


### PR DESCRIPTION
…tributeHandler in modcluster subsystem.

(cherry picked from commit bc9ea205d330cf243724e55318a446cc81d79ea0)

Issue: https://issues.redhat.com/browse/WFLY-16358
add missing AttributeDefinition to ReloadRequiredWriteAttributeHandler in modcluster subsystem.

main branch PR: https://github.com/wildfly/wildfly/pull/15537
