### PR TITLE
[WFLY-16527] Faces 4 fails if CDI isn't enabled for the deployment

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jsf/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jsf/layer-spec.xml
@@ -2,7 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jsf">
     <dependencies>
         <layer name="web-server"/>
-        <layer name="cdi" optional="true"/>
+        <layer name="cdi"/>
         <layer name="bean-validation" optional="true"/>
     </dependencies>
     <feature spec="subsystem.jsf"/>

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
@@ -21,12 +21,9 @@
  */
 package org.jboss.as.jsf.deployment;
 
-import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.structure.DeploymentType;
 import org.jboss.as.ee.structure.DeploymentTypeMarker;
 import org.jboss.as.jsf.logging.JSFLogger;
@@ -38,7 +35,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.web.common.WarMetaData;
-import org.jboss.as.weld.WeldCapability;
 import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
@@ -162,7 +158,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
                 .getClassLoader().getResource(JAVAX_FACES_EVENT_NAMEDEVENT_class) == null);
     }
 
-    // Add a flag to the sevlet context so that we know if we need to instantiate
+    // Add a flag to the servlet context so that we know if we need to instantiate
     // a Jakarta Contexts and Dependency Injection ViewHandler.
     private void addCDIFlag(WarMetaData warMetaData, DeploymentUnit deploymentUnit) {
         JBossWebMetaData webMetaData = warMetaData.getMergedJBossWebMetaData();
@@ -176,16 +172,9 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
             contextParams = new ArrayList<ParamValueMetaData>();
         }
 
-        boolean isCDI = false;
-        final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-        if (support.hasCapability(WELD_CAPABILITY_NAME)) {
-            isCDI = support.getOptionalCapabilityRuntimeAPI(WELD_CAPABILITY_NAME, WeldCapability.class).get()
-                    .isPartOfWeldDeployment(deploymentUnit);
-        }
-
         ParamValueMetaData param = new ParamValueMetaData();
         param.setParamName(IS_CDI_PARAM);
-        param.setParamValue(Boolean.toString(isCDI));
+        param.setParamValue("true");
         contextParams.add(param);
 
         webMetaData.setContextParams(contextParams);

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/subsystem/JSFResourceDefinition.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/subsystem/JSFResourceDefinition.java
@@ -18,19 +18,22 @@
  */
 package org.jboss.as.jsf.subsystem;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.weld.Capabilities;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Defines attributes and operations for the Jakarta Server Faces Subsystem
@@ -42,6 +45,9 @@ public class JSFResourceDefinition extends PersistentResourceDefinition {
     public static final String DEFAULT_SLOT_ATTR_NAME = "default-jsf-impl-slot";
     public static final String DISALLOW_DOCTYPE_DECL_ATTR_NAME = "disallow-doctype-decl";
     public static final String DEFAULT_SLOT = "main";
+    private static final RuntimeCapability<Void> FACES_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.faces")
+            .addRequirements(Capabilities.WELD_CAPABILITY_NAME)
+            .build();
 
     public static final JSFResourceDefinition INSTANCE = new JSFResourceDefinition();
 
@@ -60,10 +66,11 @@ public class JSFResourceDefinition extends PersistentResourceDefinition {
                     .build();
 
     private JSFResourceDefinition() {
-        super(JSFExtension.PATH_SUBSYSTEM,
-                JSFExtension.getResourceDescriptionResolver(),
-                JSFSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(JSFExtension.PATH_SUBSYSTEM, JSFExtension.getResourceDescriptionResolver())
+                .setAddHandler(JSFSubsystemAdd.INSTANCE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(FACES_CAPABILITY)
+        );
     }
 
     @Override

--- a/jsf/subsystem/src/test/java/org/jboss/as/jsf/subsystem/JSFSubsystemTestCase.java
+++ b/jsf/subsystem/src/test/java/org/jboss/as/jsf/subsystem/JSFSubsystemTestCase.java
@@ -24,13 +24,14 @@ package org.jboss.as.jsf.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  *
@@ -55,7 +56,7 @@ public class JSFSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testAttributes() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(null)
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXml(getSubsystemXml());
         KernelServices kernelServices = builder.build();
         ModelNode rootModel = kernelServices.readWholeModel();

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -3541,7 +3541,6 @@
                                         <exclude>org/jboss/as/test/integration/jsf/beanvalidation/cdi/BeanValidationCdiIntegrationTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jsf/doctype/DoctypeDeclTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jsf/jsf23/JSF23SanityTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jsf/testurl/ForbiddenUrlTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/deploy/runtime/JaxrsRuntimeNameTestCase.java</exclude><!-- test expects javax strings in mgmt api responses -->
                                         <exclude>org/jboss/as/test/integration/weld/ejb/SessionObjectReferenceTestCase.java</exclude>
                                         <exclude>org/wildfly/test/integration/web/annotationsmodule/EarModuleDeploymentTestCase.java</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/ForbiddenUrlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/ForbiddenUrlTestCase.java
@@ -23,9 +23,12 @@
 /**
  * UnallowedUrlTestCase
  * For more information visit <a href="https://issues.redhat.com/browse/WFLY-13439">https://issues.redhat.com/browse/WFLY-13439</a>
+ *
  * @author Petr Adamec
  */
 package org.jboss.as.test.integration.jsf.testurl;
+
+import java.net.URL;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -36,14 +39,13 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 /**
  * Test if 404 is returned for url address which isn't allowed
@@ -73,18 +75,20 @@ public class ForbiddenUrlTestCase {
     /**
      * Test if 200 is returned for allowed url
      * <br /> For more information see https://issues.redhat.com/browse/WFLY-13439.
+     *
      * @throws Exception
      */
     @Test
     public void testAllowedUrl() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
-            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + ALLOWED_URL);
+            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + jakartafiUrl(ALLOWED_URL));
             try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
                 int statusCode = getVarResponse.getStatusLine().getStatusCode();
-                Assert.assertEquals("Status code should be " + ALLOWED_STATUS_CODE + ", but is " + statusCode + ". For more information see JBEAP-18842. ", ALLOWED_STATUS_CODE, statusCode);
+                Assert.assertEquals("Status code should be " + ALLOWED_STATUS_CODE + ", but is " + statusCode +
+                        ". For more information see JBEAP-18842. ", ALLOWED_STATUS_CODE, statusCode);
             }
         }
     }
@@ -92,19 +96,40 @@ public class ForbiddenUrlTestCase {
     /**
      * Test id 404 is returned fot forbidden url.
      * <br /> For more information see https://issues.redhat.com/browse/WFLY-13439
+     *
      * @throws Exception
      */
     @Test
     public void testForbiddenUrl() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
-            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + FORBIDDEN_URL);
+            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + jakartafiUrl(FORBIDDEN_URL));
             try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
                 int statusCode = getVarResponse.getStatusLine().getStatusCode();
-                Assert.assertEquals("Status code should be " + FORBIDDEN_STATUS_CODE + ", but is " + statusCode + ". For more information see JBEAP-18842. ", FORBIDDEN_STATUS_CODE, statusCode);
+                Assert.assertEquals("Status code should be " + FORBIDDEN_STATUS_CODE + ", but is " + statusCode +
+                        ". For more information see JBEAP-18842. ", FORBIDDEN_STATUS_CODE, statusCode);
             }
+        }
+    }
+
+    /**
+     * TODO: Temporary hack
+     * EE 9 changes the namespace from javax.* to jakarta.*. Running these tests under EE 9 or later, as WildFly Preview does, will
+     * cause the tests to fail, since they're using the old namespace in strings. This method will alter the URLs if it can detect
+     * that the tests are running under EE 9 or later. Once WildFly switches completely to EE 10, this hack can be removed, and the
+     * strings updated appropriately.
+     *
+     * @param url
+     * @return
+     */
+    @Deprecated
+    private String jakartafiUrl(String url) {
+        if (AssumeTestGroupUtil.isWildFlyPreview()) {
+            return url.replaceAll("javax", "jakarta");
+        } else {
+            return url;
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
@@ -21,13 +21,14 @@
  */
 package org.jboss.as.test.integration.jsf.version;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.io.FilePermission;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.PropertyPermission;
-
 import javax.faces.context.FacesContext;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -64,13 +65,12 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 
 /**
  * Tests different ways to add Jakarta Server Faces implementation in ear files
- * @author tmiyar
  *
+ * @author tmiyar
  */
 @RunWith(Arquillian.class)
 @ServerSetup({JSFDeploymentProcessorTestCase.TestLogHandlerSetup.class})
@@ -105,6 +105,7 @@ public class JSFDeploymentProcessorTestCase {
     /**
      * Creates a war with all the libraries needed in the war/lib folder, this sample does not call the
      * ejb as it is not necessary to test if the bundled Jakarta Server Faces is loaded
+     *
      * @return
      */
     @Deployment(name = WEB_BUNDLED_JSF, testable = false, managed = false)
@@ -143,6 +144,7 @@ public class JSFDeploymentProcessorTestCase {
 
     /**
      * Creates a war with only the faces-config to indicate it is using Jakarta Server Faces, that way it will load the one provided by Wildfly
+     *
      * @return
      */
     @Deployment(name = WEB_FACES_CONFIG_XML, testable = false)
@@ -176,6 +178,7 @@ public class JSFDeploymentProcessorTestCase {
     /**
      * Facing intermitent problem on myfaces 2.3 documented here https://issues.jboss.org/browse/WELD-1387
      * using myfaces 2.0 instead
+     *
      * @throws Exception
      */
     @Test
@@ -202,17 +205,20 @@ public class JSFDeploymentProcessorTestCase {
     @Test
     public void facesConfigXmlTest() throws Exception {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        try(CloseableHttpClient client = httpClientBuilder.build()) {
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
 
             HttpUriRequest getVarRequest = new HttpGet(facesConfigXml.toExternalForm() + "jsfversion.xhtml");
             try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
                 String text = EntityUtils.toString(getVarResponse.getEntity());
-                String facesVersion = FacesContext.class.getPackage().getSpecificationTitle();
-                Assert.assertTrue("Text should contain ["+ facesVersion+ "] but it contains [" + text + "]", text.contains(facesVersion));
+                Package aPackage = FacesContext.class.getPackage();
+                System.err.println("***** package = " + aPackage);
+                String facesVersion = aPackage.getSpecificationTitle();
+                Assert.assertTrue("Text should contain [" + facesVersion + "] but it contains [" + text + "]", text.contains(facesVersion));
             }
         }
         Assert.assertFalse("Unexpected log message: " + LOG_MESSAGE, LoggingUtil.hasLogMessage(managementClient, TEST_HANDLER_NAME, LOG_MESSAGE));
     }
+
     private static final String TEST_HANDLER_NAME;
     private static final String TEST_LOG_FILE_NAME;
     private static final String LOG_MESSAGE;
@@ -238,10 +244,12 @@ public class JSFDeploymentProcessorTestCase {
         public String getLevel() {
             return "WARN";
         }
+
         @Override
         public String getHandlerName() {
             return TEST_HANDLER_NAME;
         }
+
         @Override
         public String getLogFileName() {
             return TEST_LOG_FILE_NAME;

--- a/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
@@ -19,7 +19,6 @@
 package org.jboss.as.weld;
 
 import java.util.function.Supplier;
-
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 
@@ -101,6 +100,12 @@ public interface WeldCapability {
      * or is a top level deployment that contains sub-deployments that are weld deployments.
      */
     boolean isWeldDeployment(DeploymentUnit unit);
+
+    /**
+     * Registers a deployment as a Weld deployment, even in the absence of spec-compliant configuration files or annotations. After
+     * a call to this method, calls to {@code isWeldDeployment(DeploymentUnit unit)} will return true.
+     */
+    void markAsWeldDeployment(DeploymentUnit unit);
 
     /**
      * Some Maven artifacts come with a precalculated Jandex index file. This is problematic when running in EE9

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
@@ -18,7 +18,6 @@
 package org.jboss.as.weld;
 
 import java.util.function.Supplier;
-
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.InterceptionType;
@@ -72,6 +71,10 @@ public class WeldCapabilityImpl implements WeldCapability {
 
     public boolean isWeldDeployment(final DeploymentUnit unit) {
         return WeldDeploymentMarker.isWeldDeployment(unit);
+    }
+
+    public void markAsWeldDeployment(DeploymentUnit unit) {
+        WeldDeploymentMarker.mark(unit);
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16527

Add check to require CDI for Faces deployments
Add method to WeldCapability to force Weld initialization
Call new method to force CDI init for Faces deployments