### PR TITLE
[WFLY-16401] Upgrade WildFly Core 19.0.0.Beta10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta9</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta10</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-16401

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta10
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta9...19.0.0.Beta10

---

<details>
                                                       
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5869'>WFCORE-5869</a>] -         standalone.bat script does not parse JAVA_OPTS containing &#39;|&#39; symbol properly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5890'>WFCORE-5890</a>] -         There is a possible typo in Management Realm definition in default host.xml configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5891'>WFCORE-5891</a>] -         Default configuration for domain uses BASIC as a http-authentication-factory mechanism
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5902'>WFCORE-5902</a>] -         UT005090: Unexpected failure: java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5904'>WFCORE-5904</a>] -         Typo &quot;Hander&quot; in some Handler filenames
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5907'>WFCORE-5907</a>] -         Elytron - cannot read runtime data of secret-key-credential-store
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5841'>WFCORE-5841</a>] -         [primary/secondary] Review the documentation of affected CLI management operations
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5896'>WFCORE-5896</a>] -         Remove the JASPI AuthConfigFactory wrapping
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5906'>WFCORE-5906</a>] -         Expand set of utility methods for creating standard operations
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5909'>WFCORE-5909</a>] -         Upgrade WildFly OpenSSL to 2.2.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5915'>WFCORE-5915</a>] -         Upgrade to JBoss Modules 2.0.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5916'>WFCORE-5916</a>] -         Upgrade to JBoss VFS 3.2.17.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5320'>WFCORE-5320</a>] -         ModelTestKernelServices do not provide BootErrorCollector info
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5905'>WFCORE-5905</a>] -         Support EE 10 permissions.xml parsing
</li>
</ul>
                                                                                                                            
</details>