### PR TITLE
[WFLY-16424] Upgrade Netty from 4.1.76.Final to 4.1.77.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
         <version.io.agroal>1.16</version.io.agroal>
         <version.io.grpc>1.38.1</version.io.grpc>
         <version.io.jaegertracing>1.6.0</version.io.jaegertracing>
-        <version.io.netty>4.1.76.Final</version.io.netty>
+        <version.io.netty>4.1.77.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.12.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentracing>0.33.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.4.0</version.io.opentracing.concurrent>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16424 Upgrade Netty from 4.1.76.Final to 4.1.77.Final

26.x branch PR: https://github.com/wildfly/wildfly/pull/15595