### PR TITLE
[WFLY-16667, WFLY-16921] Upgrade galleon-plugins to 6.0.0.Beta1

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" ?>
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <delete path="docs/licenses/licenses.html"/>
     <xml-merge basedir="docs/licenses" output="docs/licenses/licenses.xml">
         <filter pattern="*-licenses.xml" include="true"/>
     </xml-merge>
     <transform stylesheet="docs/licenses/licenses.xsl" src="docs/licenses/licenses.xml" output="docs/licenses/licenses.html" phase="FINALIZING"/>
+    <line-endings phase="FINALIZING">
+      <unix>
+        <filter pattern="docs?licenses?licenses.html" include="true"/>
+      </unix>
+    </line-endings>
 </tasks>

--- a/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" ?>
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/full-licenses.xsl"/>
     <transform stylesheet="docs/licenses/full-licenses.xsl" src="docs/licenses/full-feature-pack-licenses.xml" output="docs/licenses/full-feature-pack-licenses.html" feature-pack-properties="true"/>
     <delete path="docs/licenses/full-licenses.xsl"/>
+    <line-endings>
+      <unix>
+        <filter pattern="docs?licenses?full-feature-pack-licenses.html" include="true"/>
+      </unix>
+    </line-endings>
 </tasks>

--- a/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="wildfly-ee@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.3" producer="wildfly-ee@maven(org.jboss.universe:community-universe):current">
 
     <default-packages>
         <package name="modules.all"/>
@@ -53,6 +53,10 @@
     <resources>
         <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
     </resources>
+
+    <system-paths>
+        <system-path path="modules/system/layers/base/"/>
+    </system-paths>
 
     <generate-feature-specs>
         <extensions>

--- a/microprofile/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" ?>
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <delete path="docs/licenses/licenses.html"/>
     <xml-merge basedir="docs/licenses" output="docs/licenses/licenses.xml">
         <filter pattern="*-licenses.xml" include="true"/>
     </xml-merge>
     <transform stylesheet="docs/licenses/licenses.xsl" src="docs/licenses/licenses.xml" output="docs/licenses/licenses.html" phase="FINALIZING"/>
+    <line-endings phase="FINALIZING">
+      <unix>
+        <filter pattern="docs?licenses?licenses.html" include="true"/>
+      </unix>
+    </line-endings>
 </tasks>

--- a/microprofile/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" ?>
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/microprofile-licenses.xsl"/>
     <transform stylesheet="docs/licenses/microprofile-licenses.xsl" src="docs/licenses/microprofile-feature-pack-licenses.xml" output="docs/licenses/microprofile-feature-pack-licenses.html" feature-pack-properties="true"/>
     <delete path="docs/licenses/microprofile-licenses.xsl"/>
+    <line-endings>
+      <unix>
+        <filter pattern="microprofile-feature-pack-licenses.html" include="true"/>
+      </unix>
+    </line-endings>
 </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -262,12 +262,12 @@
          -->
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.7</version.org.jacoco>
-        <version.org.jboss.galleon>5.0.3.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.0.5.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.0.0.Alpha6</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.jar.plugin>7.0.0.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.galleon-plugins>6.0.0.Alpha7</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.jar.plugin>8.0.0.Alpha3</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.0.0.Alpha7</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.0.0.Beta1</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>8.0.0.Alpha3</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>

--- a/servlet-feature-pack/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/packages/docs.licenses.merge/pm/wildfly/tasks.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" ?>
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <delete path="docs/licenses/licenses.html"/>
     <xml-merge basedir="docs/licenses" output="docs/licenses/licenses.xml">
         <filter pattern="*-licenses.xml" include="true"/>
     </xml-merge>
     <transform stylesheet="docs/licenses/licenses.xsl" src="docs/licenses/licenses.xml" output="docs/licenses/licenses.html" phase="FINALIZING"/>
+    <line-endings phase="FINALIZING">
+      <unix>
+        <filter pattern="docs?licenses?licenses.html" include="true"/>
+      </unix>
+    </line-endings>
 </tasks>


### PR DESCRIPTION
Includes two issues: Mark system modules as system-paths in Galleon feature pack (WFLY-16667) and Force Unix line endings in licenses (WFLY-16921)

Issue: https://issues.redhat.com/browse/WFLY-16667 https://issues.redhat.com/browse/WFLY-16921

cc @jfdenise, @jmesnil 