### PR TITLE
[WFLY-16633] Re-enable WildFlyElytronClientDefaultSSLContextProviderTestCase

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WildFlyElytronClientDefaultSSLContextProviderTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WildFlyElytronClientDefaultSSLContextProviderTestCase.java
@@ -52,7 +52,6 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.WildFlyElytronClientDefaultSSLContextProvider;
@@ -63,7 +62,6 @@ import org.wildfly.security.auth.client.WildFlyElytronClientDefaultSSLContextPro
  * WildFlyElytronClientDefaultSSLContextProvider is configured on client side to provide default SSL context that RESTEsy client utilizes to connect to the server.
  */
 @RunWith(Arquillian.class)
-@Ignore("WFLY-16633")
 public class WildFlyElytronClientDefaultSSLContextProviderTestCase {
     private static final String[] SERVER_KEY_STORE1 = {"subsystem", "elytron", "key-store", "twoWayKS"};
     private static final String[] SERVER_KEY_MANAGER1 = {"subsystem", "elytron", "key-manager", "twoWayKM"};


### PR DESCRIPTION
Depends on [WFLY-16725](https://issues.redhat.com/browse/WFLY-16725) (Upgrade WildFly Elytron to 2.0.0.Beta2) : https://github.com/wildfly/wildfly/pull/15861
