### PR TITLE
[WFLY-16121]:  Intermittent failure in ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase.java
@@ -63,7 +63,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,7 +73,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase.SetupTask.class)
-@Ignore("WFLY-16121")
 public class ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase {
 
     public static final String QUEUE_LOOKUP = "java:/jms/AutomaticQueueCreationOnExternalMessagingDeploymentTestCase/myQueue";


### PR DESCRIPTION
 * This seems to occur only on JDK8 which is no longer used.

Jira: https://issues.redhat.com/browse/WFLY-16121