### PR TITLE
[WFLY-16693] Remove commons-lang3 from full WildFly's dependencyManagement

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1400,11 +1400,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${version.commons-lang3}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,6 @@
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-digester>1.8.1</version.commons-digester>
         <version.commons-io>2.11.0</version.commons-io>
-        <version.commons-lang3>3.12.0</version.commons-lang3>
         <version.dom4j>2.1.3</version.dom4j>
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.groovy-all>2.4.21</version.groovy-all>


### PR DESCRIPTION

Issue: https://issues.redhat.com/browse/WFLY-16693

commons-lang3 version 3.12.0 has been integrated in WFLY via WildFly Core 19.0.0.Beta15  
