### PR TITLE
[WFLY-16121-reopen]: Intermittent failure in

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
@@ -108,11 +108,11 @@ public class ExternalJMSQueueService implements Service<Queue> {
                         @Override
                         public void nodeDown(long eventUID, String nodeID) {}
                     };
-                    locator.addClusterTopologyListener(listener);
                     Collection<TopologyMemberImpl> members = locator.getTopology().getMembers();
-                    if (members == null || members.isEmpty()) {
+                    if (members == null || members.isEmpty() || members.size() == 1) {
                         config.createQueue(cf, managementQueue, queueName);
                     }
+                    locator.addClusterTopologyListener(listener);
                 } else {
                     config.createQueue(cf, managementQueue, queueName);
                 }


### PR DESCRIPTION
ExternalJMSDestinationDefinitionLegacyPrefixMessagingDeploymentTestCase.

* Fixing the failure by making sure that the queue is properly created
  locally instead of waiting for the topology.

Jira: https://issues.redhat.com/browse/WFLY-16121

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>