### PR TITLE
Temporarily workaround the WFLY-16694 problem for big-bang by disabli…

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -3791,14 +3791,14 @@
         </dependencies>
     </dependencyManagement>
 
-    <profiles>
+<!--    <profiles>
         <profile>
             <id>skip.preview</id>
             <activation>
                 <property>
                     <name>!skip.preview</name>
                 </property>
-            </activation>
+            </activation>-->
 
             <modules>
                 <module>source-transform</module>
@@ -3812,7 +3812,7 @@
                 <module>galleon-content</module>
                 <module>galleon-content-microprofile</module>
             </modules>
-        </profile>
-    </profiles>
+<!--        </profile>
+    </profiles>-->
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <module>rts</module>
         <module>testsuite/shared</module>
         <module>testsuite/test-feature-pack</module>
+        <module>testsuite/test-feature-pack-preview</module>
         <module>testsuite</module>
     </modules>
 
@@ -5264,19 +5265,6 @@
             <properties>
                 <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=*:8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
-        </profile>
-        <!-- Skip preview builds if specified -->
-        <profile>
-            <id>skip.preview</id>
-            <activation>
-                <property>
-                    <name>!skip.preview</name>
-                </property>
-            </activation>
-
-            <modules>
-                <module>testsuite/test-feature-pack-preview</module>
-            </modules>
         </profile>
 
         <profile>


### PR DESCRIPTION
…ng skip.preview while 'preview' is used outside of the ts.ee9 and ts.bootable.ee9 profiles

This reverts commit 2855116551abfcccc9085a1c26498397562d981c.

Draft PR #15840 is a longer term solution to the problem but will break big-bang. This is a temp workaround until WFLY-16652 removes the current 'special' use of WFP in the ts.

I'm doing this separately from my WFLY-16652 PR so it's not delayed by ongoing work on the other one. I'll merge this branch into that branch though, then revert this commit and merge my #15840 branch.