### PR TITLE
WFLY-16628 Weld EARs containing distributed web applications do not use expected ContextualStore

### DIFF
--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/MarshallableContextual.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/MarshallableContextual.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2021, Red Hat, Inc., and individual contributors
+ * Copyright 2022, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,16 +22,14 @@
 
 package org.wildfly.clustering.weld.contexts;
 
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.PassivationCapable;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 
 /**
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableBeanMarshaller<B extends Bean<I> & PassivationCapable, I> extends PassivationCapableSerializableMarshaller<PassivationCapableSerializableBean<B, I>, B, I> {
+public interface MarshallableContextual<C> {
 
-    @SuppressWarnings("unchecked")
-    PassivationCapableSerializableBeanMarshaller() {
-        super((Class<PassivationCapableSerializableBean<B, I>>) (Class<?>) PassivationCapableSerializableBean.class, PassivationCapableSerializableBean::new, PassivationCapableSerializableBean::new, PassivationCapableSerializableBean::getContextId);
-    }
+    BeanIdentifier getIdentifier();
+
+    C getInstance();
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableBean.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableBean.java
@@ -22,25 +22,50 @@
 
 package org.wildfly.clustering.weld.contexts;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.PassivationCapable;
 
+import org.jboss.weld.Container;
 import org.jboss.weld.bean.ForwardingBean;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
+import org.jboss.weld.serialization.spi.ContextualStore;
+import org.jboss.weld.util.Beans;
 
 /**
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableBean<B extends Bean<I> & PassivationCapable, I> extends ForwardingBean<I> implements PassivationCapableContextual<B, I> {
+public class PassivationCapableSerializableBean<B extends Bean<I> & PassivationCapable, I> extends ForwardingBean<I> implements PassivationCapableContextual<B, I>, MarshallableContextual<B> {
     private static final long serialVersionUID = -840179425829721439L;
 
     private final String contextId;
-    private final B instance;
+    private final BeanIdentifier identifier;
+    private B instance;
 
     public PassivationCapableSerializableBean(String contextId, B instance) {
+        this(contextId, Beans.getIdentifier(instance, Container.instance(contextId).services().get(ContextualStore.class)), instance);
+    }
+
+    PassivationCapableSerializableBean(String contextId, BeanIdentifier identifier) {
+        this(contextId, identifier, null);
+    }
+
+    private PassivationCapableSerializableBean(String contextId, BeanIdentifier identifier, B instance) {
         this.contextId = contextId;
         this.instance = instance;
+        this.identifier = identifier;
+    }
+
+    @Override
+    public BeanIdentifier getIdentifier() {
+        return this.identifier;
+    }
+
+    @Override
+    public B getInstance() {
+        return this.instance;
     }
 
     @Override
@@ -50,6 +75,12 @@ public class PassivationCapableSerializableBean<B extends Bean<I> & PassivationC
 
     @Override
     public B get() {
+        // Resolve contextual lazily
+        if (this.instance == null) {
+            Container container = Container.instance(this.contextId);
+            ContextualStore store = container.services().get(ContextualStore.class);
+            this.instance = store.getContextual(this.identifier);
+        }
         return this.instance;
     }
 
@@ -63,7 +94,8 @@ public class PassivationCapableSerializableBean<B extends Bean<I> & PassivationC
         return this.contextId;
     }
 
-    private Object writeReplace() {
-        return (this.instance instanceof Serializable) ? this : new PassivationCapableSerializableContextualProxy<>(this.contextId, this.instance);
+    @SuppressWarnings("unused")
+    private Object writeReplace() throws ObjectStreamException {
+        return (this.instance instanceof Serializable) ? this : new PassivationCapableSerializableContextualProxy<>(this.contextId, this.identifier);
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableBeanProxy.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableBeanProxy.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2021, Red Hat, Inc., and individual contributors
+ * Copyright 2022, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,16 +22,25 @@
 
 package org.wildfly.clustering.weld.contexts;
 
+import java.io.ObjectStreamException;
+
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.PassivationCapable;
+
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 
 /**
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableBeanMarshaller<B extends Bean<I> & PassivationCapable, I> extends PassivationCapableSerializableMarshaller<PassivationCapableSerializableBean<B, I>, B, I> {
+public class PassivationCapableSerializableBeanProxy<B extends Bean<I> & PassivationCapable, I> extends PassivationCapableSerializableProxy {
+    private static final long serialVersionUID = -6265576522828887136L;
 
-    @SuppressWarnings("unchecked")
-    PassivationCapableSerializableBeanMarshaller() {
-        super((Class<PassivationCapableSerializableBean<B, I>>) (Class<?>) PassivationCapableSerializableBean.class, PassivationCapableSerializableBean::new, PassivationCapableSerializableBean::new, PassivationCapableSerializableBean::getContextId);
+    PassivationCapableSerializableBeanProxy(String contextId, BeanIdentifier identifier) {
+        super(contextId, identifier);
+    }
+
+    @SuppressWarnings("unused")
+    private Object readResolve() throws ObjectStreamException {
+        return new PassivationCapableSerializableBean<>(this.getContextId(), this.getIdentifier());
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextual.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextual.java
@@ -81,7 +81,6 @@ public class PassivationCapableSerializableContextual<C extends Contextual<I> & 
             Container container = Container.instance(this.contextId);
             ContextualStore store = container.services().get(ContextualStore.class);
             this.instance = store.getContextual(this.identifier);
-            System.out.println("Contextual lazily resolved to " + this.instance.getClass().getName());
         }
         return this.instance;
     }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextual.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextual.java
@@ -22,35 +22,67 @@
 
 package org.wildfly.clustering.weld.contexts;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.inject.spi.PassivationCapable;
 
+import org.jboss.weld.Container;
 import org.jboss.weld.bean.WrappedContextual;
 import org.jboss.weld.contexts.ForwardingContextual;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
+import org.jboss.weld.serialization.spi.ContextualStore;
+import org.jboss.weld.util.Beans;
 
 /**
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableContextual<C extends Contextual<I> & PassivationCapable, I> extends ForwardingContextual<I> implements PassivationCapableContextual<C, I>, WrappedContextual<I> {
+public class PassivationCapableSerializableContextual<C extends Contextual<I> & PassivationCapable, I> extends ForwardingContextual<I> implements PassivationCapableContextual<C, I>, WrappedContextual<I>, MarshallableContextual<C> {
     private static final long serialVersionUID = 5113888683790476497L;
 
     private final String contextId;
-    private final C instance;
+    private final BeanIdentifier identifier;
+    private C instance;
 
     public PassivationCapableSerializableContextual(String contextId, C instance) {
+        this(contextId, Beans.getIdentifier(instance, Container.instance(contextId).services().get(ContextualStore.class)), instance);
+    }
+
+    PassivationCapableSerializableContextual(String contextId, BeanIdentifier identifier) {
+        this(contextId, identifier, null);
+    }
+
+    private PassivationCapableSerializableContextual(String contextId, BeanIdentifier identifier, C instance) {
         this.contextId = contextId;
+        this.identifier = identifier;
         this.instance = instance;
     }
 
     @Override
+    public BeanIdentifier getIdentifier() {
+        return this.identifier;
+    }
+
+    @Override
+    public C getInstance() {
+        return this.instance;
+    }
+
+    @Override
     public String getId() {
-        return this.instance.getId();
+        return this.get().getId();
     }
 
     @Override
     public C get() {
+        // Resolve contextual lazily
+        if (this.instance == null) {
+            Container container = Container.instance(this.contextId);
+            ContextualStore store = container.services().get(ContextualStore.class);
+            this.instance = store.getContextual(this.identifier);
+            System.out.println("Contextual lazily resolved to " + this.instance.getClass().getName());
+        }
         return this.instance;
     }
 
@@ -64,7 +96,8 @@ public class PassivationCapableSerializableContextual<C extends Contextual<I> & 
         return this.contextId;
     }
 
-    private Object writeReplace() {
-        return (this.instance instanceof Serializable) ? this : new PassivationCapableSerializableContextualProxy<>(this.contextId, this.instance);
+    @SuppressWarnings("unused")
+    private Object writeReplace() throws ObjectStreamException {
+        return (this.instance instanceof Serializable) ? this : new PassivationCapableSerializableContextualProxy<>(this.contextId, this.identifier);
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextualMarshaller.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextualMarshaller.java
@@ -32,6 +32,6 @@ public class PassivationCapableSerializableContextualMarshaller<C extends Contex
 
     @SuppressWarnings("unchecked")
     PassivationCapableSerializableContextualMarshaller() {
-        super((Class<PassivationCapableSerializableContextual<C, I>>) (Class<?>) PassivationCapableSerializableContextual.class, PassivationCapableSerializableContextual::new, PassivationCapableSerializableContextual::getContextId);
+        super((Class<PassivationCapableSerializableContextual<C, I>>) (Class<?>) PassivationCapableSerializableContextual.class, PassivationCapableSerializableContextual::new, PassivationCapableSerializableContextual::new, PassivationCapableSerializableContextual::getContextId);
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextualProxy.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableContextualProxy.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2021, Red Hat, Inc., and individual contributors
+ * Copyright 2022, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,34 +22,25 @@
 
 package org.wildfly.clustering.weld.contexts;
 
-import java.io.Serializable;
+import java.io.ObjectStreamException;
 
 import javax.enterprise.context.spi.Contextual;
-import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.PassivationCapable;
 
-import org.jboss.weld.Container;
-import org.jboss.weld.serialization.spi.ContextualStore;
-import org.jboss.weld.util.reflection.Reflections;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 
 /**
- * Serialization proxy for passivation capable contextuals that are not serializable.
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableContextualProxy<C extends Contextual<I> & PassivationCapable, I> implements Serializable {
-    private static final long serialVersionUID = 4906800089125597758L;
+public class PassivationCapableSerializableContextualProxy<C extends Contextual<I> & PassivationCapable, I> extends PassivationCapableSerializableProxy {
+    private static final long serialVersionUID = -5640463865738900184L;
 
-    private final String contextId;
-    private final String id;
-
-    PassivationCapableSerializableContextualProxy(String contextId, C contextual) {
-        this.contextId = contextId;
-        this.id = contextual.getId();
+    PassivationCapableSerializableContextualProxy(String contextId, BeanIdentifier identifier) {
+        super(contextId, identifier);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private Object readResolve() {
-        C contextual = Container.instance(this.contextId).services().get(ContextualStore.class).getContextual(this.id);
-        return (contextual instanceof Bean) ? new PassivationCapableSerializableBean(this.contextId, Reflections.<Bean<I>>cast(contextual)) : new PassivationCapableSerializableContextual(this.contextId, contextual);
+    @SuppressWarnings("unused")
+    private Object readResolve() throws ObjectStreamException {
+        return new PassivationCapableSerializableContextual<>(this.getContextId(), this.getIdentifier());
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableMarshaller.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableMarshaller.java
@@ -31,7 +31,8 @@ import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.infinispan.protostream.descriptors.WireType;
 import org.jboss.weld.Container;
-import org.jboss.weld.serialization.spi.ContextualStore;
+import org.jboss.weld.serialization.BeanIdentifierIndex;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 import org.jboss.weld.serialization.spi.helpers.SerializableContextual;
 import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
 import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
@@ -40,19 +41,22 @@ import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
 /**
  * @author Paul Ferraro
  */
-public class PassivationCapableSerializableMarshaller<SC extends SerializableContextual<C, I> & PassivationCapable, C extends Contextual<I> & PassivationCapable, I> implements ProtoStreamMarshaller<SC> {
+public class PassivationCapableSerializableMarshaller<SC extends SerializableContextual<C, I> & PassivationCapable & MarshallableContextual<C>, C extends Contextual<I> & PassivationCapable, I> implements ProtoStreamMarshaller<SC> {
 
     private static final int CONTEXT_INDEX = 1;
     private static final int CONTEXTUAL_INDEX = 2;
     private static final int IDENTIFIER_INDEX = 3;
+    private static final int INDEX_INDEX = 4;
 
     private final Class<SC> targetClass;
-    private final BiFunction<String, C, SC> factory;
+    private final BiFunction<String, C, SC> resolvedFactory;
+    private final BiFunction<String, BeanIdentifier, SC> unresolvedFactory;
     private final Function<SC, String> contextFunction;
 
-    PassivationCapableSerializableMarshaller(Class<SC> targetClass, BiFunction<String, C, SC> factory, Function<SC, String> contextFunction) {
+    PassivationCapableSerializableMarshaller(Class<SC> targetClass, BiFunction<String, C, SC> resolvedFactory, BiFunction<String, BeanIdentifier, SC> unresolvedFactory, Function<SC, String> contextFunction) {
         this.targetClass = targetClass;
-        this.factory = factory;
+        this.resolvedFactory = resolvedFactory;
+        this.unresolvedFactory = unresolvedFactory;
         this.contextFunction = contextFunction;
     }
 
@@ -66,7 +70,8 @@ public class PassivationCapableSerializableMarshaller<SC extends SerializableCon
     public SC readFrom(ProtoStreamReader reader) throws IOException {
         String contextId = null;
         C contextual = null;
-        String identifier = null;
+        BeanIdentifier identifier = null;
+        int beanIndex = 0;
         while (!reader.isAtEnd()) {
             int tag = reader.readTag();
             switch (WireType.getTagFieldNumber(tag)) {
@@ -77,25 +82,44 @@ public class PassivationCapableSerializableMarshaller<SC extends SerializableCon
                     contextual = (C) reader.readAny();
                     break;
                 case IDENTIFIER_INDEX:
-                    identifier = reader.readAny(String.class);
+                    identifier = reader.readAny(BeanIdentifier.class);
+                    break;
+                case INDEX_INDEX:
+                    beanIndex = reader.readUInt32();
                     break;
                 default:
                     reader.skipField(tag);
             }
         }
-        if (contextual == null) {
-            contextual = Container.instance(contextId).services().get(ContextualStore.class).getContextual(identifier);
+        if (contextual != null) {
+            return this.resolvedFactory.apply(contextId, contextual);
         }
-        return this.factory.apply(contextId, contextual);
+        if (identifier == null) {
+            BeanIdentifierIndex index = Container.instance(contextId).services().get(BeanIdentifierIndex.class);
+            identifier = index.getIdentifier(beanIndex);
+        }
+        return this.unresolvedFactory.apply(contextId, identifier);
     }
 
     @Override
     public void writeTo(ProtoStreamWriter writer, SC contextual) throws IOException {
+        String contextId = this.contextFunction.apply(contextual);
         writer.writeAny(CONTEXT_INDEX, this.contextFunction.apply(contextual));
-        if (writer.getSerializationContext().canMarshall(contextual.get())) {
-            writer.writeAny(CONTEXTUAL_INDEX, contextual.get());
+        C instance = contextual.getInstance();
+        if ((instance != null) && writer.getSerializationContext().canMarshall(instance)) {
+            writer.writeAny(CONTEXTUAL_INDEX, instance);
         } else {
-            writer.writeAny(IDENTIFIER_INDEX, contextual.getId());
+            BeanIdentifier identifier = contextual.getIdentifier();
+            BeanIdentifierIndex index = Container.instance(contextId).services().get(BeanIdentifierIndex.class);
+            Integer beanIndex = (index != null) && index.isBuilt() ? index.getIndex(identifier) : null;
+            if (beanIndex != null) {
+                int value = beanIndex.intValue();
+                if (value != 0) {
+                    writer.writeUInt32(INDEX_INDEX, value);
+                }
+            } else {
+                writer.writeAny(IDENTIFIER_INDEX, identifier);
+            }
         }
     }
 }

--- a/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableProxy.java
+++ b/clustering/weld/core/src/main/java/org/wildfly/clustering/weld/contexts/PassivationCapableSerializableProxy.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.weld.contexts;
+
+import java.io.Serializable;
+
+import org.jboss.weld.Container;
+import org.jboss.weld.serialization.BeanIdentifierIndex;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
+
+/**
+ * Serialization proxy for passivation capable contextuals that are not serializable.
+ * @author Paul Ferraro
+ */
+public abstract class PassivationCapableSerializableProxy implements Serializable {
+    private static final long serialVersionUID = 4906800089125597758L;
+
+    private final String contextId;
+    private final BeanIdentifier identifier;
+    private final Integer beanIndex;
+
+    PassivationCapableSerializableProxy(String contextId, BeanIdentifier identifier) {
+        this.contextId = contextId;
+        BeanIdentifierIndex index = Container.instance(contextId).services().get(BeanIdentifierIndex.class);
+        this.beanIndex = (index != null) && index.isBuilt() ? index.getIndex(identifier) : null;
+        this.identifier = (this.beanIndex == null) ? identifier : null;
+    }
+
+    String getContextId() {
+        return this.contextId;
+    }
+
+    BeanIdentifier getIdentifier() {
+        return (this.identifier != null) ? this.identifier : Container.instance(this.contextId).services().get(BeanIdentifierIndex.class).getIdentifier(this.beanIndex);
+    }
+}

--- a/clustering/weld/core/src/main/resources/org.wildfly.clustering.weld.contexts.proto
+++ b/clustering/weld/core/src/main/resources/org.wildfly.clustering.weld.contexts.proto
@@ -7,6 +7,7 @@ message PassivationCapableSerializableBean {
 	optional	bytes	contextId	= 1;
 	optional	bytes	contextual	= 2;
 	optional	bytes	identifier	= 3;
+	optional	uint32	beanIndex	= 4;
 }
 
 /**
@@ -16,4 +17,5 @@ message PassivationCapableSerializableContextual {
 	optional	bytes	contextId	= 1;
 	optional	bytes	contextual	= 2;
 	optional	bytes	identifier	= 3;
+	optional	uint32	beanIndex	= 4;
 }

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/protostream/main/module.xml
@@ -24,10 +24,6 @@
 
 <module xmlns="urn:jboss:module:1.9" name="org.infinispan.protostream">
 
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
     <resources>
         <artifact name="${org.infinispan.protostream:protostream}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -77,7 +77,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.vfs"/>
-        <module name="org.wildfly.common"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/weld/core/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/weld/core/main/module.xml
@@ -38,7 +38,9 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.weld.spi"/>
+        <module name="org.jboss.modules"/>
         <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/ProtoStreamCDIFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/ProtoStreamCDIFailoverTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
@@ -47,10 +48,11 @@ import org.junit.runner.RunWith;
 public class ProtoStreamCDIFailoverTestCase extends AbstractWebFailoverTestCase {
 
     private static final String MODULE_NAME = CDIFailoverTestCase.class.getSimpleName();
-    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".ear";
+    private static final String WEB_DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public ProtoStreamCDIFailoverTestCase() {
-        super(DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);
+        super(DEPLOYMENT_NAME + '.' + WEB_DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);
     }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
@@ -72,13 +74,15 @@ public class ProtoStreamCDIFailoverTestCase extends AbstractWebFailoverTestCase 
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_DEPLOYMENT_NAME);
         war.addPackage(IncrementorBean.class.getPackage());
         war.addClasses(Incrementor.class, SimpleServlet.class, Mutable.class);
         ClusterTestUtil.addTopologyListenerDependencies(war);
         war.setWebXML(CDIFailoverTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(CDIFailoverTestCase.class.getPackage(), "distributable-web.xml", "distributable-web.xml");
         war.addAsServiceProvider(SerializationContextInitializer.class.getName(), CDISerializationContextInitializer.class.getName() + "Impl");
-        return war;
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, DEPLOYMENT_NAME);
+        ear.addAsModule(war);
+        return ear;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -68,7 +68,8 @@ public class SimpleServlet extends HttpServlet {
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        this.getServletContext().log(String.format("[%s] %s?%s", request.getMethod(), request.getRequestURI(), request.getQueryString()));
+        String query = request.getQueryString();
+        this.getServletContext().log(String.format("[%s] %s%s", request.getMethod(), request.getRequestURI(), (query != null) ? '?' + query : ""));
         super.service(request, response);
     }
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/CompositeClassLoader.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/CompositeClassLoader.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.weld.deployment.processors;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@link ClassLoader} that delegates loading of classes and resources to a list of delegate class loaders.
+ * @author Paul Ferraro
+ */
+class CompositeClassLoader extends ClassLoader {
+    private List<ClassLoader> loaders;
+
+    CompositeClassLoader(List<ClassLoader> loaders) {
+        super(null);
+        this.loaders = loaders;
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        for (ClassLoader loader : this.loaders) {
+            try {
+                return loader.loadClass(name);
+            } catch (ClassNotFoundException e) {
+                // Ignore
+            }
+        }
+        return super.findClass(name);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        List<Enumeration<URL>> results = new ArrayList<>(this.loaders.size());
+        for (ClassLoader loader : this.loaders) {
+            results.add(loader.getResources(name));
+        }
+        Iterator<Enumeration<URL>> iterator = results.iterator();
+        return new Enumeration<>() {
+            private Enumeration<URL> urls = Collections.emptyEnumeration();
+
+            @Override
+            public boolean hasMoreElements() {
+                return this.getURLs().hasMoreElements();
+            }
+
+            @Override
+            public URL nextElement() {
+                return this.getURLs().nextElement();
+            }
+
+            private Enumeration<URL> getURLs() {
+                if (!this.urls.hasMoreElements() && iterator.hasNext()) {
+                    this.urls = iterator.next();
+                }
+                return this.urls;
+            }
+        };
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        for (ClassLoader loader : this.loaders) {
+            URL resource = loader.getResource(name);
+            if (resource != null) {
+                return resource;
+            }
+        }
+        return super.findResource(name);
+    }
+}


### PR DESCRIPTION
If any distributable web application within an EAR uses ProtoStream, the EAR must be configured to use the DistributedContextualStore.

https://issues.redhat.com/browse/WFLY-16628

Follow-up fix for https://issues.redhat.com/browse/WFLY-13904