### PR TITLE
[WFLY-16545] Register the @Provider, @Path and @ApplicationPath annot…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIApplicationPathIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIApplicationPathIntegrationTestCase.java
@@ -31,7 +31,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +52,7 @@ public class CDIApplicationPathIntegrationTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class,"jaxrsapp.war");
         war.addPackage(HttpRequest.class.getPackage());
         war.addClasses(CDIApplicationPathIntegrationTestCase.class, CDIBean.class, CDIPathApplication.class, CDIResource.class);
-        war.add(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "WEB-INF/beans.xml");
+        war.add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIBean.java
@@ -21,9 +21,12 @@
  */
 package org.jboss.as.test.integration.jaxrs.integration.cdi;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 /**
  * @author Stuart Douglas
  */
+@ApplicationScoped
 public class CDIBean {
 
     public String message() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIResourceInjectionEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIResourceInjectionEarTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.jaxrs.packaging.war.WebXml;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -58,7 +58,7 @@ public class CDIResourceInjectionEarTestCase {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class,"jaxrsnoap.war");
         war.addPackage(HttpRequest.class.getPackage());
-        war.add(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "WEB-INF/beans.xml");
+        war.add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
         war.addClasses(CDIResourceInjectionEarTestCase.class, CDIResource.class, CDIBean.class);
         war.addAsWebInfResource(WebXml.get("<servlet-mapping>\n" +
                 "        <servlet-name>jakarta.ws.rs.core.Application</servlet-name>\n" +

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIResourceInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIResourceInjectionTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.jaxrs.packaging.war.WebXml;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +52,7 @@ public class CDIResourceInjectionTestCase {
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class,"jaxrsnoap.war");
         war.addPackage(HttpRequest.class.getPackage());
-        war.add(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "WEB-INF/beans.xml");
+        war.add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
         war.addClasses(CDIResourceInjectionTestCase.class, CDIResource.class, CDIBean.class);
         war.addAsWebInfResource(WebXml.get("<servlet-mapping>\n" +
                 "        <servlet-name>jakarta.ws.rs.core.Application</servlet-name>\n" +

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CdiInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CdiInjectionTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.cdi;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CdiInjectionTestCase {
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, CdiInjectionTestCase.class.getSimpleName() + ".war")
+                .add(new StringAsset("<beans bean-discovery-mode=\"annotated\"></beans>"), "WEB-INF/beans.xml")
+                .addClasses(CDIApplication.class, CDIProvider.class, CDIResource.class, CDIBean.class, InjectionResource.class);
+    }
+
+
+    private static Client CLIENT;
+
+    @ArquillianResource
+    private URL url;
+
+    @BeforeClass
+    public static void createClient() {
+        CLIENT = ClientBuilder.newClient();
+    }
+
+    @AfterClass
+    public static void closeClient() {
+        if (CLIENT != null) {
+            CLIENT.close();
+        }
+    }
+
+    @Test
+    public void checkApplication() throws Exception {
+        checkResponse("app", CDIApplication.class);
+    }
+
+    @Test
+    public void checkProvider() throws Exception {
+        checkResponse("provider", CDIProvider.class);
+    }
+
+    @Test
+    public void checkResource() throws Exception {
+        checkResponse("resource", CDIResource.class);
+    }
+
+    private void checkResponse(final String path, final Class<?> expectedType) throws Exception {
+        try (
+                Response response = CLIENT.target(createUri(path))
+                        .request()
+                        .get()
+        ) {
+            final String text = response.readEntity(String.class);
+            Assert.assertEquals(text, Response.Status.OK, response.getStatusInfo());
+            Assert.assertTrue(String.format("Expected type %s, but found %s", expectedType.getName(), text), text.startsWith(expectedType.getName()));
+        }
+    }
+
+    private UriBuilder createUri(final String path) throws URISyntaxException {
+        return UriBuilder.fromUri(url.toURI())
+                .path("rest/inject/" + path);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/InjectionResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/InjectionResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.cdi;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Path("/inject")
+@Produces(MediaType.TEXT_PLAIN)
+public class InjectionResource {
+
+    @Inject
+    private Application app;
+    @Inject
+    private CDIProvider provider;
+    @Inject
+    private CDIResource resource;
+
+    @GET
+    @Path("/app")
+    public Response app() {
+        if (app == null) {
+            return Response.serverError().entity("Application was null").build();
+        }
+        return Response.ok(app.getClass().getName()).build();
+    }
+
+    @GET
+    @Path("/provider")
+    public Response provider() {
+        if (provider == null) {
+            return Response.serverError().entity("Provider was null").build();
+        }
+        return Response.ok(provider.getClass().getName()).build();
+    }
+
+    @GET
+    @Path("/resource")
+    public Response resource() {
+        if (resource == null) {
+            return Response.serverError().entity("Resource was null").build();
+        }
+        return Response.ok(resource.getClass().getName()).build();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/JaxrsComponentBeanDefinitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/JaxrsComponentBeanDefinitionTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +50,7 @@ public class JaxrsComponentBeanDefinitionTestCase {
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
-        war.add(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "WEB-INF/beans.xml");
+        war.add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
         war.addClasses(JaxrsComponentBeanDefinitionTestCase.class, CDIBean.class, CDIResource.class, CDIApplication.class, CDIProvider.class);
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jaxrs.validator;
 
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
+
 import java.net.URL;
 
 import jakarta.ws.rs.ApplicationPath;
@@ -31,6 +33,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+import org.hibernate.validator.HibernateValidatorPermission;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -67,7 +70,9 @@ public class BeanValidationIntegrationTestCase {
                 ValidatorResource.class,
                 AnotherValidatorResource.class,
                 YetAnotherValidatorResource.class
-            );
+            ).addAsManifestResource(createPermissionsXmlAsset(
+                HibernateValidatorPermission.ACCESS_PRIVATE_MEMBERS
+        ), "permissions.xml");
     }
 
     @ArquillianResource

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
@@ -41,7 +41,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,7 +48,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.openapi.service.TestApplication;
-import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestEjb;
+import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestBean;
 import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestRequest;
 import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestResource;
 import org.wildfly.test.integration.microprofile.openapi.service.multimodule.TestResponse;
@@ -73,16 +72,13 @@ public class OpenAPIMultiModuleDeploymentIndexTestCase {
                                      .addAsResource(TestResource.class.getResource("beans.xml"), "WEB-INF/beans.xml")
                                      .addClasses(TestApplication.class, TestResource.class);
         JavaArchive core = ShrinkWrap.create(JavaArchive.class, "core.jar")
-                                     .addClasses(TestEjb.class, TestRequest.class)
-                                     .addAsResource(new StringAsset(
-                                                     "<ejb-jar version=\"3.0\" "
-                                                             + "metadata-complete=\"true\"></ejb-jar>"),
-                                             "META-INF/ejb-jar.xml");
+                                     .addClasses(TestBean.class, TestRequest.class)
+                                     .addAsResource(TestResource.class.getResource("beans.xml"), "WEB-INF/beans.xml");
         JavaArchive common = ShrinkWrap.create(JavaArchive.class, "common.jar").addClass(TestResponse.class);
         return ShrinkWrap.create(EnterpriseArchive.class, PARENT_DEPLOYMENT_NAME)
                          .addAsModules(jaxrs, core)
                          .addAsManifestResource(
-                                 TestEjb.class.getResource("application.xml"),
+                                 TestBean.class.getResource("application.xml"),
                                  "application.xml")
                          .addAsLibraries(common);
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestBean.java
@@ -16,13 +16,13 @@
 
 package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
 
-import jakarta.ejb.Stateless;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * @author Joachim Grimm
  */
-@Stateless
-public class TestEjb {
+@ApplicationScoped
+public class TestBean {
 
     public TestResponse hello(TestRequest request) {
         TestResponse testResponse = new TestResponse();

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestResource.java
@@ -43,7 +43,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 public class TestResource {
 
     @Inject
-    private TestEjb testEjb;
+    private TestBean testEjb;
 
     @POST
     @Operation(summary = "Test the indexing of multi module deployments")

--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/common/WorkRestATResource.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/common/WorkRestATResource.java
@@ -49,7 +49,7 @@ import org.jboss.jbossts.star.util.TxStatusMediaType;
 import org.jboss.jbossts.star.util.TxSupport;
 
 @Path(WorkRestATResource.PATH_SEGMENT)
-public final class WorkRestATResource {
+public class WorkRestATResource {
 
     public static final String PATH_SEGMENT = "txresource";
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BeanDefiningAnnotationProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BeanDefiningAnnotationProcessor.java
@@ -34,6 +34,10 @@ public class BeanDefiningAnnotationProcessor implements DeploymentUnitProcessor 
 
     private static final DotName VIEW_SCOPED_NAME = DotName.createSimple("javax.faces.view.ViewScoped");
     private static final DotName FLOW_SCOPED_NAME = DotName.createSimple("javax.faces.flow.FlowScoped");
+    // Jakarta REST annotations
+    private static final DotName PROVIDER = DotName.createSimple("javax.ws.rs.ext.Provider");
+    private static final DotName APPLICATION_PATH = DotName.createSimple("javax.ws.rs.ApplicationPath");
+    private static final DotName PATH = DotName.createSimple("javax.ws.rs.Path");
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
@@ -52,6 +56,15 @@ public class BeanDefiningAnnotationProcessor implements DeploymentUnitProcessor 
         addAnnotation(deploymentUnit, new AnnotationType(TransactionScoped.class));
         addAnnotation(deploymentUnit, new AnnotationType(VIEW_SCOPED_NAME, true));
         addAnnotation(deploymentUnit, new AnnotationType(FLOW_SCOPED_NAME, true));
+        // Per section 11.2.3 of the Jakarta REST 3.1 specification:
+        // In a product that supports CDI, implementations MUST support the use of CDI-style Beans as root resource
+        // classes, providers and Application subclasses. Providers and Application subclasses MUST be singletons or
+        // use application scope.
+        // Currently, these are not specified as @Stereotype annotations with a default scope. In a later spec this may
+        // happen, in which case these can be removed.
+        addAnnotation(deploymentUnit, new AnnotationType(PROVIDER, false));
+        addAnnotation(deploymentUnit, new AnnotationType(APPLICATION_PATH, false));
+        addAnnotation(deploymentUnit, new AnnotationType(PATH, false));
 
         for (AnnotationType annotationType : CdiAnnotations.BEAN_DEFINING_META_ANNOTATIONS) {
             addAnnotations(deploymentUnit, getAnnotationsAnnotatedWith(index, annotationType.getName()));


### PR DESCRIPTION
…ations as bean defining annotations.

https://issues.redhat.com/browse/WFLY-16545

Note the some what of a revert back to an empty `beans.xml` for these tests as `@ApplicationScoped` was added to the `CDIBean`. This was the requirement for the `bean-discovery-mode="all"`. However, by defining the scope on the bean that resolves the bean discovery issue.