### PR TITLE
[WFLY-15666] Ignore transforming log4j 1.x. This is set for removal i…

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -574,6 +574,12 @@
                                 <exclude>org.glassfish:jakarta.json\z</exclude>
                                 <exclude>activemq-artemis-native\z</exclude>
                                 <exclude>org.jboss.activemq.artemis.integration:artemis-wildfly-jakarta-integration\z</exclude>
+                                <!-- Issue filed for removal of log4j 1.x, WFCORE-5781. Skipping this may break users
+                                     who use appenders like the SMTPAppender. However, most of the Jakarta EE appenders
+                                     do not work with WildFly. We should ignore the transformation as we'll be removing
+                                     in the near future.
+                                  -->
+                                <excluded>org.jboss.logmanager:log4j-jboss-logmanager\z</excluded>
                             </jakarta-transform-excluded-artifacts>
                         </configuration>
                     </execution>


### PR DESCRIPTION
…n WFCORE-5781. For now, we should exclude it transformation.

https://issues.redhat.com/browse/WFLY-15666

Note that if we end up not being able to remove this we're going to have do a release with a migrated namespace anyway. Ignoring for now seems like the right thing to do.