### PR TITLE
[WFLY-16711] Update BufferPool to use Undertow's ByteBufferPool rather than XNIO's

### DIFF
--- a/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/undertow-base.xml
+++ b/servlet-feature-pack/galleon-common/src/main/resources/feature_groups/undertow-base.xml
@@ -6,6 +6,9 @@
         <feature spec="subsystem.undertow.buffer-cache">
             <param name="buffer-cache" value="default" />
         </feature>
+        <feature spec="subsystem.undertow.byte-buffer-pool">
+            <param name="byte-buffer-pool" value="default" />
+        </feature>
         <feature spec="subsystem.undertow.configuration.filter"/>
         <feature spec="subsystem.undertow.configuration.handler"/>
         <feature spec="subsystem.undertow.server">


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16711

Update WildFly Core version to get buffer-pool removal
Update feature-group to define new byte-buffer-pool
