### PR TITLE
WFLY-16654 Upgrade smallrye-fault-tolerance to 6.0.0-RC4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
         <preview.version.io.smallrye.open-api>3.0.0-RC1</preview.version.io.smallrye.open-api>
         <preview.version.io.smallrye.smallrye-common>2.0.0-RC2</preview.version.io.smallrye.smallrye-common>
         <preview.version.io.smallrye.smallrye-config>3.0.0-RC2</preview.version.io.smallrye.smallrye-config>
-        <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC2</preview.version.io.smallrye.smallrye-fault-tolerance>
+        <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</preview.version.io.smallrye.smallrye-fault-tolerance>
         <preview.version.io.smallrye.smallrye-health>4.0.0-RC2</preview.version.io.smallrye.smallrye-health>
         <preview.version.io.smallrye.smallrye-jwt>4.0.0-RC2</preview.version.io.smallrye.smallrye-jwt>
         <preview.version.io.smallrye.smallrye-metrics>4.0.0-RC1</preview.version.io.smallrye.smallrye-metrics>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16654