### PR TITLE
[WFLY-16440] Upgrade WildFly HTTP Client to 1.1.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>19.0.0.Beta11</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.1.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>1.19.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.transaction.client>2.0.1.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFLY-16440
26.x PR: #15665 


        Release Notes - WildFly EJB HTTP Client - Version 1.1.12.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-73'>WEJBHTTP-73</a>] -         WildflyClientInputStream.read() and close() fail to throw ioException after waiting on lock
</li>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-80'>WEJBHTTP-80</a>] -         Digest authentication creates URI with port -1 when using standard ports
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-75'>WEJBHTTP-75</a>] -         Problematic Language usage deprecation and replacement
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-82'>WEJBHTTP-82</a>] -         Upgrade jakarta.ejb-api from 4.0.0 to 4.0.1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-76'>WEJBHTTP-76</a>] -         Remove unused class org.wildfly.httpclient.ejb.ModuleIdentifier
</li>
</ul>
                                                                                                                                    