### PR TITLE
WFLY-16719 TCP-based stacks require UFC to avoid async senders from overwhelming receiver.

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/jgroups.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/jgroups.xml
@@ -36,6 +36,9 @@
           <param name="protocol" value="pbcast.GMS"/>
         </feature>
         <feature spec="subsystem.jgroups.stack.protocol">
+          <param name="protocol" value="UFC"/>
+        </feature>
+        <feature spec="subsystem.jgroups.stack.protocol">
           <param name="protocol" value="MFC"/>
         </feature>
         <feature spec="subsystem.jgroups.stack.protocol">


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16719