### PR TITLE
WFLY-16495: exclude wildfly-cli:client from transformation, WFLY-16500: upgrade galleon-plugins

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -586,6 +586,13 @@
                                 <exclude>org.glassfish:jakarta.json\z</exclude>
                                 <exclude>activemq-artemis-native\z</exclude>
                                 <exclude>org.jboss.activemq.artemis.integration:artemis-wildfly-jakarta-integration\z</exclude>
+
+                                <!-- Depends on javax.json API that it bundles.
+                                   Transformation bound to org.wildfly.security.auth.client.spi.WebServicesClientConfigProviderImpl
+                                   is meaningless, this class is not being used by CLI.
+                                -->
+                                <exclude>org.wildfly.core:wildfly-cli:client\z</exclude>
+
                                 <!-- Issue filed for removal of log4j 1.x, WFCORE-5781. Skipping this may break users
                                      who use appenders like the SMTPAppender. However, most of the Jakarta EE appenders
                                      do not work with WildFly. We should ignore the transformation as we'll be removing

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.0.0.Alpha4</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.0.0.Alpha5</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
Issues:
https://issues.redhat.com/browse/WFLY-16495
https://issues.redhat.com/browse/WFLY-16500

The Galleon upgrade is required to be able to exclude wildfly-cli:client artifact taking into account its classifier.