### PR TITLE
WFLY-16383 mod_cluster: Do not register contexts when in suspend mode

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/modcluster/StartWorkersInSuspendedModeTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/modcluster/StartWorkersInSuspendedModeTestCase.java
@@ -39,7 +39,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.controller.client.helpers.ClientConstants.ADDRESS;
 import static org.jboss.as.controller.client.helpers.ClientConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_RESOURCE_OPERATION;
@@ -85,7 +84,6 @@ public class StartWorkersInSuspendedModeTestCase extends AbstractClusteringTestC
 
         ModelNode op = createOpNode("subsystem=undertow/configuration=filter/mod-cluster=load-balancer/balancer=mycluster/node=" + NODE_1,
                                     READ_RESOURCE_OPERATION);
-        op.get(ADDRESS).add("context", "/" + MODULE_NAME);
         op.get(RECURSIVE).set(true);
         op.get(INCLUDE_RUNTIME).set(true);
 
@@ -105,8 +103,11 @@ public class StartWorkersInSuspendedModeTestCase extends AbstractClusteringTestC
             Thread.sleep(100);
         }
 
-        Assert.assertEquals(SUCCESS, modelNode.get(OUTCOME).asString());
-        Assert.assertEquals("stopped", modelNode.get(RESULT).get(STATUS).asString());
+        Assert.assertEquals("Operation failed: " + modelNode.asString(),
+                SUCCESS, modelNode.get(OUTCOME).asString());
+        Assert.assertFalse("No contexts are expected to be registered by mod_cluster: "
+                        + modelNode.get(RESULT).get("context").asString(),
+                modelNode.get(RESULT).get("context").isDefined());
     }
 
     static class ServerSetupTask extends CLIServerSetupTask {


### PR DESCRIPTION
This change prevents mod_cluster from registering web contexts when the
container is started in suspended mode. The result is, that when the
contexts remain unregistered, reverse proxy will keep serving 404
responses (rather than 503) on those contexts.

There has been previous attempts to achieve this behavior (WFLY-14121,
WFLY-13074).

https://issues.redhat.com/browse/WFLY-16383