### PR TITLE
[WFLY-16470] OpenTelemetry Instance Leak in OpenTelemetryClientRequestFilter

### DIFF
--- a/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/OpenTelemetryClientRequestFilter.java
+++ b/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/OpenTelemetryClientRequestFilter.java
@@ -31,8 +31,7 @@ import io.opentelemetry.context.Context;
 public class OpenTelemetryClientRequestFilter implements ClientRequestFilter {
     @Override
     public void filter(ClientRequestContext requestContext) {
-        CDI.current()
-                .select(OpenTelemetry.class).get()
+        CDI.current().getBeanManager().createInstance().select(OpenTelemetry.class).get()
                 .getPropagators()
                 .getTextMapPropagator()
                 .inject(Context.current(), requestContext,


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16470

Modify how instance is retrieved via CDI to avoid leak