### PR TITLE
WFLY-16666 Do not use component class as superclass for local home in…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
@@ -155,6 +155,6 @@ public class EJBViewDescription extends ViewDescription {
 
     @Override
     public boolean requiresSuperclassInProxy() {
-        return !(isEjb2xView() || methodIntf == MethodIntf.HOME);
+        return !(isEjb2xView() || methodIntf == MethodIntf.LOCAL_HOME || methodIntf == MethodIntf.HOME);
     }
 }


### PR DESCRIPTION
…terface proxy

https://issues.redhat.com/browse/WFLY-16666

Port the fix https://github.com/wildfly/wildfly/pull/15828 from main to 26.x branch.