### PR TITLE
[WFLY-16484] Extend LdapRealmTestCase to cover follow referral mode

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmFollowReferralsTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmFollowReferralsTestCase.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of Apache License v2.0 which
+ *  accompanies this distribution.
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.realm;
+
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Configures referral mode to follow and executes the smoke tests.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({AbstractLdapRealmTest.LDAPServerSetupTask.class, LdapRealmFollowReferralsTestCase.SetupTask.class})
+public class LdapRealmFollowReferralsTestCase extends AbstractLdapRealmTest {
+
+    @Override
+    public void testReferralUser(@ArquillianResource URL webAppURL) throws Exception {
+        // the referral user should be found with the proper role as referrals are followed
+        testAssignedRoles(webAppURL, USER_REFERRAL, CORRECT_PASSWORD, "ReferralRole");
+    }
+
+    /**
+     * SetupTask with referral mode to follow.
+     */
+    static class SetupTask extends AbstractLdapRealmTest.SetupTask {
+        @Override
+        public String getReferralMode() {
+            return "follow";
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmIgnoreReferralsTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmIgnoreReferralsTestCase.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of Apache License v2.0 which
+ *  accompanies this distribution.
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.realm;
+
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Configures referral mode to ignore and executes the smoke tests.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({AbstractLdapRealmTest.LDAPServerSetupTask.class, LdapRealmIgnoreReferralsTestCase.SetupTask.class})
+public class LdapRealmIgnoreReferralsTestCase extends AbstractLdapRealmTest {
+
+    @Override
+    public void testReferralUser(@ArquillianResource URL webAppURL) throws Exception {
+        // the referral user should not be found as referrals are ignored
+        assertAuthenticationFailed(webAppURL, USER_REFERRAL, CORRECT_PASSWORD);
+    }
+
+    /**
+     * SetupTask with referral mode to ignore.
+     */
+    static class SetupTask extends AbstractLdapRealmTest.SetupTask {
+        @Override
+        public String getReferralMode() {
+            return "ignore";
+        }
+
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.ldif
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.ldif
@@ -38,7 +38,7 @@ objectClass: inetOrgPerson
 cn: cryptUserCharsetHex
 sn: cryptUserCharsetHex
 uid: cryptUserCharsetHex
-userPassword: {crypt}XQ8317569289fa78a2
+userPassword: {crypt}yJ6bYS7DdX.NI
 # Password password密码 using a the GB2312 character set
 
 dn: uid=userWithoutRole,ou=People,dc=jboss,dc=org
@@ -71,3 +71,29 @@ objectClass: top
 cn: TheDuke
 description: the duke role
 member: uid=userWithMoreRoles,ou=People,dc=jboss,dc=org
+
+dn: ou=People2,dc=jboss,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: People2
+
+dn: uid=referralUser,ou=People2,dc=jboss,dc=org
+objectclass: top
+objectclass: person
+objectClass: inetOrgPerson
+uid: referralUser
+cn: Referral User
+sn: Referral User
+userPassword: Password1
+
+dn: ou=Roles2,dc=jboss,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: Roles2
+
+dn: cn=ReferralRole,ou=Roles2,dc=jboss,dc=org
+objectClass: top
+objectClass: groupOfNames
+cn: ReferralRole
+description: the ReferralRole group
+member: uid=referralUser,ou=People2,dc=jboss,dc=org

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/ldap-realm-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/ldap-realm-web.xml
@@ -25,5 +25,8 @@
     <security-role>
         <role-name>TheDuke</role-name>
     </security-role>
+    <security-role>
+        <role-name>ReferralRole</role-name>
+    </security-role>
 
 </web-app>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16484

Main changes:

* Test dependency apache-ds should be upgraded to last AM26 cos referrals are manged wrong in current M24. The dependency now needs to be `apacheds-test-framework` (and `apacheds-interceptor-kerberos` for some kerberos tests). This upgrade needs some changes in other test classes that depend in the apache-ds API (for example eh-cache is no longer used in the implementation).
* Now the `LdapRealmTestCase` is abstract and two new classes extend it configuring referral to ignore and follow.
* The ldif data contains a two new branches (People2 and Roles2) and referrals are created in the previous entries to point to the new branches.
* The same previous tests are run in both classes and a new `testReferralUser` method is added that behaves differently depending referrals are followed or ignored. If ignored the referral user and role should not be found, and if followed the user should be valid and with the new role.

Everything works OK in my laptop. Let's see in the CI environment.