### PR TITLE
[WFLY-16415] Exclude community versions of transitive dependencies

### DIFF
--- a/ee-feature-pack/pom.xml
+++ b/ee-feature-pack/pom.xml
@@ -3651,6 +3651,14 @@
                         <groupId>org.jboss.threads</groupId>
                         <artifactId>jboss-threads</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                        <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.resource</groupId>
+                        <artifactId>jboss-connector-api_1.7_spec</artifactId>
+                    </exclusion>
                     <!-- TODO remove this exclusion once this supports Jakarta Transactions 1.3 -->
                     <!-- superseded by org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec -->
                     <exclusion>
@@ -3697,6 +3705,22 @@
                         <groupId>org.jboss.security</groupId>
                         <artifactId>jboss-security-spi-bare</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                        <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.validation</groupId>
+                        <artifactId>jakarta.validation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jboss-transaction-spi</artifactId>
+                    </exclusion>
                     <!-- TODO remove this exclusion once this supports Jakarta Transactions 1.3 -->
                     <!-- superseded by org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec -->
                     <exclusion>
@@ -3724,6 +3748,20 @@
                 <groupId>org.jboss.ironjacamar</groupId>
                 <artifactId>ironjacamar-deployers-common</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                        <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.resource</groupId>
+                        <artifactId>jboss-connector-api_1.7_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.validation</groupId>
+                        <artifactId>jakarta.validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -3731,6 +3769,14 @@
                 <artifactId>ironjacamar-jdbc</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                        <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.resource</groupId>
+                        <artifactId>jboss-connector-api_1.7_spec</artifactId>
+                    </exclusion>
                     <!-- TODO remove this exclusion once this supports Jakarta Transactions 1.3 -->
                     <!-- superseded by org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec -->
                     <exclusion>
@@ -4048,6 +4094,12 @@
                 <groupId>org.jboss.spec.javax.resource</groupId>
                 <artifactId>jboss-connector-api_1.7_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                        <artifactId>jboss-transaction-api_1.3_spec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -56,6 +56,16 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -117,6 +117,16 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>


### PR DESCRIPTION
Community versions of some transitive dependencies are not being properly resolved to their
productized versions, which cause the productized compilation of the server to fail due to multiple
versions of the same GAVs. The community versions of those dependencies need to be excluded.

Issue: https://issues.redhat.com/browse/WFLY-16415
