### PR TITLE
[26.x] WFLY-16448 Duplicate key in LocalDescriptions.properties file in iiop-openjdk

### DIFF
--- a/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
+++ b/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
@@ -20,7 +20,6 @@ iiop-openjdk.authentication-context=The name of the authentication context used 
 iiop-openjdk.transactions=Indicates whether the transactions interceptors are to be installed (full or spec) or not (none). The value 'full' enabled JTS while 'spec' enables a spec compliant mode (non JTS) that rejects incoming transaction contexts.
 
 # naming configuration properties.
-iiop-openjdk.remove=Removes naming configuration.
 iiop-openjdk.root-context=The naming service root context.
 iiop-openjdk.export-corbaloc=Indicates whether the root context should be exported as corbaloc::address:port/NameService (on) or not (off).
 


### PR DESCRIPTION
Same issue as https://github.com/wildfly/wildfly/pull/15611
https://issues.redhat.com/browse/WFLY-16448
