### PR TITLE
[WFLY-14769] Access checking for txn namespace lookup

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -514,6 +514,9 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addDependency(UserTransactionAccessControlService.SERVICE_NAME, UserTransactionAccessControlService.class, userTxAccessControlService.getUserTransactionAccessControlServiceInjector())
                 .install();
 
+        final TransactionNamespaceAccessControlService transactionNamespaceAccessControlService = new TransactionNamespaceAccessControlService();
+        context.getServiceTarget().addService(TransactionNamespaceAccessControlService.SERVICE_NAME).setInstance(transactionNamespaceAccessControlService).install();
+
         // add ejb suspend handler service
         boolean enableGracefulShutdown = EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN.resolveModelAttribute(context, model).asBoolean();
         final EJBSuspendHandlerService ejbSuspendHandlerService = new EJBSuspendHandlerService(enableGracefulShutdown);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TransactionNamespaceAccessControlService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TransactionNamespaceAccessControlService.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2023, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
+import org.jboss.as.ejb3.component.allowedmethods.MethodType;;
+
+import org.jboss.as.naming.InitialContext;
+import org.jboss.as.naming.LookupInterceptor;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import javax.naming.InvalidNameException;
+import javax.naming.Name;
+import javax.naming.NamingException;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+public class TransactionNamespaceAccessControlService implements Service {
+    private static final String REMOTE_USER_TRANSACTION = "RemoteUserTransaction";
+    private static final String LOCAL_USER_TRANSACTION = "LocalUserTransaction";
+
+    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb3", "TransactionNamespaceAccessControlService");
+
+    private LookupInterceptor userTransactionLookupInterceptor = new LookupInterceptor() {
+
+        @Override
+        public void aroundLookup(Name name) throws NamingException {
+            if (requiresCheckAllowed(name)) {
+                try {
+                    AllowedMethodsInformation.checkAllowed(MethodType.GET_USER_TRANSACTION);
+                } catch (IllegalStateException e) {
+                    throw new NamingException(e.getMessage());
+                }
+            }
+        }
+
+        private boolean requiresCheckAllowed(Name origName) throws InvalidNameException {
+            if (origName.isEmpty() || !origName.get(0).startsWith("txn:")) {
+                return false;
+            }
+            final Name reparsedName = (Name) origName.clone();
+            final String first = reparsedName.get(0);
+            final int idx = first.indexOf(':');
+            final String segment = first.substring(idx + 1);
+            reparsedName.remove(0);
+            if (segment.length() > 0 || (origName.size() > 1 && origName.get(1).length() > 0)) {
+                reparsedName.add(0, segment);
+            }
+            if (reparsedName.toString().equals(REMOTE_USER_TRANSACTION) || reparsedName.toString().equals(LOCAL_USER_TRANSACTION)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
+
+    @Override
+    public void start(StartContext context) {
+        InitialContext.getInitialContextFactory().addInterceptor(userTransactionLookupInterceptor);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        InitialContext.getInitialContextFactory().removeInterceptor(userTransactionLookupInterceptor);
+    }
+}

--- a/naming/src/main/java/org/jboss/as/naming/InServerInitialContextFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/InServerInitialContextFactory.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+public final class InServerInitialContextFactory implements InitialContextFactory {
+
+    private List<LookupInterceptor> interceptors = new CopyOnWriteArrayList<>();
+
+    public void addInterceptor(LookupInterceptor interceptor){
+        interceptors.add(interceptor);
+    }
+
+    public void removeInterceptor(LookupInterceptor interceptor) {
+        interceptors.remove(interceptor);
+    }
+
+    /**
+     * Get a new initial context.
+     *
+     * @param environment the context environment
+     * @return the initial context
+     * @throws NamingException if constructing the initial context fails
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public Context getInitialContext(final Hashtable<?, ?> environment) throws NamingException {
+        return new WildFlyRootContextWrapper(environment, interceptors);
+    }
+}

--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -39,7 +39,6 @@ import javax.naming.spi.ObjectFactory;
 
 import org.jboss.as.naming.context.NamespaceContextSelector;
 import org.jboss.as.naming.logging.NamingLogger;
-import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -53,7 +52,11 @@ public class InitialContext extends InitialLdapContext {
      */
     private static volatile Map<String, ObjectFactory> urlContextFactories = Collections.emptyMap();
 
-    private final WildFlyInitialContextFactory delegate = new WildFlyInitialContextFactory();
+    private static InServerInitialContextFactory delegate = new InServerInitialContextFactory();
+
+    public static InServerInitialContextFactory getInitialContextFactory() {
+        return delegate;
+    }
 
     /**
      * Add an ObjectFactory to handle requests for a specific URL scheme.

--- a/naming/src/main/java/org/jboss/as/naming/LookupInterceptor.java
+++ b/naming/src/main/java/org/jboss/as/naming/LookupInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2023, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import javax.naming.Name;
+import javax.naming.NamingException;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+
+/**
+ * A naming interceptor applied before the name is being resolved by the InitialContext
+ */
+public interface LookupInterceptor {
+
+    /**
+     * Handles the naming invocation.
+     *
+     * @param name the name being resolved
+     * @throws NamingException if an invocation error occurs
+     */
+    public void aroundLookup(Name name) throws NamingException;
+}

--- a/naming/src/main/java/org/jboss/as/naming/WildFlyRootContextWrapper.java
+++ b/naming/src/main/java/org/jboss/as/naming/WildFlyRootContextWrapper.java
@@ -1,0 +1,346 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import org.wildfly.naming.client.WildFlyRootContext;
+import org.wildfly.naming.client.util.FastHashtable;
+
+import javax.naming.Binding;
+import javax.naming.CompositeName;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+
+class WildFlyRootContextWrapper implements DirContext {
+
+    private static final NameParser NAME_PARSER = CompositeName::new;
+
+    private final WildFlyRootContext delegate;
+
+    private final List<LookupInterceptor> interceptors;
+
+    public WildFlyRootContextWrapper(final Hashtable<?, ?> environment, List<LookupInterceptor> interceptors) throws NamingException {
+        this.delegate = new WildFlyRootContext(new FastHashtable<>((Map<String, Object>) (Map) environment));
+        this.interceptors = interceptors;
+    }
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        aroundLookup(name);
+        return delegate.lookup(name);
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        aroundLookup(NAME_PARSER.parse(name));
+        return delegate.lookup(name);
+    }
+
+
+    @Override
+    public Attributes getAttributes(Name name) throws NamingException {
+        return delegate.getAttributes(name);
+    }
+
+    @Override
+    public Attributes getAttributes(String nameString) throws NamingException {
+        return delegate.getAttributes(nameString);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name, String[] strings) throws NamingException {
+        return delegate.getAttributes(name, strings);
+    }
+
+    @Override
+    public Attributes getAttributes(String nameString, String[] strings) throws NamingException {
+        return delegate.getAttributes(nameString, strings);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, int i, Attributes attributes) throws NamingException {
+        delegate.modifyAttributes(name, i, attributes);
+    }
+
+    @Override
+    public void modifyAttributes(String nameString, int i, Attributes attributes) throws NamingException {
+        delegate.modifyAttributes(nameString, i, attributes);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, ModificationItem[] modificationItems) throws NamingException {
+        delegate.modifyAttributes(name, modificationItems);
+    }
+
+    @Override
+    public void modifyAttributes(String nameString, ModificationItem[] modificationItems) throws NamingException {
+        delegate.modifyAttributes(nameString, modificationItems);
+    }
+
+    @Override
+    public void bind(Name name, Object object, Attributes attributes) throws NamingException {
+        delegate.bind(name, object, attributes);
+    }
+
+    @Override
+    public void bind(String nameString, Object object, Attributes attributes) throws NamingException {
+        delegate.bind(nameString, object, attributes);
+    }
+
+    @Override
+    public void rebind(Name name, Object object, Attributes attributes) throws NamingException {
+        delegate.rebind(name, object, attributes);
+    }
+
+    @Override
+    public void rebind(String nameString, Object object, Attributes attributes) throws NamingException {
+        delegate.rebind(nameString, object, attributes);
+    }
+
+    @Override
+    public DirContext createSubcontext(Name name, Attributes attributes) throws NamingException {
+        return delegate.createSubcontext(name, attributes);
+    }
+
+    @Override
+    public DirContext createSubcontext(String nameString, Attributes attributes) throws NamingException {
+        return delegate.createSubcontext(nameString, attributes);
+    }
+
+    @Override
+    public DirContext getSchema(Name name) throws NamingException {
+        return delegate.getSchema(name);
+    }
+
+    @Override
+    public DirContext getSchema(String nameString) throws NamingException {
+        return delegate.getSchema(nameString);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(Name name) throws NamingException {
+        return delegate.getSchemaClassDefinition(name);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(String nameString) throws NamingException {
+        return delegate.getSchemaClassDefinition(nameString);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes attributes, String[] strings) throws NamingException {
+        return delegate.search(name, attributes, strings);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String nameString, Attributes attributes, String[] strings) throws NamingException {
+        return delegate.search(nameString, attributes, strings);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes attributes) throws NamingException {
+        return delegate.search(name, attributes);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String nameString, Attributes attributes) throws NamingException {
+        return delegate.search(nameString, attributes);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String s, SearchControls searchControls) throws NamingException {
+        return delegate.search(name, s, searchControls);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String nameString, String s, SearchControls searchControls) throws NamingException {
+        return delegate.search(nameString, s, searchControls);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String s, Object[] objects, SearchControls searchControls) throws NamingException {
+        return delegate.search(name, s, objects, searchControls);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String nameString, String s, Object[] objects, SearchControls searchControls) throws NamingException {
+        return delegate.search(nameString, s, objects, searchControls);
+    }
+
+    @Override
+    public void bind(Name name, Object o) throws NamingException {
+        delegate.bind(name, o);
+    }
+
+    @Override
+    public void bind(String nameString, Object o) throws NamingException {
+        delegate.bind(nameString, o);
+    }
+
+    @Override
+    public void rebind(Name name, Object o) throws NamingException {
+        delegate.rebind(name, o);
+    }
+
+    @Override
+    public void rebind(String nameString, Object o) throws NamingException {
+        delegate.rebind(nameString, o);
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        delegate.unbind(name);
+    }
+
+    @Override
+    public void unbind(String nameString) throws NamingException {
+        delegate.unbind(nameString);
+    }
+
+    @Override
+    public void rename(Name name, Name name1) throws NamingException {
+        delegate.rename(name, name1);
+    }
+
+    @Override
+    public void rename(String nameString, String name1) throws NamingException {
+        delegate.rename(nameString, name1);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        return delegate.list(name);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String nameString) throws NamingException {
+        return delegate.list(nameString);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        return delegate.listBindings(name);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String nameString) throws NamingException {
+        return delegate.listBindings(nameString);
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        delegate.destroySubcontext(name);
+    }
+
+    @Override
+    public void destroySubcontext(String nameString) throws NamingException {
+        delegate.destroySubcontext(nameString);
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        return delegate.createSubcontext(name);
+    }
+
+    @Override
+    public Context createSubcontext(String nameString) throws NamingException {
+        return delegate.createSubcontext(nameString);
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        aroundLookup(name);
+        return delegate.lookupLink(name);
+    }
+
+    @Override
+    public Object lookupLink(String nameString) throws NamingException {
+        Name name = NAME_PARSER.parse(nameString);
+        return lookupLink(name);
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        return delegate.getNameParser(name);
+    }
+
+    @Override
+    public NameParser getNameParser(String nameString) throws NamingException {
+        return delegate.getNameParser(nameString);
+    }
+
+    @Override
+    public Name composeName(Name name, Name name1) throws NamingException {
+        return delegate.composeName(name, name1);
+    }
+
+    @Override
+    public String composeName(String nameString, String name1) throws NamingException {
+        return delegate.composeName(nameString, name1);
+    }
+
+    @Override
+    public Object addToEnvironment(String nameString, Object object) throws NamingException {
+        return delegate.addToEnvironment(nameString, object);
+    }
+
+    @Override
+    public Object removeFromEnvironment(String nameString) throws NamingException {
+        return delegate.removeFromEnvironment(nameString);
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+        return delegate.getEnvironment();
+    }
+
+    @Override
+    public void close() throws NamingException {
+        delegate.close();
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        return delegate.getNameInNamespace();
+    }
+
+    private final void aroundLookup(Name name) throws NamingException {
+        for (LookupInterceptor interceptor : interceptors) {
+            interceptor.aroundLookup(name);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/BMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/BMTSLSB.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@Stateless
+@TransactionManagement(value = TransactionManagementType.BEAN)
+public class BMTSLSB {
+
+    @PostConstruct
+    void onConstruct() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void checkUserTransactionAvailability() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private void checkUserTransactionAccess() throws NamingException {
+        final String remoteUserTransactionName = "txn:RemoteUserTransaction";
+        final UserTransaction remoteUserTransaction = InitialContext.doLookup(remoteUserTransactionName);
+        if (remoteUserTransaction == null) {
+            throw new RuntimeException("UserTransaction lookup at " + remoteUserTransactionName + " returned null in a BMT bean");
+        }
+        final String localUserTransactionName = "txn:LocalUserTransaction";
+        final UserTransaction localUserTransaction = InitialContext.doLookup(localUserTransactionName);
+        if (localUserTransaction == null) {
+            throw new RuntimeException("UserTransaction lookup at " + localUserTransaction + " returned null in a BMT bean");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/CMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/CMTSLSB.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@Stateless
+public class CMTSLSB {
+
+    private static final Logger logger = Logger.getLogger(CMTSLSB.class);
+
+    @PostConstruct
+    void onConstruct() {
+        this.checkUserTransactionAccess();
+    }
+
+    public void checkUserTransactionAccessDenial() {
+        this.checkUserTransactionAccess();
+    }
+
+    private void checkUserTransactionAccess() {
+        try {
+            final String remoteUserTransactionName = "txn:RemoteUserTransaction";
+            InitialContext.doLookup(remoteUserTransactionName);
+            throw new RuntimeException("UserTransaction lookup at " + remoteUserTransactionName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.trace("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+        try {
+            final String localUserTransactionName = "txn:LocalUserTransaction";
+            InitialContext.doLookup(localUserTransactionName);
+            throw new RuntimeException("UserTransaction lookup at " + localUserTransactionName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.trace("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/TransactionNamespaceAccessTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/TransactionNamespaceAccessTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.context.ContextPermission;
+
+import javax.naming.InitialContext;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@RunWith(Arquillian.class)
+public class TransactionNamespaceAccessTestCase {
+
+    private static final String MODULE_NAME = "transaction-namespace-access-test-case";
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(TransactionNamespaceAccessTestCase.class.getPackage())
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new ContextPermission("org.wildfly.transaction.client.context.remote", "get")
+                ), "permissions.xml");
+        return jar;
+    }
+
+    @Test
+    public void testUserTransactionLookupInCMT() throws Exception {
+        final CMTSLSB cmtSlsb = InitialContext.doLookup("java:module/" + CMTSLSB.class.getSimpleName() + "!" + CMTSLSB.class.getName());
+        cmtSlsb.checkUserTransactionAccessDenial();
+    }
+
+    @Test
+    public void testUserTransactionLookupInBMT() throws Exception {
+        final BMTSLSB bmtslsb = InitialContext.doLookup("java:module/" + BMTSLSB.class.getSimpleName() + "!" + BMTSLSB.class.getName());
+        bmtslsb.checkUserTransactionAvailability();
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14769

I have added a wrapper to WildFlyNamingContext which enables installation of aroundLookup interceptors. This functionality is used to perform access check for objects from "txn" namespace.
