### PR TITLE
WFLY-16664 Upgrade Narayana to 5.13.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.metadata>15.1.0.Alpha2</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.narayana>5.12.7.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.13.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>
         <legacy.version.org.jboss.resteasy>4.7.4.Final</legacy.version.org.jboss.resteasy>
         <version.org.jboss.resteasy>6.1.0.Beta3</version.org.jboss.resteasy>

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/annotation/client/CompensatableTestCase.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/annotation/client/CompensatableTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.as.test.xts.annotation.service.CompensatableServiceImpl;
 import org.jboss.as.test.xts.util.DeploymentHelper;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,7 +38,6 @@ import com.arjuna.mw.wst11.UserBusinessActivity;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 @RunWith(Arquillian.class)
-@Ignore("Remove ignore when JBTM-3647 and WFLY-16664 are resolved")
 public class CompensatableTestCase {
 
     private static final String DEPLOYMENT_NAME = "compensatable-test";

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/annotation/compensationscoped/CompensationScopedTestCase.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/annotation/compensationscoped/CompensationScopedTestCase.java
@@ -33,7 +33,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,7 +42,6 @@ import jakarta.inject.Inject;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 @RunWith(Arquillian.class)
-@Ignore("Remove ignore when JBTM-3647 and WFLY-16664 are resolved")
 public class CompensationScopedTestCase {
 
     @Inject


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16664 (Upgrade Narayana to 5.13.0.Final)

The release contains 26 fixes ([https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12390988](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12390988)).

The highlights include:
- removal of support for JDK 8 (11 is now the minimum supported version);
- removal of support for JacORB
- adds support for JDK 17

The upgrade also contains James' fix for [JBTM-3647] - Some CDI Extensions use deprecated methods that have been removed in the CDI 4.0 spec