### PR TITLE
[WFLY-16493] Upgrade WildFly Core to 19.0.0.Beta12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta11</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta12</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-16493


---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta12
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta11...19.0.0.Beta12

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5853'>WFCORE-5853</a>] -         Deployment SubModel for logging should be runtime only
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5917'>WFCORE-5917</a>] -         Duplicating -Djboss.server.base.dir if defined in more than one place
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5918'>WFCORE-5918</a>] -         Adding SSO to application security domain via YamlConfigurationExtension doesn&#39;t work.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5932'>WFCORE-5932</a>] -         Incorrect values for keys in LocalDescriptions.properties files
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5933'>WFCORE-5933</a>] -         JUnit assertions should not be used in &quot;run&quot; methods
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5934'>WFCORE-5934</a>] -         Fix DeletionCollisionTest&#39;s byteman rule file for proper method match at runtime
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5936'>WFCORE-5936</a>] -         Ldap autentication using referrals fails on JDK 17 with ApacheDS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5943'>WFCORE-5943</a>] -         Exclude undertow-servlet transitive dependencies
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5931'>WFCORE-5931</a>] -         Upgrade JBoss Remoting to 5.0.25.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5946'>WFCORE-5946</a>] -         Upgrade Undertow to 2.2.18.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5852'>WFCORE-5852</a>] -         CLI autocomplete suggests non-existent subsystems
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5944'>WFCORE-5944</a>] -         Eliminate now useless undertow-*-jakarta dependencies from pom.xml file
</li>
</ul>
</details>
