### PR TITLE
Simple documentation change to add a section link to the headers. Thi…

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -70,6 +70,7 @@
 
                         <!-- Default asciidoc setting attributes -->
                         <linkcss>false</linkcss>
+                        <sectanchors/>
                         <toc>left</toc>
                     </attributes>
                     <backend>html5</backend>


### PR DESCRIPTION
…s allows for easily copying a header link when you hover over the header.

Example output:
![image](https://user-images.githubusercontent.com/420065/173975240-6c1c59e1-b11c-45bf-a7d9-a9744e6163cc.png)

The link on the left of the header can be used to easily copy the link to the header.