### PR TITLE
[WFLY-16631] Fix NoClassDefFoundError: org/jboss/as/process/protocol/StreamUtils stoping mixed domain test hosts

### DIFF
--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -130,6 +130,11 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-process-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Jira issues:

https://issues.redhat.com/browse/WFLY-16631