### PR TITLE
[WFLY-16681] Update version properties to reflect the move of std WF to EE 10

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -608,28 +608,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.sun.xml.bind.external</groupId>
-                <artifactId>relaxng-datatype</artifactId>
-                <version>${version.sun.jaxb}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind.external</groupId>
-                <artifactId>rngom</artifactId>
-                <version>${version.sun.jaxb}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>relaxngDatatype</groupId>
-                        <artifactId>relaxngDatatype</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.xml.bind.external</groupId>
-                        <artifactId>relaxng-datatype</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>com.sun.xml.fastinfoset</groupId>
                 <artifactId>FastInfoset</artifactId>
                 <version>${version.com.sun.xml.fastinfoset}</version>
@@ -1625,18 +1603,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${version.org.glassfish.jakarta.el}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+			
             <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-commons</artifactId>

--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -368,7 +368,7 @@
             <dependency>
                 <groupId>antlr</groupId>
                 <artifactId>antlr</artifactId>
-                <version>${version.antlr}</version>
+                <version>${legacy.version.antlr}</version>
             </dependency>
 
             <!-- Begin deps previously in ee-feature-pack/pom.xml -->
@@ -398,13 +398,13 @@
             <dependency>
                 <groupId>com.sun.faces</groupId>
                 <artifactId>jsf-impl</artifactId>
-                <version>${version.com.sun.faces}</version>
+                <version>${legacy.version.com.sun.faces}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-runtime</artifactId>
-                <version>${version.com.sun.istack}</version>
+                <version>${legacy.version.com.sun.istack}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>
@@ -416,7 +416,7 @@
             <dependency>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-tools</artifactId>
-                <version>${version.com.sun.istack}</version>
+                <version>${legacy.version.com.sun.istack}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun</groupId>
@@ -432,7 +432,29 @@
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>jakarta.mail</artifactId>
-                <version>${version.jakarta.mail}</version>
+                <version>${legacy.version.jakarta.mail}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind.external</groupId>
+                <artifactId>relaxng-datatype</artifactId>
+                <version>${legacy.version.sun.jaxb}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind.external</groupId>
+                <artifactId>rngom</artifactId>
+                <version>${legacy.version.sun.jaxb}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>relaxngDatatype</groupId>
+                        <artifactId>relaxngDatatype</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind.external</groupId>
+                        <artifactId>relaxng-datatype</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -478,13 +500,13 @@
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-api</artifactId>
-                <version>${version.io.agroal}</version>
+                <version>${legacy.version.io.agroal}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-narayana</artifactId>
-                <version>${version.io.agroal}</version>
+                <version>${legacy.version.io.agroal}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss</groupId>
@@ -500,13 +522,13 @@
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-pool</artifactId>
-                <version>${version.io.agroal}</version>
+                <version>${legacy.version.io.agroal}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.undertow.jastow</groupId>
                 <artifactId>jastow</artifactId>
-                <version>${version.io.undertow.jastow}</version>
+                <version>${legacy.version.io.undertow.jastow}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -518,7 +540,7 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${version.jakarta.enterprise}</version>
+                <version>${legacy.version.jakarta.enterprise}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -530,7 +552,7 @@
             <dependency>
                 <groupId>jakarta.json.bind</groupId>
                 <artifactId>jakarta.json.bind-api</artifactId>
-                <version>${version.jakarta.json.bind.api}</version>
+                <version>${legacy.version.jakarta.json.bind.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -542,25 +564,25 @@
             <dependency>
                 <groupId>jakarta.jws</groupId>
                 <artifactId>jakarta.jws-api</artifactId>
-                <version>${version.jakarta.jws.jakarta.jws-api}</version>
+                <version>${legacy.version.jakarta.jws.jakarta.jws-api}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${version.jakarta.persistence}</version>
+                <version>${legacy.version.jakarta.persistence}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.security.enterprise</groupId>
                 <artifactId>jakarta.security.enterprise-api</artifactId>
-                <version>${version.jakarta.security.enterprise}</version>
+                <version>${legacy.version.jakarta.security.enterprise}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.transaction</groupId>
                 <artifactId>jakarta.transaction-api</artifactId>
-                <version>${version.jakarta.transaction}</version>
+                <version>${legacy.version.jakarta.transaction}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -584,7 +606,7 @@
             <dependency>
                 <groupId>jboss.jaxbintros</groupId>
                 <artifactId>jboss-jaxb-intros</artifactId>
-                <version>${version.jboss.jaxbintros}</version>
+                <version>${legacy.version.jboss.jaxbintros}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-beanutils</groupId>
@@ -612,7 +634,7 @@
             <dependency>
                 <groupId>net.shibboleth.utilities</groupId>
                 <artifactId>java-support</artifactId>
-                <version>${version.net.shibboleth.utilities.java-support}</version>
+                <version>${legacy.version.net.shibboleth.utilities.java-support}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -672,7 +694,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.ws.xmlschema</groupId>
@@ -712,7 +734,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-coloc</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -804,7 +826,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-soap</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -868,7 +890,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-xml</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -928,7 +950,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-databinding-aegis</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -988,7 +1010,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-databinding-jaxb</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
@@ -1049,7 +1071,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-features-clustering</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.osgi</groupId>
@@ -1113,7 +1135,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-features-logging</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -1169,7 +1191,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxws</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
@@ -1265,7 +1287,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-simple</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xalan</groupId>
@@ -1317,7 +1339,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-management</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -1405,7 +1427,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-security</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -1461,7 +1483,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-security-saml</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xalan</groupId>
@@ -1517,7 +1539,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
@@ -1609,7 +1631,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-hc</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -1709,7 +1731,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-jms</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -1813,7 +1835,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-local</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -1873,7 +1895,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-addr</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xalan</groupId>
@@ -1925,7 +1947,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-mex</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xalan</groupId>
@@ -1977,7 +1999,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-policy</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -2077,7 +2099,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-rm</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -2181,7 +2203,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-security</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>net.sf.ehcache</groupId>
@@ -2285,7 +2307,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-wsdl</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -2345,7 +2367,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-common</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
@@ -2413,7 +2435,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-java2ws</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -2553,7 +2575,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-validator</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -2701,7 +2723,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-core</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
@@ -2817,7 +2839,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind</groupId>
@@ -2913,7 +2935,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -3009,7 +3031,7 @@
             <dependency>
                 <groupId>org.apache.cxf.services.sts</groupId>
                 <artifactId>cxf-services-sts-core</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -3069,7 +3091,7 @@
             <dependency>
                 <groupId>org.apache.cxf.services.ws-discovery</groupId>
                 <artifactId>cxf-services-ws-discovery-api</artifactId>
-                <version>${version.org.apache.cxf}</version>
+                <version>${legacy.version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
@@ -3125,7 +3147,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjc-utils</groupId>
                 <artifactId>cxf-xjc-runtime</artifactId>
-                <version>${version.org.apache.cxf.xjcplugins}</version>
+                <version>${legacy.version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.commons</groupId>
@@ -3173,7 +3195,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-boolean</artifactId>
-                <version>${version.org.apache.cxf.xjcplugins}</version>
+                <version>${legacy.version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.xml.bind</groupId>
@@ -3249,7 +3271,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-bug986</artifactId>
-                <version>${version.org.apache.cxf.xjcplugins}</version>
+                <version>${legacy.version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.commons</groupId>
@@ -3297,7 +3319,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-dv</artifactId>
-                <version>${version.org.apache.cxf.xjcplugins}</version>
+                <version>${legacy.version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.xml.bind</groupId>
@@ -3337,7 +3359,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-ts</artifactId>
-                <version>${version.org.apache.cxf.xjcplugins}</version>
+                <version>${legacy.version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.commons</groupId>
@@ -3385,29 +3407,29 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-common</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <!-- Legacy dependency, useful for Hibernate Search 5 only -->
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-backward-codecs</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-facet</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-join</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.lucene</groupId>
@@ -3424,17 +3446,17 @@
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-misc</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-queries</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-queryparser</artifactId>
-                <version>${version.org.apache.lucene}</version>
+                <version>${legacy.version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.lucene</groupId>
@@ -3446,13 +3468,13 @@
             <dependency>
                 <groupId>org.apache.myfaces.core</groupId>
                 <artifactId>myfaces-api</artifactId>
-                <version>${version.org.apache.myfaces.core}</version>
+                <version>${legacy.version.org.apache.myfaces.core}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.myfaces.core</groupId>
                 <artifactId>myfaces-impl</artifactId>
-                <version>${version.org.apache.myfaces.core}</version>
+                <version>${legacy.version.org.apache.myfaces.core}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -3694,7 +3716,7 @@
             <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
-                <version>${version.org.eclipse.yasson}</version>
+                <version>${legacy.version.org.eclipse.yasson}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3707,7 +3729,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-api</artifactId>
-                <version>${version.org.eclipse.microprofile.health.api}</version>
+                <version>${legacy.version.org.eclipse.microprofile.health.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.inject</groupId>
@@ -3719,7 +3741,7 @@
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>eclipselink</artifactId>
-                <version>${version.org.eclipselink.version}</version>
+                <version>${legacy.version.org.eclipselink.version}</version>
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
@@ -3745,8 +3767,20 @@
 
             <dependency>
                 <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${legacy.version.org.glassfish.jakarta.el}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.enterprise.concurrent</artifactId>
-                <version>${version.org.glassfish.jakarta.enterprise.concurrent}</version>
+                <version>${legacy.version.org.glassfish.jakarta.enterprise.concurrent}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3758,13 +3792,13 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>codemodel</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-jxc</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun</groupId>
@@ -3776,7 +3810,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.activation</groupId>
@@ -3796,7 +3830,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-xjc</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.dtd-parser</groupId>
@@ -3808,13 +3842,13 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>txw2</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>xsom</artifactId>
-                <version>${version.sun.jaxb}</version>
+                <version>${legacy.version.sun.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind.external</groupId>
@@ -3830,13 +3864,13 @@
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
                 <artifactId>jakarta.security.enterprise</artifactId>
-                <version>${version.org.glassfish.soteria}</version>
+                <version>${legacy.version.org.glassfish.soteria}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>${version.org.hibernate}</version>
+                <version>${legacy.version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3848,7 +3882,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
-                <version>${version.org.hibernate}</version>
+                <version>${legacy.version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3860,7 +3894,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-envers</artifactId>
-                <version>${version.org.hibernate}</version>
+                <version>${legacy.version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3872,7 +3906,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-java8</artifactId>
-                <version>${version.org.hibernate}</version>
+                <version>${legacy.version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3886,7 +3920,7 @@
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-backend-jms</artifactId>
-                <version>${version.org.hibernate.search}</version>
+                <version>${legacy.version.org.hibernate.search}</version>
             </dependency>
 
             <dependency>
@@ -3894,7 +3928,7 @@
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-engine</artifactId>
-                <version>${version.org.hibernate.search}</version>
+                <version>${legacy.version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -3908,7 +3942,7 @@
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-orm</artifactId>
-                <version>${version.org.hibernate.search}</version>
+                <version>${legacy.version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.hibernate</groupId>
@@ -3942,13 +3976,13 @@
                 <!-- TODO WFLY-16362: Remove before WildFly 27 is released -->
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-serialization-avro</artifactId>
-                <version>${version.org.hibernate.search}</version>
+                <version>${legacy.version.org.hibernate.search}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>${version.org.hibernate.commons.annotations}</version>
+                <version>${legacy.version.org.hibernate.commons.annotations}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -3960,7 +3994,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>${version.org.hibernate.validator}</version>
+                <version>${legacy.version.org.hibernate.validator}</version>
                 <exclusions>
                     <!-- TODO remove this exclusion once this supports Jakarta Validation -->
                     <!-- Superceded by jakarta.validation:jakarta.validation-api -->
@@ -3974,7 +4008,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator-cdi</artifactId>
-                <version>${version.org.hibernate.validator}</version>
+                <version>${legacy.version.org.hibernate.validator}</version>
             </dependency>
 
             <dependency>
@@ -4004,7 +4038,7 @@
             <dependency>
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
-                <version>${version.org.jberet}</version>
+                <version>${legacy.version.org.jberet}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -4493,7 +4527,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>jose-jwt</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4505,7 +4539,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-atom-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4517,7 +4551,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-cdi</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4529,7 +4563,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4541,7 +4575,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client-api</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4553,7 +4587,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4565,7 +4599,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core-spi</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4577,7 +4611,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-crypto</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4589,7 +4623,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jackson2-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4601,7 +4635,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jaxb-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4613,7 +4647,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jsapi</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4625,7 +4659,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-binding-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4637,7 +4671,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-p-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4649,7 +4683,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-multipart-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4661,7 +4695,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-rxjava2</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4673,7 +4707,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-spring</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4685,7 +4719,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-validator-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
+                <version>${legacy.version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4823,7 +4857,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-api</artifactId>
-                <version>${version.org.jboss.weld.weld-api}</version>
+                <version>${legacy.version.org.jboss.weld.weld-api}</version>
                 <exclusions>
                     <!-- TODO remove this exclusion once this depends on Jakarta CDI -->
                     <!-- superseded by jakarta.enterprise:jakarta.enterprise.cdi-api -->
@@ -4843,7 +4877,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core-impl</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4855,13 +4889,13 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-spi</artifactId>
-                <version>${version.org.jboss.weld.weld-api}</version>
+                <version>${legacy.version.org.jboss.weld.weld-api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-ejb</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4873,7 +4907,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-jsf</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4885,7 +4919,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-jta</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4897,7 +4931,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-web</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4909,7 +4943,7 @@
             <dependency>
                 <groupId>org.jboss.weld.probe</groupId>
                 <artifactId>weld-probe-core</artifactId>
-                <version>${version.org.jboss.weld.weld}</version>
+                <version>${legacy.version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4921,7 +4955,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-api</artifactId>
-                <version>${version.org.jboss.ws.api}</version>
+                <version>${legacy.version.org.jboss.ws.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4933,7 +4967,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-common</artifactId>
-                <version>${version.org.jboss.ws.common}</version>
+                <version>${legacy.version.org.jboss.ws.common}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4945,7 +4979,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-spi</artifactId>
-                <version>${version.org.jboss.ws.spi}</version>
+                <version>${legacy.version.org.jboss.ws.spi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -4957,7 +4991,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-client</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>asm</groupId>
@@ -5126,20 +5160,20 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-factories</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-resources</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
                 <classifier>wildfly2700</classifier>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-server</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>asm</groupId>
@@ -5312,7 +5346,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-transports-udp</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.woodstox</groupId>
@@ -5340,7 +5374,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-transports-undertow</artifactId>
-                <version>${version.org.jboss.ws.cxf}</version>
+                <version>${legacy.version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -5368,7 +5402,7 @@
             <dependency>
                 <groupId>org.jboss.ws.projects</groupId>
                 <artifactId>jaxws-undertow-httpspi</artifactId>
-                <version>${version.org.jboss.ws.jaxws-undertow-httpspi}</version>
+                <version>${legacy.version.org.jboss.ws.jaxws-undertow-httpspi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.xml.ws</groupId>
@@ -5380,7 +5414,7 @@
             <dependency>
                 <groupId>org.jvnet.staxex</groupId>
                 <artifactId>stax-ex</artifactId>
-                <version>${version.org.jvnet.staxex}</version>
+                <version>${legacy.version.org.jvnet.staxex}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>
@@ -5396,7 +5430,7 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-core</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.dropwizard.metrics</groupId>
@@ -5408,19 +5442,19 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-profile-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-saml-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-saml-impl</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.velocity</groupId>
@@ -5432,55 +5466,55 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-security-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-security-impl</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-soap-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-impl</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-saml-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-saml-impl</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xmlsec-api</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xmlsec-impl</artifactId>
-                <version>${version.org.opensaml.opensaml}</version>
+                <version>${legacy.version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>

--- a/boms/legacy-expansion/pom.xml
+++ b/boms/legacy-expansion/pom.xml
@@ -122,13 +122,13 @@
             <dependency>
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-tracerresolver</artifactId>
-                <version>${version.io.opentracing.tracerresolver}</version>
+                <version>${legacy.version.io.opentracing.tracerresolver}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance</artifactId>
-                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${legacy.version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -139,114 +139,114 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-api</artifactId>
-                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${legacy.version.io.smallrye.smallrye-fault-tolerance}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${legacy.version.io.smallrye.smallrye-fault-tolerance}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-core</artifactId>
-                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${legacy.version.io.smallrye.smallrye-fault-tolerance}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-health</artifactId>
-                <version>${version.io.smallrye.smallrye-health}</version>
+                <version>${legacy.version.io.smallrye.smallrye-health}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt</artifactId>
-                <version>${version.io.smallrye.smallrye-jwt}</version>
+                <version>${legacy.version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-cdi-extension</artifactId>
-                <version>${version.io.smallrye.smallrye-jwt}</version>
+                <version>${legacy.version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-common</artifactId>
-                <version>${version.io.smallrye.smallrye-jwt}</version>
+                <version>${legacy.version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-http-mechanism</artifactId>
-                <version>${version.io.smallrye.smallrye-jwt}</version>
+                <version>${legacy.version.io.smallrye.smallrye-jwt}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-metrics</artifactId>
-                <version>${version.io.smallrye.smallrye-metrics}</version>
+                <version>${legacy.version.io.smallrye.smallrye-metrics}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-metrics-api</artifactId>
-                <version>${version.io.smallrye.smallrye-metrics}</version>
+                <version>${legacy.version.io.smallrye.smallrye-metrics}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-core</artifactId>
-                <version>${version.io.smallrye.open-api}</version>
+                <version>${legacy.version.io.smallrye.open-api}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-jaxrs</artifactId>
-                <version>${version.io.smallrye.open-api}</version>
+                <version>${legacy.version.io.smallrye.open-api}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-opentracing</artifactId>
-                <version>${version.io.smallrye.opentracing}</version>
+                <version>${legacy.version.io.smallrye.opentracing}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-annotation</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-classloader</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-constraint</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-expression</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-function</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-vertx-context</artifactId>
-                <version>${version.io.smallrye.smallrye-common}</version>
+                <version>${legacy.version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
-                <version>${version.io.smallrye.smallrye-config}</version>
+                <version>${legacy.version.io.smallrye.smallrye-config}</version>
                 <exclusions>
                     <!-- TODO remove this exclusion once this depends on Jakarta Annotations -->
                     <!-- Superceded by jakarta.annotation:jakarta.annotation-api -->
@@ -266,25 +266,25 @@
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-common</artifactId>
-                <version>${version.io.smallrye.smallrye-config}</version>
+                <version>${legacy.version.io.smallrye.smallrye-config}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-core</artifactId>
-                <version>${version.io.smallrye.smallrye-config}</version>
+                <version>${legacy.version.io.smallrye.smallrye-config}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-source-file-system</artifactId>
-                <version>${version.io.smallrye.smallrye-config}</version>
+                <version>${legacy.version.io.smallrye.smallrye-config}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-api</artifactId>
-                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${legacy.version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -296,7 +296,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka</artifactId>
-                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${legacy.version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -308,7 +308,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka-api</artifactId>
-                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${legacy.version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -320,7 +320,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-provider</artifactId>
-                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${legacy.version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -332,86 +332,37 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
-                <version>${version.org.eclipse.microprofile.config.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.config</groupId>
-                <artifactId>microprofile-config-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.config.api}</version>
-                <scope>test</scope>
+                <version>${legacy.version.org.eclipse.microprofile.config.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
                 <artifactId>microprofile-fault-tolerance-api</artifactId>
-                <version>${version.org.eclipse.microprofile.fault-tolerance.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-                <artifactId>microprofile-fault-tolerance-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.fault-tolerance.tck}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.microprofile.health</groupId>
-                <artifactId>microprofile-health-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.health.api}</version>
-                <scope>test</scope>
+                <version>${legacy.version.org.eclipse.microprofile.fault-tolerance.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-api</artifactId>
-                <version>${version.org.eclipse.microprofile.jwt.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.jwt</groupId>
-                <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.jwt.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.jwt</groupId>
-                <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.jwt.api}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
+                <version>${legacy.version.org.eclipse.microprofile.jwt.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api</artifactId>
-                <version>${version.org.eclipse.microprofile.metrics.api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.metrics</groupId>
-                <artifactId>microprofile-metrics-api-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.metrics.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.metrics</groupId>
-                <artifactId>microprofile-metrics-rest-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.metrics.api}</version>
-                <scope>test</scope>
+                <version>${legacy.version.org.eclipse.microprofile.metrics.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
                 <artifactId>microprofile-openapi-api</artifactId>
-                <version>${version.org.eclipse.microprofile.openapi}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.openapi</groupId>
-                <artifactId>microprofile-openapi-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.openapi}</version>
+                <version>${legacy.version.org.eclipse.microprofile.openapi}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-api</artifactId>
-                <version>${version.org.eclipse.microprofile.opentracing}</version>
+                <version>${legacy.version.org.eclipse.microprofile.opentracing}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
@@ -419,21 +370,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.opentracing</groupId>
-                <artifactId>microprofile-opentracing-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.opentracing}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.opentracing</groupId>
-                <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
-                <version>${version.org.eclipse.microprofile.opentracing}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-api</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <version>${legacy.version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -445,28 +386,11 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-core</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <version>${legacy.version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
                         <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
-                <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <!--
-                        Depends on org.reactivestreams:reactive-streams-tck which in turn has a dependency
-                        on an ancient version of this spi
-                     -->
-                    <exclusion>
-                        <groupId>org.jboss.arquillian.test</groupId>
-                        <artifactId>arquillian-test-spi</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -474,38 +398,19 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
                 <artifactId>microprofile-reactive-messaging-api</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
+                <version>${legacy.version.org.eclipse.microprofile.reactive-messaging.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
-                <artifactId>microprofile-reactive-messaging-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
                 <artifactId>microprofile-rest-client-api</artifactId>
-                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.microprofile.rest.client</groupId>
-                <artifactId>microprofile-rest-client-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
-                <scope>test</scope>
+                <version>${legacy.version.org.eclipse.microprofile.rest.client.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -517,7 +422,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client-microprofile</artifactId>
-                <version>${version.org.jboss.resteasy.microprofile}</version>
+                <version>${legacy.version.org.jboss.resteasy.microprofile}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -529,7 +434,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client-microprofile-base</artifactId>
-                <version>${version.org.jboss.resteasy.microprofile}</version>
+                <version>${legacy.version.org.jboss.resteasy.microprofile}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -539,16 +444,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.org.testng}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-jwt</artifactId>
-                <version>${version.org.wildfly.security.elytron-mp}</version>
+                <version>${legacy.version.org.wildfly.security.elytron-mp}</version>
             </dependency>
 
         </dependencies>

--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -634,7 +634,7 @@
             <dependency>
                 <groupId>com.sun.faces</groupId>
                 <artifactId>jsf-impl</artifactId>
-                <version>${preview.version.com.sun.faces}</version>
+                <version>${version.com.sun.faces}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -646,7 +646,7 @@
             <dependency>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-runtime</artifactId>
-                <version>${preview.version.com.sun.istack}</version>
+                <version>${version.com.sun.istack}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -658,7 +658,7 @@
             <dependency>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-tools</artifactId>
-                <version>${preview.version.com.sun.istack}</version>
+                <version>${version.com.sun.istack}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -668,9 +668,31 @@
             </dependency>
 
             <dependency>
+                <groupId>com.sun.xml.bind.external</groupId>
+                <artifactId>relaxng-datatype</artifactId>
+                <version>${version.sun.jaxb}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind.external</groupId>
+                <artifactId>rngom</artifactId>
+                <version>${version.sun.jaxb}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>relaxngDatatype</groupId>
+                        <artifactId>relaxngDatatype</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind.external</groupId>
+                        <artifactId>relaxng-datatype</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>com.sun.xml.messaging.saaj</groupId>
                 <artifactId>saaj-impl</artifactId>
-                <version>${preview.version.com.sun.xml.messaging.saaj}</version>
+                <version>${version.com.sun.xml.messaging.saaj}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -682,7 +704,7 @@
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-api</artifactId>
-                <version>${preview.version.io.agroal}</version>
+                <version>${version.io.agroal}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -694,7 +716,7 @@
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-narayana</artifactId>
-                <version>${preview.version.io.agroal}</version>
+                <version>${version.io.agroal}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -706,7 +728,7 @@
             <dependency>
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-pool</artifactId>
-                <version>${preview.version.io.agroal}</version>
+                <version>${version.io.agroal}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -718,7 +740,7 @@
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
-                <version>${preview.version.io.undertow}</version>
+                <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -730,7 +752,7 @@
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-servlet</artifactId>
-                <version>${preview.version.io.undertow}</version>
+                <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -742,7 +764,7 @@
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-websockets-jsr</artifactId>
-                <version>${preview.version.io.undertow}</version>
+                <version>${version.io.undertow}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -754,7 +776,7 @@
             <dependency>
                 <groupId>io.undertow.jastow</groupId>
                 <artifactId>jastow</artifactId>
-                <version>${preview.version.io.undertow.jastow}</version>
+                <version>${version.io.undertow.jastow}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -766,7 +788,7 @@
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
-                <version>${preview.version.jakarta.activation.jakarta.activation-api}</version>
+                <version>${version.jakarta.activation.jakarta.activation-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -778,7 +800,7 @@
             <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
-                <version>${preview.version.jakarta.annotation.jakarta-annotation-api}</version>
+                <version>${version.jakarta.annotation.jakarta-annotation-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -790,7 +812,7 @@
             <dependency>
                 <groupId>jakarta.authentication</groupId>
                 <artifactId>jakarta.authentication-api</artifactId>
-                <version>${preview.version.jakarta.authentication.jakarta-authentication-api}</version>
+                <version>${version.jakarta.authentication.jakarta-authentication-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -802,7 +824,7 @@
             <dependency>
                 <groupId>jakarta.authorization</groupId>
                 <artifactId>jakarta.authorization-api</artifactId>
-                <version>${preview.version.jakarta.authorization.jakarta-authorization-api}</version>
+                <version>${version.jakarta.authorization.jakarta-authorization-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -814,7 +836,7 @@
             <dependency>
                 <groupId>jakarta.batch</groupId>
                 <artifactId>jakarta.batch-api</artifactId>
-                <version>${preview.version.jakarta.batch.jakarta.batch-api}</version>
+                <version>${version.jakarta.batch.jakarta.batch-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -826,7 +848,7 @@
             <dependency>
                 <groupId>jakarta.ejb</groupId>
                 <artifactId>jakarta.ejb-api</artifactId>
-                <version>${preview.version.jakarta.ejb.jakarta-ejb-api}</version>
+                <version>${version.jakarta.ejb.jakarta-ejb-api}</version>
                 <!-- Exclude dependencies declared in the servlet-feature-pack-ee-8-api module -->
                 <exclusions>
                     <exclusion>
@@ -839,7 +861,7 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${preview.version.jakarta.enterprise}</version>
+                <version>${version.jakarta.enterprise}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -851,7 +873,7 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.lang-model</artifactId>
-                <version>${preview.version.jakarta.enterprise}</version>
+                <version>${version.jakarta.enterprise}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -863,7 +885,7 @@
             <dependency>
                 <groupId>jakarta.enterprise.concurrent</groupId>
                 <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-                <version>${preview.version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api}</version>
+                <version>${version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -875,7 +897,7 @@
             <dependency>
                 <groupId>jakarta.faces</groupId>
                 <artifactId>jakarta.faces-api</artifactId>
-                <version>${preview.version.jakarta.faces.jakarta-faces-api}</version>
+                <version>${version.jakarta.faces.jakarta-faces-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -887,7 +909,7 @@
             <dependency>
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject-api</artifactId>
-                <version>${preview.version.jakarta.inject.jakarta.inject-api}</version>
+                <version>${version.jakarta.inject.jakarta.inject-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -899,7 +921,7 @@
             <dependency>
                 <groupId>jakarta.interceptor</groupId>
                 <artifactId>jakarta.interceptor-api</artifactId>
-                <version>${preview.version.jakarta.interceptor.jakarta-interceptors-api}</version>
+                <version>${version.jakarta.interceptor.jakarta-interceptors-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -911,7 +933,7 @@
             <dependency>
                 <groupId>jakarta.jms</groupId>
                 <artifactId>jakarta.jms-api</artifactId>
-                <version>${preview.version.jakarta.jms.jakarta-jms-api}</version>
+                <version>${version.jakarta.jms.jakarta-jms-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -923,19 +945,19 @@
             <dependency>
                 <groupId>jakarta.json</groupId>
                 <artifactId>jakarta.json-api</artifactId>
-                <version>${preview.version.jakarta.json.jakarta-json-api}</version>
+                <version>${version.jakarta.json.jakarta-json-api}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.json.bind</groupId>
                 <artifactId>jakarta.json.bind-api</artifactId>
-                <version>${preview.version.jakarta.json.bind.api}</version>
+                <version>${version.jakarta.json.bind.api}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.jws</groupId>
                 <artifactId>jakarta.jws-api</artifactId>
-                <version>${preview.version.jakarta.jws.jakarta-jws-api}</version>
+                <version>${version.jakarta.jws.jakarta-jws-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -947,7 +969,7 @@
             <dependency>
                 <groupId>jakarta.mail</groupId>
                 <artifactId>jakarta.mail-api</artifactId>
-                <version>${preview.version.jakarta.mail-api}</version>
+                <version>${version.jakarta.mail-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -959,7 +981,7 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${preview.version.jakarta.persistence}</version>
+                <version>${version.jakarta.persistence}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -971,7 +993,7 @@
             <dependency>
                 <groupId>jakarta.resource</groupId>
                 <artifactId>jakarta.resource-api</artifactId>
-                <version>${preview.version.jakarta.resource.jakarta-resource-api}</version>
+                <version>${version.jakarta.resource.jakarta-resource-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -983,7 +1005,7 @@
             <dependency>
                 <groupId>jakarta.security.enterprise</groupId>
                 <artifactId>jakarta.security.enterprise-api</artifactId>
-                <version>${preview.version.jakarta.security.enterprise}</version>
+                <version>${version.jakarta.security.enterprise}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -995,7 +1017,7 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>${preview.version.jakarta.servlet.jakarta-servlet-api}</version>
+                <version>${version.jakarta.servlet.jakarta-servlet-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1007,7 +1029,7 @@
             <dependency>
                 <groupId>jakarta.servlet.jsp</groupId>
                 <artifactId>jakarta.servlet.jsp-api</artifactId>
-                <version>${preview.version.jakarta.servlet.jsp.jakarta-servlet-jsp-api}</version>
+                <version>${version.jakarta.servlet.jsp.jakarta-servlet-jsp-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1019,7 +1041,7 @@
             <dependency>
                 <groupId>jakarta.servlet.jsp.jstl</groupId>
                 <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-                <version>${preview.version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api}</version>
+                <version>${version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1031,7 +1053,7 @@
             <dependency>
                 <groupId>jakarta.transaction</groupId>
                 <artifactId>jakarta.transaction-api</artifactId>
-                <version>${preview.version.jakarta.transaction.jakarta-transaction-api}</version>
+                <version>${version.jakarta.transaction.jakarta-transaction-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1043,7 +1065,7 @@
             <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
-                <version>${preview.version.jakarta.validation.jakarta-validation-api}</version>
+                <version>${version.jakarta.validation.jakarta-validation-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1055,7 +1077,7 @@
             <dependency>
                 <groupId>jakarta.websocket</groupId>
                 <artifactId>jakarta.websocket-api</artifactId>
-                <version>${preview.version.jakarta.websocket.jakarta-websocket-api}</version>
+                <version>${version.jakarta.websocket.jakarta-websocket-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1066,7 +1088,7 @@
             <dependency>
                 <groupId>jakarta.websocket</groupId>
                 <artifactId>jakarta.websocket-client-api</artifactId>
-                <version>${preview.version.jakarta.websocket.jakarta-websocket-api}</version>
+                <version>${version.jakarta.websocket.jakarta-websocket-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1077,12 +1099,12 @@
             <dependency>
                 <groupId>jakarta.ws.rs</groupId>
                 <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>${preview.version.jakarta.ws.rs.jakarta-ws-rs-api}</version>
+                <version>${version.jakarta.ws.rs.jakarta-ws-rs-api}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${preview.version.jakarta.xml.bind.jakarta-xml-bind-api}</version>
+                <version>${version.jakarta.xml.bind.jakarta-xml-bind-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1094,7 +1116,7 @@
             <dependency>
                 <groupId>jakarta.xml.ws</groupId>
                 <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>${preview.version.jakarta.xml.ws.jakarta.xml.ws-api}</version>
+                <version>${version.jakarta.xml.ws.jakarta.xml.ws-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1105,7 +1127,7 @@
             <dependency>
                 <groupId>jboss.jaxbintros</groupId>
                 <artifactId>jboss-jaxb-intros</artifactId>
-                <version>${preview.version.jboss.jaxbintros}</version>
+                <version>${version.jboss.jaxbintros}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1117,7 +1139,7 @@
             <dependency>
                 <groupId>net.shibboleth.utilities</groupId>
                 <artifactId>java-support</artifactId>
-                <version>${preview.version.net.shibboleth.utilities.java-support}</version>
+                <version>${version.net.shibboleth.utilities.java-support}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -1129,7 +1151,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4</artifactId>
-                <version>${preview.version.antlr}</version>
+                <version>${version.antlr}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1141,7 +1163,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
-                <version>${preview.version.antlr}</version>
+                <version>${version.antlr}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1199,7 +1221,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1211,7 +1233,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-coloc</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1223,7 +1245,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-soap</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1235,7 +1257,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-xml</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1247,7 +1269,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-databinding-aegis</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1259,7 +1281,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-databinding-jaxb</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1271,7 +1293,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-features-clustering</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1283,7 +1305,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-features-logging</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1295,7 +1317,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxws</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1307,7 +1329,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-simple</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1319,7 +1341,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-management</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1331,7 +1353,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-security</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1343,7 +1365,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-security-saml</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1355,7 +1377,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1367,7 +1389,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-hc</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1379,7 +1401,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-jms</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1391,7 +1413,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-local</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1403,7 +1425,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-addr</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1415,7 +1437,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-mex</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1427,7 +1449,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-policy</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1439,7 +1461,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-rm</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1451,7 +1473,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-security</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1463,7 +1485,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-wsdl</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1475,7 +1497,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-common</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1487,7 +1509,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-java2ws</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1499,7 +1521,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-validator</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1511,7 +1533,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-core</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1523,7 +1545,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1535,7 +1557,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1547,7 +1569,7 @@
             <dependency>
                 <groupId>org.apache.cxf.services.sts</groupId>
                 <artifactId>cxf-services-sts-core</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1559,7 +1581,7 @@
             <dependency>
                 <groupId>org.apache.cxf.services.ws-discovery</groupId>
                 <artifactId>cxf-services-ws-discovery-api</artifactId>
-                <version>${preview.version.org.apache.cxf}</version>
+                <version>${version.org.apache.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1571,7 +1593,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjc-utils</groupId>
                 <artifactId>cxf-xjc-runtime</artifactId>
-                <version>${preview.version.org.apache.cxf.xjcplugins}</version>
+                <version>${version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1583,7 +1605,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-boolean</artifactId>
-                <version>${preview.version.org.apache.cxf.xjcplugins}</version>
+                <version>${version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1594,7 +1616,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-bug986</artifactId>
-                <version>${preview.version.org.apache.cxf.xjcplugins}</version>
+                <version>${version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1606,7 +1628,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-dv</artifactId>
-                <version>${preview.version.org.apache.cxf.xjcplugins}</version>
+                <version>${version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1618,7 +1640,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjcplugins</groupId>
                 <artifactId>cxf-xjc-ts</artifactId>
-                <version>${preview.version.org.apache.cxf.xjcplugins}</version>
+                <version>${version.org.apache.cxf.xjcplugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1630,7 +1652,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-common</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1641,7 +1663,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1652,7 +1674,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-facet</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1663,7 +1685,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-join</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1674,7 +1696,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-queries</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1685,7 +1707,7 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-queryparser</artifactId>
-                <version>${preview.version.org.apache.lucene}</version>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1697,7 +1719,7 @@
             <dependency>
                 <groupId>org.apache.myfaces.core</groupId>
                 <artifactId>myfaces-impl</artifactId>
-                <version>${preview.version.org.apache.myfaces.core}</version>
+                <version>${version.org.apache.myfaces.core}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1709,7 +1731,7 @@
             <dependency>
                 <groupId>org.apache.santuario</groupId>
                 <artifactId>xmlsec</artifactId>
-                <version>${preview.version.org.apache.xmlsec}</version>
+                <version>${version.org.apache.xmlsec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1720,7 +1742,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-bindings</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1731,7 +1753,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-policy</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1742,7 +1764,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-ws-security-common</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1753,7 +1775,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-ws-security-dom</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1764,7 +1786,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-ws-security-policy-stax</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1775,7 +1797,7 @@
             <dependency>
                 <groupId>org.apache.wss4j</groupId>
                 <artifactId>wss4j-ws-security-stax</artifactId>
-                <version>${preview.version.org.apache.wss4j}</version>
+                <version>${version.org.apache.wss4j}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1787,7 +1809,7 @@
             <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
-                <version>${preview.version.org.eclipse.yasson}</version>
+                <version>${version.org.eclipse.yasson}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1804,7 +1826,7 @@
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-activation</artifactId>
-                <version>${preview.version.org.eclipse.angus.angus-activation}</version>
+                <version>${version.org.eclipse.angus.angus-activation}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1816,7 +1838,7 @@
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-mail</artifactId>
-                <version>${preview.version.org.eclipse.angus.angus-mail}</version>
+                <version>${version.org.eclipse.angus.angus-mail}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1829,7 +1851,7 @@
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>parsson</artifactId>
-                <version>${preview.version.org.eclipse.parsson}</version>
+                <version>${version.org.eclipse.parsson}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1841,7 +1863,7 @@
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>eclipselink</artifactId>
-                <version>${preview.version.org.eclipselink.version}</version>
+                <version>${version.org.eclipselink.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1853,7 +1875,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.enterprise.concurrent</artifactId>
-                <version>${preview.version.org.glassfish.jakarta.enterprise.concurrent}</version>
+                <version>${version.org.glassfish.jakarta.enterprise.concurrent}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1865,7 +1887,19 @@
             <dependency>
                 <groupId>org.glassfish.expressly</groupId>
                 <artifactId>expressly</artifactId>
-                <version>${preview.version.org.glassfish.expressly}</version>
+                <version>${version.org.glassfish.expressly}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.org.glassfish.jakarta.el}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1877,13 +1911,13 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>codemodel</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-core</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1895,7 +1929,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-jxc</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun</groupId>
@@ -1907,7 +1941,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.activation</groupId>
@@ -1927,7 +1961,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-xjc</artifactId>
-                <version>${preview.version.org.glassfish.jaxb.jaxb-xjc}</version>
+                <version>${version.org.glassfish.jaxb.jaxb-xjc}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1939,13 +1973,13 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>txw2</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>xsom</artifactId>
-                <version>${preview.version.org.glassfish.jaxb}</version>
+                <version>${version.org.glassfish.jaxb}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.xml.bind.external</groupId>
@@ -1961,7 +1995,7 @@
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
                 <artifactId>jakarta.security.enterprise</artifactId>
-                <version>${preview.version.org.glassfish.soteria}</version>
+                <version>${version.org.glassfish.soteria}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1973,7 +2007,7 @@
             <dependency>
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-                <version>${preview.version.org.glassfish.web.jakarta.servlet.jsp.jstl}</version>
+                <version>${version.org.glassfish.web.jakarta.servlet.jsp.jstl}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1985,7 +2019,7 @@
             <dependency>
                 <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
-                <version>${preview.version.org.hibernate.commons.annotations}</version>
+                <version>${version.org.hibernate.commons.annotations}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -1997,7 +2031,7 @@
             <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>${preview.version.org.hibernate}</version>
+                <version>${version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2009,7 +2043,7 @@
             <dependency>
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-envers</artifactId>
-                <version>${preview.version.org.hibernate}</version>
+                <version>${version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2020,7 +2054,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-backend-elasticsearch</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2031,7 +2065,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-backend-lucene</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2042,7 +2076,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-engine</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2053,7 +2087,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -2065,7 +2099,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2076,7 +2110,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-pojo-base</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2088,7 +2122,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-common</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2099,7 +2133,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -2111,7 +2145,7 @@
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-v5migrationhelper-orm-orm6</artifactId>
-                <version>${preview.version.org.hibernate.search}</version>
+                <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -2124,7 +2158,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>${preview.version.org.hibernate.validator}</version>
+                <version>${version.org.hibernate.validator}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2136,7 +2170,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator-cdi</artifactId>
-                <version>${preview.version.org.hibernate.validator}</version>
+                <version>${version.org.hibernate.validator}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2168,7 +2202,7 @@
             <dependency>
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
-                <version>${preview.version.org.jberet}</version>
+                <version>${version.org.jberet}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2234,7 +2268,7 @@
             <dependency>
                 <groupId>org.jboss.invocation</groupId>
                 <artifactId>jboss-invocation-jakarta</artifactId>
-                <version>${preview.version.org.jboss.invocation}</version>
+                <version>${version.org.jboss.invocation}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2515,7 +2549,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>jose-jwt</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2527,31 +2561,31 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-atom-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-cdi</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client-api</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2563,7 +2597,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core-spi</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2575,7 +2609,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-crypto</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2587,7 +2621,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jackson2-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2599,7 +2633,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jaxb-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2611,43 +2645,43 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jsapi</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-binding-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-json-p-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-multipart-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-rxjava2</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-validator-provider</artifactId>
-                <version>${preview.version.org.jboss.resteasy}</version>
+                <version>${version.org.jboss.resteasy}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy.spring</groupId>
                 <artifactId>resteasy-spring</artifactId>
-                <version>${preview.version.org.jboss.resteasy.spring}</version>
+                <version>${version.org.jboss.resteasy.spring}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2659,7 +2693,7 @@
             <dependency>
                 <groupId>org.jboss.spec.jakarta.el</groupId>
                 <artifactId>jboss-el-api_5.0_spec</artifactId>
-                <version>${preview.version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec}</version>
+                <version>${version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2671,7 +2705,7 @@
             <dependency>
                 <groupId>org.jboss.spec.jakarta.xml.soap</groupId>
                 <artifactId>jboss-saaj-api_3.0_spec</artifactId>
-                <version>${preview.version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec}</version>
+                <version>${version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2683,7 +2717,7 @@
             <dependency>
                 <groupId>org.jboss.spec.jakarta.xml.ws</groupId>
                 <artifactId>jboss-jakarta-xml-ws-api_4.0_spec</artifactId>
-                <version>${preview.version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec}</version>
+                <version>${version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2695,7 +2729,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-api</artifactId>
-                <version>${preview.version.org.jboss.weld.weld-api}</version>
+                <version>${version.org.jboss.weld.weld-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2707,7 +2741,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core-impl</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2719,7 +2753,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-lite-extension-translator</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2731,7 +2765,7 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-spi</artifactId>
-                <version>${preview.version.org.jboss.weld.weld-api}</version>
+                <version>${version.org.jboss.weld.weld-api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2743,7 +2777,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-ejb</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2755,7 +2789,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-jsf</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2767,7 +2801,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-jta</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2779,7 +2813,7 @@
             <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-web</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2791,7 +2825,7 @@
             <dependency>
                 <groupId>org.jboss.weld.probe</groupId>
                 <artifactId>weld-probe-core</artifactId>
-                <version>${preview.version.org.jboss.weld.weld}</version>
+                <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2803,7 +2837,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-api</artifactId>
-                <version>${preview.version.org.jboss.ws.api}</version>
+                <version>${version.org.jboss.ws.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2815,7 +2849,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-common</artifactId>
-                <version>${preview.version.org.jboss.ws.common}</version>
+                <version>${version.org.jboss.ws.common}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2826,7 +2860,7 @@
             <dependency>
                 <groupId>org.jboss.ws</groupId>
                 <artifactId>jbossws-spi</artifactId>
-                <version>${preview.version.org.jboss.ws.spi}</version>
+                <version>${version.org.jboss.ws.spi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2838,7 +2872,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-client</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2850,7 +2884,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-factories</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2862,7 +2896,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-resources</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <classifier>wildfly2700</classifier>
                 <exclusions>
                     <exclusion>
@@ -2875,7 +2909,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-server</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2887,7 +2921,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-transports-udp</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2899,7 +2933,7 @@
             <dependency>
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-transports-undertow</artifactId>
-                <version>${preview.version.org.jboss.ws.cxf}</version>
+                <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2911,7 +2945,7 @@
             <dependency>
                 <groupId>org.jboss.ws.projects</groupId>
                 <artifactId>jaxws-undertow-httpspi</artifactId>
-                <version>${preview.version.org.jboss.ws.jaxws-undertow-httpspi}</version>
+                <version>${version.org.jboss.ws.jaxws-undertow-httpspi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2923,7 +2957,7 @@
             <dependency>
                 <groupId>org.jvnet.staxex</groupId>
                 <artifactId>stax-ex</artifactId>
-                <version>${preview.version.org.jvnet.staxex}</version>
+                <version>${version.org.jvnet.staxex}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -2934,7 +2968,7 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-core</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.dropwizard.metrics</groupId>
@@ -2946,19 +2980,19 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-profile-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-saml-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-saml-impl</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.velocity</groupId>
@@ -2970,68 +3004,68 @@
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-security-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-security-impl</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-soap-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-impl</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-saml-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xacml-saml-impl</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xmlsec-api</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml-xmlsec-impl</artifactId>
-                <version>${preview.version.org.opensaml.opensaml}</version>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>${preview.version.org.testng}</version>
+                <version>${version.org.testng}</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-audit</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3043,7 +3077,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-client</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3055,7 +3089,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-oidc</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3067,7 +3101,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-json-util</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3079,7 +3113,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-jwt</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron-mp}</version>
+                <version>${version.org.wildfly.security.elytron-mp}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3091,7 +3125,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-mechanism-oauth2</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3103,7 +3137,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-realm-token</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3115,7 +3149,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-tool</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3127,7 +3161,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-x500-cert-acme</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron}</version>
+                <version>${version.org.wildfly.security.elytron}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3139,7 +3173,7 @@
             <dependency>
                 <groupId>org.wildfly.security.elytron-web</groupId>
                 <artifactId>undertow-server-servlet</artifactId>
-                <version>${preview.version.org.wildfly.security.elytron-web}</version>
+                <version>${version.org.wildfly.security.elytron-web}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3151,7 +3185,7 @@
             <dependency>
                 <groupId>org.wildfly.security.jakarta</groupId>
                 <artifactId>jakarta-authentication</artifactId>
-                <version>${preview.version.org.wildfly.security.jakarta.elytron-ee}</version>
+                <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3163,7 +3197,7 @@
             <dependency>
                 <groupId>org.wildfly.security.jakarta</groupId>
                 <artifactId>jakarta-authorization</artifactId>
-                <version>${preview.version.org.wildfly.security.jakarta.elytron-ee}</version>
+                <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3175,7 +3209,7 @@
             <dependency>
                 <groupId>org.wildfly.security.jakarta</groupId>
                 <artifactId>jakarta-client-resteasy</artifactId>
-                <version>${preview.version.org.wildfly.security.jakarta.elytron-ee}</version>
+                <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -3187,7 +3221,7 @@
             <dependency>
                 <groupId>org.wildfly.security.jakarta</groupId>
                 <artifactId>jakarta-client-webservices</artifactId>
-                <version>${preview.version.org.wildfly.security.jakarta.elytron-ee}</version>
+                <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/boms/standard-expansion/pom.xml
+++ b/boms/standard-expansion/pom.xml
@@ -171,7 +171,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -182,7 +182,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-api</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -193,7 +193,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -204,7 +204,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-core</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-fault-tolerance}</version>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -216,7 +216,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-health</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-health}</version>
+                <version>${version.io.smallrye.smallrye-health}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -228,28 +228,28 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-jwt}</version>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-cdi-extension</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-jwt}</version>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-common</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-jwt}</version>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-jwt-http-mechanism</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-jwt}</version>
+                <version>${version.io.smallrye.smallrye-jwt}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-metrics</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-metrics}</version>
+                <version>${version.io.smallrye.smallrye-metrics}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -260,7 +260,7 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-metrics-api</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-metrics}</version>
+                <version>${version.io.smallrye.smallrye-metrics}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -272,18 +272,18 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-core</artifactId>
-                <version>${preview.version.io.smallrye.open-api}</version>
+                <version>${version.io.smallrye.open-api}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-jaxrs</artifactId>
-                <version>${preview.version.io.smallrye.open-api}</version>
+                <version>${version.io.smallrye.open-api}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-opentracing</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-opentracing}</version>
+                <version>${version.io.smallrye.smallrye-opentracing}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -294,13 +294,13 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-opentracing-contrib</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-opentracing}</version>
+                <version>${version.io.smallrye.smallrye-opentracing}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-annotation</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.enterprise</groupId>
@@ -315,33 +315,33 @@
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-classloader</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-constraint</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-expression</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-function</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-vertx-context</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-common}</version>
+                <version>${version.io.smallrye.smallrye-common}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-config}</version>
+                <version>${version.io.smallrye.smallrye-config}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.annotation</groupId>
@@ -356,28 +356,28 @@
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-common</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-config}</version>
+                <version>${version.io.smallrye.smallrye-config}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-core</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-config}</version>
+                <version>${version.io.smallrye.smallrye-config}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-source-file-system</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-config}</version>
+                <version>${version.io.smallrye.smallrye-config}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-api</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -388,7 +388,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-kafka-api</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -399,7 +399,7 @@
             <dependency>
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>smallrye-reactive-messaging-provider</artifactId>
-                <version>${preview.version.io.smallrye.smallrye-reactive-messaging}</version>
+                <version>${version.io.smallrye.smallrye-reactive-messaging}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -411,7 +411,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.config.api}</version>
+                <version>${version.org.eclipse.microprofile.config.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -422,7 +422,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.config.api}</version>
+                <version>${version.org.eclipse.microprofile.config.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
@@ -430,7 +430,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
                 <artifactId>microprofile-fault-tolerance-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.fault-tolerance.api}</version>
+                <version>${version.org.eclipse.microprofile.fault-tolerance.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -441,7 +441,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
                 <artifactId>microprofile-fault-tolerance-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.fault-tolerance.api}</version>
+                <version>${version.org.eclipse.microprofile.fault-tolerance.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
@@ -449,7 +449,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.health.api}</version>
+                <version>${version.org.eclipse.microprofile.health.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -460,7 +460,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.health.api}</version>
+                <version>${version.org.eclipse.microprofile.health.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
@@ -468,7 +468,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.jwt.api}</version>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -479,14 +479,14 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.jwt.api}</version>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.jwt.api}</version>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
@@ -495,7 +495,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.metrics.api}</version>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -506,14 +506,14 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.metrics.api}</version>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-rest-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.metrics.api}</version>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
@@ -521,7 +521,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
                 <artifactId>microprofile-openapi-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.openapi}</version>
+                <version>${version.org.eclipse.microprofile.openapi}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -532,14 +532,14 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
                 <artifactId>microprofile-openapi-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.openapi}</version>
+                <version>${version.org.eclipse.microprofile.openapi}</version>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.opentracing}</version>
+                <version>${version.org.eclipse.microprofile.opentracing}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -550,20 +550,20 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.opentracing}</version>
+                <version>${version.org.eclipse.microprofile.opentracing}</version>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.opentracing}</version>
+                <version>${version.org.eclipse.microprofile.opentracing}</version>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -574,7 +574,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-core</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -585,7 +585,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
                 <scope>test</scope>
                 <exclusions>
                     <!--
@@ -602,7 +602,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
                 <artifactId>microprofile-reactive-messaging-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.reactive-messaging.api}</version>
+                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -613,14 +613,14 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
                 <artifactId>microprofile-reactive-messaging-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.reactive-messaging.api}</version>
+                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
                 <artifactId>microprofile-rest-client-api</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.rest.client.api}</version>
+                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -631,7 +631,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
                 <artifactId>microprofile-rest-client-tck</artifactId>
-                <version>${preview.version.org.eclipse.microprofile.rest.client.api}</version>
+                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
                 <scope>test</scope>
                 <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
@@ -639,7 +639,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy.microprofile</groupId>
                 <artifactId>microprofile-config</artifactId>
-                <version>${preview.version.org.jboss.resteasy.microprofile}</version>
+                <version>${version.org.jboss.resteasy.microprofile}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -650,7 +650,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy.microprofile</groupId>
                 <artifactId>microprofile-rest-client</artifactId>
-                <version>${preview.version.org.jboss.resteasy.microprofile}</version>
+                <version>${version.org.jboss.resteasy.microprofile}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -661,7 +661,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy.microprofile</groupId>
                 <artifactId>microprofile-rest-client-base</artifactId>
-                <version>${preview.version.org.jboss.resteasy.microprofile}</version>
+                <version>${version.org.jboss.resteasy.microprofile}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -587,7 +587,7 @@
         <preview.version.org.eclipse.microprofile.rest.client.api>3.0</preview.version.org.eclipse.microprofile.rest.client.api>
         <!-- Implementations -->
         <preview.version.io.smallrye.open-api>3.0.0-RC2</preview.version.io.smallrye.open-api>
-        <preview.version.io.smallrye.smallrye-common>2.0.0-RC2</preview.version.io.smallrye.smallrye-common>
+        <preview.version.io.smallrye.smallrye-common>2.0.0-RC3</preview.version.io.smallrye.smallrye-common>
         <preview.version.io.smallrye.smallrye-config>3.0.0-RC3</preview.version.io.smallrye.smallrye-config>
         <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</preview.version.io.smallrye.smallrye-fault-tolerance>
         <preview.version.io.smallrye.smallrye-health>4.0.0-RC2</preview.version.io.smallrye.smallrye-health>

--- a/pom.xml
+++ b/pom.xml
@@ -588,7 +588,7 @@
         <!-- Implementations -->
         <preview.version.io.smallrye.open-api>3.0.0-RC2</preview.version.io.smallrye.open-api>
         <preview.version.io.smallrye.smallrye-common>2.0.0-RC2</preview.version.io.smallrye.smallrye-common>
-        <preview.version.io.smallrye.smallrye-config>3.0.0-RC2</preview.version.io.smallrye.smallrye-config>
+        <preview.version.io.smallrye.smallrye-config>3.0.0-RC3</preview.version.io.smallrye.smallrye-config>
         <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</preview.version.io.smallrye.smallrye-fault-tolerance>
         <preview.version.io.smallrye.smallrye-health>4.0.0-RC2</preview.version.io.smallrye.smallrye-health>
         <preview.version.io.smallrye.smallrye-jwt>4.0.0-RC2</preview.version.io.smallrye.smallrye-jwt>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,9 @@
         <module.jakarta.suffix>-jakarta</module.jakarta.suffix>
         <module.jms.suffix>jakarta</module.jms.suffix>
 
+        <!-- Base wildfly version used by testsuite/galleon/update test to install a server that gets updated to the SNAPSHOT version -->
+        <wildfly.test.galleon.update.base.version>26.1.1.Final</wildfly.test.galleon.update.base.version>
+
         <!--
             *Plugin* Dependency versions. Please keep alphabetical.
 
@@ -296,8 +299,13 @@
             For example: <version.org.jboss.hal.release-stream>
             to sort automatically use
              mvn com.github.ekryd.sortpom:sortpom-maven-plugin:2.8.0:sort -Dsort.sortProperties=true -Dsort.nrOfIndentSpace=4 -Dsort.keepBlankLines=true -Dsort.sortDependencies=scope,groupId,artifactId
+			
+			For properties only used for building legacy modules not used in standard WildFly or WildFly Preview, prefix the property name with 'legacy.'
+			Place the property in the proper alphabetical location as if the 'legacy.' was not present. In the typical case where there's also the same
+			property without 'legacy.', put the legacy property first.
          -->
-        <version.antlr>2.7.7</version.antlr>
+        <legacy.version.antlr>2.7.7</legacy.version.antlr>
+        <version.antlr>4.10</version.antlr>
         <version.com.beust>1.78</version.com.beust>
         <version.com.carrotsearch.hppc>0.8.1</version.com.carrotsearch.hppc>
         <version.org.elasticsearch.client.rest-client>7.16.3</version.org.elasticsearch.client.rest-client>
@@ -325,9 +333,12 @@
         <version.com.squareup.okhttp3>3.14.9</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.17.5</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.2</version.com.sun.activation.jakarta.activation>
-        <version.com.sun.faces>2.3.17.SP01</version.com.sun.faces>
-        <version.com.sun.istack>3.0.12</version.com.sun.istack>
+        <legacy.version.com.sun.faces>2.3.17.SP01</legacy.version.com.sun.faces>
+        <version.com.sun.faces>4.0.0.SP01</version.com.sun.faces>
+        <legacy.version.com.sun.istack>3.0.12</legacy.version.com.sun.istack>
+        <version.com.sun.istack>4.1.0</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.18</version.com.sun.xml.fastinfoset>
+        <version.com.sun.xml.messaging.saaj>3.0.0-M2</version.com.sun.xml.messaging.saaj>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
         <version.commons-codec>1.15</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
@@ -338,7 +349,8 @@
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.groovy-all>2.4.21</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
-        <version.io.agroal>1.16</version.io.agroal>
+        <legacy.version.io.agroal>1.16</legacy.version.io.agroal>
+        <version.io.agroal>2.0</version.io.agroal>
         <version.io.grpc>1.38.1</version.io.grpc>
         <version.io.jaegertracing>1.6.0</version.io.jaegertracing>
         <version.io.netty>4.1.77.Final</version.io.netty>
@@ -347,102 +359,179 @@
         <version.io.opentracing.concurrent>0.4.0</version.io.opentracing.concurrent>
         <version.io.opentracing.interceptors>0.1.3</version.io.opentracing.interceptors>
         <version.io.opentracing.jaxrs2>1.0.0</version.io.opentracing.jaxrs2>
-        <version.io.opentracing.tracerresolver>0.1.8</version.io.opentracing.tracerresolver>
+        <legacy.version.io.opentracing.tracerresolver>0.1.8</legacy.version.io.opentracing.tracerresolver>
         <version.io.opentracing.servlet>0.2.3</version.io.opentracing.servlet>
         <version.io.perfmark>0.23.0</version.io.perfmark>
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.4</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>2.1.23</version.io.smallrye.open-api>
-        <version.io.smallrye.opentracing>2.0.0</version.io.smallrye.opentracing>
+        <legacy.version.io.smallrye.open-api>2.1.23</legacy.version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>3.0.0-RC2</version.io.smallrye.open-api>
+        <legacy.version.io.smallrye.opentracing>2.0.0</legacy.version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
-        <version.io.smallrye.smallrye-common>1.12.0</version.io.smallrye.smallrye-common>
-        <version.io.smallrye.smallrye-config>2.10.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>5.5.0</version.io.smallrye.smallrye-fault-tolerance>
-        <version.io.smallrye.smallrye-health>3.2.1</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-jwt>3.1.1</version.io.smallrye.smallrye-jwt>
-        <version.io.smallrye.smallrye-metrics>3.0.4</version.io.smallrye.smallrye-metrics>
+        <legacy.version.io.smallrye.smallrye-common>1.12.0</legacy.version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>2.0.0-RC3</version.io.smallrye.smallrye-common>
+        <legacy.version.io.smallrye.smallrye-config>2.10.1</legacy.version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>3.0.0-RC3</version.io.smallrye.smallrye-config>
+        <legacy.version.io.smallrye.smallrye-fault-tolerance>5.5.0</legacy.version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</version.io.smallrye.smallrye-fault-tolerance>
+        <legacy.version.io.smallrye.smallrye-health>3.2.1</legacy.version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>4.0.0-RC2</version.io.smallrye.smallrye-health>
+        <legacy.version.io.smallrye.smallrye-jwt>3.1.1</legacy.version.io.smallrye.smallrye-jwt>
+        <version.io.smallrye.smallrye-jwt>4.0.0-RC2</version.io.smallrye.smallrye-jwt>
+        <legacy.version.io.smallrye.smallrye-metrics>3.0.4</legacy.version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>4.0.0-RC1</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.smallrye-mutiny>1.6.0</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>2.23.0</version.io.smallrye.smallrye-mutiny-vertx>
-        <version.io.smallrye.smallrye-reactive-messaging>3.18.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.undertow.jastow>2.0.10.Final</version.io.undertow.jastow>
+        <version.io.smallrye.smallrye-opentracing>3.0.0-RC1</version.io.smallrye.smallrye-opentracing>
+        <legacy.version.io.smallrye.smallrye-reactive-messaging>3.18.0</legacy.version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.smallrye.smallrye-reactive-messaging>4.0.0.RC1</version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.undertow>2.3.0.Alpha1</version.io.undertow>
+        <legacy.version.io.undertow.jastow>2.0.10.Final</legacy.version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.2.1.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.1</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>${version.io.vertx.vertx}</version.io.vertx.vertx-kafka-client>
-        <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
-        <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
-        <version.jakarta.mail>1.6.7</version.jakarta.mail>
-        <version.jakarta.persistence>2.2.3</version.jakarta.persistence>
-        <version.jakarta.security.enterprise>1.0.2</version.jakarta.security.enterprise>
-        <version.jakarta.transaction>2.0.0</version.jakarta.transaction>
+        <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
+        <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
+        <version.jakarta.authentication.jakarta-authentication-api>3.0.0</version.jakarta.authentication.jakarta-authentication-api>
+        <version.jakarta.authorization.jakarta-authorization-api>2.1.0</version.jakarta.authorization.jakarta-authorization-api>
+        <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
+        <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
+        <version.jakarta.el.jakarta-el-api>5.0.0</version.jakarta.el.jakarta-el-api>
+        <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>3.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
+        <legacy.version.jakarta.enterprise>2.0.2</legacy.version.jakarta.enterprise>
+        <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
+        <version.jakarta.faces.jakarta-faces-api>4.0.1</version.jakarta.faces.jakarta-faces-api>
+        <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
+        <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
+        <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
+        <legacy.version.jakarta.json.bind.api>1.0.2</legacy.version.jakarta.json.bind.api>
+        <version.jakarta.json.bind.api>3.0.0</version.jakarta.json.bind.api>
+        <version.jakarta.json.jakarta-json-api>2.1.0</version.jakarta.json.jakarta-json-api>
+        <legacy.version.jakarta.jws.jakarta.jws-api>2.1.0</legacy.version.jakarta.jws.jakarta.jws-api>
+        <version.jakarta.jws.jakarta-jws-api>3.0.0</version.jakarta.jws.jakarta-jws-api>
+        <legacy.version.jakarta.mail>1.6.7</legacy.version.jakarta.mail>
+        <version.jakarta.mail-api>2.1.0</version.jakarta.mail-api>
+        <legacy.version.jakarta.persistence>2.2.3</legacy.version.jakarta.persistence>
+        <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
+        <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
+        <legacy.version.jakarta.security.enterprise>1.0.2</legacy.version.jakarta.security.enterprise>
+        <version.jakarta.security.enterprise>3.0.0</version.jakarta.security.enterprise>
+        <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
+        <version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>3.1.0</version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
+        <version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>3.0.0</version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>
+        <legacy.version.jakarta.transaction>2.0.0</legacy.version.jakarta.transaction>
+        <version.jakarta.transaction.jakarta-transaction-api>2.0.0</version.jakarta.transaction.jakarta-transaction-api>
         <version.jakarta.validation>2.0.2</version.jakarta.validation>
+        <version.jakarta.validation.jakarta-validation-api>3.0.2</version.jakarta.validation.jakarta-validation-api>
+        <version.jakarta.websocket.jakarta-websocket-api>2.1.0-jbossorg-2</version.jakarta.websocket.jakarta-websocket-api>
+        <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
+        <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.0</version.jakarta.xml.bind.jakarta-xml-bind-api>
+        <version.jakarta.xml.ws.jakarta.xml.ws-api>4.0.0</version.jakarta.xml.ws.jakarta.xml.ws-api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
-        <version.jakarta.jws.jakarta.jws-api>2.1.0</version.jakarta.jws.jakarta.jws-api>
         <version.jaxen>1.1.6</version.jaxen>
-        <version.jboss.jaxbintros>1.0.3.GA</version.jboss.jaxbintros>
+        <legacy.version.jboss.jaxbintros>1.0.3.GA</legacy.version.jboss.jaxbintros>
+        <version.jboss.jaxbintros>2.0.0</version.jboss.jaxbintros>
         <version.joda-time>2.10.14</version.joda-time>
         <version.jsoup>1.14.2</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
-        <version.net.shibboleth.utilities.java-support>7.3.0</version.net.shibboleth.utilities.java-support>
+        <legacy.version.net.shibboleth.utilities.java-support>7.3.0</legacy.version.net.shibboleth.utilities.java-support>
+        <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>2.23.1</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.11.0</version.org.apache.avro>
-        <version.org.apache.cxf>3.5.2</version.org.apache.cxf>
-        <version.org.apache.cxf.xjcplugins>3.3.1</version.org.apache.cxf.xjcplugins>
+        <legacy.version.org.apache.cxf>3.5.2</legacy.version.org.apache.cxf>
+        <version.org.apache.cxf>3.5.2-jbossorg-2</version.org.apache.cxf>
+        <legacy.version.org.apache.cxf.xjcplugins>3.3.1</legacy.version.org.apache.cxf.xjcplugins>
+        <version.org.apache.cxf.xjcplugins>4.0.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.7</version.org.apache.james.apache-mime4j>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
         <version.org.apache.kafka>3.1.0</version.org.apache.kafka>
-        <version.org.apache.lucene>5.5.5</version.org.apache.lucene>
-        <version.org.apache.myfaces.core>2.3.9</version.org.apache.myfaces.core>
+        <legacy.version.org.apache.lucene>5.5.5</legacy.version.org.apache.lucene>
+        <version.org.apache.lucene>8.11.1</version.org.apache.lucene>
+        <legacy.version.org.apache.myfaces.core>2.3.9</legacy.version.org.apache.myfaces.core>
+        <version.org.apache.myfaces.core>3.0.1</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>3.1.2</version.org.apache.openjpa>
         <version.org.apache.qpid.proton>0.33.10</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.3.0</version.org.apache.santuario>
         <version.org.apache.thrift>0.14.1</version.org.apache.thrift>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>
+        <version.org.apache.wss4j>2.4.1-jbossorg-1</version.org.apache.wss4j>
         <version.org.apache.ws.security>2.4.1</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.3.0</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-5</version.org.apache.xalan>
         <version.org.apache.xerces>2.12.0.SP04</version.org.apache.xerces>
+        <version.org.apache.xmlsec>3.0.0</version.org.apache.xmlsec>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.bitbucket.jose4j>0.7.11</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.12.9</version.org.bytebuddy>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.2.8</version.org.codehaus.woodstox.woodstox-core>
+        <version.org.eclipse.angus.angus-activation>1.0.0</version.org.eclipse.angus.angus-activation>
+        <version.org.eclipse.angus.angus-mail>1.0.0</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.26.0</version.org.eclipse.jdt>
         <!-- Required by the Wiremock used in the MicroProfile REST Client TCK -->
         <version.org.eclipse.jetty>9.2.30.v20200428</version.org.eclipse.jetty>
         <version.org.eclipse.microprofile>4.1</version.org.eclipse.microprofile>
-        <version.org.eclipse.microprofile.config.api>2.0</version.org.eclipse.microprofile.config.api>
-        <version.org.eclipse.microprofile.fault-tolerance.api>3.0</version.org.eclipse.microprofile.fault-tolerance.api>
+        <legacy.version.org.eclipse.microprofile.config.api>2.0</legacy.version.org.eclipse.microprofile.config.api>
+        <version.org.eclipse.microprofile.config.api>3.0</version.org.eclipse.microprofile.config.api>
+        <legacy.version.org.eclipse.microprofile.fault-tolerance.api>3.0</legacy.version.org.eclipse.microprofile.fault-tolerance.api>
+        <version.org.eclipse.microprofile.fault-tolerance.api>4.0</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.fault-tolerance.tck>${version.org.eclipse.microprofile.fault-tolerance.api}</version.org.eclipse.microprofile.fault-tolerance.tck>
-        <version.org.eclipse.microprofile.health.api>3.1</version.org.eclipse.microprofile.health.api>
-        <version.org.eclipse.microprofile.jwt.api>1.2.1</version.org.eclipse.microprofile.jwt.api>
-        <version.org.eclipse.microprofile.metrics.api>3.0</version.org.eclipse.microprofile.metrics.api>
-        <version.org.eclipse.microprofile.openapi>2.0.1</version.org.eclipse.microprofile.openapi>
-        <version.org.eclipse.microprofile.opentracing>2.0</version.org.eclipse.microprofile.opentracing>
-        <version.org.eclipse.microprofile.reactive-messaging.api>2.0.1</version.org.eclipse.microprofile.reactive-messaging.api>
-        <version.org.eclipse.microprofile.reactive-streams-operators.api>2.0</version.org.eclipse.microprofile.reactive-streams-operators.api>
-        <version.org.eclipse.microprofile.rest.client.api>2.0</version.org.eclipse.microprofile.rest.client.api>
-        <version.org.eclipse.yasson>1.0.11</version.org.eclipse.yasson>
-        <version.org.eclipselink.version>2.7.10</version.org.eclipselink.version>
-        <version.org.glassfish.jakarta.el>3.0.3.jbossorg-4</version.org.glassfish.jakarta.el>
-        <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>
-        <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
+        <legacy.version.org.eclipse.microprofile.health.api>3.1</legacy.version.org.eclipse.microprofile.health.api>
+        <version.org.eclipse.microprofile.health.api>4.0</version.org.eclipse.microprofile.health.api>
+        <legacy.version.org.eclipse.microprofile.jwt.api>1.2.1</legacy.version.org.eclipse.microprofile.jwt.api>
+        <version.org.eclipse.microprofile.jwt.api>2.0</version.org.eclipse.microprofile.jwt.api>
+        <legacy.version.org.eclipse.microprofile.metrics.api>3.0</legacy.version.org.eclipse.microprofile.metrics.api>
+        <version.org.eclipse.microprofile.metrics.api>4.0</version.org.eclipse.microprofile.metrics.api>
+        <legacy.version.org.eclipse.microprofile.openapi>2.0.1</legacy.version.org.eclipse.microprofile.openapi>
+        <version.org.eclipse.microprofile.openapi>3.0</version.org.eclipse.microprofile.openapi>
+        <legacy.version.org.eclipse.microprofile.opentracing>2.0</legacy.version.org.eclipse.microprofile.opentracing>
+        <version.org.eclipse.microprofile.opentracing>3.0</version.org.eclipse.microprofile.opentracing>
+        <legacy.version.org.eclipse.microprofile.reactive-messaging.api>2.0.1</legacy.version.org.eclipse.microprofile.reactive-messaging.api>
+        <version.org.eclipse.microprofile.reactive-messaging.api>3.0-RC2</version.org.eclipse.microprofile.reactive-messaging.api>
+        <legacy.version.org.eclipse.microprofile.reactive-streams-operators.api>2.0</legacy.version.org.eclipse.microprofile.reactive-streams-operators.api>
+        <version.org.eclipse.microprofile.reactive-streams-operators.api>3.0-RC1</version.org.eclipse.microprofile.reactive-streams-operators.api>
+        <legacy.version.org.eclipse.microprofile.rest.client.api>2.0</legacy.version.org.eclipse.microprofile.rest.client.api>
+        <version.org.eclipse.microprofile.rest.client.api>3.0</version.org.eclipse.microprofile.rest.client.api>
+        <version.org.eclipse.parsson>1.1.0</version.org.eclipse.parsson>
+        <legacy.version.org.eclipse.yasson>1.0.11</legacy.version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>3.0.0</version.org.eclipse.yasson>
+        <legacy.version.org.eclipselink.version>2.7.10</legacy.version.org.eclipselink.version>
+        <version.org.eclipselink.version>3.0.2</version.org.eclipselink.version>
+        <version.org.glassfish.expressly>5.0.0-M2</version.org.glassfish.expressly>
+        <legacy.version.org.glassfish.jakarta.el>3.0.3.jbossorg-4</legacy.version.org.glassfish.jakarta.el>
+        <version.org.glassfish.jakarta.el>5.0.0-M1</version.org.glassfish.jakarta.el>
+        <legacy.version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</legacy.version.org.glassfish.jakarta.enterprise.concurrent>
+        <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
+        <!-- WFLY-14723 For XJC we use a jbossorg variant in WF. Use the version expression from the root
+         pom here so we detect if the base version changes there and we didn't do a -jbossorg of that version -->
+        <version.org.glassfish.jaxb>4.0.0</version.org.glassfish.jaxb>
+        <version.org.glassfish.jaxb.jaxb-xjc>${version.org.glassfish.jaxb}</version.org.glassfish.jaxb.jaxb-xjc>
+        <legacy.version.org.glassfish.soteria>1.0.1-jbossorg-1</legacy.version.org.glassfish.soteria>
+        <version.org.glassfish.soteria>3.0.0</version.org.glassfish.soteria>
+        <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.27.Final</version.org.hibernate>
-        <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.search>5.10.11.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.23.Final</version.org.hibernate.validator>
+        <legacy.version.org.hibernate>5.3.27.Final</legacy.version.org.hibernate>
+        <version.org.hibernate>6.0.2.Final</version.org.hibernate>
+        <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
+        <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
+        <legacy.version.org.hibernate.search>5.10.11.Final</legacy.version.org.hibernate.search>
+        <version.org.hibernate.search>6.1.5.Final</version.org.hibernate.search>
+        <legacy.version.org.hibernate.validator>6.0.23.Final</legacy.version.org.hibernate.validator>
+        <version.org.hibernate.validator>8.0.0.CR1</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>13.0.10.Final</version.org.infinispan>
         <version.org.infinispan.protostream>4.4.3.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.27.0-GA</version.org.javassist>
-        <version.org.jberet>1.3.12.Final</version.org.jberet>
+        <legacy.version.org.jberet>1.3.12.Final</legacy.version.org.jberet>
+        <version.org.jberet>2.1.0.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.6</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.7.0.Alpha10</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
@@ -452,6 +541,7 @@
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.6.2.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
+        <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.5.7.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
@@ -460,13 +550,19 @@
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.12.7.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>4.7.4.Final</version.org.jboss.resteasy>
-        <version.org.jboss.resteasy.microprofile>${version.org.jboss.resteasy}</version.org.jboss.resteasy.microprofile>
+        <legacy.version.org.jboss.resteasy>4.7.4.Final</legacy.version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.1.0.Beta2</version.org.jboss.resteasy>
+        <legacy.version.org.jboss.resteasy.microprofile>${legacy.version.org.jboss.resteasy}</legacy.version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.spring>3.0.0.Alpha3</version.org.jboss.resteasy.spring>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
+        <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.0.CR1</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
+        <version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>
+        <version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>2.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
         <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>2.0.0.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
@@ -485,24 +581,33 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.9.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>3.1.SP4</version.org.jboss.weld.weld-api>
-        <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
-        <version.org.jboss.ws.common>3.3.3.Final</version.org.jboss.ws.common>
+        <legacy.version.org.jboss.weld.weld>3.1.9.Final</legacy.version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>5.0.1.Final</version.org.jboss.weld.weld>
+        <legacy.version.org.jboss.weld.weld-api>3.1.SP4</legacy.version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld-api>5.0.SP2</version.org.jboss.weld.weld-api>
+        <legacy.version.org.jboss.ws.api>1.1.2.Final</legacy.version.org.jboss.ws.api>
+        <version.org.jboss.ws.api>2.0.0.Final</version.org.jboss.ws.api>
+        <legacy.version.org.jboss.ws.common>3.3.3.Final</legacy.version.org.jboss.ws.common>
+        <version.org.jboss.ws.common>4.0.0.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.4.0.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>5.5.0.Final</version.org.jboss.ws.cxf>
-        <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
-        <version.org.jboss.ws.spi>3.4.0.Final</version.org.jboss.ws.spi>
+        <legacy.version.org.jboss.ws.cxf>5.5.0.Final</legacy.version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>6.0.0.Final</version.org.jboss.ws.cxf>
+        <legacy.version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</legacy.version.org.jboss.ws.jaxws-undertow-httpspi>
+        <version.org.jboss.ws.jaxws-undertow-httpspi>2.0.0.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
+        <legacy.version.org.jboss.ws.spi>3.4.0.Final</legacy.version.org.jboss.ws.spi>
+        <version.org.jboss.ws.spi>4.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
         <version.org.jgroups>4.2.21.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.3.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.16.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
-        <version.org.jvnet.staxex>1.8.3</version.org.jvnet.staxex>
+        <legacy.version.org.jvnet.staxex>1.8.3</legacy.version.org.jvnet.staxex>
+        <version.org.jvnet.staxex>2.0.1</version.org.jvnet.staxex>
         <version.org.keycloak>17.0.1</version.org.keycloak>
         <version.org.kohsuke.metainf-services>1.8</version.org.kohsuke.metainf-services>
-        <version.org.opensaml.opensaml>3.4.6</version.org.opensaml.opensaml>
+        <legacy.version.org.opensaml.opensaml>3.4.6</legacy.version.org.opensaml.opensaml>
+        <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.3</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
@@ -510,134 +615,34 @@
         <version.org.keycloak.keycloak-saml-wildfly-subsystem>17.0.1</version.org.keycloak.keycloak-saml-wildfly-subsystem>
         <version.org.springframework.kafka>2.8.2</version.org.springframework.kafka>
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
-        <version.org.testng>6.14.3</version.org.testng>
+        <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian>
         <version.org.wildfly.core>19.0.0.Beta14</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.security.elytron-mp>1.19.0.Final</version.org.wildfly.security.elytron-mp>
+        <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
+        <legacy.version.org.wildfly.security.elytron-mp>1.19.0.Final</legacy.version.org.wildfly.security.elytron-mp>
+        <version.org.wildfly.security.elytron-mp>2.0.0.Beta3</version.org.wildfly.security.elytron-mp>
+        <version.org.wildfly.security.elytron-web>3.0.0.Beta1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.wildfly.transaction.client>2.0.1.Final</version.org.wildfly.transaction.client>
         <version.rhino.js>1.7R2</version.rhino.js>
-        <version.sun.jaxb>2.3.3-b02</version.sun.jaxb>
+        <legacy.version.sun.jaxb>2.3.3-b02</legacy.version.sun.jaxb>
+        <version.sun.jaxb>${version.org.glassfish.jaxb}</version.sun.jaxb>
         <version.sun.saaj-impl>1.5.3</version.sun.saaj-impl>
         <version.wsdl4j>1.6.3</version.wsdl4j>
         <version.xml-resolver>1.2</version.xml-resolver>
         <version.xom>1.3.7</version.xom>
 
-        <!-- WildFly Preview version propertie -->
-        <preview.version.antlr>4.10</preview.version.antlr>
-        <preview.version.com.sun.faces>4.0.0.SP01</preview.version.com.sun.faces>
-        <preview.version.com.sun.istack>4.1.0</preview.version.com.sun.istack>
-        <preview.version.com.sun.xml.messaging.saaj>3.0.0-M2</preview.version.com.sun.xml.messaging.saaj>
-        <preview.version.io.agroal>2.0</preview.version.io.agroal>
-        <preview.version.io.undertow>2.3.0.Alpha1</preview.version.io.undertow>
-        <preview.version.io.undertow.jastow>2.2.1.Final</preview.version.io.undertow.jastow>
-        <preview.version.jakarta.activation.jakarta.activation-api>2.1.0</preview.version.jakarta.activation.jakarta.activation-api>
-        <preview.version.jakarta.annotation.jakarta-annotation-api>2.1.1</preview.version.jakarta.annotation.jakarta-annotation-api>
-        <preview.version.jakarta.authentication.jakarta-authentication-api>3.0.0</preview.version.jakarta.authentication.jakarta-authentication-api>
-        <preview.version.jakarta.authorization.jakarta-authorization-api>2.1.0</preview.version.jakarta.authorization.jakarta-authorization-api>
-        <preview.version.jakarta.batch.jakarta.batch-api>2.1.1</preview.version.jakarta.batch.jakarta.batch-api>
-        <preview.version.jakarta.ejb.jakarta-ejb-api>4.0.1</preview.version.jakarta.ejb.jakarta-ejb-api>
-        <preview.version.jakarta.el.jakarta-el-api>5.0.0</preview.version.jakarta.el.jakarta-el-api>
-        <preview.version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>3.0.0</preview.version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
-        <preview.version.jakarta.enterprise>4.0.0</preview.version.jakarta.enterprise>
-        <preview.version.jakarta.faces.jakarta-faces-api>4.0.1</preview.version.jakarta.faces.jakarta-faces-api>
-        <preview.version.jakarta.inject.jakarta.inject-api>2.0.1</preview.version.jakarta.inject.jakarta.inject-api>
-        <preview.version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</preview.version.jakarta.interceptor.jakarta-interceptors-api>
-        <preview.version.jakarta.jms.jakarta-jms-api>3.1.0</preview.version.jakarta.jms.jakarta-jms-api>
-        <preview.version.jakarta.mail-api>2.1.0</preview.version.jakarta.mail-api>
-        <preview.version.jakarta.json.bind.api>3.0.0</preview.version.jakarta.json.bind.api>
-        <preview.version.jakarta.json.jakarta-json-api>2.1.0</preview.version.jakarta.json.jakarta-json-api>
-        <preview.version.jakarta.jws.jakarta-jws-api>3.0.0</preview.version.jakarta.jws.jakarta-jws-api>
-        <preview.version.jakarta.xml.ws.jakarta.xml.ws-api>4.0.0</preview.version.jakarta.xml.ws.jakarta.xml.ws-api>
-        <preview.version.jakarta.persistence>3.1.0</preview.version.jakarta.persistence>
-        <preview.version.jakarta.resource.jakarta-resource-api>2.1.0</preview.version.jakarta.resource.jakarta-resource-api>
-        <preview.version.jakarta.security.enterprise>3.0.0</preview.version.jakarta.security.enterprise>
-        <preview.version.jakarta.servlet.jakarta-servlet-api>6.0.0</preview.version.jakarta.servlet.jakarta-servlet-api>
-        <preview.version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>3.1.0</preview.version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
-        <preview.version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>3.0.0</preview.version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>
-        <preview.version.jakarta.transaction.jakarta-transaction-api>2.0.0</preview.version.jakarta.transaction.jakarta-transaction-api>
-        <preview.version.jakarta.validation.jakarta-validation-api>3.0.2</preview.version.jakarta.validation.jakarta-validation-api>
-        <preview.version.jakarta.websocket.jakarta-websocket-api>2.1.0-jbossorg-2</preview.version.jakarta.websocket.jakarta-websocket-api>
-        <preview.version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</preview.version.jakarta.ws.rs.jakarta-ws-rs-api>
-        <preview.version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.0</preview.version.jakarta.xml.bind.jakarta-xml-bind-api>
-        <preview.version.net.shibboleth.utilities.java-support>8.0.0</preview.version.net.shibboleth.utilities.java-support>
-        <preview.version.org.apache.cxf>3.5.2-jbossorg-2</preview.version.org.apache.cxf>
-        <preview.version.org.apache.cxf.xjcplugins>4.0.0</preview.version.org.apache.cxf.xjcplugins>
-        <preview.version.org.apache.lucene>8.11.1</preview.version.org.apache.lucene>
-        <preview.version.org.apache.myfaces.core>3.0.1</preview.version.org.apache.myfaces.core>
-        <preview.version.org.apache.wss4j>2.4.1-jbossorg-1</preview.version.org.apache.wss4j>
-        <preview.version.org.apache.xmlsec>3.0.0</preview.version.org.apache.xmlsec>
-        <preview.version.org.eclipse.angus.angus-activation>1.0.0</preview.version.org.eclipse.angus.angus-activation>
-        <preview.version.org.eclipse.angus.angus-mail>1.0.0</preview.version.org.eclipse.angus.angus-mail>
-        <preview.version.org.eclipse.parsson>1.1.0</preview.version.org.eclipse.parsson>
-        <!--
-            Overrides for MP5. Also make sure to update these in testsuite/integration/microprofile-tck/pom.xml
-        -->
-        <preview.version.org.eclipse.microprofile.config.api>3.0</preview.version.org.eclipse.microprofile.config.api>
-        <preview.version.org.eclipse.microprofile.fault-tolerance.api>4.0</preview.version.org.eclipse.microprofile.fault-tolerance.api>
-        <preview.version.org.eclipse.microprofile.jwt.api>2.0</preview.version.org.eclipse.microprofile.jwt.api>
-        <preview.version.org.eclipse.microprofile.health.api>4.0</preview.version.org.eclipse.microprofile.health.api>
-        <preview.version.org.eclipse.microprofile.metrics.api>4.0</preview.version.org.eclipse.microprofile.metrics.api>
-        <preview.version.org.eclipse.microprofile.openapi>3.0</preview.version.org.eclipse.microprofile.openapi>
-        <preview.version.org.eclipse.microprofile.opentracing>3.0</preview.version.org.eclipse.microprofile.opentracing>
-        <preview.version.org.eclipse.microprofile.reactive-messaging.api>3.0-RC2</preview.version.org.eclipse.microprofile.reactive-messaging.api>
-        <preview.version.org.eclipse.microprofile.reactive-streams-operators.api>3.0-RC1</preview.version.org.eclipse.microprofile.reactive-streams-operators.api>
-        <preview.version.org.eclipse.microprofile.rest.client.api>3.0</preview.version.org.eclipse.microprofile.rest.client.api>
-        <!-- Implementations -->
-        <preview.version.io.smallrye.open-api>3.0.0-RC2</preview.version.io.smallrye.open-api>
-        <preview.version.io.smallrye.smallrye-common>2.0.0-RC3</preview.version.io.smallrye.smallrye-common>
-        <preview.version.io.smallrye.smallrye-config>3.0.0-RC3</preview.version.io.smallrye.smallrye-config>
-        <preview.version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</preview.version.io.smallrye.smallrye-fault-tolerance>
-        <preview.version.io.smallrye.smallrye-health>4.0.0-RC2</preview.version.io.smallrye.smallrye-health>
-        <preview.version.io.smallrye.smallrye-jwt>4.0.0-RC2</preview.version.io.smallrye.smallrye-jwt>
-        <preview.version.io.smallrye.smallrye-metrics>4.0.0-RC1</preview.version.io.smallrye.smallrye-metrics>
-        <preview.version.io.smallrye.smallrye-opentracing>3.0.0-RC1</preview.version.io.smallrye.smallrye-opentracing>
-        <preview.version.io.smallrye.smallrye-reactive-messaging>4.0.0.RC1</preview.version.io.smallrye.smallrye-reactive-messaging>
-        <!-- MP5 - END -->
-        <preview.version.jboss.jaxbintros>2.0.0</preview.version.jboss.jaxbintros>
-        <preview.version.org.eclipse.yasson>3.0.0</preview.version.org.eclipse.yasson>
-        <preview.version.org.eclipselink.version>3.0.2</preview.version.org.eclipselink.version>
-        <preview.version.org.glassfish.expressly>5.0.0-M2</preview.version.org.glassfish.expressly>
-        <preview.version.org.glassfish.jakarta.el>5.0.0-M1</preview.version.org.glassfish.jakarta.el>
-        <preview.version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</preview.version.org.glassfish.jakarta.enterprise.concurrent>
-        <!-- WFLY-14723 For XJC we use a jbossorg variant in WF Preview. Use the version expression from the root
-         pom here so we detect if the base version changes there and we didn't do a -jbossorg of that version -->
-        <preview.version.org.glassfish.jaxb>4.0.0</preview.version.org.glassfish.jaxb>
-        <preview.version.org.glassfish.jaxb.jaxb-xjc>${preview.version.org.glassfish.jaxb}</preview.version.org.glassfish.jaxb.jaxb-xjc>
-        <preview.version.org.glassfish.soteria>3.0.0</preview.version.org.glassfish.soteria>
-        <preview.version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</preview.version.org.glassfish.web.jakarta.servlet.jsp.jstl>
-        <preview.version.org.hibernate>6.0.2.Final</preview.version.org.hibernate>
-        <preview.version.org.hibernate.commons.annotations>6.0.1.Final</preview.version.org.hibernate.commons.annotations>
-        <preview.version.org.hibernate.search>6.1.5.Final</preview.version.org.hibernate.search>
-        <preview.version.org.hibernate.validator>8.0.0.CR1</preview.version.org.hibernate.validator>
-        <preview.version.org.jberet>2.1.0.Final</preview.version.org.jberet>
-        <preview.version.org.jboss.invocation>1.7.0.Final</preview.version.org.jboss.invocation>
-        <preview.version.org.jboss.resteasy>6.1.0.Beta2</preview.version.org.jboss.resteasy>
-        <preview.version.org.jboss.resteasy.microprofile>2.0.0.Beta1</preview.version.org.jboss.resteasy.microprofile>
-        <preview.version.org.jboss.resteasy.spring>3.0.0.Alpha3</preview.version.org.jboss.resteasy.spring>
-        <preview.version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.0.CR1</preview.version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
-        <preview.version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>1.0.0.Final</preview.version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>
-        <preview.version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>1.0.0.Final</preview.version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>
-        <preview.version.org.jboss.weld.weld>5.0.1.Final</preview.version.org.jboss.weld.weld>
-        <preview.version.org.jboss.weld.weld-api>5.0.SP2</preview.version.org.jboss.weld.weld-api>
-        <preview.version.org.jboss.ws.api>2.0.0.Final</preview.version.org.jboss.ws.api>
-        <preview.version.org.jboss.ws.common>4.0.0.Final</preview.version.org.jboss.ws.common>
-        <preview.version.org.jboss.ws.cxf>6.0.0.Final</preview.version.org.jboss.ws.cxf>
-        <preview.version.org.jboss.ws.jaxws-undertow-httpspi>2.0.0.Final</preview.version.org.jboss.ws.jaxws-undertow-httpspi>
-        <preview.version.org.jboss.ws.spi>4.1.0.Final</preview.version.org.jboss.ws.spi>
-        <preview.version.org.opensaml.opensaml>4.2.0</preview.version.org.opensaml.opensaml>
-        <preview.version.org.jvnet.staxex>2.0.1</preview.version.org.jvnet.staxex>
-        <preview.version.org.testng>7.4.0</preview.version.org.testng>
-        <preview.version.org.wildfly.security.elytron>2.0.0.Beta1</preview.version.org.wildfly.security.elytron>
-        <preview.version.org.wildfly.security.elytron-mp>2.0.0.Beta3</preview.version.org.wildfly.security.elytron-mp>
-        <preview.version.org.wildfly.security.elytron-web>3.0.0.Beta1</preview.version.org.wildfly.security.elytron-web>
-        <preview.version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta2</preview.version.org.wildfly.security.jakarta.elytron-ee>
-        <preview.version.sun.jaxb>${preview.version.org.glassfish.jaxb}</preview.version.sun.jaxb>
 
-        <!-- Base wildfly version used by testsuite/galleon/update test to install a server that gets updated to the SNAPSHOT version -->
-        <wildfly.test.galleon.update.base.version>26.1.1.Final</wildfly.test.galleon.update.base.version>
+        <!-- 
+            WildFly Preview version properties.
+			Property names should be in the form 'preview.version.xxx'. 
+        -->
+
+        <!-- currently none-->
+
     </properties>
 
     <dependencyManagement>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -884,7 +884,7 @@
                                 <artifactItem>
                                     <groupId>org.hibernate.search</groupId>
                                     <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
-                                    <version>${preview.version.org.hibernate.search}</version>
+                                    <version>${version.org.hibernate.search}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/testlib</outputDirectory>
@@ -893,7 +893,7 @@
                                 <artifactItem>
                                     <groupId>org.hibernate.search</groupId>
                                     <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
-                                    <version>${preview.version.org.hibernate.search}</version>
+                                    <version>${version.org.hibernate.search}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/testlib</outputDirectory>
@@ -902,7 +902,7 @@
                                 <artifactItem>
                                     <groupId>org.hibernate.search</groupId>
                                     <artifactId>hibernate-search-v5migrationhelper-orm-orm6</artifactId>
-                                    <version>${preview.version.org.hibernate.search}</version>
+                                    <version>${version.org.hibernate.search}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/testlib</outputDirectory>

--- a/testsuite/integration/legacy-ejb-client/pom.xml
+++ b/testsuite/integration/legacy-ejb-client/pom.xml
@@ -26,8 +26,6 @@
         <!-- Blow up compilation if anything pulls in jboss-ejb-client -->
         <version.org.jboss.ejb-client>The legacy testsuite is unintentionally including ejb client!
             It MUST be excluded to function properly! See the HACK comment in pom.xml</version.org.jboss.ejb-client>
-        <preview.version.org.jboss.ejb-client>The legacy testsuite is unintentionally including ejb client!
-            It MUST be excluded to function properly! See the HACK comment in pom.xml</preview.version.org.jboss.ejb-client>
 
         <!-- Use the legacy javax.* testsuite/shared as it's used client-side and client-side is currently javax.* -->
         <wildfly-testsuite-shared.artifactId>wildfly-testsuite-shared</wildfly-testsuite-shared.artifactId>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -615,12 +615,12 @@
                 <dependency>
                     <groupId>io.smallrye</groupId>
                     <artifactId>smallrye-opentracing</artifactId>
-                    <version>${preview.version.io.smallrye.smallrye-opentracing}</version>
+                    <version>${version.io.smallrye.smallrye-opentracing}</version>
                 </dependency>
                 <dependency>
                     <groupId>io.smallrye</groupId>
                     <artifactId>smallrye-opentracing-contrib</artifactId>
-                    <version>${preview.version.io.smallrye.smallrye-opentracing}</version>
+                    <version>${version.io.smallrye.smallrye-opentracing}</version>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
Rename version.xxx properties that were overridden in WF Preview to legacy.version.xxx
Rename the preview.version.xxx properties to version.xxx
Move a couple dependencies out from boms/common-ee as legacy and standard are using different versions
Prune a few legacy dependencies that I know aren't used (primarily old MicroProfile TCKs)

https://issues.redhat.com/browse/WFLY-16681

Builds on #15850 to avoid conflict as @kabir 's work there was modifying the properties that got renamed.
