### PR TITLE
[WFLY-14313] Connector: More informative log after datasource test fa…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
@@ -100,7 +100,7 @@ public abstract class PoolOperations implements OperationStepHandler {
                             }
 
                         } catch (Exception e) {
-                            throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.failedToInvokeOperation(e.getLocalizedMessage()));
+                            throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.failedToInvokeOperation(concatenateExceptionCauses(e)));
                         }
                         if (operationResult != null) {
                             context.getResult().set(operationResult);
@@ -110,6 +110,17 @@ public abstract class PoolOperations implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
+    }
+
+    private String concatenateExceptionCauses(Exception e) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(e.toString());
+        Throwable t = e.getCause();
+        while (t != null) {
+            sb.append(" Caused by: ").append(t.toString());
+            t = t.getCause();
+        }
+        return sb.toString();
     }
 
     protected abstract ModelNode invokeCommandOn(Pool pool, Object... parameters) throws Exception;


### PR DESCRIPTION
…ilure

https://issues.redhat.com/browse/WFLY-14313

After the fix the message contains a list of exception causes when there is a problem during connection establishment:

`
{
    "outcome" => "failed",
    "failure-description" => "WFLYJCA0040: failed to invoke operation: WFLYJCA0047: Connection is not valid javax.resource.ResourceException: IJ031084: Unable to create connection IJ031084: Unable to create conn
ection  FATAL: password authentication failed for user \"tomek\"",
    "rolled-back" => true
}
`

@hpehl could you please review?
