### PR TITLE
WFLY-16649 Fix regression in execution time of OrderedChildResourcesTestCase

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -42,12 +42,12 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
  */
 public abstract class BuildConfigurationTestBase {
 
-    static final String masterAddress = System.getProperty("jboss.test.host.master.address", "localhost");
+    static final String PRIMARY_ADDRESS = System.getProperty("jboss.test.host.master.address", "localhost");
     static final String PRIMARY_HOST_NAME = "primary";
     static final File CONFIG_DIR = new File("target/wildfly/domain/configuration/");
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName, final String testConfiguration) {
-        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, PRIMARY_HOST_NAME, masterAddress, 9990);
+        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, PRIMARY_HOST_NAME, PRIMARY_ADDRESS, 9990);
     }
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName,
@@ -58,7 +58,7 @@ public abstract class BuildConfigurationTestBase {
         configuration.setHostControllerManagementAddress(hostAddress);
         configuration.setHostControllerManagementPort(hostPort);
         configuration.setHostControllerManagementProtocol("remote+http");
-        configuration.setHostCommandLineProperties("-Djboss.domain.primary.address=" + masterAddress +
+        configuration.setHostCommandLineProperties("-Djboss.domain.primary.address=" + PRIMARY_ADDRESS +
                 " -Djboss.management.http.port=" + hostPort);
         configuration.setDomainConfigFile(hackFixDomainConfig(new File(CONFIG_DIR, domainXmlName)).getAbsolutePath());
         configuration.setHostConfigFile(hackFixHostConfig(new File(CONFIG_DIR, hostXmlName), hostName, hostAddress).getAbsolutePath());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -43,11 +43,11 @@ import org.jboss.as.test.shared.TestSuiteEnvironment;
 public abstract class BuildConfigurationTestBase {
 
     static final String masterAddress = System.getProperty("jboss.test.host.master.address", "localhost");
-
+    static final String PRIMARY_HOST_NAME = "primary";
     static final File CONFIG_DIR = new File("target/wildfly/domain/configuration/");
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName, final String testConfiguration) {
-        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "primary", masterAddress, 9990);
+        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, PRIMARY_HOST_NAME, masterAddress, 9990);
     }
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
@@ -64,7 +64,7 @@ public class DefaultConfigSmokeTestCase extends BuildConfigurationTestBase {
         try {
             utils.start();
             // Double-check server status by confirming server-one can accept a web request to the root
-            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(masterAddress) + ":8080").openConnection();
+            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(PRIMARY_ADDRESS) + ":8080").openConnection();
             connection.connect();
 
             if (Boolean.getBoolean("expression.audit")) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -121,8 +121,8 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
     }
 
     private void reloadMaster(DomainLifecycleUtil domainMasterLifecycleUtil, boolean adminOnly) throws Exception{
-        ModelNode restartAdminOnly = Util.createEmptyOperation("reload", PathAddress.pathAddress(HOST, PRIMARY_HOST_NAME));
-        restartAdminOnly.get("admin-only").set(adminOnly);
+        ModelNode restartAdminOnly = Util.createEmptyOperation(RELOAD, PathAddress.pathAddress(HOST, PRIMARY_HOST_NAME));
+        restartAdminOnly.get(ADMIN_ONLY).set(adminOnly);
         domainMasterLifecycleUtil.executeAwaitConnectionClosed(restartAdminOnly);
         domainMasterLifecycleUtil.connect();
         domainMasterLifecycleUtil.awaitHostController(System.currentTimeMillis());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -61,11 +61,10 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
     @Test
     public void testOrderedChildResources() throws Exception {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-primary.xml", getClass().getSimpleName());
-        final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-secondary.xml", getClass().getSimpleName(),
                 SECONDARY_HOST_NAME, slaveAddress, 19990);
-        final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
-        try {
+        try (DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
+                DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig)) {
             masterUtils.start();
             slaveUtils.start();
 
@@ -118,12 +117,6 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
             rodOp.get(NAME).set(ADD);
             ModelNode result = DomainTestUtils.executeForResult(rodOp, masterUtils.getDomainClient());
             Assert.assertTrue(result.get(REQUEST_PROPERTIES).hasDefined(ADD_INDEX));
-        } finally {
-            try {
-                slaveUtils.stop();
-            } finally {
-                masterUtils.stop();
-            }
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -121,7 +121,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
     }
 
     private void reloadMaster(DomainLifecycleUtil domainMasterLifecycleUtil, boolean adminOnly) throws Exception{
-        ModelNode restartAdminOnly = Util.createEmptyOperation("reload", PathAddress.pathAddress(HOST, "master"));
+        ModelNode restartAdminOnly = Util.createEmptyOperation("reload", PathAddress.pathAddress(HOST, PRIMARY_HOST_NAME));
         restartAdminOnly.get("admin-only").set(adminOnly);
         domainMasterLifecycleUtil.executeAwaitConnectionClosed(restartAdminOnly);
         domainMasterLifecycleUtil.connect();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -54,7 +54,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
 
 
     public static final String slaveAddress = System.getProperty("jboss.test.host.slave.address", "127.0.0.1");
-
+    private static final String SECONDARY_HOST_NAME = "secondary";
     private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
 
     @Test
@@ -62,7 +62,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-primary.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-secondary.xml", getClass().getSimpleName(),
-                "secondary", slaveAddress, 19990);
+                SECONDARY_HOST_NAME, slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();
@@ -159,7 +159,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
             List<ModelNode> list = ret.asList();
             if (list.size() == 2) {
                 for (ModelNode entry : list) {
-                    if ("slave".equals(entry.asString())){
+                    if (SECONDARY_HOST_NAME.equals(entry.asString())){
                         return true;
                     }
                 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -79,12 +79,10 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
             Assert.assertEquals(originalMasterStack, originalSlaveStack);
 
             int index = -1;
-            ModelNode value = null;
             Iterator<Property> it = originalMasterStack.get(PROTOCOL).asPropertyList().iterator();
             for (int i = 0; it.hasNext(); i++) {
                 Property property = it.next();
                 if (property.getName().equals(TARGET_PROTOCOL)) {
-                    value = property.getValue();
                     index = i;
                     break;
                 }
@@ -101,10 +99,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
 
             //Reload the master into admin-only and re-add the protocol
             reloadMaster(masterUtils, true);
-            ModelNode add = value.clone();
-            add.get(OP).set(ADD);
-            add.get(OP_ADDR).set(targetProtocolAddress.toModelNode());
-            add.get(ADD_INDEX).set(index);
+            ModelNode add = Util.createAddOperation(targetProtocolAddress, index);
             DomainTestUtils.executeForResult(add, masterUtils.getDomainClient());
 
             //Reload the master into normal mode and check the protocol is in the right place on the slave


### PR DESCRIPTION
... due to https://issues.redhat.com/browse/WFLY-16147 causing a mismatched host controller name.

https://issues.redhat.com/browse/WFLY-16649

Additionally:
* Leverage constants to reduce likelihood of future regressions like this.
* Future-proof test case by using a JGroups protocol that is less likely to change (e.g. when we upgrade to JGroups 5.x)
* Fix problematic language in test code
