### PR TITLE
[WFLY-16567] EJB response contains ContextData that has been removed in the server side interceptors

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -88,6 +88,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ * @author <a href="mailto:jbaesner@redhat.com">Joerg Baesner</a>
  */
 final class AssociationImpl implements Association, AutoCloseable {
 
@@ -642,6 +643,9 @@ final class AssociationImpl implements Association, AutoCloseable {
         for(String key : returnKeys) {
             if(interceptorContext.getContextData().containsKey(key)) {
                 contextDataHolder.put(key, interceptorContext.getContextData().get(key));
+            } else {
+                // need to remove the attachment, as the ContextData value for this key got removed
+                content.getAttachments().remove(key);
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16567

When handling ContextData in AssociationImpl.handleReturningContextData,
any client side requested key that is not part of the ContextData
anymore must be removed from the attachments for the response.
