### PR TITLE
[WFLY-16387] Convert the test resources to use Jakarta REST 3.1. Also…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1272,6 +1272,7 @@
                         <!-- Narayana transaction data storage for transaction started at client side -->
                         <ObjectStoreEnvironmentBean.objectStoreDir>target/NarayanaObjectStore</ObjectStoreEnvironmentBean.objectStoreDir>
                         <ObjectStoreEnvironmentBean.communicationStore.objectStoreDir>target/NarayanaObjectStore</ObjectStoreEnvironmentBean.communicationStore.objectStoreDir>
+                        <server.jvm.args>${server.jvm.args} -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</server.jvm.args>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.java
@@ -28,17 +28,21 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMapping.RbacWithUseIdenityRolesSetup.class})
-public class JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMapping extends AbstractJmxAccessFromDeploymentWithRbacTest {
+@ServerSetup({JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.RbacWithUseIdenityRolesSetup.class})
+public class JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMappingTestCase extends AbstractJmxAccessFromDeploymentWithRbacTest {
 
     @Deployment(testable = false)
     public static Archive<?> deploy() {
-        return AbstractJmxAccessFromDeploymentWithRbacTest.deploy(true);
+        return AbstractJmxAccessFromDeploymentWithRbacTest.deploy(false);
+    }
+
+    public JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMappingTestCase() {
+        super(false);
     }
 
     static class RbacWithUseIdenityRolesSetup extends EnableRbacSetupTask {
         public RbacWithUseIdenityRolesSetup() {
-            super(false, true);
+            super(false, false);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRolesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRolesTestCase.java
@@ -28,8 +28,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRoles.RbacWithUseIdenityRolesSetup.class})
-public class JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRoles extends AbstractJmxAccessFromDeploymentWithRbacTest {
+@ServerSetup({JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRolesTestCase.RbacWithUseIdenityRolesSetup.class})
+public class JmxAccessFromSecuredDeploymentWithRbacUsingIdentityRolesTestCase extends AbstractJmxAccessFromDeploymentWithRbacTest {
 
     @Deployment(testable = false)
     public static Archive<?> deploy() {

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.java
@@ -28,21 +28,17 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMapping.RbacWithUseIdenityRolesSetup.class})
-public class JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMapping extends AbstractJmxAccessFromDeploymentWithRbacTest {
+@ServerSetup({JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMappingTestCase.RbacWithUseIdenityRolesSetup.class})
+public class JmxAccessFromSecuredDeploymentWithRbacUsingUserRoleMappingTestCase extends AbstractJmxAccessFromDeploymentWithRbacTest {
 
     @Deployment(testable = false)
     public static Archive<?> deploy() {
-        return AbstractJmxAccessFromDeploymentWithRbacTest.deploy(false);
-    }
-
-    public JmxAccessFromNonSecuredDeploymentWithRbacUsingUserRoleMapping() {
-        super(false);
+        return AbstractJmxAccessFromDeploymentWithRbacTest.deploy(true);
     }
 
     static class RbacWithUseIdenityRolesSetup extends EnableRbacSetupTask {
         public RbacWithUseIdenityRolesSetup() {
-            super(false, false);
+            super(false, true);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/deployment/ApplicationClass.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/deployment/ApplicationClass.java
@@ -24,8 +24,8 @@
 
 package org.wildfly.test.integration.jmx.rbac.deployment;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/")
 public class ApplicationClass extends Application {

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/deployment/JmxResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jmx/rbac/deployment/JmxResource.java
@@ -31,11 +31,11 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +46,7 @@ import java.util.Map;
 public class JmxResource {
     private static final String MBEAN_NAME = "jboss.as:subsystem=datasources,data-source=ExampleDS,statistics=pool";
 
-    String HOST_NAME = "127.0.0.1";
+    String HOST_NAME = "localhost";
     String PORT = "9990";
 
 

--- a/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jmx/rbac/jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jmx/rbac/jboss-deployment-structure.xml
@@ -4,6 +4,8 @@
       <module name="org.jboss.remoting-jmx"  services="import"/>
       <module name="org.jboss.xnio"/>
       <module name="org.jboss.remoting"/>
+      <!-- Required for the ControllerPermission -->
+      <module name="org.jboss.as.controller"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
… disable the deployment transformer.

The test renames are required to ensure the tests run.

https://issues.redhat.com/browse/WFLY-16387