### PR TITLE
WFLY-16729: unify jndi-name, use-java-context defintion and handling …

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
@@ -44,7 +44,7 @@ import org.jboss.as.connector.subsystems.datasources.DataSourcesSubsystemProvide
 import org.jboss.as.connector.subsystems.datasources.LocalDataSourceService;
 import org.jboss.as.connector.subsystems.datasources.ModifiableDataSource;
 import org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource;
-import org.jboss.as.connector.subsystems.datasources.Util;
+import org.jboss.as.connector.subsystems.common.jndi.Util;
 import org.jboss.as.connector.subsystems.datasources.XMLDataSourceRuntimeHandler;
 import org.jboss.as.connector.subsystems.datasources.XMLXaDataSourceRuntimeHandler;
 import org.jboss.as.connector.subsystems.datasources.XaDataSourceService;

--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -648,22 +648,22 @@ public interface ConnectorLogger extends BasicLogger {
     @Message(id = 69, value = "At least one xa-datasource-property is required for an xa-datasource")
     OperationFailedException xaDataSourcePropertiesNotPresent();
 
-    /**
-     * A message indicating that jndi-name is missing and it's a required attribute
-     *
-     * @return the message.
-     */
-    @Message(id = 70, value = "Jndi name is required")
-    OperationFailedException jndiNameRequired();
+//    /**
+//     * A message indicating that jndi-name is missing and it's a required attribute
+//     *
+//     * @return the message.
+//     */
+//    @Message(id = 70, value = "Jndi name is required")
+//    OperationFailedException jndiNameRequired();
 
 
-    /**
-     * A message indicating that jndi-name has an invalid format
-     *
-     * @return the message.
-     */
-    @Message(id = 71, value = "Jndi name have to start with java:/ or java:jboss/")
-    OperationFailedException jndiNameInvalidFormat();
+//    /**
+//     * A message indicating that jndi-name has an invalid format
+//     *
+//     * @return the message.
+//     */
+//    @Message(id = 71, value = "Jndi name have to start with java:/ or java:jboss/")
+//    OperationFailedException jndiNameInvalidFormat();
 
     /**
      * Creates an exception indicating the deployment failed.

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
@@ -56,6 +56,7 @@ import org.jboss.as.connector.services.resourceadapters.ConnectionFactoryReferen
 import org.jboss.as.connector.services.resourceadapters.ConnectionFactoryService;
 import org.jboss.as.connector.services.resourceadapters.deployment.registry.ResourceAdapterDeploymentRegistry;
 import org.jboss.as.connector.services.workmanager.NamedWorkManager;
+import org.jboss.as.connector.subsystems.common.jndi.Util;
 import org.jboss.as.connector.subsystems.jca.JcaSubsystemConfiguration;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdaptersSubsystemService;
 import org.jboss.as.connector.util.ConnectorServices;
@@ -721,19 +722,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
         // Override this method to change how jndiName is build in AS7
         @Override
         protected String buildJndiName(String rawJndiName, Boolean javaContext) {
-            final String jndiName;
-            if (!rawJndiName.startsWith("java:")) {
-                if (rawJndiName.startsWith("jboss/")) {
-                    // Bind to java:jboss/ namespace
-                    jndiName = "java:" + rawJndiName;
-                } else {
-                    // Bind to java:/ namespace
-                    jndiName= "java:/" + rawJndiName;
-                }
-            } else {
-                jndiName = rawJndiName;
-            }
-            return jndiName;
+            return Util.cleanJndiName(rawJndiName, javaContext);
         }
 
         @Override

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/statistics/ConnectionDefinitionStatisticsService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/statistics/ConnectionDefinitionStatisticsService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.jboss.as.connector.dynamicresource.StatisticsResourceDefinition;
 import org.jboss.as.connector.metadata.deployment.ResourceAdapterDeployment;
+import org.jboss.as.connector.subsystems.common.jndi.Util;
 import org.jboss.as.connector.subsystems.resourceadapters.CommonAttributes;
 import org.jboss.as.connector.subsystems.resourceadapters.Constants;
 import org.jboss.as.controller.PathAddress;
@@ -65,10 +66,11 @@ public class ConnectionDefinitionStatisticsService implements Service<Management
      */
     public ConnectionDefinitionStatisticsService(final ManagementResourceRegistration registration,
                                                  final String jndiName,
+                                                 final boolean useJavaContext,
                                                  final String poolName,
                                                  final boolean statsEnabled) {
         super();
-        this.jndiName = jndiName;
+        this.jndiName = Util.cleanJndiName(jndiName, useJavaContext);
         if (registration.isAllowsOverride()) {
             overrideRegistration = registration.registerOverrideModel(poolName, new OverrideDescriptionProvider() {
                 @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/jndi/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/jndi/Constants.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2022, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.connector.subsystems.common.jndi;
+
+import org.jboss.as.connector.logging.ConnectorLogger;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.jca.common.api.metadata.Defaults;
+import org.jboss.jca.common.api.metadata.ds.DataSource;
+
+public class Constants {
+
+    private static final String JNDINAME_NAME = "jndi-name";
+
+    private static final String USE_JAVA_CONTEXT_NAME = "use-java-context";
+
+    public static SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder(JNDINAME_NAME, ModelType.STRING, false)
+            .setXmlName(DataSource.Attribute.JNDI_NAME.getLocalName())
+            .setAllowExpression(true)
+            .setValidator((__, value) -> {
+                if (value.getType() != ModelType.EXPRESSION) {
+                    String str = value.asString();
+                    if (str.endsWith("/") || str.indexOf("//") != -1) {
+                        throw ConnectorLogger.ROOT_LOGGER.jndiNameShouldValidate();
+                    }
+                }
+            })
+            .setRestartAllServices()
+            .build();
+
+    public static SimpleAttributeDefinition USE_JAVA_CONTEXT = new SimpleAttributeDefinitionBuilder(USE_JAVA_CONTEXT_NAME, ModelType.BOOLEAN, true)
+            .setXmlName(DataSource.Attribute.USE_JAVA_CONTEXT.getLocalName())
+            .setDefaultValue(new ModelNode(Defaults.USE_JAVA_CONTEXT))
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
+}

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/jndi/Util.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/jndi/Util.java
@@ -20,10 +20,10 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.connector.subsystems.datasources;
+package org.jboss.as.connector.subsystems.common.jndi;
 
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
-import static org.jboss.as.connector.subsystems.datasources.Constants.USE_JAVA_CONTEXT;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -37,7 +37,7 @@ import org.jboss.dmr.ModelNode;
 public class Util {
 
     /**
-     * Extracts the raw JNDINAME value from the given model node, and depending on the value and
+     * Extracts the raw JNDI_NAME value from the given model node, and depending on the value and
      * the value of any USE_JAVA_CONTEXT child node, converts the raw name into a compliant jndi name.
      *
      * @param modelNode the model node; either an operation or the model behind a datasource resource
@@ -49,7 +49,7 @@ public class Util {
         return cleanJndiName(rawJndiName, USE_JAVA_CONTEXT.resolveModelAttribute(context, modelNode).asBoolean());
     }
 
-    public static String cleanJndiName(String rawJndiName, boolean useJavaContext) {
+    public static String cleanJndiName(String rawJndiName, Boolean useJavaContext) {
         final String jndiName;
         if (!rawJndiName.startsWith("java:") && useJavaContext) {
             if(rawJndiName.startsWith("jboss/")) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
-import org.jboss.as.connector.subsystems.datasources.Util;
+import org.jboss.as.connector.subsystems.common.jndi.Util;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USERNAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.PASSWORD;
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -24,11 +24,11 @@ package org.jboss.as.connector.subsystems.datasources;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_DATASOURCES_LOGGER;
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_RA_LOGGER;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.AUTHENTICATION_CONTEXT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_DRIVER;
 import static org.jboss.as.connector.subsystems.datasources.Constants.ELYTRON_ENABLED;
 import static org.jboss.as.connector.subsystems.datasources.Constants.ENABLED;
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
 import static org.jboss.as.connector.subsystems.datasources.Constants.RECOVERY_AUTHENTICATION_CONTEXT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.RECOVERY_ELYTRON_ENABLED;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -47,6 +47,7 @@ import org.jboss.as.connector.metadata.api.common.Credential;
 import org.jboss.as.connector.security.ElytronSubjectFactory;
 import org.jboss.as.connector.services.driver.InstalledDriver;
 import org.jboss.as.connector.services.driver.registry.DriverRegistry;
+import org.jboss.as.connector.subsystems.common.jndi.Util;
 import org.jboss.as.connector.util.Injection;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -713,19 +714,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
         // Override this method to change how dsName is build in AS7
         @Override
         protected String buildJndiName(String rawJndiName, Boolean javaContext) {
-            final String jndiName;
-            if (!rawJndiName.startsWith("java:") && javaContext) {
-                if (rawJndiName.startsWith("jboss/")) {
-                    // Bind to java:jboss/ namespace
-                    jndiName = "java:" + rawJndiName;
-                } else {
-                    // Bind to java:/ namespace
-                    jndiName= "java:/" + rawJndiName;
-                }
-            } else {
-                jndiName = rawJndiName;
-            }
-            return jndiName;
+            return Util.cleanJndiName(rawJndiName, javaContext);
         }
 
         @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -21,17 +21,17 @@
  */
 package org.jboss.as.connector.subsystems.datasources;
 
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLE;
 
 import org.jboss.as.connector._private.Capabilities;
-import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.connector.metadata.api.common.Credential;
 import org.jboss.as.connector.metadata.api.common.Security;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -42,7 +42,6 @@ import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
@@ -113,8 +112,6 @@ public class Constants {
 
     private static final String URL_SELECTOR_STRATEGY_CLASS_NAME_NAME = "url-selector-strategy-class-name";
 
-    private static final String USE_JAVA_CONTEXT_NAME = "use-java-context";
-
     private static final String CONNECTABLE_NAME = "connectable";
 
     private static final String MCP_NAME = "mcp";
@@ -128,8 +125,6 @@ public class Constants {
     private static final String ENABLED_NAME = "enabled";
 
     private static final String JTA_NAME = "jta";
-
-    private static final String JNDINAME_NAME = "jndi-name";
 
     private static final String ALLOCATION_RETRY_NAME = "allocation-retry";
 
@@ -278,34 +273,6 @@ public class Constants {
             .setRestartAllServices()
             .build();
 
-    static SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder(JNDINAME_NAME, ModelType.STRING, false)
-            .setXmlName(DataSource.Attribute.JNDI_NAME.getLocalName())
-            .setAllowExpression(true)
-            .setValidator(new ParameterValidator() {
-                @Override
-                public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
-                    if (value.isDefined()) {
-                        if (value.getType() != ModelType.EXPRESSION) {
-                            String str = value.asString();
-                            if (!str.startsWith("java:/") && !str.startsWith("java:jboss/")) {
-                                throw ConnectorLogger.ROOT_LOGGER.jndiNameInvalidFormat();
-                            } else if (str.endsWith("/") || str.indexOf("//") != -1) {
-                                throw ConnectorLogger.ROOT_LOGGER.jndiNameShouldValidate();
-                            }
-                        }
-                    } else {
-                        throw ConnectorLogger.ROOT_LOGGER.jndiNameRequired();
-                    }
-                }
-
-                @Override
-                public void validateResolvedParameter(String parameterName, ModelNode value) throws OperationFailedException {
-                    validateParameter(parameterName, value.resolve());
-                }
-            })
-            .setRestartAllServices()
-            .build();
-
 
     static SimpleAttributeDefinition DATASOURCE_DRIVER = new SimpleAttributeDefinitionBuilder(DATASOURCE_DRIVER_NAME, ModelType.STRING, false)
             .setXmlName(DataSource.Tag.DRIVER.getLocalName())
@@ -336,13 +303,6 @@ public class Constants {
 
     static SimpleAttributeDefinition URL_SELECTOR_STRATEGY_CLASS_NAME = new SimpleAttributeDefinitionBuilder(URL_SELECTOR_STRATEGY_CLASS_NAME_NAME, ModelType.STRING, true)
             .setXmlName(DataSource.Tag.URL_SELECTOR_STRATEGY_CLASS_NAME.getLocalName())
-            .setAllowExpression(true)
-            .setRestartAllServices()
-            .build();
-
-    static SimpleAttributeDefinition USE_JAVA_CONTEXT = new SimpleAttributeDefinitionBuilder(USE_JAVA_CONTEXT_NAME, ModelType.BOOLEAN, true)
-            .setXmlName(DataSource.Attribute.USE_JAVA_CONTEXT.getLocalName())
-            .setDefaultValue(new ModelNode(Defaults.USE_JAVA_CONTEXT))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -57,7 +59,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_
 import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_SORTER_MODULE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_SORTER_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MCP;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NEW_CONNECTION_SQL;
@@ -92,7 +93,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.URL_PROPER
 import static org.jboss.as.connector.subsystems.datasources.Constants.URL_SELECTOR_STRATEGY_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USERNAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.datasources.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_TRY_LOCK;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALIDATE_ON_MATCH;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALID_CONNECTION_CHECKER_CLASSNAME;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceRemove.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import javax.sql.DataSource;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
@@ -22,6 +22,8 @@
 package org.jboss.as.connector.subsystems.datasources;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_DATASOURCES_LOGGER;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -69,7 +71,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_
 import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_SORTER_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.INTERLEAVING;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER_NAME;
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MCP;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
@@ -107,7 +108,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.URL_PROPER
 import static org.jboss.as.connector.subsystems.datasources.Constants.URL_SELECTOR_STRATEGY_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USERNAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.datasources.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_TRY_LOCK;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALIDATE_ON_MATCH;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALID_CONNECTION_CHECKER_CLASSNAME;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DisableRequiredWriteAttributeHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DisableRequiredWriteAttributeHandler.java
@@ -40,7 +40,7 @@ public class DisableRequiredWriteAttributeHandler extends AbstractWriteAttribute
         ModelNode submodel = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
         //do the job
         return (submodel.hasDefined(Constants.ENABLED.getName()) && submodel.get(Constants.ENABLED.getName()).asBoolean()) ||
-                Constants.JNDI_NAME.getName().equals(attributeName);
+                org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME.getName().equals(attributeName);
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
@@ -23,6 +23,8 @@ package org.jboss.as.connector.subsystems.datasources;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -70,7 +72,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_
 import static org.jboss.as.connector.subsystems.datasources.Constants.EXCEPTION_SORTER_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.INTERLEAVING;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER_NAME;
-import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MCP;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
@@ -108,7 +109,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.URL_PROPER
 import static org.jboss.as.connector.subsystems.datasources.Constants.URL_SELECTOR_STRATEGY_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USERNAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.datasources.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_TRY_LOCK;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALIDATE_ON_MATCH;
 import static org.jboss.as.connector.subsystems.datasources.Constants.VALID_CONNECTION_CHECKER_CLASSNAME;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/EnlistmentTraceAttributeWriteHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/EnlistmentTraceAttributeWriteHandler.java
@@ -54,7 +54,8 @@ public class EnlistmentTraceAttributeWriteHandler extends AbstractWriteAttribute
                                            final String parameterName, final ModelNode newValue,
                                            final ModelNode currentValue, final HandbackHolder<List<DataSource>> handbackHolder) throws OperationFailedException {
 
-        final String jndiName = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().get(Constants.JNDI_NAME.getName()).asString();
+        final String jndiName = context.readResource(PathAddress.EMPTY_ADDRESS).getModel()
+                .get(org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME.getName()).asString();
 
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XMLDataSourceRuntimeHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XMLDataSourceRuntimeHandler.java
@@ -78,7 +78,7 @@ public class XMLDataSourceRuntimeHandler extends AbstractXMLDataSourceRuntimeHan
             setStringIfNotNull(context, dataSource.getDriverClass());
         } else if (attributeName.equals(Constants.DATASOURCE_CLASS.getName())) {
             setStringIfNotNull(context, dataSource.getDataSourceClass());
-        } else if (attributeName.equals(Constants.JNDI_NAME.getName())) {
+        } else if (attributeName.equals(org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME.getName())) {
             setStringIfNotNull(context, dataSource.getJndiName());
         } else if (attributeName.equals(Constants.DATASOURCE_DRIVER.getName())) {
             setStringIfNotNull(context, dataSource.getDriver());
@@ -88,7 +88,7 @@ public class XMLDataSourceRuntimeHandler extends AbstractXMLDataSourceRuntimeHan
             setStringIfNotNull(context, dataSource.getUrlDelimiter());
         } else if (attributeName.equals(Constants.URL_SELECTOR_STRATEGY_CLASS_NAME.getName())) {
             setStringIfNotNull(context, dataSource.getUrlSelectorStrategyClassName());
-        } else if (attributeName.equals(Constants.USE_JAVA_CONTEXT.getName())) {
+        } else if (attributeName.equals(org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT.getName())) {
             setBooleanIfNotNull(context, dataSource.isUseJavaContext());
         } else if (attributeName.equals(Constants.JTA.getName())) {
             setBooleanIfNotNull(context, dataSource.isJTA());

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XMLXaDataSourceRuntimeHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XMLXaDataSourceRuntimeHandler.java
@@ -67,7 +67,7 @@ public class XMLXaDataSourceRuntimeHandler extends AbstractXMLDataSourceRuntimeH
     private void handleDatasourceAttribute(final String attributeName, final OperationContext context, final XaDataSource dataSource) {
         if (attributeName.equals(Constants.XA_DATASOURCE_CLASS.getName())) {
             setStringIfNotNull(context, dataSource.getXaDataSourceClass());
-        } else if (attributeName.equals(Constants.JNDI_NAME.getName())) {
+        } else if (attributeName.equals(org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME.getName())) {
             setStringIfNotNull(context, dataSource.getJndiName());
         } else if (attributeName.equals(Constants.DATASOURCE_DRIVER.getName())) {
             setStringIfNotNull(context, dataSource.getDriver());
@@ -79,7 +79,7 @@ public class XMLXaDataSourceRuntimeHandler extends AbstractXMLDataSourceRuntimeH
             setStringIfNotNull(context, dataSource.getUrlProperty());
         } else if (attributeName.equals(Constants.URL_SELECTOR_STRATEGY_CLASS_NAME.getName())) {
             setStringIfNotNull(context, dataSource.getUrlSelectorStrategyClassName());
-        } else if (attributeName.equals(Constants.USE_JAVA_CONTEXT.getName())) {
+        } else if (attributeName.equals(org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT.getName())) {
             setBooleanIfNotNull(context, dataSource.isUseJavaContext());
         } else if (attributeName.equals(Constants.ENABLED.getName())) {
             setBooleanIfNotNull(context, dataSource.isEnabled());

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonAttributes.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonAttributes.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.subsystems.resourceadapters;
 
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -54,7 +56,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENABL
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MCP;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MODULE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NOTXSEPARATEPOOL;
@@ -76,7 +77,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.STATI
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRANSACTION_SUPPORT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_ELYTRON_SECURITY_DOMAIN;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_DEFAULT_GROUPS;
@@ -113,7 +113,7 @@ public class CommonAttributes {
     };
     static final AttributeDefinition[] CONNECTION_DEFINITIONS_NODE_ATTRIBUTE = {
             CLASS_NAME,
-            JNDINAME,
+            JNDI_NAME,
             USE_JAVA_CONTEXT,
             ENABLED, CONNECTABLE, TRACKING,
             MAX_POOL_SIZE,
@@ -160,7 +160,7 @@ public class CommonAttributes {
 
     static final AttributeDefinition[] ADMIN_OBJECTS_NODE_ATTRIBUTE = new AttributeDefinition[]{
             CLASS_NAME,
-            JNDINAME,
+            JNDI_NAME,
             USE_JAVA_CONTEXT,
             ENABLED
     };

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
@@ -23,6 +23,8 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -53,7 +55,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENABL
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MCP;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NOTXSEPARATEPOOL;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NO_RECOVERY;
@@ -73,7 +74,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SECUR
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SHARABLE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WRAP_XA_RESOURCE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.XA_RESOURCE_TIMEOUT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
@@ -177,7 +177,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                 }
                 case JNDI_NAME: {
                     jndiName = value;
-                    JNDINAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
+                    JNDI_NAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
                     break;
                 }
                 case POOL_NAME: {
@@ -342,7 +342,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                 }
                 case JNDI_NAME: {
                     jndiName = value;
-                    JNDINAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
+                    JNDI_NAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
                     break;
                 }
                 case POOL_NAME: {
@@ -504,7 +504,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                 }
                 case JNDI_NAME: {
                     jndiName = value;
-                    JNDINAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
+                    JNDI_NAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
                     break;
                 }
                 case POOL_NAME: {
@@ -688,7 +688,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                     }
                     case JNDI_NAME: {
                         jndiName = value;
-                        JNDINAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
+                        JNDI_NAME.parseAndSetParameter(jndiName, connectionDefinitionNode, reader);
                         break;
                     }
                     case POOL_NAME: {
@@ -932,9 +932,9 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                     break;
                 }
                 case JNDI_NAME: {
-                    jndiName = rawAttributeText(reader, JNDINAME.getXmlName());
+                    jndiName = rawAttributeText(reader, JNDI_NAME.getXmlName());
                     if (jndiName != null) {
-                        JNDINAME.parseAndSetParameter(jndiName, adminObjectNode, reader);
+                        JNDI_NAME.parseAndSetParameter(jndiName, adminObjectNode, reader);
                     }
                     break;
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
@@ -23,6 +23,8 @@
 package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_RA_LOGGER;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.jca.Constants.DEFAULT_NAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.CommonAttributes.CONNECTION_DEFINITIONS_NODE_ATTRIBUTE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.APPLICATION;
@@ -30,7 +32,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ARCHI
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.AUTHENTICATION_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.AUTHENTICATION_CONTEXT_AND_APPLICATION;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ELYTRON_ENABLED;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MODULE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RECOVERY_AUTHENTICATION_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RECOVERY_CREDENTIAL_REFERENCE;
@@ -94,7 +95,7 @@ public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
 
         final ModelNode address = operation.require(OP_ADDR);
         PathAddress path = context.getCurrentAddress();
-        final String jndiName = JNDINAME.resolveModelAttribute(context, operation).asString();
+        final String jndiName = JNDI_NAME.resolveModelAttribute(context, operation).asString();
         final String raName = path.getParent().getLastElement().getValue();
 
         final String archiveOrModuleName;
@@ -231,8 +232,9 @@ public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
                 bootStrapCtxName = raxml.getBootstrapContext();
             }
 
+            final boolean useJavaContext = USE_JAVA_CONTEXT.resolveModelAttribute(context, raModel).asBoolean();
 
-            ConnectionDefinitionStatisticsService connectionDefinitionStatisticsService = new ConnectionDefinitionStatisticsService(context.getResourceRegistrationForUpdate(), jndiName, poolName, statsEnabled);
+            ConnectionDefinitionStatisticsService connectionDefinitionStatisticsService = new ConnectionDefinitionStatisticsService(context.getResourceRegistrationForUpdate(), jndiName, useJavaContext, poolName, statsEnabled);
 
             ServiceBuilder statsServiceBuilder = serviceTarget.addService(serviceName.append(ConnectorServices.STATISTICS_SUFFIX), connectionDefinitionStatisticsService);
             statsServiceBuilder.addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append(bootStrapCtxName), Object.class, connectionDefinitionStatisticsService.getBootstrapContextInjector())

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -84,15 +84,11 @@ public class Constants {
 
     static final String POOL_NAME_NAME = "pool-name";
 
-    private static final String USE_JAVA_CONTEXT_NAME = "use-java-context";
-
     private static final String ENABLED_NAME = "enabled";
 
     private static final String CONNECTABLE_NAME = "connectable";
 
     private static final String TRACKING_NAME = "tracking";
-
-    private static final String JNDINAME_NAME = "jndi-name";
 
     private static final String ALLOCATION_RETRY_NAME = "allocation-retry";
 
@@ -214,12 +210,6 @@ public class Constants {
 
     static final SimpleAttributeDefinition CLASS_NAME = new SimpleAttributeDefinitionBuilder(CLASS_NAME_NAME, ModelType.STRING, false)
             .setXmlName(ConnectionDefinition.Attribute.CLASS_NAME.getLocalName())
-            .setAllowExpression(true)
-            .setRestartAllServices()
-            .build();
-
-    static SimpleAttributeDefinition JNDINAME = new SimpleAttributeDefinitionBuilder(JNDINAME_NAME, ModelType.STRING, true)
-            .setXmlName(ConnectionDefinition.Attribute.JNDI_NAME.getLocalName())
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -393,13 +383,6 @@ public class Constants {
     static final SimpleAttributeDefinition BEANVALIDATIONGROUP = new SimpleAttributeDefinitionBuilder(BEANVALIDATIONGROUPS_NAME, ModelType.STRING, true)
             .setXmlName(Activation.Tag.BEAN_VALIDATION_GROUP.getLocalName())
             .setAllowExpression(true)
-            .build();
-
-    static SimpleAttributeDefinition USE_JAVA_CONTEXT = new SimpleAttributeDefinitionBuilder(USE_JAVA_CONTEXT_NAME, ModelType.BOOLEAN, true)
-            .setXmlName(DataSource.Attribute.USE_JAVA_CONTEXT.getLocalName())
-            .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(Defaults.USE_JAVA_CONTEXT))
-            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ENABLED = new SimpleAttributeDefinitionBuilder(ENABLED_NAME, ModelType.BOOLEAN, true)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/EnlistmentTraceAttributeWriteHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/EnlistmentTraceAttributeWriteHandler.java
@@ -53,7 +53,8 @@ public class EnlistmentTraceAttributeWriteHandler extends AbstractWriteAttribute
     protected boolean applyUpdateToRuntime(final OperationContext context, final ModelNode operation,
                                            final String parameterName, final ModelNode newValue,
                                            final ModelNode currentValue, final HandbackHolder<List<ConnectionManager>> handbackHolder) throws OperationFailedException {
-        final String jndiName = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().get(Constants.JNDINAME.getName()).asString();
+        final String jndiName = context.readResource(PathAddress.EMPTY_ADDRESS).getModel()
+                .get(org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME.getName()).asString();
 
         final ServiceController<?> managementRepoService = context.getServiceRegistry(false).getService(
                 ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/IronJacamarResourceCreator.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/IronJacamarResourceCreator.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.subsystems.resourceadapters;
 
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -50,7 +52,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ELYTR
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENABLED;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NOTXSEPARATEPOOL;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NO_RECOVERY;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.PAD_XID;
@@ -67,7 +68,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SECUR
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SHARABLE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_MAPPING_GROUP;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_MAPPING_USER;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WRAP_XA_RESOURCE;
@@ -144,14 +144,14 @@ public class IronJacamarResourceCreator {
     private void addConnectionDefinition(final Resource parent, ConnectionDefinition connDef) {
         final Resource connDefResource = new IronJacamarResource.IronJacamarRuntimeResource();
         final ModelNode model = connDefResource.getModel();
-        setAttribute(model, Constants.JNDINAME, connDef.getJndiName());
+        setAttribute(model, JNDI_NAME, connDef.getJndiName());
         if (connDef.getConfigProperties() != null) {
             for (Map.Entry<String, String> config : connDef.getConfigProperties().entrySet()) {
                 addConfigProperties(connDefResource, config.getKey(), config.getValue());
             }
         }
         setAttribute(model, CLASS_NAME, connDef.getClassName());
-        setAttribute(model, JNDINAME, connDef.getJndiName());
+        setAttribute(model, JNDI_NAME, connDef.getJndiName());
         setAttribute(model, USE_JAVA_CONTEXT, connDef.isUseJavaContext());
         setAttribute(model, ENABLED, connDef.isEnabled());
 
@@ -284,7 +284,7 @@ public class IronJacamarResourceCreator {
         final Resource adminObjectResource = new IronJacamarResource.IronJacamarRuntimeResource();
         final ModelNode model = adminObjectResource.getModel();
         setAttribute(model, CLASS_NAME, adminObject.getClassName());
-        setAttribute(model, JNDINAME, adminObject.getJndiName());
+        setAttribute(model, JNDI_NAME, adminObject.getJndiName());
         setAttribute(model, USE_JAVA_CONTEXT, adminObject.isUseJavaContext());
         setAttribute(model, ENABLED, adminObject.isEnabled());
         if (adminObject.getConfigProperties() != null) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
@@ -23,6 +23,8 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector._private.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 import static org.jboss.as.connector._private.Capabilities.ELYTRON_SECURITY_DOMAIN_CAPABILITY;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -54,7 +56,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENABL
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MCP;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NOTXSEPARATEPOOL;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NO_RECOVERY;
@@ -73,7 +74,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SHARA
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRANSACTION_SUPPORT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_ELYTRON_SECURITY_DOMAIN;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_DEFAULT_GROUPS;
@@ -210,7 +210,7 @@ public class RaOperationUtil {
                                                                     final boolean isXa, ExceptionSupplier<CredentialSource, Exception> recoveryCredentialSourceSupplier) throws OperationFailedException, ValidateException {
         Map<String, String> configProperties = new HashMap<String, String>(0);
         String className = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, connDefModel, CLASS_NAME);
-        String jndiName = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, connDefModel, JNDINAME);
+        String jndiName = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, connDefModel, JNDI_NAME);
         boolean enabled = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, connDefModel, ENABLED);
         boolean connectable = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, connDefModel, CONNECTABLE);
         Boolean tracking = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, connDefModel, TRACKING);
@@ -312,7 +312,7 @@ public class RaOperationUtil {
     public static ModifiableAdminObject buildAdminObjects(final OperationContext context, ModelNode operation, final String poolName) throws OperationFailedException, ValidateException {
         Map<String, String> configProperties = new HashMap<String, String>(0);
         String className = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, operation, CLASS_NAME);
-        String jndiName = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, operation, JNDINAME);
+        String jndiName = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(context, operation, JNDI_NAME);
         boolean enabled = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, operation, ENABLED);
         boolean useJavaContext = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, operation, USE_JAVA_CONTEXT);
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -23,6 +23,8 @@
 package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_RA_LOGGER;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.JNDI_NAME;
+import static org.jboss.as.connector.subsystems.common.jndi.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATION;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BACKGROUNDVALIDATIONMILLIS;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.BLOCKING_TIMEOUT_WAIT_MILLIS;
@@ -58,7 +60,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENABL
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.INTERLEAVING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.JNDINAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MCP;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.MODULE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.NOTXSEPARATEPOOL;
@@ -84,7 +85,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.STATI
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRANSACTION_SUPPORT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_ELYTRON_SECURITY_DOMAIN;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_DEFAULT_GROUP;
@@ -288,7 +288,7 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
     private void writeAdminObject(XMLExtendedStreamWriter streamWriter, ModelNode adminObject, final String poolName) throws XMLStreamException {
         streamWriter.writeStartElement(Activation.Tag.ADMIN_OBJECT.getLocalName());
         CLASS_NAME.marshallAsAttribute(adminObject, streamWriter);
-        JNDINAME.marshallAsAttribute(adminObject, streamWriter);
+        JNDI_NAME.marshallAsAttribute(adminObject, streamWriter);
         ENABLED.marshallAsAttribute(adminObject, streamWriter);
         USE_JAVA_CONTEXT.marshallAsAttribute(adminObject, streamWriter);
         streamWriter.writeAttribute("pool-name", poolName);
@@ -301,7 +301,7 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
     private void writeConDef(XMLExtendedStreamWriter streamWriter, ModelNode conDef, final String poolName, final boolean isXa) throws XMLStreamException {
         streamWriter.writeStartElement(Activation.Tag.CONNECTION_DEFINITION.getLocalName());
         CLASS_NAME.marshallAsAttribute(conDef, streamWriter);
-        JNDINAME.marshallAsAttribute(conDef, streamWriter);
+        JNDI_NAME.marshallAsAttribute(conDef, streamWriter);
         ENABLED.marshallAsAttribute(conDef, streamWriter);
         CONNECTABLE.marshallAsAttribute(conDef, streamWriter);
         TRACKING.marshallAsAttribute(conDef, streamWriter);


### PR DESCRIPTION
…between subsystems

Issue: [WFLY-16729](https://issues.redhat.com/browse/WFLY-16729)

There are two `jndi-name` attribute definitions - one is validated for prefix, the other one is not. Given that we have a method to add the prefix if it's missing I've opted to remove the validation. (There are several other attributes that are shared between the resource adapters and datasources but they're not relevant for this issue)