### PR TITLE
[DRAFT] standalone default configs expressed with layers

### DIFF
--- a/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
+++ b/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" ?>
 
-<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-ha.xml" model="standalone">
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full-ha.xml" model="standalone">
     <layers>
         <include name="jaxrs-server"/>
         <include name="ee-security"/>
         <include name="metrics"/>
         <include name="health"/>
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+
         <exclude name="jpa"/>      
         <include name="jpa-distributed"/>            
-                        
+
         <include name="h2-default-datasource"/>
-        <!--<layer>elytron-oidc-client</layer>-->
-                        
+        <include name="elytron-oidc-client"/>
+
         <include name="ejb-http-invoker"/>
+        <include name="ejb"/>
         <exclude name="ejb-local-cache"/>
         <include name="ejb-dist-cache"/>
-        <include name="resource-adapters"/>
-        <include name="remoting"/>
-                        
+
         <include name="web-clustering"/>
         <include name="undertow-https"/>
         <include name="jdr"/>
@@ -27,8 +29,13 @@
         <include name="mail"/>
         <include name="sar"/>
         <include name="batch-jberet"/>
-        <exclude name="messaging-activemq"/>
-    </layers>
 
-    <feature-group name="adjust-standalone-ha-config"/>
+        <include name="iiop-openjdk"/>
+        <!-- Preview does not contain embedded broker that ee and full feature-packs contain -->
+        <include name="remote-activemq"/>
+    </layers>
+    
+    <feature-group name="adjust-standalone-full-ha-config"/>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
 </config>

--- a/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-full.xml/config.xml
+++ b/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-full.xml/config.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full.xml" model="standalone">
-       <layers>
+    <layers>
         <include name="jaxrs-server"/>
         <include name="ee-security"/>
         <include name="metrics"/>
         <include name="health"/>
-
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
         <include name="h2-default-datasource"/>
-        <!--<layer>elytron-oidc-client</layer>-->
+        <include name="elytron-oidc-client"/>
         <include name="ejb"/>               
         <include name="ejb-http-invoker"/>
 
@@ -23,7 +24,11 @@
         <include name="batch-jberet"/>
 
         <include name="iiop-openjdk"/>
+        <!-- Preview does not contain embedded broker that ee and full feature-packs contain -->
+        <include name="remote-activemq"/>
     </layers>
 
     <feature-group name="adjust-standalone-full-config"/>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
 </config>

--- a/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
+++ b/ee-9/galleon-content/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
@@ -1,20 +1,27 @@
 <?xml version="1.0" ?>
 
-<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-ha.xml" model="standalone">
     <layers>
         <include name="jaxrs-server"/>
         <include name="ee-security"/>
         <include name="metrics"/>
         <include name="health"/>
-
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+            
+        <exclude name="jpa"/>      
+        <include name="jpa-distributed"/>            
+                        
         <include name="h2-default-datasource"/>
-        <!--<layer>elytron-oidc-client</layer>-->
+        <include name="elytron-oidc-client"/>
                         
         <include name="ejb-http-invoker"/>
+        <exclude name="ejb-local-cache"/>
+        <include name="ejb-dist-cache"/>
         <include name="resource-adapters"/>
         <include name="remoting"/>
                         
-        <include name="web-passivation"/>
+        <include name="web-clustering"/>
         <include name="undertow-https"/>
         <include name="jdr"/>
         <include name="jsf"/>
@@ -25,6 +32,9 @@
         <include name="batch-jberet"/>
         <exclude name="messaging-activemq"/>
     </layers>
-    
-    <feature-group name="adjust-standalone-config"/>
+
+    <feature-group name="adjust-standalone-ha-config"/>
+
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
 </config>

--- a/ee-9/galleon-content/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/ee-9/galleon-content/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -6,9 +6,10 @@
         <include name="ee-security"/>
         <include name="metrics"/>
         <include name="health"/>
-
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
         <include name="h2-default-datasource"/>
-        <!--<layer>elytron-oidc-client</layer>-->
+        <include name="elytron-oidc-client"/>
                         
         <include name="ejb-http-invoker"/>
         <include name="resource-adapters"/>
@@ -25,6 +26,9 @@
         <include name="batch-jberet"/>
         <exclude name="messaging-activemq"/>
     </layers>
-    
+
     <feature-group name="adjust-standalone-config"/>
+    
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
 </config>

--- a/ee-9/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
+++ b/ee-9/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="adjust-standalone-full-config-common"/>
+    <!-- the module it depends on is forced to be provisioned by galleon, so we are fine: WFLY-16099  -->
+    <feature-group name="infinispan-local-server"/>
+    <!-- Preview does not contain embedded broker that ee and full feature-packs contain -->
+</feature-group-spec>

--- a/ee-9/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
+++ b/ee-9/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-ha-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="adjust-standalone-ha-config-common"/>
+    <feature-group name="adjust-standalone-full-config-common"/>
+    <!-- Preview does not contain embedded broker that ee and full feature-packs contain -->
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/ejb3-mdb-pool.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/ejb3-mdb-pool.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="ejb3-mdb-pool" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.ejb3">
+        <feature spec="subsystem.ejb3.strict-max-bean-instance-pool">
+            <param name="strict-max-bean-instance-pool" value="mdb-strict-max-pool"/>
+            <param name="derive-size" value="from-cpu-count"/>
+            <param name="timeout" value="5"/>
+            <param name="timeout-unit" value="MINUTES"/>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/ejb3-remote-service.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/ejb3-remote-service.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="ejb3-remote-service" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.ejb3">
+        <feature spec="subsystem.ejb3.service.remote">
+            <param name="connectors" value="[http-remoting-connector]"/>
+            <param name="thread-pool-name" value="default"/>
+            <feature spec="subsystem.ejb3.service.remote.channel-creation-options">
+                <param name="channel-creation-options" value="MAX_OUTBOUND_MESSAGES"/>
+                <param name="value" value="1234"/>
+                <param name="type" value="remoting"/>
+            </feature>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/remote-naming.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/remote-naming.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="remote-naming" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.naming">
+        <feature spec="subsystem.naming.service.remote-naming"/>
+    </feature>    
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/undertow-ajp-listener.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/undertow-ajp-listener.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="undertow-ajp-listener" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.undertow.server">
+        <param name="server" value="default-server"/>
+        <feature spec="subsystem.undertow.server.ajp-listener">
+            <param name="ajp-listener" value="ajp"/>
+            <param name="socket-binding" value="ajp"/>
+            <unset param="worker"/>
+            <unset param="buffer-pool"/>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/unsecured-basic-ha-profile.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/unsecured-basic-ha-profile.xml
@@ -2,23 +2,11 @@
 <feature-group-spec name="unsecured-basic-ha-profile" xmlns="urn:jboss:galleon:feature-group:1.0">
 
     <feature-group name="unsecured-basic-profile">
-        <include feature-id="subsystem.undertow:subsystem=undertow">
-            <feature spec="subsystem.undertow.server">
-                <param name="server" value="default-server"/>
-                <feature spec="subsystem.undertow.server.ajp-listener">
-                    <param name="ajp-listener" value="ajp"/>
-                    <param name="socket-binding" value="ajp"/>
-                    <unset param="worker"/>
-                    <unset param="buffer-pool"/>
-                </feature>
-            </feature>
-        </include>
-
         <include feature-id="subsystem.ejb3:subsystem=ejb3">
             <param name="default-sfsb-cache" value="distributable"/>
         </include>
     </feature-group>
-
+    <feature-group name="undertow-ajp-listener"/>
     <feature-group name="modcluster"/>
     <feature-group name="infinispan-dist"/>
     <feature-group name="jgroups"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
@@ -8,29 +8,10 @@
         <layer name="messaging-activemq"/>    <!-- change to messaging-activemq when available -->
         <layer name="remoting"/>
         <layer name="undertow"/>
-
     </dependencies>
 
-    <feature spec="subsystem.naming">
-        <feature spec="subsystem.naming.service.remote-naming"/>
-    </feature>
-    <feature spec="subsystem.ejb3">
-        <param name="default-resource-adapter-name" value="${ejb.resource-adapter-name:activemq-ra.rar}"/>
-        <param name="default-mdb-instance-pool" value="mdb-strict-max-pool"/>
-        <feature spec="subsystem.ejb3.strict-max-bean-instance-pool">
-            <param name="strict-max-bean-instance-pool" value="mdb-strict-max-pool"/>
-            <param name="derive-size" value="from-cpu-count"/>
-            <param name="timeout" value="5"/>
-            <param name="timeout-unit" value="MINUTES"/>
-        </feature>
-        <feature spec="subsystem.ejb3.service.remote">
-            <param name="connectors" value="[http-remoting-connector]"/>
-            <param name="thread-pool-name" value="default"/>
-            <feature spec="subsystem.ejb3.service.remote.channel-creation-options">
-                <param name="channel-creation-options" value="MAX_OUTBOUND_MESSAGES"/>
-                <param name="value" value="1234"/>
-                <param name="type" value="remoting"/>
-            </feature>
-        </feature>
-    </feature>
+    <feature-group name="remote-naming"/>
+    <feature-group name="ejb3-mdb"/>
+    <feature-group name="ejb3-mdb-pool"/>
+    <feature-group name="ejb3-remote-service"/>
 </layer-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
@@ -1,5 +1,34 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full-ha.xml" model="standalone">
-    <feature-group name="standalone-full-ha"/>
+    <layers>
+        <include name="jaxrs-server"/>
+        <include name="ee-security"/>
+        <include name="metrics"/>
+        <include name="health"/>
+        <exclude name="jpa"/>      
+        <include name="jpa-distributed"/>            
+
+        <include name="h2-default-datasource"/>
+        <!--<include name="elytron-oidc-client"/>-->
+
+        <include name="ejb-http-invoker"/>
+        <include name="ejb"/>
+        <exclude name="ejb-local-cache"/>
+        <include name="ejb-dist-cache"/>
+
+        <include name="web-clustering"/>
+        <include name="undertow-https"/>
+        <include name="jdr"/>
+        <include name="jsf"/>
+        <include name="webservices"/>
+        <include name="pojo"/>
+        <include name="mail"/>
+        <include name="sar"/>
+        <include name="batch-jberet"/>
+
+        <include name="iiop-openjdk"/>
+    </layers>
+
+    <feature-group name="adjust-standalone-full-ha-config"/>
 </config>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config-common.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config-common.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-config-common" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="undertow-default-config"/>
+
+    <feature spec="subsystem.remoting">
+        <feature spec="subsystem.remoting.configuration.endpoint">
+            <unset param="worker"/>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="remote-naming"/>
+    <feature-group name="ejb3-mdb-pool"/>
+    <feature-group name="ejb3-remote-service"/>
+    <!-- the module it depends on is forced to be provisioned by galleon, so we are fine: WFLY-16099  -->
+    <feature-group name="infinispan-local-server"/>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config-common.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config-common.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-config-common" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.ejb3">
+        <feature spec="subsystem.ejb3.service.iiop">
+            <param name="enable-by-default" value="false"/>
+            <param name="use-qualified-name" value="false"/>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="adjust-standalone-full-config-common"/>
+    <!-- the module it depends on is forced to be provisioned by galleon, so we are fine: WFLY-16099  -->
+    <feature-group name="infinispan-local-server"/>
+    <!-- A layer for embedded broker is in progress -->
+    <feature-group name="messaging-activemq"/>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-ha-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="adjust-standalone-ha-config-common"/>
+    <feature-group name="adjust-standalone-full-config-common"/>
+    <feature-group name="messaging-activemq-ha"/>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config-common.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config-common.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-ha-config-common" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <!-- the module it depends on is forced to be provisioned by galleon, so we are fine: WFLY-16099  -->
+    <feature-group name="infinispan-dist-server"/>
+    
+    <!-- clustering not in layer -->
+    <feature-group name="undertow-ajp-listener"/>
+    <feature spec="socket-binding-group">
+        <param name="socket-binding-group" value="standard-sockets" />
+        <feature-group name="modcluster-sockets"/>
+    </feature>
+    <feature-group name="modcluster"/>
+    <feature-group name="singleton"/>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config.xml
+++ b/ee-feature-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-ha-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature-group name="adjust-standalone-config-common"/>
+    <feature-group name="adjust-standalone-ha-config-common"/>
+    <feature-group name="remote-naming"/>
+    <feature-group name="ejb3-mdb-pool"/>
+    <feature-group name="ejb3-remote-service"/>
+</feature-group-spec>

--- a/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
@@ -1,5 +1,36 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full-ha.xml" model="standalone">
-    <feature-group name="standalone-full-ha"/>
+    <layers>
+        <include name="jaxrs-server"/>
+        <include name="ee-security"/>
+        <include name="metrics"/>
+        <include name="health"/>
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+
+        <exclude name="jpa"/>      
+        <include name="jpa-distributed"/>            
+
+        <include name="h2-default-datasource"/>
+        <include name="elytron-oidc-client"/>
+
+        <include name="ejb-http-invoker"/>
+        <include name="ejb"/>
+        <exclude name="ejb-local-cache"/>
+        <include name="ejb-dist-cache"/>
+
+        <include name="web-clustering"/>
+        <include name="undertow-https"/>
+        <include name="jdr"/>
+        <include name="jsf"/>
+        <include name="webservices"/>
+        <include name="pojo"/>
+        <include name="mail"/>
+        <include name="sar"/>
+        <include name="batch-jberet"/>
+
+        <include name="iiop-openjdk"/>
+    </layers>
+    <feature-group name="adjust-standalone-full-ha-config"/>
 </config>

--- a/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-full.xml/config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-full.xml/config.xml
@@ -1,5 +1,29 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full.xml" model="standalone">
-    <feature-group name="standalone-full"/>
+    <layers>
+        <include name="jaxrs-server"/>
+        <include name="ee-security"/>
+        <include name="metrics"/>
+        <include name="health"/>
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+        <include name="h2-default-datasource"/>
+        <include name="elytron-oidc-client"/>
+        <include name="ejb"/>               
+        <include name="ejb-http-invoker"/>
+
+        <include name="web-passivation"/>
+        <include name="undertow-https"/>
+        <include name="jdr"/>
+        <include name="jsf"/>
+        <include name="webservices"/>
+        <include name="pojo"/>
+        <include name="mail"/>
+        <include name="sar"/>
+        <include name="batch-jberet"/>
+
+        <include name="iiop-openjdk"/>
+    </layers>
+    <feature-group name="adjust-standalone-full-config"/>
 </config>

--- a/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
@@ -1,5 +1,38 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone-ha.xml" model="standalone">
-    <feature-group name="standalone-ha"/>
+    <layers>
+        <include name="jaxrs-server"/>
+        <include name="ee-security"/>
+        <include name="metrics"/>
+        <include name="health"/>
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+            
+        <exclude name="jpa"/>      
+        <include name="jpa-distributed"/>            
+                        
+        <include name="h2-default-datasource"/>
+        <include name="elytron-oidc-client"/>
+                        
+        <include name="ejb-http-invoker"/>
+        <exclude name="ejb-local-cache"/>
+        <include name="ejb-dist-cache"/>
+        <include name="resource-adapters"/>
+        <include name="remoting"/>
+                        
+        <include name="web-clustering"/>
+        <include name="undertow-https"/>
+        <include name="jdr"/>
+        <include name="jsf"/>
+        <include name="webservices"/>
+        <include name="pojo"/>
+        <include name="mail"/>
+        <include name="sar"/>
+        <include name="batch-jberet"/>
+        <exclude name="messaging-activemq"/>
+    </layers>
+
+    <feature-group name="adjust-standalone-ha-config"/>
+
 </config>

--- a/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -1,5 +1,32 @@
 <?xml version="1.0" ?>
 
 <config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
-    <feature-group name="standalone"/>
+    <layers>
+        <include name="jaxrs-server"/>
+        <include name="ee-security"/>
+        <include name="metrics"/>
+        <include name="health"/>
+        <include name="microprofile-jwt"/>
+        <include name="microprofile-opentracing"/>
+        <include name="h2-default-datasource"/>
+        <include name="elytron-oidc-client"/>
+                        
+        <include name="ejb-http-invoker"/>
+        <include name="resource-adapters"/>
+        <include name="remoting"/>
+                        
+        <include name="web-passivation"/>
+        <include name="undertow-https"/>
+        <include name="jdr"/>
+        <include name="jsf"/>
+        <include name="webservices"/>
+        <include name="pojo"/>
+        <include name="mail"/>
+        <include name="sar"/>
+        <include name="batch-jberet"/>
+        <exclude name="messaging-activemq"/>
+    </layers>
+
+    <feature-group name="adjust-standalone-config"/>
+
 </config>

--- a/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+
+    <origin name="org.wildfly:wildfly-ee-galleon-pack">
+        <feature-group name="adjust-standalone-config"/>
+    </origin>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
+
+</feature-group-spec>

--- a/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+
+    <origin name="org.wildfly:wildfly-ee-galleon-pack">
+        <feature-group name="adjust-standalone-full-config"/>
+    </origin>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
+
+</feature-group-spec>

--- a/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-full-ha-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-full-ha-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+
+    <origin name="org.wildfly:wildfly-ee-galleon-pack">
+        <feature-group name="adjust-standalone-full-ha-config"/>
+    </origin>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
+
+</feature-group-spec>

--- a/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config.xml
+++ b/galleon-pack/galleon-content/src/main/resources/feature_groups/adjust-standalone-ha-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="adjust-standalone-ha-config" xmlns="urn:jboss:galleon:feature-group:1.0">
+
+    <origin name="org.wildfly:wildfly-ee-galleon-pack">
+        <feature-group name="adjust-standalone-ha-config"/>
+    </origin>
+    <!-- The jaeger module is referenced from opentracing extension, using the feature-group is ok -->
+    <feature-group name="microprofile-opentracing-jaeger"/>
+
+</feature-group-spec>

--- a/testsuite/layers/full-config.xml
+++ b/testsuite/layers/full-config.xml
@@ -1,0 +1,6 @@
+<!-- Allow to re-name standalone-ha.xml file standalone.xml, expected by tests -->    
+<config  xmlns="urn:jboss:galleon:config:1.0" model="standalone" name="standalone-full.xml">
+    <props>
+        <prop name="--server-config" value="standalone.xml"/>
+    </props> 
+</config>

--- a/testsuite/layers/full-ha-config.xml
+++ b/testsuite/layers/full-ha-config.xml
@@ -1,0 +1,6 @@
+<!-- Allow to re-name standalone-ha.xml file standalone.xml, expected by tests -->    
+<config  xmlns="urn:jboss:galleon:config:1.0" model="standalone" name="standalone-full-ha.xml">
+    <props>
+        <prop name="--server-config" value="standalone.xml"/>
+    </props> 
+</config>

--- a/testsuite/layers/ha-config.xml
+++ b/testsuite/layers/ha-config.xml
@@ -1,0 +1,6 @@
+<!-- Allow to re-name standalone-ha.xml file standalone.xml, expected by tests -->    
+<config  xmlns="urn:jboss:galleon:config:1.0" model="standalone" name="standalone-ha.xml">
+    <props>
+        <prop name="--server-config" value="standalone.xml"/>
+    </props> 
+</config>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -52,7 +52,13 @@
         <!-- An empty directory for this will disable 'ee' tests which are meant for testing
              the ee feature pack default config. -->
         <ee.layers.install.root>${ee.layers.install.dir}</ee.layers.install.root>
-        
+
+        <ee.ha.layers.install.dir>${project.build.directory}/ee-ha-layers-results</ee.ha.layers.install.dir>
+        <!-- An empty directory for this will disable 'ee' tests which are meant for testing
+             the ee feature pack default config. -->
+        <ee.ha.layers.install.root>${ee.ha.layers.install.dir}</ee.ha.layers.install.root>
+        <ha.layers.install.dir>${project.build.directory}/ha-layers-results</ha.layers.install.dir>
+
         <layers.delete.installations>true</layers.delete.installations>
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
         
@@ -120,6 +126,8 @@
                 <servlet.layers.install.root></servlet.layers.install.root>
                 <!-- An empty value for this will disable the ee test -->
                 <ee.layers.install.root></ee.layers.install.root>
+                <!-- An empty value for this will disable the ee ha test -->
+                <ee.ha.layers.install.root></ee.ha.layers.install.root>
             </properties>
         </profile>
     </profiles>
@@ -1100,6 +1108,154 @@
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
                                             </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- wildfly ee default standalone-ha config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the ee feature pack. -->
+                                <id>test-ee-ha-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.ha.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-ha with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-ee-ha-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.ha.layers.install.dir}/test-standalone-ha</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-provisioning-ee-ha</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.ha.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+                                                
+                                                <!-- Missing layers for singleton and mod_cluster, there is a workaround in test 
+                                                        for the modules they are bringing, tracked by 
+                                              https://issues.redhat.com/browse/WFLY-16452 and https://issues.redhat.com/browse/WFLY-16453 -->
+
+                                            </layers>
+                                            <excluded-layers>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>jpa</layer>
+                                            </excluded-layers>
                                         </config>
                                     </configurations>
                                 </configuration>
@@ -2738,6 +2894,158 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+                            <!-- wildfly default standalone-ha config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the full feature pack. -->
+                                <id>test-full-ha-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${ha.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-ha with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-full-ha-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${ha.layers.install.dir}/test-standalone-ha</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-standalone-ha-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${ha.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+                                                
+                                                <!-- Missing layers for singleton and mod_cluster, there is a workaround in test
+                                                        for the modules they are bringing, tracked by
+                                              https://issues.redhat.com/browse/WFLY-16452 and https://issues.redhat.com/browse/WFLY-16453 -->
+
+                                                <!-- layers only present in full standalone-ha.xml -->
+                                                <layer>elytron-oidc-client</layer>
+                                                <layer>microprofile-jwt</layer>
+                                                <layer>microprofile-opentracing</layer>
+                                            </layers>
+                                            <excluded-layers>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>jpa</layer>
+                                            </excluded-layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                             <!-- Core Layers - These can't be tested in Core as they require Undertow -->
                             <execution>
                                 <id>remoting-provisioning</id>
@@ -2811,6 +3119,8 @@
                                 <servlet.layers.install.root>${servlet.layers.install.root}</servlet.layers.install.root>
                                 <layers.install.root>${layers.install.dir}</layers.install.root>
                                 <ee.layers.install.root>${ee.layers.install.root}</ee.layers.install.root>
+                                <ee.ha.layers.install.root>${ee.ha.layers.install.root}</ee.ha.layers.install.root>
+                                <ha.layers.install.root>${ha.layers.install.dir}</ha.layers.install.root>
                                 <jbossas.version>${project.parent.version}</jbossas.version>
                                 <cleanup.tmp>${cleanup.tmp}</cleanup.tmp>
                                 <layers.delete.installations>${layers.delete.installations}</layers.delete.installations>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -59,6 +59,12 @@
         <ee.ha.layers.install.root>${ee.ha.layers.install.dir}</ee.ha.layers.install.root>
         <ha.layers.install.dir>${project.build.directory}/ha-layers-results</ha.layers.install.dir>
 
+        <ee.full.layers.install.dir>${project.build.directory}/ee-full-layers-results</ee.full.layers.install.dir>
+        <!-- An empty directory for this will disable 'ee' tests which are meant for testing
+             the ee feature pack default config. -->
+        <ee.full.layers.install.root>${ee.full.layers.install.dir}</ee.full.layers.install.root>
+        <full.layers.install.dir>${project.build.directory}/full-layers-results</full.layers.install.dir>
+
         <layers.delete.installations>true</layers.delete.installations>
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
         
@@ -128,6 +134,8 @@
                 <ee.layers.install.root></ee.layers.install.root>
                 <!-- An empty value for this will disable the ee ha test -->
                 <ee.ha.layers.install.root></ee.ha.layers.install.root>
+                <!-- An empty value for this will disable the ee full test -->
+                <ee.full.layers.install.root></ee.full.layers.install.root>
             </properties>
         </profile>
     </profiles>
@@ -1112,7 +1120,7 @@
                                     </configurations>
                                 </configuration>
                             </execution>
-                            <!-- wildfly ee default standalone-ha config and all layers comparison -->
+                                                       <!-- wildfly ee default standalone-ha config and all layers comparison -->
                             <execution>
                                 <!-- Build the test-standalone-reference from the ee feature pack. -->
                                 <id>test-ee-ha-standalone-reference-provisioning</id>
@@ -1246,7 +1254,7 @@
                                                 <layer>web-console</layer>
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
-                                                
+
                                                 <!-- Missing layers for singleton and mod_cluster, there is a workaround in test 
                                                         for the modules they are bringing, tracked by 
                                               https://issues.redhat.com/browse/WFLY-16452 and https://issues.redhat.com/browse/WFLY-16453 -->
@@ -1256,6 +1264,146 @@
                                                 <layer>ejb-local-cache</layer>
                                                 <layer>jpa</layer>
                                             </excluded-layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- wildfly ee default standalone-full config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the ee feature pack. -->
+                                <id>test-ee-full-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-full with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-ee-full-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.layers.install.dir}/test-standalone-full</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-provisioning-ee-full</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-passivation</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+                                                
+                                                <!-- Missing layers for embedded broker (WFLY-13798), the test contains a workaround -->
+                                            </layers>
                                         </config>
                                     </configurations>
                                 </configuration>
@@ -3046,6 +3194,151 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+                            <!-- wildfly default standalone-full config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the full feature pack. -->
+                                <id>test-full-full-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-full with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-full-full-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.layers.install.dir}/test-standalone-full</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-standalone-full-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-passivation</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+
+                                                <!-- only in standalone-full.xml in full -->
+                                                <layer>elytron-oidc-client</layer>
+                                                <layer>microprofile-jwt</layer>
+                                                <layer>microprofile-opentracing</layer>
+                                                
+                                                <!-- Missing layers for embedded broker (WFLY-13798), the test contains a workaround -->
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                             <!-- Core Layers - These can't be tested in Core as they require Undertow -->
                             <execution>
                                 <id>remoting-provisioning</id>
@@ -3121,6 +3414,8 @@
                                 <ee.layers.install.root>${ee.layers.install.root}</ee.layers.install.root>
                                 <ee.ha.layers.install.root>${ee.ha.layers.install.root}</ee.ha.layers.install.root>
                                 <ha.layers.install.root>${ha.layers.install.dir}</ha.layers.install.root>
+                                <ee.full.layers.install.root>${ee.full.layers.install.root}</ee.full.layers.install.root>
+                                <full.layers.install.root>${full.layers.install.dir}</full.layers.install.root>
                                 <jbossas.version>${project.parent.version}</jbossas.version>
                                 <cleanup.tmp>${cleanup.tmp}</cleanup.tmp>
                                 <layers.delete.installations>${layers.delete.installations}</layers.delete.installations>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -65,6 +65,12 @@
         <ee.full.layers.install.root>${ee.full.layers.install.dir}</ee.full.layers.install.root>
         <full.layers.install.dir>${project.build.directory}/full-layers-results</full.layers.install.dir>
 
+        <ee.full.ha.layers.install.dir>${project.build.directory}/ee-full-ha-layers-results</ee.full.ha.layers.install.dir>
+        <!-- An empty directory for this will disable 'ee' tests which are meant for testing
+             the ee feature pack default config. -->
+        <ee.full.ha.layers.install.root>${ee.full.ha.layers.install.dir}</ee.full.ha.layers.install.root>
+        <full.ha.layers.install.dir>${project.build.directory}/full-ha-layers-results</full.ha.layers.install.dir>
+
         <layers.delete.installations>true</layers.delete.installations>
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
         
@@ -136,6 +142,8 @@
                 <ee.ha.layers.install.root></ee.ha.layers.install.root>
                 <!-- An empty value for this will disable the ee full test -->
                 <ee.full.layers.install.root></ee.full.layers.install.root>
+                <!-- An empty value for this will disable the ee full ha test -->
+                <ee.full.ha.layers.install.root></ee.full.ha.layers.install.root>
             </properties>
         </profile>
     </profiles>
@@ -1404,6 +1412,154 @@
                                                 
                                                 <!-- Missing layers for embedded broker (WFLY-13798), the test contains a workaround -->
                                             </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- wildfly ee default standalone-full-ha config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the ee feature pack. -->
+                                <id>test-ee-full-ha-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.ha.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-full with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-ee-full-ha-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.ha.layers.install.dir}/test-standalone-full-ha</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-provisioning-ee-full-ha</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.full.ha.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+
+                                                <!-- Missing layers for singleton and mod_cluster, there is a workaround in test
+                                                        for the modules they are bringing, tracked by
+                                              https://issues.redhat.com/browse/WFLY-16452 and https://issues.redhat.com/browse/WFLY-16453 -->
+                                              <!-- Missing layers for embedded broker (WFLY-13798), the test contains a workaround -->
+                                            </layers>
+                                            <excluded-layers>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>jpa</layer>
+                                            </excluded-layers>     
                                         </config>
                                     </configurations>
                                 </configuration>
@@ -3339,6 +3495,160 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+                            <!-- wildfly default standalone-full-ha config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the full feature pack. -->
+                                <id>test-full-full-ha-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.ha.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone-full-ha with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-full-full-ha-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.ha.layers.install.dir}/test-standalone-full-ha</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full-ha.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <custom-config>full-ha-config.xml</custom-config>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-standalone-full-ha-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${full.ha.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+
+                                                <!-- Missing layers for singleton and mod_cluster, there is a workaround in test
+                                                        for the modules they are bringing, tracked by
+                                              https://issues.redhat.com/browse/WFLY-16452 and https://issues.redhat.com/browse/WFLY-16453 -->
+
+                                                <!-- layers only present in full standalone-ha.xml -->
+                                                <layer>elytron-oidc-client</layer>
+                                                <layer>microprofile-jwt</layer>
+                                                <layer>microprofile-opentracing</layer>
+                                               
+                                                <!-- Missing layers for embedded broker (WFLY-13798), the test contains a workaround -->
+                                            </layers>
+                                            <excluded-layers>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>jpa</layer>
+                                            </excluded-layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                             <!-- Core Layers - These can't be tested in Core as they require Undertow -->
                             <execution>
                                 <id>remoting-provisioning</id>
@@ -3416,6 +3726,8 @@
                                 <ha.layers.install.root>${ha.layers.install.dir}</ha.layers.install.root>
                                 <ee.full.layers.install.root>${ee.full.layers.install.root}</ee.full.layers.install.root>
                                 <full.layers.install.root>${full.layers.install.dir}</full.layers.install.root>
+                                <ee.full.ha.layers.install.root>${ee.full.ha.layers.install.root}</ee.full.ha.layers.install.root>
+                                <full.ha.layers.install.root>${full.ha.layers.install.dir}</full.ha.layers.install.root>
                                 <jbossas.version>${project.parent.version}</jbossas.version>
                                 <cleanup.tmp>${cleanup.tmp}</cleanup.tmp>
                                 <layers.delete.installations>${layers.delete.installations}</layers.delete.installations>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -47,6 +47,12 @@
         <!-- An empty layer for this will disable 'servlet dist' tests which are meant for testing
              the servlet feature pack. -->
         <servlet.layers.install.root>${project.build.directory}/servlet-layers-results</servlet.layers.install.root>
+        
+        <ee.layers.install.dir>${project.build.directory}/ee-layers-results</ee.layers.install.dir>
+        <!-- An empty directory for this will disable 'ee' tests which are meant for testing
+             the ee feature pack default config. -->
+        <ee.layers.install.root>${ee.layers.install.dir}</ee.layers.install.root>
+        
         <layers.delete.installations>true</layers.delete.installations>
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
         
@@ -112,6 +118,8 @@
                 <servlet.layers.install.dir>${layers.install.dir}</servlet.layers.install.dir>
                 <!-- An empty value for this will disable the servlet test -->
                 <servlet.layers.install.root></servlet.layers.install.root>
+                <!-- An empty value for this will disable the ee test -->
+                <ee.layers.install.root></ee.layers.install.root>
             </properties>
         </profile>
     </profiles>
@@ -954,6 +962,143 @@
                                                 required to compare all layers with reference installation -->
                                                 <layer>core-server</layer>
                                                 <layer>core-tools</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- wildfly ee default standalone config and all layers comparison -->
+                            <execution>
+                                <!-- Build the test-standalone-reference from the ee feature pack. -->
+                                <id>test-ee-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Provision standalone with a name different than test-standalone-reference to enforce execution of it by test. -->
+                                <id>test-ee-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.layers.install.dir}/test-standalone</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-provisioning-ee</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
+                                <configuration>
+                                    <install-dir>${ee.layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${ee.feature.pack.groupId}</groupId>
+                                            <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                            <version>${ee.feature.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-passivation</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
                                             </layers>
                                         </config>
                                     </configurations>
@@ -2255,7 +2400,7 @@
                             </execution>
 
                             <!--
-                                All layers provisioned all together
+                                All local layers provisioned all together
                              -->
                             <execution>
                                 <id>all-layers-provisioning-full</id>
@@ -2264,7 +2409,7 @@
                                 </goals>
                                 <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
-                                    <install-dir>${layers.install.dir}/test-all-layers</install-dir>
+                                    <install-dir>${layers.install.dir}/test-all-layers-jpa</install-dir>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${full.maven.groupId}</groupId>
@@ -2452,6 +2597,147 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <!-- Build the test-standalone-reference from the full feature pack. -->
+                                <id>test-full-standalone-reference-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/test-standalone-reference</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- Enforce execution of standalone.xml of full. -->
+                                <id>test-full-standalone-execution</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/test-standalone-full</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>all-layers-standalone-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase}</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/test-all-layers</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>${full.feature.pack.artifactId}</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>base-server</layer>
+                                                <layer>batch-jberet</layer>
+                                                <layer>bean-validation</layer>
+                                                <layer>cdi</layer>
+                                                <layer>cloud-profile</layer>
+                                                <layer>cloud-server</layer>
+                                                <layer>core-management</layer>
+                                                <layer>core-server</layer>
+                                                <layer>core-tools</layer>
+                                                <layer>datasources</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>deployment-scanner</layer>
+                                                <layer>discovery</layer>
+                                                <layer>ee</layer>
+                                                <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-http-invoker</layer>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-local-cache</layer>
+                                                <layer>elytron</layer>
+                                                <layer>h2-datasource</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>h2-driver</layer>
+                                                <layer>iiop-openjdk</layer>
+                                                <layer>io</layer>
+                                                <layer>jaxrs</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
+                                                <layer>jms-activemq</layer>
+                                                <layer>jmx</layer>
+                                                <layer>jmx-remoting</layer>
+                                                <layer>jpa</layer>
+                                                <layer>jsf</layer>
+                                                <layer>jsonb</layer>
+                                                <layer>jsonp</layer>
+                                                <layer>logging</layer>
+                                                <layer>mail</layer>
+                                                <layer>management</layer>
+                                                <layer>messaging-activemq</layer>
+                                                <layer>naming</layer>
+                                                <layer>observability</layer>
+                                                <layer>opentelemetry</layer>
+                                                <layer>pojo</layer>
+                                                <layer>remote-activemq</layer>
+                                                <layer>remoting</layer>
+                                                <layer>request-controller</layer>
+                                                <layer>resource-adapters</layer>
+                                                <layer>sar</layer>
+                                                <layer>security-manager</layer>
+                                                <layer>transactions</layer>
+                                                <layer>undertow</layer>
+                                                <layer>undertow-https</layer>
+                                                <layer>undertow-load-balancer</layer>
+                                                <layer>web-passivation</layer>
+                                                <layer>web-console</layer>
+                                                <layer>web-server</layer>
+                                                <layer>webservices</layer>
+                                               
+                                                <!-- only in standalone.xml in full -->
+                                                <layer>elytron-oidc-client</layer>
+                                                <layer>microprofile-jwt</layer>
+                                                <layer>microprofile-opentracing</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                             <!-- Core Layers - These can't be tested in Core as they require Undertow -->
                             <execution>
                                 <id>remoting-provisioning</id>
@@ -2524,6 +2810,7 @@
                                 <!-- maven.local.repo is set in parent pom.xml, system property surefire.system.args -->
                                 <servlet.layers.install.root>${servlet.layers.install.root}</servlet.layers.install.root>
                                 <layers.install.root>${layers.install.dir}</layers.install.root>
+                                <ee.layers.install.root>${ee.layers.install.root}</ee.layers.install.root>
                                 <jbossas.version>${project.parent.version}</jbossas.version>
                                 <cleanup.tmp>${cleanup.tmp}</cleanup.tmp>
                                 <layers.delete.installations>${layers.delete.installations}</layers.delete.installations>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -180,6 +180,8 @@ public class LayersTestCase {
     public static String haRoot;
     public static String eeFullRoot;
     public static String fullRoot;
+    public static String eeFullHaRoot;
+    public static String fullHaRoot;
 
     @BeforeClass
     public static void setUp() {
@@ -190,6 +192,8 @@ public class LayersTestCase {
         haRoot = System.getProperty("ha.layers.install.root");
         eeFullRoot = System.getProperty("ee.full.layers.install.root");
         fullRoot = System.getProperty("full.layers.install.root");
+        eeFullHaRoot = System.getProperty("ee.full.ha.layers.install.root");
+        fullHaRoot = System.getProperty("full.ha.layers.install.root");
     }
 
     @AfterClass
@@ -232,6 +236,18 @@ public class LayersTestCase {
             }
             if (fullRoot != null && fullRoot.length() > 0) {
                 installations = new File(fullRoot).listFiles(File::isDirectory);
+                for (File f : installations) {
+                    LayersTest.recursiveDelete(f.toPath());
+                }
+            }
+            if (eeFullHaRoot != null && eeFullHaRoot.length() > 0) {
+                installations = new File(eeFullHaRoot).listFiles(File::isDirectory);
+                for (File f : installations) {
+                    LayersTest.recursiveDelete(f.toPath());
+                }
+            }
+            if (fullHaRoot != null && fullHaRoot.length() > 0) {
+                installations = new File(fullHaRoot).listFiles(File::isDirectory);
                 for (File f : installations) {
                     LayersTest.recursiveDelete(f.toPath());
                 }
@@ -280,6 +296,19 @@ public class LayersTestCase {
     }
 
     @Test
+    public void testEEFullHA() throws Exception {
+        org.junit.Assume.assumeTrue("EE Full HA testing disabled", eeFullHaRoot != null && eeFullHaRoot.length() > 0);
+        LayersTest.test(eeFullHaRoot, new HashSet<>(EE_NOT_REFERENCED_LIST),
+                new HashSet<>(Arrays.asList(NOT_USED)));
+    }
+
+    @Test
+    public void testFullHA() throws Exception {
+        LayersTest.test(fullHaRoot, new HashSet<>(FULL_NOT_REFERENCED_LIST),
+                new HashSet<>(Arrays.asList(NOT_USED)));
+    }
+
+    @Test
     public void test() throws Exception {
        LayersTest.test(root, new HashSet<>(FULL_NOT_REFERENCED_LIST),
        new HashSet<>(Arrays.asList(NOT_USED)));
@@ -311,6 +340,14 @@ public class LayersTestCase {
         }
         if (fullRoot != null && fullRoot.length() > 0) {
             HashMap<String, String> eeResults = LayersTest.checkBannedModules(fullRoot, BANNED_MODULES_CONF);
+            results.putAll(eeResults);
+        }
+        if (eeFullHaRoot != null && eeFullHaRoot.length() > 0) {
+            HashMap<String, String> eeResults = LayersTest.checkBannedModules(eeFullHaRoot, BANNED_MODULES_CONF);
+            results.putAll(eeResults);
+        }
+        if (fullHaRoot != null && fullHaRoot.length() > 0) {
+            HashMap<String, String> eeResults = LayersTest.checkBannedModules(fullHaRoot, BANNED_MODULES_CONF);
             results.putAll(eeResults);
         }
         Assert.assertTrue("The following banned modules were provisioned " + results.toString(), results.isEmpty());


### PR DESCRIPTION
This would allow to provision trimmed default configs. 
Main use case being Bootable JAR for wildfly-ee-galleon-pack bare metal (standalone.xml) and cloud (standalone-ha.xml).

ISSUES

These issues are blocking the merge of this PR:

We have some subsystem included with no layers defined:
* singleton WFLY-16453
* modcluster: WFLY-16452
* embedded broker: WFLY-13798
