### PR TITLE
WFLY-16669: Upgrade HAL to 3.6.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>
-        <version.org.jboss.hal.console>3.6.1.Final</version.org.jboss.hal.console>
+        <version.org.jboss.hal.console>3.6.2.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.5.7.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16669

Contains only one fix compared to HAL 3.6.1.Final:
- [HAL-1800](https://issues.redhat.com/browse/HAL-1800): Provide backward compatibility after migration from master/slave → primary/secondary