### PR TITLE
[WFLY-16639] Use the correct embedded broker config in WFP's standalo…

### DIFF
--- a/ee-9/galleon-content/src/main/resources/feature_groups/standalone-full-ha.xml
+++ b/ee-9/galleon-content/src/main/resources/feature_groups/standalone-full-ha.xml
@@ -21,7 +21,7 @@
     <!-- TODO go back to a non-embedded-broker config
     <feature-group name="messaging-remote-activemq"/>
     -->
-    <feature-group name="messaging-activemq"/>
+    <feature-group name="messaging-activemq-ha"/>
 
     <feature spec="subsystem.ejb3">
         <feature spec="subsystem.ejb3.service.iiop">

--- a/ee-9/galleon-content/src/main/resources/feature_groups/standalone-full.xml
+++ b/ee-9/galleon-content/src/main/resources/feature_groups/standalone-full.xml
@@ -4,9 +4,4 @@
     <feature-group name="standalone-full-x-messaging"/>
     <feature-group name="messaging-remote-activemq"/>
 
-    <feature spec="socket-binding-group">
-        <param name="socket-binding-group" value="standard-sockets" />
-        <feature-group name="messaging-remote-sockets"/>
-    </feature>
-
 </feature-group-spec>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -950,10 +950,6 @@
                                         <include>${test-group}/**/group/*TestCase.java</include>
                                         <include>${test-group}/**/jms/*TestCase.java</include>
                                     </includes>
-                                    <excludes>
-                                        <!-- Requires the /subsystem=messaging-activemq/server=default to exist for it's setup tasks -->
-                                        <exclude>${test-group}/jms/ClusteredMessagingTestCase.java</exclude>
-                                    </excludes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <!-- required by arquillian.xml -->


### PR DESCRIPTION
…ne-full-ha.xml

Fixes an incorrect implementation of the temp restoration of the embedded broker to the WFP configs (WFLY-16499).

Also removes a messaging socket binding config from standalone.xml that isn't used when the embedded broker is in the config.

Also restores execution of ClusteredMessagingTestCase to ts.surefire.clustering.fullha, under the assumption it was disabled due to WFLY-16499 or my flawed impl that fix.

https://issues.redhat.com/browse/WFLY-16639