### PR TITLE
[WFLY-16753]: Avoid the Json serialization/deserialization to get Art…

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
@@ -206,8 +206,7 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
                 reportListOfStrings(context, list);
             } else if (GET_ROLES.equals(operationName)) {
                 String addressMatch = ADDRESS_MATCH.resolveModelAttribute(context, operation).asString();
-                String json = serverControl.getRolesAsJSON(addressMatch);
-                reportRoles(context, json);
+                reportRoles(context, serverControl.getRoles(addressMatch));
             } else if (GET_ROLES_AS_JSON.equals(operationName)) {
                 String addressMatch = ADDRESS_MATCH.resolveModelAttribute(context, operation).asString();
                 String json = serverControl.getRolesAsJSON(addressMatch);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressControlHandler.java
@@ -34,7 +34,6 @@ import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService
 import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService.rollbackOperationIfServerNotActive;
 import static org.wildfly.extension.messaging.activemq.ManagementUtil.reportListOfStrings;
 import static org.wildfly.extension.messaging.activemq.ManagementUtil.reportRoles;
-import static org.wildfly.extension.messaging.activemq.ManagementUtil.reportRolesAsJSON;
 
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
@@ -96,8 +95,7 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
 
         try {
             if (ROLES_ATTR_NAME.equals(name)) {
-                String json = addressControl.getRolesAsJSON();
-                reportRoles(context, json);
+                reportRoles(context, addressControl.getRoles());
             } else if (QUEUE_NAMES.equals(name)) {
                 String[] queues = addressControl.getQueueNames();
                 reportListOfStrings(context, queues);
@@ -114,18 +112,6 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
                 // Bug
                 throw MessagingLogger.ROOT_LOGGER.unsupportedAttribute(name);
             }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            context.getFailureDescription().set(e.getLocalizedMessage());
-        }
-    }
-
-    private void handleGetRolesAsJson(final OperationContext context, final ModelNode operation) {
-        final AddressControl addressControl = getAddressControl(context, operation);
-        try {
-            String json = addressControl.getRolesAsJSON();
-            reportRolesAsJSON(context, json);
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
@@ -22,12 +22,13 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.NAME;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ROLE;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
@@ -162,14 +163,8 @@ public class CoreAddressResource implements Resource {
         if (addressControl == null) {
             return Collections.emptySet();
         } else {
-            Set<String> names = new HashSet<String>();
             try {
-                ModelNode res = ModelNode.fromJSONString(addressControl.getRolesAsJSON());
-                ModelNode converted = ManagementUtil.convertSecurityRole(res);
-                for (ModelNode role : converted.asList()) {
-                    names.add(role.get(NAME).asString());
-                }
-                return names;
+                return Stream.of(addressControl.getRoles()).map(objRole -> ((Object[])objRole)[0].toString()).collect(Collectors.toSet());
             } catch (Exception e) {
                 return Collections.emptySet();
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ManagementUtil.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ManagementUtil.java
@@ -22,6 +22,15 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.client.helpers.ClientConstants.NAME;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.CONSUME;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.CREATE_DURABLE_QUEUE;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.DELETE_DURABLE_QUEUE;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.MANAGE;
+import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.SEND;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -40,10 +49,28 @@ public class ManagementUtil {
         context.getResult().set(json);
     }
 
-    public static void reportRoles(OperationContext context, String rolesAsJSON) {
-        ModelNode camelCase = ModelNode.fromJSONString(rolesAsJSON);
-        ModelNode converted = convertSecurityRole(camelCase);
-        context.getResult().set(converted);
+    public static void reportRoles(OperationContext context, Object[] roles) {
+        context.getResult().set(convertRoles(roles));
+    }
+
+    public static ModelNode convertRoles(Object[] roles) {
+        final ModelNode result = new ModelNode();
+        result.setEmptyList();
+        if (roles != null && roles.length > 0) {
+            for (Object objRole : roles) {
+                Object[] role = (Object[])objRole;
+                final ModelNode roleNode = result.add();
+                roleNode.get(NAME).set(role[0].toString());
+                roleNode.get(SEND.getName()).set((Boolean)role[1]);
+                roleNode.get(CONSUME.getName()).set((Boolean)role[2]);
+                roleNode.get(CREATE_DURABLE_QUEUE.getName()).set((Boolean)role[3]);
+                roleNode.get(DELETE_DURABLE_QUEUE.getName()).set((Boolean)role[4]);
+                roleNode.get(CREATE_NON_DURABLE_QUEUE.getName()).set((Boolean)role[5]);
+                roleNode.get(DELETE_NON_DURABLE_QUEUE.getName()).set((Boolean)role[6]);
+                roleNode.get(MANAGE.getName()).set((Boolean)role[7]);
+            }
+        }
+        return result;
     }
 
     public static void reportListOfStrings(OperationContext context, String[] strings) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleReadAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleReadAttributeHandler.java
@@ -72,9 +72,7 @@ public class SecurityRoleReadAttributeHandler extends AbstractRuntimeOnlyHandler
         }
 
         try {
-            String rolesAsJSON = control.getRolesAsJSON();
-            ModelNode res = ModelNode.fromJSONString(rolesAsJSON);
-            ModelNode roles = ManagementUtil.convertSecurityRole(res);
+            ModelNode roles = ManagementUtil.convertRoles(control.getRoles());
             ModelNode matchedRole = findRole(roleName, roles);
             if (matchedRole == null || !matchedRole.hasDefined(attributeName)) {
                 throw MessagingLogger.ROOT_LOGGER.unsupportedAttribute(attributeName);


### PR DESCRIPTION
…emis security roles.

* Using 'getRoles' we obtain an array of roles (as Object[]) instead of a Json String to parse and 'fix'.

Jira: https://issues.redhat.com/browse/WFLY-16753

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>