### PR TITLE
[WFLY-16437] Remove duplicate dependency declaration to fix maven warn

### DIFF
--- a/testsuite/preview/source-transform/smoke/pom.xml
+++ b/testsuite/preview/source-transform/smoke/pom.xml
@@ -299,11 +299,6 @@
             <artifactId>wildfly-naming-client</artifactId>
             <scope>test</scope>
         </dependency>
-                <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-naming-client</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Minor follow-on change to the already resolved https://issues.redhat.com/browse/WFLY-16437