### PR TITLE
Fix DomainTestSuite failures - restore test configuration to use local-only caches.

### DIFF
--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -464,46 +464,33 @@
                 <default-missing-method-permissions-deny-access value="true"/>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:12.0">
-                <cache-container name="ejb" default-cache="dist" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="ejb" default-cache="passivation" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
                 </cache-container>
-                <cache-container name="server" default-cache="default" aliases="singleton cluster" modules="org.wildfly.clustering.server">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="default">
-                        <transaction mode="BATCH"/>
-                    </replicated-cache>
+                <cache-container name="web" default-cache="passivation" modules="org.wildfly.clustering.web.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                    <local-cache name="sso"/>
                 </cache-container>
-                <cache-container name="web" default-cache="sso" modules="org.wildfly.clustering.web.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="sso">
-                        <file-store/>
-                    </replicated-cache>
-                    <replicated-cache name="routing"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="server" default-cache="default" modules="org.wildfly.clustering.server">
+                    <local-cache name="default"/>
                 </cache-container>
                 <cache-container name="hibernate" modules="org.infinispan.hibernate-cache">
-                    <transport lock-timeout="60000"/>
+                    <local-cache name="entity">
+                        <heap-memory size="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
                     <local-cache name="local-query">
                         <heap-memory size="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
+                    <local-cache name="timestamps"/>
                     <local-cache name="pending-puts">
                         <expiration max-idle="60000"/>
                     </local-cache>
-                    <invalidation-cache name="entity">
-                        <heap-memory size="10000"/>
-                        <expiration max-idle="100000"/>
-                    </invalidation-cache>
-                    <replicated-cache name="timestamps"/>
                 </cache-container>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jgroups:8.0">

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -178,46 +178,33 @@
                 <default-missing-method-permissions-deny-access value="true"/>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:12.0">
-                <cache-container name="ejb" default-cache="dist" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="ejb" default-cache="passivation" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
                 </cache-container>
-                <cache-container name="server" default-cache="default" aliases="singleton cluster" modules="org.wildfly.clustering.server">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="default">
-                        <transaction mode="BATCH"/>
-                    </replicated-cache>
+                <cache-container name="web" default-cache="passivation" modules="org.wildfly.clustering.web.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                    <local-cache name="sso"/>
                 </cache-container>
-                <cache-container name="web" default-cache="sso" modules="org.wildfly.clustering.web.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="sso">
-                        <file-store/>
-                    </replicated-cache>
-                    <replicated-cache name="routing"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="server" default-cache="default" modules="org.wildfly.clustering.server">
+                    <local-cache name="default"/>
                 </cache-container>
                 <cache-container name="hibernate" modules="org.infinispan.hibernate-cache">
-                    <transport lock-timeout="60000"/>
+                    <local-cache name="entity">
+                        <heap-memory size="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
                     <local-cache name="local-query">
                         <heap-memory size="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
+                    <local-cache name="timestamps"/>
                     <local-cache name="pending-puts">
                         <expiration max-idle="60000"/>
                     </local-cache>
-                    <invalidation-cache name="entity">
-                        <heap-memory size="10000"/>
-                        <expiration max-idle="100000"/>
-                    </invalidation-cache>
-                    <replicated-cache name="timestamps"/>
                 </cache-container>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jgroups:8.0">
@@ -544,46 +531,33 @@
                 <default-missing-method-permissions-deny-access value="true"/>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:12.0">
-                <cache-container name="ejb" default-cache="dist" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="ejb" default-cache="passivation" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
                 </cache-container>
-                <cache-container name="server" default-cache="default" aliases="singleton cluster" modules="org.wildfly.clustering.server">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="default">
-                        <transaction mode="BATCH"/>
-                    </replicated-cache>
+                <cache-container name="web" default-cache="passivation" modules="org.wildfly.clustering.web.infinispan">
+                    <local-cache name="passivation">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                    <local-cache name="sso"/>
                 </cache-container>
-                <cache-container name="web" default-cache="sso" modules="org.wildfly.clustering.web.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="sso">
-                        <file-store/>
-                    </replicated-cache>
-                    <replicated-cache name="routing"/>
-                    <distributed-cache name="dist">
-                        <locking isolation="REPEATABLE_READ"/>
-                        <transaction mode="BATCH"/>
-                        <file-store/>
-                    </distributed-cache>
+                <cache-container name="server" default-cache="default" modules="org.wildfly.clustering.server">
+                    <local-cache name="default"/>
                 </cache-container>
                 <cache-container name="hibernate" modules="org.infinispan.hibernate-cache">
-                    <transport lock-timeout="60000"/>
+                    <local-cache name="entity">
+                        <heap-memory size="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
                     <local-cache name="local-query">
                         <heap-memory size="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
+                    <local-cache name="timestamps"/>
                     <local-cache name="pending-puts">
                         <expiration max-idle="60000"/>
                     </local-cache>
-                    <invalidation-cache name="entity">
-                        <heap-memory size="10000"/>
-                        <expiration max-idle="100000"/>
-                    </invalidation-cache>
-                    <replicated-cache name="timestamps"/>
                 </cache-container>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jgroups:8.0">


### PR DESCRIPTION
Fixes regressions in GlobalDirectoryDomainTestCase and ReadEnvironmentVariablesTestCase due to test configuration changes introduced by https://github.com/wildfly/wildfly/pull/15572
