### PR TITLE
WFLY-16674/WFLY-16675 Upgrade smallrye-open-api to 2.1.22/3.0.0-CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.4</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.22</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.1.23</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>1.12.0</version.io.smallrye.smallrye-common>

--- a/pom.xml
+++ b/pom.xml
@@ -578,7 +578,7 @@
         <preview.version.org.eclipse.microprofile.reactive-streams-operators.api>3.0-RC1</preview.version.org.eclipse.microprofile.reactive-streams-operators.api>
         <preview.version.org.eclipse.microprofile.rest.client.api>3.0</preview.version.org.eclipse.microprofile.rest.client.api>
         <!-- Implementations -->
-        <preview.version.io.smallrye.open-api>3.0.0-RC1</preview.version.io.smallrye.open-api>
+        <preview.version.io.smallrye.open-api>3.0.0-RC2</preview.version.io.smallrye.open-api>
         <preview.version.io.smallrye.smallrye-common>2.0.0-RC2</preview.version.io.smallrye.smallrye-common>
         <preview.version.io.smallrye.smallrye-config>3.0.0-RC2</preview.version.io.smallrye.smallrye-config>
         <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</preview.version.io.smallrye.smallrye-fault-tolerance>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16674
https://issues.redhat.com/browse/WFLY-16675