### PR TITLE
[WFLY-16468] The microprofile-opentracing layer is redundant

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -363,7 +363,7 @@ link:#gal.microprofile-health[microprofile-health] (optional) +
 link:#gal.microprofile-jwt[microprofile-jwt] (optional) +
 link:#gal.microprofile-metrics[microprofile-metrics] (optional) +
 link:#gal.microprofile-openapi[microprofile-openapi] (optional) +
-link:#gal.open-tracing[microprofile-opentracing] (optional) +
+link:#gal.microprofile-opentracing[microprofile-opentracing] (optional) +
 link:#gal.microprofile-rest-client[microprofile-rest-client] (optional) +
 
 |[[gal.microprofile-rest-client]]microprofile-rest-client
@@ -399,13 +399,7 @@ link:#gal.base-server[base-server] +
 link:#gal.microprofile-config[microprofile-config] (optional) +
 link:#gal.microprofile-health[microprofile-health] (optional) +
 link:#gal.microprofile-metrics[microprofile-metrics] (optional) +
-link:#gal.open-tracing[open-tracing] (optional) +
-
-|[[gal.open-tracing]]open-tracing
-|*Deprecated* Use link:#gal.microprofile-opentracing[microprofile-opentracing]
-|
-link:#gal.cdi[cdi] +
-link:#gal.microprofile-config[microprofile-config] +
+link:#gal.microprofile-opentracing[microprofile-opentracing] (optional) +
 
 |[[gal.pojo]]pojo
 | Support for legacy JBoss Microcontainer applications.

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-opentracing/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-opentracing/layer-spec.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-opentracing">
     <dependencies>
-        <layer name="open-tracing"/>
+        <layer name="cdi"/>
         <layer name="microprofile-config"/>
     </dependencies>
+    <feature spec="subsystem.microprofile-opentracing-smallrye"/>
 </layer-spec>

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -3,7 +3,7 @@
     <dependencies>
         <layer name="microprofile-config" optional="true"/>
         <layer name="microprofile-metrics" optional="true"/>
-        <layer name="open-tracing" optional="true"/>
+        <layer name="microprofile-opentracing" optional="true"/>
         <layer name="microprofile-health" optional="true"/>
     </dependencies>
 </layer-spec>

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="open-tracing">
-    <dependencies>
-        <layer name="cdi"/>
-        <layer name="microprofile-config"/>
-    </dependencies>
-    <feature spec="subsystem.microprofile-opentracing-smallrye"/>
-</layer-spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16468

Combine "open-tracing" and "microprofile-opentracing" into the latter
Remove the "open-tracing" layer
Adjust references to the "open-tracing" layer to point to new combined layer