### PR TITLE
[WFLY-16415] Exclude transitive openjdk-orb from wildfly-messaging

### DIFF
--- a/legacy/messaging/pom.xml
+++ b/legacy/messaging/pom.xml
@@ -132,6 +132,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging-activemq-subsystem</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.openjdk-orb</groupId>
+                    <artifactId>openjdk-orb</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Build fails with dependency convergence error for the community version of
'org.jboss.openjdk-orb:openjdk-orb' coming from module @wildfly-messaging,
from wildfly-messaging-activemq-subsystem.
Excluding it.

Issue: https://issues.redhat.com/browse/WFLY-16415


