### PR TITLE
[WFLY-16483] Eliminate undertow-*-jakarta dependencies from pom.xml files

### DIFF
--- a/ee-9/source-transform/rts/pom.xml
+++ b/ee-9/source-transform/rts/pom.xml
@@ -94,7 +94,7 @@
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>

--- a/testsuite/preview/source-transform/smoke/pom.xml
+++ b/testsuite/preview/source-transform/smoke/pom.xml
@@ -161,7 +161,7 @@
 
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16483
