### PR TITLE
WFLY-16548 Upgrade smallrye-fault-tolerance to 5.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.12.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>2.10.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>5.4.0</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>5.4.1</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>3.2.1</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>3.0.4</version.io.smallrye.smallrye-metrics>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16548