### PR TITLE
WFLY-16240 Component Upgrade of Narayana to 5.12.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.metadata>15.1.0.Alpha1</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.narayana>5.12.5.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.12.6.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>4.7.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.microprofile>${version.org.jboss.resteasy}</version.org.jboss.resteasy.microprofile>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16240

The component upgrade brings some minor updates (mainly testing) and also backs out the native jakarta version of LRA (since quarkus isn't ready for Jakarta just yet).

The release notes are https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12380127
