### PR TITLE
[WFLY-16517] Remove unneeded testsuite-specific modular.jdk.args

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -160,13 +160,7 @@
         <surefire.memory.args>-Xmx512m -XX:MetaspaceSize=128m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
-        <modular.jdk.testsuite.args>${modular.jdk.args}
-            --add-opens=java.base/javax.crypto=ALL-UNNAMED
-            --add-opens=java.base/sun.security.validator=ALL-UNNAMED
-            --add-exports=java.base/sun.security.validator=ALL-UNNAMED
-            --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
-            --add-exports=java.base/com.sun.crypto.provider=ALL-UNNAMED
-        </modular.jdk.testsuite.args>
+        <modular.jdk.testsuite.args>${modular.jdk.args}</modular.jdk.testsuite.args>
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />
         <!-- needed for arquillian-byteman-extension -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16517

Since PR CI only uses SE 17 for WildFly Preview, https://ci.wildfly.org/viewLog.html?buildId=311540&buildTypeId=WF_MainJdk17&tab=buildResultsDiv tested this change on SE 17 with standard WildFly.