### PR TITLE
[WFLY-16375] Upgrade WildFly Core 18.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.1.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>18.1.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-16375

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/18.1.1.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/18.1.0.Final...18.1.1.Final

---

<details>
<summary>
        Release Notes - WildFly Core - Version 18.1.1.Final</summary>
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5649'>WFCORE-5649</a>] -         Assertion arguments should be passed in the correct order (cli)
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3407'>WFCORE-3407</a>] -         Logging deployments that contain a logging configuration file do not clear the log context
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5805'>WFCORE-5805</a>] -         HostControllerBootOperationsTestCase fails intermittently when Security Manager is enabled
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5861'>WFCORE-5861</a>] -         InaccessibleObjectException with OpenJDK17 and embed-server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5871'>WFCORE-5871</a>] -         Invalid operator error launching the server in dash
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5894'>WFCORE-5894</a>] -         The test UndertowService is missing required permissions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5902'>WFCORE-5902</a>] -         UT005090: Unexpected failure: java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5799'>WFCORE-5799</a>] -         Restore ReloadRedirectTestCase.testRedirectWithSecurityCommands and CLIAuthenticationTestCase
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5867'>WFCORE-5867</a>] -         Upgrade Undertow to 2.2.17.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5887'>WFCORE-5887</a>] -         Upgrade XNIO to 3.8.7.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5888'>WFCORE-5888</a>] -         Upgrade httpcore to 4.4.15
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5909'>WFCORE-5909</a>] -         Upgrade WildFly OpenSSL to 2.2.1.Final
</li>
</ul>
                                                                                                                                
</details>