### PR TITLE
[WFLY-16572] Disable the Galleon transformer for the WildFly Preview …

### DIFF
--- a/ee-9/build/pom.xml
+++ b/ee-9/build/pom.xml
@@ -88,7 +88,6 @@
                             <plugin-options>
                                 <jboss-maven-dist/>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
                         </configuration>

--- a/ee-9/dist/pom.xml
+++ b/ee-9/dist/pom.xml
@@ -101,7 +101,6 @@
                             <offline>true</offline>
                             <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <jboss-maven-provisioning-repo>${project.basedir}/../feature-pack/target/jakarta-transform-maven-repo</jboss-maven-provisioning-repo>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>                               
                             </plugin-options>
                             <feature-packs>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -62,9 +62,6 @@
         <module.jakarta.classifier>::jakarta</module.jakarta.classifier>
         <module.jakarta.suffix>-jakarta</module.jakarta.suffix>
         <module.jms.suffix>jakarta</module.jms.suffix>
-
-        <!-- Miscellaneous properties -->
-        <jakarta.transform.verbose>false</jakarta.transform.verbose>
     </properties>
 
     <build>
@@ -478,142 +475,8 @@
                             <release-name>${preview.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <task-properties>
-                                <jakarta.transform.artifacts>true</jakarta.transform.artifacts>
-                                <jakarta.transform.modules>false</jakarta.transform.modules>
-                                <jakarta.transform.artifacts.suffix>-ee9</jakarta.transform.artifacts.suffix>
                                 <product.release.version>${preview.dist.product.release.version}</product.release.version>
                             </task-properties>
-                            <jakarta-transform>true</jakarta-transform>
-                            <!--<jakarta-transform-configs-dir>EXTERNAL_FOLDER</jakarta-transform-configs-dir>-->
-                            <jakarta-transform-verbose>${jakarta.transform.verbose}</jakarta-transform-verbose>
-                            <jakarta-transform-excluded-artifacts>
-                                <!-- Don't transform libs that use javax.servlet to provide side
-                                     functionality (e.g. consoles or similar) that we do not support. -->
-                                <exclude>com.h2database:h2\z</exclude>
-                                <exclude>org.apache.thrift:libthrift\z</exclude>
-                                <exclude>org.jasypt:jasypt\z</exclude>
-                                <!-- Don't transform libraries that use the javax.annotation package but
-                                     not the Jakarta Annotations APIs that share it with other APIs.
-                                     Generally (perhaps always), this is from use of JSR 305 annotations -->
-                                <exclude>com.github.fge:jackson-coreutils\z</exclude>
-                                <exclude>com.github.fge:json-patch\z</exclude>
-                                <exclude>com.github.fge:msg-simple\z</exclude>
-                                <exclude>com.google.guava:guava\z</exclude>
-                                <exclude>com.google.protobuf:protobuf-java-util\z</exclude>
-                                <exclude>com.squareup.okhttp3:okhttp\z</exclude>
-                                <exclude>com.squareup.okio:okio\z</exclude>
-                                <exclude>io.grpc:grpc-api\z</exclude>
-                                <exclude>io.grpc:grpc-context\z</exclude>
-                                <exclude>io.grpc:grpc-protobuf\z</exclude>
-                                <exclude>io.grpc:grpc-okhttp\z</exclude>
-                                <exclude>io.grpc:grpc-core\z</exclude>
-                                <exclude>io.grpc:grpc-protobuf-lite\z</exclude>
-                                <exclude>io.grpc:grpc-stub\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-api\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-context\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-exporter-jaeger\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-exporter-otlp-common\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-exporter-otlp-trace\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-sdk\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-sdk-common\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-sdk-logs\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-sdk-metrics\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-sdk-trace\z</exclude>
-                                <exclude>io.opentelemetry:opentelemetry-semconv\z</exclude>
-                                <exclude>io.perfmark:perfmark-api\z</exclude>
-                                <exclude>io.smallrye:smallrye-open-api-core</exclude>
-                                <exclude>io.smallrye:smallrye-open-api-jaxrs</exclude>
-                                <exclude>io.undertow:undertow-servlet\z</exclude>
-                                <exclude>net.bytebuddy:byte-buddy\z</exclude>
-                                <exclude>net.shibboleth.utilities:java-support\z</exclude>
-                                <exclude>org.opensaml:opensaml-core\z</exclude>
-                                <exclude>org.opensaml:opensaml-profile-api\z</exclude>
-                                <exclude>org.opensaml:opensaml-security-impl\z</exclude>
-                                <exclude>org.opensaml:opensaml-soap-api\z</exclude>
-                                <exclude>org.opensaml:opensaml-saml-api\z</exclude>
-                                <exclude>org.opensaml:opensaml-saml-impl\z</exclude>
-                                <exclude>org.opensaml:opensaml-security-api\z</exclude>
-                                <exclude>org.opensaml:opensaml-xmlsec-api\z</exclude>
-                                <exclude>org.opensaml:opensaml-xmlsec-impl\z</exclude>
-                                <!-- end javax.annotations excludes -->
-                                <!-- Don't transform org.dom4j:dom4j as we don't use its package
-                                     that uses jaxp -->
-                                <exclude>org.dom4j:dom4j\z</exclude>
-                                <!-- Don't transform artifacts only transformed due to data in a
-                                     module-info.class or OSGi attributes in a MANIFEST.MF.
-                                     These things are irrelevant to WildFly's use of artifacts.-->
-                                <exclude>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base\z</exclude>
-                                <exclude>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider\z</exclude>
-                                <exclude>com.fasterxml.jackson.module:jackson-module-jaxb-annotations\z</exclude>
-                                <!-- end JPMS or OSGi metadata excludes -->
-                                <!-- Only contains hard-coded strings that are either not used or both the javax and
-                                jakarta names are used or legacy text files like XSD's or XML configuration files -->
-                                <exclude>jakarta.xml.bind:jakarta.xml.bind-api\z</exclude>
-                                <exclude>org.apache.logging.log4j:log4j-api\z</exclude>
-                                <exclude>org.apache.cxf:cxf-core\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-bindings-xml\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-databinding-jaxb\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-frontend-simple\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-transports-jms\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-transports-http\z</exclude>
-                                <exclude>org.apache.cxf:cxf-rt-ws-rm\z</exclude>
-                                <exclude>org.apache.cxf:cxf-tools-common\z</exclude>
-                                <exclude>org.apache.cxf:cxf-tools-java2ws\z</exclude>
-                                <exclude>org.glassfish.jaxb:jaxb-xjc\z</exclude>
-                                <exclude>org.hibernate.orm:hibernate-core\z</exclude>
-                                <exclude>org.hibernate.orm:hibernate-envers\z</exclude>
-                                <exclude>org.hibernate.search:hibernate-search-mapper-orm-orm6\z</exclude>
-                                <exclude>org.jboss.narayana.xts:jbossxts-jakarta\z</exclude>
-
-                                <!-- Uses JSON only for formatting and uses an internal JSON generator -->
-                                <exlude>org.jboss.logmanager:jboss-logmanager\z</exlude>
-                                <!-- Uses javax JSON internally -->
-                                <exclude>org.wildfly.core:wildfly-event-logger\z</exclude>
-                                <!-- Don't transform Infinispan modules and its dependents -->
-                                <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
-                                <exclude>org.infinispan:.+\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-ee-cache\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-ee-infinispan\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-ee-hotrod\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-infinispan-client-.*\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-infinispan-embedded-.+\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-infinispan-extension\z</exclude>
-                                <exclude>org.wildfly:wildfly-clustering-web-infinispan\z</exclude>
-
-                                <exclude>org.hornetq:.+\z</exclude>
-                                <exclude>org.apache.activemq:artemis-jakarta-client\z</exclude>
-                                <exclude>org.apache.activemq:artemis-jakarta-ra\z</exclude>
-                                <exclude>org.apache.activemq:artemis-jakarta-server\z</exclude>
-                                <exclude>org.apache.activemq:artemis-jakarta-service-extensions\z</exclude>
-                                <exclude>org.apache.activemq:artemis-journal\z</exclude>
-                                <exclude>org.apache.activemq:artemis-jdbc-store\z</exclude>
-                                <exclude>org.apache.activemq:artemis-amqp-protocol\z</exclude>
-                                <exclude>org.apache.activemq:artemis-hornetq-protocol\z</exclude>
-                                <exclude>org.apache.activemq:artemis-stomp-protocol\z</exclude>
-                                <exclude>org.apache.activemq:artemis-hqclient-protocol\z</exclude>
-                                <exclude>org.apache.activemq:artemis-selector\z</exclude>
-                                <exclude>org.apache.activemq:artemis-cli\z</exclude>
-                                <exclude>org.apache.activemq:artemis-commons\z</exclude>
-                                <exclude>org.apache.activemq:artemis-core-client\z</exclude>
-                                <exclude>org.apache.activemq:artemis-dto\z</exclude>
-                                <exclude>org.apache.activemq:artemis-server\z</exclude>
-                                <exclude>org.glassfish:jakarta.json\z</exclude>
-                                <exclude>activemq-artemis-native\z</exclude>
-                                <exclude>org.jboss.activemq.artemis.integration:artemis-wildfly-jakarta-integration\z</exclude>
-
-                                <!-- Depends on javax.json API that it bundles.
-                                   Transformation bound to org.wildfly.security.auth.client.spi.WebServicesClientConfigProviderImpl
-                                   is meaningless, this class is not being used by CLI.
-                                -->
-                                <exclude>org.wildfly.core:wildfly-cli:client\z</exclude>
-
-                                <!-- Issue filed for removal of log4j 1.x, WFCORE-5781. Skipping this may break users
-                                     who use appenders like the SMTPAppender. However, most of the Jakarta EE appenders
-                                     do not work with WildFly. We should ignore the transformation as we'll be removing
-                                     in the near future.
-                                  -->
-                                <exclude>org.jboss.logmanager:log4j-jboss-logmanager\z</exclude>
-                            </jakarta-transform-excluded-artifacts>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -5300,7 +5300,6 @@
                 <!-- No separate web dist -->
                 <wildfly.web.build.output.dir>${wildfly.build.output.dir}</wildfly.web.build.output.dir>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
-                <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
                 <!-- Disable the surefire tests (at least the default ones) for all modules except for
                      those where this profile turns them back on. -->
                 <surefire.default-test.phase>none</surefire.default-test.phase>
@@ -5321,7 +5320,6 @@
             </activation>
             <properties>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
-                <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
                 <!-- Disable the default surefire test execution for all modules except for
                      those where this profile turns them back on. -->
                 <surefire.default-test.phase>none</surefire.default-test.phase>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -312,9 +312,6 @@
                     <name>ts.ee9</name>
                 </property>
             </activation>
-            <properties>
-                <maven.local.repo>${wildfly.transformed.repo.dir}</maven.local.repo>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -330,7 +327,7 @@
                                     <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager ${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>
                                     
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                         
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                         <jboss.home>${project.basedir}/target/wildfly</jboss.home>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -52,7 +52,6 @@
         <wildfly-testsuite-shared.artifactId>wildfly-testsuite-shared-jakarta</wildfly-testsuite-shared.artifactId>
         <!-- No separate web dist -->
         <wildfly.web.build.output.dir>${wildfly.build.output.dir}</wildfly.web.build.output.dir>
-        <wildfly.transformed.repo.dir>${jbossas.project.dir}/ee-9/feature-pack/target/jakarta-transform-maven-repo</wildfly.transformed.repo.dir>
         <!-- WildFly Arquillian Adapter with Jakarta EE Support -->
         <version.org.jboss.arquillian.core>1.7.0.Alpha10</version.org.jboss.arquillian.core>
         <version.org.wildfly.arquillian>5.0.0.Alpha1</version.org.wildfly.arquillian>
@@ -1125,7 +1124,6 @@
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                             </plugin-options>
                             <feature-packs>
                                 <feature-pack>
@@ -1161,7 +1159,6 @@
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                             </plugin-options>
                             <feature-packs>
                                 <feature-pack>
@@ -1788,7 +1785,7 @@
             </activation>
             <properties>
                 <jboss.dist>${project.build.directory}/wildfly</jboss.dist>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -1900,7 +1897,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -1941,7 +1937,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -1982,7 +1977,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2024,7 +2018,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2066,7 +2059,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2112,7 +2104,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2153,7 +2144,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2197,7 +2187,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2238,7 +2227,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2281,7 +2269,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2324,7 +2311,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2368,7 +2354,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2410,7 +2395,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2452,7 +2436,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2494,7 +2477,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2535,7 +2517,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2577,7 +2558,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2618,7 +2598,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -2659,7 +2638,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -3571,7 +3549,7 @@
                 <bootable-jar-maven-jar-plugin.create.modules.phase>process-test-classes</bootable-jar-maven-jar-plugin.create.modules.phase>
                 <bootable-jar-jpa-packaging.phase>process-test-classes</bootable-jar-jpa-packaging.phase>
                 <bootable-jar-cloud-profile-packaging.phase>process-test-classes</bootable-jar-cloud-profile-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -3584,7 +3562,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -3593,7 +3570,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -2183,7 +2183,7 @@
                 <bootable-jar-load-balancer-packaging.phase>process-test-resources</bootable-jar-load-balancer-packaging.phase>
                 <bootable-jar-web-passivation-packaging.phase>process-test-resources</bootable-jar-web-passivation-packaging.phase>
                 <bootable-jar-configure-windows-paths.phase>generate-test-sources</bootable-jar-configure-windows-paths.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -2248,7 +2248,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -2259,7 +2258,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -2270,7 +2268,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -2281,7 +2278,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -151,7 +151,6 @@
                             <offline>true</offline>
                             <plugin-options>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
@@ -385,7 +384,6 @@
                                     <plugin-options>
                                         <jboss-maven-dist/>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                     </plugin-options>
@@ -436,7 +434,7 @@
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
                                 <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is
                                         expected by microprofile-config tests -->
-                                <server.jvm.args>-Dnode0=${node0} -Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                <server.jvm.args>-Dnode0=${node0} -Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -634,7 +632,7 @@
             </dependencies>
             <properties>
                 <bootable-jar-packaging.phase>process-test-resources</bootable-jar-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -690,7 +688,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -934,7 +934,7 @@
                 </property>
             </activation>
             <properties>
-                <maven.local.repo>${wildfly.transformed.repo.dir}</maven.local.repo>
+                <maven.local.repo>${settings.localRepository}</maven.local.repo>
             </properties>
             <build>
                 <plugins>
@@ -944,7 +944,7 @@
                         <version>${version.org.wildfly.plugin}</version>
                         <configuration>
                             <system-properties>
-                                <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
                             </system-properties>
                         </configuration>
                     </plugin>
@@ -977,7 +977,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <!-- These include a module to be used which currently uses javax and is not transformed -->
                                     <excludedGroups>org.jboss.as.test.shared.categories.RequiresTransformedClass</excludedGroups>
@@ -988,7 +988,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir} -Djava.security.properties=${security.properties}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} -Djava.security.properties=${security.properties}</server.jvm.args>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -291,7 +291,7 @@
             </activation>
             <properties>
                 <jboss.dist>${project.build.directory}/wildfly</jboss.dist>
-                <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                <maven.repo.local>${settings.localRepository}</maven.repo.local>
                 <!-- Disable the standard copy-based provisioning -->
                 <ts.copy-wildfly.phase>none</ts.copy-wildfly.phase>
 
@@ -317,7 +317,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -454,7 +453,7 @@
             <properties>
                 <!-- Disable the standard copy-based provisioning -->
                 <ts.copy-wildfly.phase>none</ts.copy-wildfly.phase>
-                <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                <maven.repo.local>${settings.localRepository}</maven.repo.local>
                 <!-- Use the WFP dependencyManagement set.
                      This is set in this profile in a parent module, but the explicit global override
                      in this module takes precedence. -->
@@ -472,7 +471,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -317,7 +317,6 @@
                             <offline>true</offline>
                             <plugin-options>
                                 <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             </plugin-options>
@@ -612,7 +611,6 @@
                                     <plugin-options>
                                         <jboss-maven-dist/>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                     </plugin-options>
@@ -669,7 +667,7 @@
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
                                 <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is
                                         expected by microprofile-config tests -->
-                                <server.jvm.args>${surefire.jpda.args} -Dnode0=${node0} -Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                <server.jvm.args>${surefire.jpda.args} -Dnode0=${node0} -Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -867,7 +865,7 @@
             </dependencies>
             <properties>
                 <bootable-jar-packaging.phase>process-test-resources</bootable-jar-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
 
                 <!-- Use the WFP dependencyManagement set.
                      This is set in this profile in a parent module, but the explicit global override
@@ -928,7 +926,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -109,7 +109,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -851,7 +851,7 @@
             </dependencies>
             <properties>
                 <bootable-jar-cloud-profile-packaging.phase>process-test-resources</bootable-jar-cloud-profile-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -898,7 +898,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -967,7 +966,6 @@
                                 <configuration>
                                     <plugin-options combine.self="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -983,7 +981,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                      <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <excludes>
                                         <!-- Requires messaging -->

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -1161,7 +1161,7 @@
                 <bootable-jar-undertow-https-packaging.phase>process-test-classes</bootable-jar-undertow-https-packaging.phase>
                 <bootable-jar-jaxrs-packaging.phase>process-test-classes</bootable-jar-jaxrs-packaging.phase>
                 <bootable-jar-cloud-packaging.phase>process-test-classes</bootable-jar-cloud-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -1212,7 +1212,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -1223,7 +1222,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -1234,7 +1232,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -1245,7 +1242,6 @@
                                 <configuration>
                                     <plugin-options>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -107,7 +107,7 @@
                 <ee.feature.pack.version>${project.version}</ee.feature.pack.version>
                 <full.feature.pack.artifactId>wildfly-preview-feature-pack</full.feature.pack.artifactId>
                 <!-- Use the transformed artifact repo -->
-                <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                <maven.repo.local>${settings.localRepository}</maven.repo.local>
                 <!-- We don't use a 'servlet feature pack' so don't provision any servers in the dir the servlet test checks -->
                 <servlet.layers.install.dir>${layers.install.dir}</servlet.layers.install.dir>
                 <!-- An empty value for this will disable the servlet test -->

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -380,7 +380,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -421,7 +420,6 @@
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <optional-packages>passive+</optional-packages>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -474,7 +472,7 @@
                                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
                                         <!-- Override the standard module path that points at the shared module set from dist -->
                                         <module.path>${project.build.directory}/wildfly/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <includes>
                                         <!-- Dummy test used to validate this pom -->
@@ -495,7 +493,7 @@
                                         <jboss.install.dir>${basedir}/target/wildfly-jpa</jboss.install.dir>
                                         <!-- Override the standard module path that points at the shared module set from dist -->
                                         <module.path>${project.build.directory}/wildfly/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <includes>
                                         <!-- Dummy test used to validate this pom -->
@@ -525,7 +523,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -588,7 +586,6 @@
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>
@@ -626,7 +623,6 @@
                                         <jboss-maven-dist/>
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                     <feature-packs>
                                         <feature-pack>

--- a/testsuite/preview/source-transform/smoke/pom.xml
+++ b/testsuite/preview/source-transform/smoke/pom.xml
@@ -951,7 +951,7 @@
             </dependencies>
             <properties>
                 <bootable-jar-cloud-profile-packaging.phase>process-test-resources</bootable-jar-cloud-profile-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -998,7 +998,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -1067,7 +1066,6 @@
                                 <configuration>
                                     <plugin-options combine.self="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -1083,7 +1081,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                      <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</server.jvm.args>
+                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                                     </systemPropertyVariables>
                                     <excludes>
                                         <!-- Requires messaging -->

--- a/testsuite/preview/source-transform/web/pom.xml
+++ b/testsuite/preview/source-transform/web/pom.xml
@@ -377,7 +377,7 @@
                 <bootable-jar-undertow-https-packaging.phase>process-test-classes</bootable-jar-undertow-https-packaging.phase>
                 <bootable-jar-jaxrs-packaging.phase>process-test-classes</bootable-jar-jaxrs-packaging.phase>
                 <bootable-jar-cloud-packaging.phase>process-test-classes</bootable-jar-cloud-packaging.phase>
-                <extra.server.jvm.args>-Dmaven.repo.local=${wildfly.transformed.repo.dir}</extra.server.jvm.args>
+                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -428,7 +428,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -439,7 +438,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -450,7 +448,6 @@
                                 <configuration>
                                     <plugin-options combine-children="append">
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>
@@ -461,7 +458,6 @@
                                 <configuration>
                                     <plugin-options>
                                         <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
                                     </plugin-options>
                                 </configuration>
                             </execution>

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -143,12 +143,6 @@
                                     <goal>provision</goal>
                                 </goals>
                                 <phase>generate-resources</phase>
-                                <configuration>
-                                    <plugin-options combine.self="append">
-                                        <jboss-jakarta-transform-artifacts>false</jboss-jakarta-transform-artifacts>
-                                        <jboss-maven-provisioning-repo>${wildfly.transformed.repo.dir}</jboss-maven-provisioning-repo>
-                                    </plugin-options>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -162,7 +156,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <maven.repo.local>${wildfly.transformed.repo.dir}</maven.repo.local>
+                                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
…Feature Pack.

https://issues.redhat.com/browse/WFLY-16572

Note that this leaves the following two artifacts un-transformed:

* `org.wildfly:wildfly-client-all`
* `org.jboss.spec.javax.xml.rpc:jboss-jaxrpc-api_1.1_spec`

The `wildfly-client-all.jar` ends up in the `bin/client` directory and will be unusable until we fully convert all dependencies to the Jakarta EE 10 version. Some tests as they are transformed *may* see issues, but that is easily fixable by using the appropriate client instead of the shaded client.