### PR TITLE
[WFLY-16372] Wrong mechanism realm name in host.xml test configurations.

### DIFF
--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -128,7 +128,7 @@
                 <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -139,7 +139,7 @@
                 <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
@@ -159,7 +159,7 @@
                 <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-2-0.xml
@@ -145,7 +145,7 @@
                 <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-3-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-3-0.xml
@@ -144,7 +144,7 @@
                 <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-4-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-4-0.xml
@@ -144,7 +144,7 @@
                 <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -112,7 +112,7 @@
                 <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="BASIC">
-                            <mechanism-realm realm-name="Management Realm"/>
+                            <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
                 </http-authentication-factory>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16372
