### PR TITLE
[WFLY-14375] Upgrade Apache DS to version AM26

### DIFF
--- a/ee-9/source-transform/shared/pom.xml
+++ b/ee-9/source-transform/shared/pom.xml
@@ -128,9 +128,10 @@
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-all</artifactId>
+            <artifactId>apacheds-test-framework</artifactId>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <version.org.apache.avro>1.11.0</version.org.apache.avro>
         <version.org.apache.cxf>3.5.2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.3.1</version.org.apache.cxf.xjcplugins>
-        <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
+        <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.7</version.org.apache.james.apache-mime4j>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
@@ -4674,7 +4674,14 @@
 
             <dependency>
                 <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-all</artifactId>
+                <artifactId>apacheds-test-framework</artifactId>
+                <version>${version.org.apache.ds}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-interceptor-kerberos</artifactId>
                 <version>${version.org.apache.ds}</version>
                 <scope>test</scope>
             </dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -41,7 +41,7 @@
         <bootable-jar-copy-module-files.phase>none</bootable-jar-copy-module-files.phase>
         <!-- Disable the default surefire test execution. -->
         <surefire.default-test.phase>none</surefire.default-test.phase>
-        <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.base/sun.security.validator=ALL-UNNAMED</modular.jdk.testsuite.args>
+        <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.base/sun.security.validator=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED</modular.jdk.testsuite.args>
     </properties>
 
     <dependencies>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/Policy.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/Policy.java
@@ -24,11 +24,10 @@ import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.wildfly.test.security.common.elytron.AbstractConfigurableElement;
-
-import net.sf.ehcache.config.generator.model.elements.ConfigurationElement;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
 /**
- * A {@link ConfigurationElement} to add a policy definition to the Elytron subsystem.
+ * A {@link ConfigurableElement} to add a policy definition to the Elytron subsystem.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -89,9 +88,9 @@ class Policy extends AbstractConfigurableElement {
         }
 
         /**
-         * Build a new Policy {@link ConfigurationElement}
+         * Build a new Policy {@link ConfigurableElement}
          *
-         * @return a new Policy {@link ConfigurationElement}
+         * @return a new Policy {@link ConfigurableElement}
          */
         public Policy build() {
             return new Policy(this);

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -160,7 +160,7 @@
         <surefire.memory.args>-Xmx512m -XX:MetaspaceSize=128m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
-        <modular.jdk.testsuite.args>${modular.jdk.args}</modular.jdk.testsuite.args>
+        <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED</modular.jdk.testsuite.args>
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />
         <!-- needed for arquillian-byteman-extension -->

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -112,9 +112,16 @@
 
         <dependency>
             <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-all</artifactId>
+            <artifactId>apacheds-test-framework</artifactId>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-interceptor-kerberos</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/ldap/InMemoryDirectoryServiceFactory.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/ldap/InMemoryDirectoryServiceFactory.java
@@ -24,20 +24,9 @@ package org.jboss.as.test.integration.ldap;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
-
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.config.CacheConfiguration;
-import net.sf.ehcache.config.Configuration;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.directory.api.ldap.codec.api.LdapApiService;
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;
-import org.apache.directory.api.ldap.model.csn.Csn;
-import org.apache.directory.api.ldap.model.entry.Entry;
-import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.api.ldap.model.ldif.LdifEntry;
-import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.LdapComparator;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.api.ldap.model.schema.comparators.NormalizingComparator;
@@ -45,34 +34,14 @@ import org.apache.directory.api.ldap.model.schema.registries.ComparatorRegistry;
 import org.apache.directory.api.ldap.model.schema.registries.SchemaLoader;
 import org.apache.directory.api.ldap.schema.loader.JarLdifSchemaLoader;
 import org.apache.directory.api.ldap.schema.manager.impl.DefaultSchemaManager;
-import org.apache.directory.api.ldap.util.tree.DnNode;
 import org.apache.directory.api.util.exception.Exceptions;
 import org.apache.directory.server.constants.ServerDNConstants;
 import org.apache.directory.server.core.DefaultDirectoryService;
-import org.apache.directory.server.core.api.AttributeTypeProvider;
-import org.apache.directory.server.core.api.CacheService;
-import org.apache.directory.server.core.api.CoreSession;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.DnFactory;
 import org.apache.directory.server.core.api.InstanceLayout;
-import org.apache.directory.server.core.api.LdapPrincipal;
-import org.apache.directory.server.core.api.ObjectClassProvider;
-import org.apache.directory.server.core.api.OperationEnum;
-import org.apache.directory.server.core.api.OperationManager;
-import org.apache.directory.server.core.api.ReferralManager;
-import org.apache.directory.server.core.api.administrative.AccessControlAdministrativePoint;
-import org.apache.directory.server.core.api.administrative.CollectiveAttributeAdministrativePoint;
-import org.apache.directory.server.core.api.administrative.SubschemaAdministrativePoint;
-import org.apache.directory.server.core.api.administrative.TriggerExecutionAdministrativePoint;
-import org.apache.directory.server.core.api.changelog.ChangeLog;
-import org.apache.directory.server.core.api.event.EventService;
-import org.apache.directory.server.core.api.interceptor.Interceptor;
-import org.apache.directory.server.core.api.journal.Journal;
 import org.apache.directory.server.core.api.partition.Partition;
-import org.apache.directory.server.core.api.partition.PartitionNexus;
 import org.apache.directory.server.core.api.schema.SchemaPartition;
-import org.apache.directory.server.core.api.subtree.SubentryCache;
-import org.apache.directory.server.core.api.subtree.SubtreeEvaluator;
 import org.apache.directory.server.core.factory.AvlPartitionFactory;
 import org.apache.directory.server.core.factory.DirectoryServiceFactory;
 import org.apache.directory.server.core.factory.PartitionFactory;
@@ -94,7 +63,6 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
 
     private final DirectoryService directoryService;
     private final PartitionFactory partitionFactory;
-    private CacheManager cacheManager;
 
     /**
      * Default constructor which creates {@link DefaultDirectoryService} instance and configures {@link AvlPartitionFactory} as
@@ -145,18 +113,6 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
         }
         directoryService.setInstanceLayout(instanceLayout);
 
-        // EhCache in disabled-like-mode
-        String cacheName = "ApacheDSTestCache-" +  id;
-        Configuration ehCacheConfig = new Configuration();
-        ehCacheConfig.setName(cacheName);
-        CacheConfiguration defaultCache = new CacheConfiguration(cacheName, 1).eternal(false).timeToIdleSeconds(30)
-                .timeToLiveSeconds(30).overflowToDisk(false);
-        ehCacheConfig.addDefaultCache(defaultCache);
-        cacheManager = new CacheManager(ehCacheConfig);
-        CacheService cacheService = new CacheService(cacheManager);
-
-        directoryService.setCacheService(cacheService);
-
         // Init the schema
         // SchemaLoader loader = new SingleLdifSchemaLoader();
         SchemaLoader loader = new JarLdifSchemaLoader();
@@ -179,7 +135,7 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
             throw new Exception(I18n.err(I18n.ERR_317, Exceptions.printErrors(errors)));
         }
 
-        DnFactory dnFactory = new DefaultDnFactory( schemaManager, cacheService.getCache( "dnCache" ) );
+        DnFactory dnFactory = new DefaultDnFactory(schemaManager, 1024);
         // Init system partition
         Partition systemPartition = partitionFactory.createPartition(directoryService.getSchemaManager(), dnFactory, "system",
                 ServerDNConstants.SYSTEM_DN, 500, new File(directoryService.getInstanceLayout().getPartitionsDirectory(),
@@ -196,7 +152,7 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
      */
     @Override
     public DirectoryService getDirectoryService() throws Exception {
-        return cacheManager != null ? new WrapperDirectoryService(directoryService, cacheManager) : directoryService;
+        return directoryService;
     }
 
     /**
@@ -206,422 +162,4 @@ public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory 
     public PartitionFactory getPartitionFactory() throws Exception {
         return partitionFactory;
     }
-
-    /**
-     * Delegating DirectoryService which ensure cacheManager shutdown on DirectoryService shutdown.
-     */
-    private class WrapperDirectoryService implements DirectoryService {
-
-        private final DirectoryService wrapped;
-        private final CacheManager cacheManager;
-
-        private WrapperDirectoryService(DirectoryService wrapped, CacheManager cacheManager) {
-            this.wrapped = wrapped;
-            this.cacheManager = cacheManager;
-        }
-
-        @Override
-        public Entry newEntry(Dn dn) throws LdapException {
-            return wrapped.newEntry(dn);
-        }
-
-        @Override
-        public long revert(long revision) throws LdapException {
-            return wrapped.revert(revision);
-        }
-
-        @Override
-        public long revert() throws LdapException {
-            return wrapped.revert();
-        }
-
-        @Override
-        public PartitionNexus getPartitionNexus() {
-            return wrapped.getPartitionNexus();
-        }
-
-        @Override
-        public void addPartition(Partition partition) throws Exception {
-            wrapped.addPartition(partition);
-        }
-
-        @Override
-        public void removePartition(Partition partition) throws Exception {
-            wrapped.removePartition(partition);
-        }
-
-        @Override
-        public SchemaManager getSchemaManager() {
-            return wrapped.getSchemaManager();
-        }
-
-        @Override
-        public LdapApiService getLdapCodecService() {
-            return wrapped.getLdapCodecService();
-        }
-
-        @Override
-        public ReferralManager getReferralManager() {
-            return wrapped.getReferralManager();
-        }
-
-        @Override
-        public void setReferralManager(ReferralManager referralManager) {
-            wrapped.setReferralManager(referralManager);
-        }
-
-        @Override
-        public SchemaPartition getSchemaPartition() {
-            return wrapped.getSchemaPartition();
-        }
-
-        @Override
-        public void setSchemaPartition(SchemaPartition schemaPartition) {
-            wrapped.setSchemaPartition(schemaPartition);
-        }
-
-        @Override
-        public EventService getEventService() {
-            return wrapped.getEventService();
-        }
-
-        @Override
-        public void setEventService(EventService eventService) {
-            wrapped.setEventService(eventService);
-        }
-
-        @Override
-        public void startup() throws Exception {
-            wrapped.startup();
-        }
-
-        @Override
-        public void shutdown() throws Exception {
-            wrapped.shutdown();
-            cacheManager.shutdown();
-        }
-
-        @Override
-        public void sync() throws Exception {
-            wrapped.sync();
-        }
-
-        @Override
-        public boolean isStarted() {
-            return wrapped.isStarted();
-        }
-
-        @Override
-        public CoreSession getAdminSession() {
-            return wrapped.getAdminSession();
-        }
-
-        @Override
-        public SubentryCache getSubentryCache() {
-            return wrapped.getSubentryCache();
-        }
-
-        @Override
-        public SubtreeEvaluator getEvaluator() {
-            return wrapped.getEvaluator();
-        }
-
-        @Override
-        public CoreSession getSession() throws Exception {
-            return wrapped.getSession();
-        }
-
-        @Override
-        public CoreSession getSession(LdapPrincipal principal) throws Exception {
-            return wrapped.getSession(principal);
-        }
-
-        @Override
-        public CoreSession getSession(Dn principalDn, byte[] credentials) throws LdapException {
-            return wrapped.getSession(principalDn, credentials);
-        }
-
-        @Override
-        public CoreSession getSession(Dn principalDn, byte[] credentials, String saslMechanism, String saslAuthId) throws Exception {
-            return wrapped.getSession(principalDn, credentials, saslMechanism, saslAuthId);
-        }
-
-        @Override
-        public void setInstanceId(String instanceId) {
-            wrapped.setInstanceId(instanceId);
-        }
-
-        @Override
-        public String getInstanceId() {
-            return wrapped.getInstanceId();
-        }
-
-        @Override
-        public Set<? extends Partition> getPartitions() {
-            return wrapped.getPartitions();
-        }
-
-        @Override
-        public void setPartitions(Set<? extends Partition> partitions) {
-            wrapped.setPartitions(partitions);
-        }
-
-        @Override
-        public boolean isAccessControlEnabled() {
-            return wrapped.isAccessControlEnabled();
-        }
-
-        @Override
-        public void setAccessControlEnabled(boolean accessControlEnabled) {
-            wrapped.setAccessControlEnabled(accessControlEnabled);
-        }
-
-        @Override
-        public boolean isAllowAnonymousAccess() {
-            return wrapped.isAllowAnonymousAccess();
-        }
-
-        @Override
-        public boolean isPasswordHidden() {
-            return wrapped.isPasswordHidden();
-        }
-
-        @Override
-        public void setPasswordHidden(boolean passwordHidden) {
-            wrapped.setPasswordHidden(passwordHidden);
-        }
-
-        @Override
-        public void setAllowAnonymousAccess(boolean enableAnonymousAccess) {
-            wrapped.setAllowAnonymousAccess(enableAnonymousAccess);
-        }
-
-        @Override
-        public List<Interceptor> getInterceptors() {
-            return wrapped.getInterceptors();
-        }
-
-        @Override
-        public List<String> getInterceptors(OperationEnum operation) {
-            return wrapped.getInterceptors(operation);
-        }
-
-        @Override
-        public void setInterceptors(List<Interceptor> interceptors) {
-            wrapped.setInterceptors(interceptors);
-        }
-
-        @Override
-        public void addFirst(Interceptor interceptor) throws LdapException {
-            wrapped.addFirst(interceptor);
-        }
-
-        @Override
-        public void addLast(Interceptor interceptor) throws LdapException {
-            wrapped.addLast(interceptor);
-        }
-
-        @Override
-        public void addAfter(String interceptorName, Interceptor interceptor) {
-            wrapped.addAfter(interceptorName, interceptor);
-        }
-
-        @Override
-        public void remove(String interceptorName) {
-            wrapped.remove(interceptorName);
-        }
-
-        @Override
-        public void setJournal(Journal journal) {
-            wrapped.setJournal(journal);
-        }
-
-        @Override
-        public List<LdifEntry> getTestEntries() {
-            return wrapped.getTestEntries();
-        }
-
-        @Override
-        public void setTestEntries(List<? extends LdifEntry> testEntries) {
-            wrapped.setTestEntries(testEntries);
-        }
-
-        @Override
-        public InstanceLayout getInstanceLayout() {
-            return wrapped.getInstanceLayout();
-        }
-
-        @Override
-        public void setInstanceLayout(InstanceLayout instanceLayout) throws IOException {
-            wrapped.setInstanceLayout(instanceLayout);
-        }
-
-        @Override
-        public void setShutdownHookEnabled(boolean shutdownHookEnabled) {
-            wrapped.setShutdownHookEnabled(shutdownHookEnabled);
-        }
-
-        @Override
-        public boolean isShutdownHookEnabled() {
-            return wrapped.isShutdownHookEnabled();
-        }
-
-        @Override
-        public void setExitVmOnShutdown(boolean exitVmOnShutdown) {
-            wrapped.setExitVmOnShutdown(exitVmOnShutdown);
-        }
-
-        @Override
-        public boolean isExitVmOnShutdown() {
-            return wrapped.isExitVmOnShutdown();
-        }
-
-
-        @Override
-        public void setSystemPartition(Partition systemPartition) {
-            wrapped.setSystemPartition(systemPartition);
-        }
-
-        @Override
-        public Partition getSystemPartition() {
-            return wrapped.getSystemPartition();
-        }
-
-        @Override
-        public boolean isDenormalizeOpAttrsEnabled() {
-            return wrapped.isDenormalizeOpAttrsEnabled();
-        }
-
-        @Override
-        public void setDenormalizeOpAttrsEnabled(boolean denormalizeOpAttrsEnabled) {
-            wrapped.setDenormalizeOpAttrsEnabled(denormalizeOpAttrsEnabled);
-        }
-
-        @Override
-        public ChangeLog getChangeLog() {
-            return wrapped.getChangeLog();
-        }
-
-        @Override
-        public Journal getJournal() {
-            return wrapped.getJournal();
-        }
-
-        @Override
-        public void setChangeLog(ChangeLog changeLog) {
-            wrapped.setChangeLog(changeLog);
-        }
-
-        @Override
-        public Entry newEntry(String ldif, String dn) {
-            return wrapped.newEntry(ldif, dn);
-        }
-
-        @Override
-        public OperationManager getOperationManager() {
-            return wrapped.getOperationManager();
-        }
-
-        @Override
-        public int getMaxPDUSize() {
-            return wrapped.getMaxPDUSize();
-        }
-
-        @Override
-        public void setMaxPDUSize(int maxPDUSize) {
-            wrapped.setMaxPDUSize(maxPDUSize);
-        }
-
-        @Override
-        public Interceptor getInterceptor(String interceptorName) {
-            return wrapped.getInterceptor(interceptorName);
-        }
-
-        @Override
-        public Csn getCSN() {
-            return wrapped.getCSN();
-        }
-
-        @Override
-        public int getReplicaId() {
-            return wrapped.getReplicaId();
-        }
-
-        @Override
-        public void setReplicaId(int replicaId) {
-            wrapped.setReplicaId(replicaId);
-        }
-
-        @Override
-        public void setSchemaManager(SchemaManager schemaManager) {
-            wrapped.setSchemaManager(schemaManager);
-        }
-
-        @Override
-        public void setSyncPeriodMillis(long syncPeriodMillis) {
-            wrapped.setSyncPeriodMillis(syncPeriodMillis);
-        }
-
-        @Override
-        public long getSyncPeriodMillis() {
-            return wrapped.getSyncPeriodMillis();
-        }
-
-        @Override
-        public CacheService getCacheService() {
-            return wrapped.getCacheService();
-        }
-
-        @Override
-        public DnNode<AccessControlAdministrativePoint> getAccessControlAPCache() {
-            return wrapped.getAccessControlAPCache();
-        }
-
-        @Override
-        public DnNode<CollectiveAttributeAdministrativePoint> getCollectiveAttributeAPCache() {
-            return wrapped.getCollectiveAttributeAPCache();
-        }
-
-        @Override
-        public DnNode<SubschemaAdministrativePoint> getSubschemaAPCache() {
-            return wrapped.getSubschemaAPCache();
-        }
-
-        @Override
-        public DnNode<TriggerExecutionAdministrativePoint> getTriggerExecutionAPCache() {
-            return wrapped.getTriggerExecutionAPCache();
-        }
-
-        @Override
-        public boolean isPwdPolicyEnabled() {
-            return wrapped.isPwdPolicyEnabled();
-        }
-
-        @Override
-        public DnFactory getDnFactory() {
-            return wrapped.getDnFactory();
-        }
-
-        @Override
-        public void setCacheService(CacheService cacheService) {
-            wrapped.setCacheService(cacheService);
-        }
-
-        @Override
-        public AttributeTypeProvider getAtProvider() {
-            return wrapped.getAtProvider();
-        }
-
-        @Override
-        public ObjectClassProvider getOcProvider() {
-            return wrapped.getOcProvider();
-        }
-
-        @Override
-        public void setDnFactory(DnFactory dnFactory) {
-            wrapped.setDnFactory(dnFactory);
-        }
-
-    }
-
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/ldap/InMemorySchemaPartition.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/ldap/InMemorySchemaPartition.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.ldap;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 import java.util.TreeSet;
@@ -30,12 +31,14 @@ import java.util.regex.Pattern;
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.api.ldap.schema.extractor.impl.DefaultSchemaLdifExtractor;
 import org.apache.directory.api.ldap.schema.extractor.impl.ResourceMap;
 import org.apache.directory.server.core.api.interceptor.context.AddOperationContext;
+import org.apache.directory.server.core.api.partition.PartitionTxn;
 import org.apache.directory.server.core.partition.ldif.AbstractLdifPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,34 +68,41 @@ public class InMemorySchemaPartition extends AbstractLdifPartition {
      * @see org.apache.directory.server.core.partition.impl.avl.AvlPartition#doInit()
      */
     @Override
-    protected void doInit() throws Exception {
+    protected void doInit() throws LdapException {
         if (initialized)
             return;
 
         LOG.debug("Initializing schema partition " + getId());
-        suffixDn.apply(schemaManager);
         super.doInit();
 
-        // load schema
-        final Map<String, Boolean> resMap = ResourceMap.getResources(Pattern.compile("schema[/\\Q\\\\E]ou=schema.*"));
-        for (String resourcePath : new TreeSet<String>(resMap.keySet())) {
-            if (resourcePath.endsWith(".ldif")) {
-                URL resource = DefaultSchemaLdifExtractor.getUniqueResource(resourcePath, "Schema LDIF file");
-                LdifReader reader = new LdifReader(resource.openStream());
-                LdifEntry ldifEntry = reader.next();
-                reader.close();
+        try {
+            // load schema
+            final Map<String, Boolean> resMap = ResourceMap.getResources(Pattern.compile("schema[/\\Q\\\\E]ou=schema.*"));
+            for (String resourcePath : new TreeSet<String>(resMap.keySet())) {
+                if (resourcePath.endsWith(".ldif")) {
+                    URL resource = DefaultSchemaLdifExtractor.getUniqueResource(resourcePath, "Schema LDIF file");
+                    LdifReader reader = new LdifReader(resource.openStream());
+                    LdifEntry ldifEntry = reader.next();
+                    reader.close();
 
-                Entry entry = new DefaultEntry(schemaManager, ldifEntry.getEntry());
-                // add mandatory attributes
-                if (entry.get(SchemaConstants.ENTRY_CSN_AT) == null) {
-                    entry.add(SchemaConstants.ENTRY_CSN_AT, defaultCSNFactory.newInstance().toString());
+                    Entry entry = new DefaultEntry(schemaManager, ldifEntry.getEntry());
+                    // add mandatory attributes
+                    if (entry.get(SchemaConstants.ENTRY_CSN_AT) == null) {
+                        entry.add(SchemaConstants.ENTRY_CSN_AT, defaultCSNFactory.newInstance().toString());
+                    }
+                    if (entry.get(SchemaConstants.ENTRY_UUID_AT) == null) {
+                        entry.add(SchemaConstants.ENTRY_UUID_AT, UUID.randomUUID().toString());
+                    }
+                    AddOperationContext addContext = new AddOperationContext(null, entry);
+                    try (PartitionTxn partitionTxn = this.beginWriteTransaction()) {
+                        addContext.setPartition(this);
+                        addContext.setTransaction(partitionTxn);
+                        super.add(addContext);
+                    }
                 }
-                if (entry.get(SchemaConstants.ENTRY_UUID_AT) == null) {
-                    entry.add(SchemaConstants.ENTRY_UUID_AT, UUID.randomUUID().toString());
-                }
-                AddOperationContext addContext = new AddOperationContext(null, entry);
-                super.add(addContext);
             }
+        } catch (IOException e) {
+            throw new LdapException(e);
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/ManagedCreateTransport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/ManagedCreateTransport.java
@@ -49,6 +49,8 @@ public class ManagedCreateTransport extends AnnotationLiteral<CreateTransport> i
     private boolean ssl;
     /** The number of threads to use. Default to 3 */
     private int nbThreads;
+    /** A flag to tell if the transport should ask for client certificate. Default to false */
+    private boolean clientAuth;
 
     // Constructors ----------------------------------------------------------
 
@@ -65,6 +67,7 @@ public class ManagedCreateTransport extends AnnotationLiteral<CreateTransport> i
         backlog = original.backlog();
         ssl = original.ssl();
         nbThreads = original.nbThreads();
+        clientAuth = original.clientAuth();
     }
 
     // Public methods --------------------------------------------------------
@@ -132,6 +135,11 @@ public class ManagedCreateTransport extends AnnotationLiteral<CreateTransport> i
         return nbThreads;
     }
 
+    @Override
+    public boolean clientAuth() {
+        return clientAuth;
+    }
+
     /**
      * Set the protocol.
      *
@@ -193,5 +201,9 @@ public class ManagedCreateTransport extends AnnotationLiteral<CreateTransport> i
      */
     public void setNbThreads(int nbThreads) {
         this.nbThreads = nbThreads;
+    }
+
+    public void setClientAuth(boolean clientAuth) {
+        this.clientAuth = clientAuth;
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14375

The upgrade needs the following:

* The dependency now is `apacheds-test-framework` and `apacheds-interceptor-kerberos` is also required for the tests that need the kerberos interceptor.
* Two new opens are added for jdk-17.
* Some changes in test classes to accommodate to the new API (eh-cache is not used anymore for example).
* I think that the modifications in `Policy.java` just fix a mistake, a eh-cache class was included for javadoc instead of the elytron one.