### PR TITLE
WFLY-16756 Remove H2 dependency from Hibernate ORM 6 module

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -55,6 +55,5 @@
         <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
         <module name="net.bytebuddy"/>
         <module name="java.xml"/>
-        <module name="com.h2database.h2" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16756

Signed-off-by: Scott Marlow <smarlow@redhat.com>

