### PR TITLE
WFLY-16099 Prune unnecessary dependencies from org.wildfly.clustering.singleton.server module

### DIFF
--- a/clustering/singleton/server/pom.xml
+++ b/clustering/singleton/server/pom.xml
@@ -51,10 +51,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-clustering-infinispan-embedded-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
         </dependency>
         <dependency>
@@ -93,6 +89,11 @@
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-infinispan-embedded-spi</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/server/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/server/main/module.xml
@@ -44,7 +44,6 @@
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.ee.cache" services="import"/>
         <module name="org.wildfly.clustering.ee.spi"/>
-        <module name="org.wildfly.clustering.infinispan.embedded.api"/>
         <module name="org.wildfly.clustering.infinispan.embedded.spi" services="import"/>
         <module name="org.wildfly.clustering.marshalling.api"/>
         <module name="org.wildfly.clustering.marshalling.jboss"/>


### PR DESCRIPTION
Follows up on https://issues.redhat.com/browse/WFLY-16099