### PR TITLE
WFLY-16464 Modifying attributes of single-sign-on resource doesn't ma…

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/WriteAttributeStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/WriteAttributeStepHandler.java
@@ -54,11 +54,6 @@ public class WriteAttributeStepHandler extends ReloadRequiredWriteAttributeHandl
     }
 
     @Override
-    protected boolean requiresRuntime(OperationContext context) {
-        return super.requiresRuntime(context) && (this.handler != null);
-    }
-
-    @Override
     public void register(ManagementResourceRegistration registration) {
         for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
             registration.registerReadWriteAttribute(attribute, null, this);
@@ -94,7 +89,7 @@ public class WriteAttributeStepHandler extends ReloadRequiredWriteAttributeHandl
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> handback) throws OperationFailedException {
         boolean updated = super.applyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handback);
-        if (updated) {
+        if (updated && handler != null) {
             PathAddress address = context.getCurrentAddress();
             if (context.isResourceServiceRestartAllowed() && this.getAttributeDefinition(attributeName).getFlags().contains(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES) && context.markResourceRestarted(address, this.handler)) {
                 this.restartServices(context);

--- a/undertow/src/test/java/org/wildfly/extension/undertow/SecurityDomainSingleSignOnAttributesTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/SecurityDomainSingleSignOnAttributesTestCase.java
@@ -1,0 +1,35 @@
+package org.wildfly.extension.undertow;
+
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SecurityDomainSingleSignOnAttributesTestCase extends AbstractSubsystemTest {
+
+    public SecurityDomainSingleSignOnAttributesTestCase() {
+        super(UndertowExtension.SUBSYSTEM_NAME, new UndertowExtension());
+    }
+
+    @Test
+    public void testPathChangeRequiresReload() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(AbstractUndertowSubsystemTestCase.RUNTIME).setSubsystemXml(readResource("undertow-13.0.xml"));
+        KernelServices mainServices = builder.build();
+        PathAddress address = PathAddress.pathAddress("subsystem", "undertow")
+                .append("application-security-domain", "other")
+                .append("setting", "single-sign-on");
+        ModelNode result = mainServices.executeOperation(
+                Operations.createWriteAttributeOperation(address, SingleSignOnDefinition.Attribute.PATH,
+                        new ModelNode("/modified-path")));
+        assertEquals("success", result.get("outcome").asString());
+        assertTrue("It is expected that reload is required after the operation.",
+                result.get("response-headers").get("operation-requires-reload").asBoolean());
+    }
+
+}


### PR DESCRIPTION
…rk restart required

The modification doesn't take effect until container reload however.

https://issues.redhat.com/browse/WFLY-16464