### PR TITLE
[WFLY-16146] Replacements of problematic language on the community documentation 

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -508,7 +508,7 @@ to identify one WildFly process to another, typically in a WildFly managed domai
 [source,options="nowrap"]
 ----
 Is this new user going to be used for one AS process to connect to another AS process? 
-e.g. for a slave host controller connecting to the master or for a Remoting connection for server to server Jakarta Enterprise Beans calls.
+e.g. for a secondary host controller connecting to the primary or for a Remoting connection for server to server Jakarta Enterprise Beans calls.
 yes/no?
 ----
 

--- a/docs/src/main/asciidoc/_admin-guide/Application_deployment.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Application_deployment.adoc
@@ -9,7 +9,7 @@ toc::[]
 == Managed Domain
 
 In a managed domain, deployments are associated with a `server-group`
-(see ﻿ <<Core_management_concepts,Core management concepts>>).
+(see <<Core_management_concepts,Core management concepts>>).
 Any server within the server group will then be provided with that
 deployment.
 
@@ -30,7 +30,7 @@ You can do this in one sweep with the CLI:
 ----
 [domain@localhost:9990 /] deploy ~/Desktop/test-application.war
 Either --all-server-groups or --server-groups must be specified.
- 
+
 [domain@localhost:9990 /] deploy ~/Desktop/test-application.war --all-server-groups
 'test-application.war' deployed successfully.
 ----
@@ -48,7 +48,7 @@ server group, and deployed on all running servers in that group:
        "test-application.war"
    ]
 }
- 
+
 [domain@localhost:9990 /] /server-group=main-server-group/deployment=test-application.war:read-resource(include-runtime)
 {
    "outcome" => "success",
@@ -86,7 +86,7 @@ You can remove binaries from server groups with the `undeploy` command:
 ----
 [domain@localhost:9990 /] undeploy test-application.war --all-relevant-server-groups
 Successfully undeployed test-application.war.
- 
+
 [domain@localhost:9990 /] /server-group=main-server-group:read-children-names(child-type=deployment)
 {
    "outcome" => "success",
@@ -353,12 +353,12 @@ stream, this is not displayable from the CLI.
 ----
 [domain@localhost:9990 /] /deployment=kitchensink.ear:read-content(path=META-INF/MANIFEST.MF)
 {
-    "outcome" => "success",
-    "result" => {"uuid" => "b373d587-72ee-4b1e-a02a-71fbb0c85d32"},
-    "response-headers" => {"attached-streams" => [{
-        "uuid" => "b373d587-72ee-4b1e-a02a-71fbb0c85d32",
-        "mime-type" => "text/plain"
-    }]}
+  "outcome" => "success",
+    "result" => {"uuid" => "b373d587-72ee-4b1e-a02a-71fbb0c85d32"},
+    "response-headers" => {"attached-streams" => [{
+        "uuid" => "b373d587-72ee-4b1e-a02a-71fbb0c85d32",
+        "mime-type" => "text/plain"
+    }]}
 }
 ----
 
@@ -428,7 +428,7 @@ servers when deploying and removing an application:
 ----
 [standalone@localhost:9990 /] deploy ~/Desktop/test-application.war
 'test-application.war' deployed successfully.
- 
+
 [standalone@localhost:9990 /] undeploy test-application.war
 Successfully undeployed test-application.war.
 ----
@@ -512,47 +512,47 @@ The relevant marker file types are:
 |File |Purpose
 
 |.dodeploy |Placed by the user to indicate that the given content
-shouldbe deployed into the runtime (or redeployed if alreadydeployed in
+should be deployed into the runtime (or redeployed if already deployed in
 the runtime.)
 
 |.skipdeploy |Disables auto-deploy of the content for as long as the
-fileis present. Most useful for allowing updates to explodedcontent
-without having the scanner initiate redeploy in themiddle of the update.
-Can be used with zipped content aswell, although the scanner will detect
-in-progress changesto zipped content and wait until changes are
+file is present. Most useful for allowing updates to exploded content
+without having the scanner initiate redeploy in the middle of the update.
+Can be used with zipped content as well, although the scanner will detect
+in-progress changes to zipped content and wait until changes are
 complete.
 
 |.isdeploying |Placed by the deployment scanner service to indicate that
-ithas noticed a .dodeploy file or new or updated auto-deploymode content
+it has noticed a .dodeploy file or new or updated auto-deploymode content
 and is in the process of deploying the content.This marker file will be
-deleted when the deployment processcompletes.
+deleted when the deployment process completes.
 
 |.deployed |Placed by the deployment scanner service to indicate that
-thegiven content has been deployed into the runtime. If an enduser
+the given content has been deployed into the runtime. If an end user
 deletes this file, the content will be undeployed.
 
 |.failed |Placed by the deployment scanner service to indicate that
-thegiven content failed to deploy into the runtime. The contentof the
+the given content failed to deploy into the runtime. The contentof the
 file will include some information about the cause ofthe failure. Note
-that with auto-deploy mode, removing thisfile will make the deployment
+that with auto-deploy mode, removing this file will make the deployment
 eligible for deployment again.
 
 |.isundeploying |Placed by the deployment scanner service to indicate
-that ithas noticed a .deployed file has been deleted and thecontent is
-being undeployed. This marker file will be deletedwhen the undeployment
+that it has noticed a .deployed file has been deleted and the content is
+being undeployed. This marker file will be deleted when the undeployment
 process completes.
 
 |.undeployed |Placed by the deployment scanner service to indicate that
-thegiven content has been undeployed from the runtime. If an enduser
+the given content has been undeployed from the runtime. If an end user
 deletes this file, it has no impact.
 
 |.pending |Placed by the deployment scanner service to indicate that
-ithas noticed the need to deploy content but has not yetinstructed the
-server to deploy it. This file is created ifthe scanner detects that
-some auto-deploy content is still inthe process of being copied or if
-there is some problem thatprevents auto-deployment. The scanner will not
-instruct theserver to deploy or undeploy any content (not just
-thedirectly affected content) as long as this condition holds.
+it has noticed the need to deploy content but has not yet instructed the
+server to deploy it. This file is created if the scanner detects that
+some auto-deploy content is still in the process of being copied or if
+there is some problem that prevents auto-deployment. The scanner will not
+instruct the server to deploy or undeploy any content (not just
+the directly affected content) as long as this condition holds.
 |=======================================================================
 
 ==== Basic workflows:
@@ -630,7 +630,7 @@ is thereafter responsible for the content it uses.
 
 With an unmanaged deployment the user provides the local filesystem path
 of deployment content, and the server directly uses that content.
-However the user is responsible for ensuring that content, e.g. for
+However, the user is responsible for ensuring that content, e.g. for
 making sure that no changes are made to it that will negatively impact
 the functioning of the deployed application.
 
@@ -705,7 +705,7 @@ where to find the deployment content in its internal content repository.
 
 In a domain each host will have a copy of the content needed by its
 servers in its own local content repository. The WildFly domain
-controller and slave host controller processes take responsibility for
+controller and secondary Host Controller processes take responsibility for
 ensuring each host has the needed content.
 
 [[unmanaged-deployments]]

--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -36,18 +36,18 @@ Host and its server instances
 
 [source,options="nowrap"]
 ----
-[domain@IP_ADDRESS:9990 /] /host=master/system-property=foo:add(value=bar)
-[domain@IP_ADDRESS:9990 /] /host=master/system-property=foo:read-resource
-[domain@IP_ADDRESS:9990 /] /host=master/system-property=foo:remove
+[domain@IP_ADDRESS:9990 /] /host=primary/system-property=foo:add(value=bar)
+[domain@IP_ADDRESS:9990 /] /host=primary/system-property=foo:read-resource
+[domain@IP_ADDRESS:9990 /] /host=primary/system-property=foo:remove
 ----
 
 Just one server instance
 
 [source,options="nowrap"]
 ----
-[domain@IP_ADDRESS:9990 /] /host=master/server-config=server-one/system-property=foo:add(value=bar)
-[domain@IP_ADDRESS:9990 /] /host=master/server-config=server-one/system-property=foo:read-resource
-[domain@IP_ADDRESS:9990 /] /host=master/server-config=server-one/system-property=foo:remove
+[domain@IP_ADDRESS:9990 /] /host=primary/server-config=server-one/system-property=foo:add(value=bar)
+[domain@IP_ADDRESS:9990 /] /host=primary/server-config=server-one/system-property=foo:read-resource
+[domain@IP_ADDRESS:9990 /] /host=primary/server-config=server-one/system-property=foo:remove
 ----
 
 [[overview-of-all-system-properties]]
@@ -68,8 +68,8 @@ Domain
 
 [source,options="nowrap"]
 ----
-[domain@IP_ADDRESS:9990 /] /host=master/core-service=platform-mbean/type=runtime:read-attribute(name=system-properties)
-[domain@IP_ADDRESS:9990 /] /host=master/server=server-one/core-service=platform-mbean/type=runtime:read-attribute(name=system-properties)
+[domain@IP_ADDRESS:9990 /] /host=primary/core-service=platform-mbean/type=runtime:read-attribute(name=system-properties)
+[domain@IP_ADDRESS:9990 /] /host=primary/server=server-one/core-service=platform-mbean/type=runtime:read-attribute(name=system-properties)
 ----
 
 == Configuration
@@ -178,11 +178,11 @@ shown by the read-resource-description command.
 [[view-configuration-as-xml-for-domain-model-or-host-model]]
 === View configuration as XML for domain model or host model
 
-Assume you have a host that is called master
+Assume you have a host that is called "primary"
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master:read-config-as-xml
+[domain@localhost:9990 /] /host=primary:read-config-as-xml
 ----
 
 Just for the domain or standalone
@@ -210,11 +210,11 @@ Just for the domain or standalone
 [[take-the-latest-snapshot-of-the-host.xml-for-a-particular-host]]
 === Take the latest snapshot of the host.xml for a particular host
 
-Assume you have a host that is called master
+Assume you have a host that is called "primary"
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /]  /host=master:take-snapshot
+[domain@localhost:9990 /]  /host=primary:take-snapshot
 {
     "outcome" => "success",
     "result" => {
@@ -274,7 +274,7 @@ It's similar for domain, just specify path to server instance:
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master/server=server-one/interface=public:read-attribute(name=resolved-address)
+[domain@localhost:9990 /] /host=primary/server=server-one/interface=public:read-attribute(name=resolved-address)
 {
     "outcome" => "success",
     "result" => "127.0.0.1"

--- a/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
@@ -52,8 +52,8 @@ want to add the user and the properties files will be updated.
 
 For the final question, as this is a user that is going to be accessing
 the admin console just answer 'n' - this option will be described later
-for adding slave host controllers that authenticate against a master
-domain controller but that is a later topic.
+for adding secondary host controllers that authenticate against a
+Domain Controller but that is a later topic.
 
 After a new user has been added the server should be restarted or the
 `load` operation should be executed on the `ManagementRealm` or

--- a/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
@@ -154,7 +154,7 @@ use:
 [source,xml,options="nowrap"]
 ----
 <domain-controller>
-   <remote protocol="http-remoting" host="192.168.0.101" port="9990" username="slave" authentication-context="hcAuthContext"/>
+   <remote protocol="http-remoting" host="192.168.0.101" port="9990" username="secondary" authentication-context="hcAuthContext"/>
 </domain-controller>
 ----
 

--- a/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
@@ -76,35 +76,35 @@ resolve a corresponding network interface.
 Please consult the chapter "Interface Configuration" for a more detailed
 explanation on how to configure network interfaces.
 
-Next by default the master domain controller is configured to require
-authentication so a user needs to be added that can be used by the slave
-domain controller to connect.
+Next by default the Domain Controller is configured to require
+authentication so a user needs to be added that can be used by the secondary
+Host Controller to connect.
 
 Make use of the `add-user` utility to add a new user, for this example I
-am adding a new user called slave.
+am adding a new user called "secondary".
 
 [NOTE]
 
-`add-user` MUST be run on the master domain controller and NOT the
-slave.
+`add-user` MUST be run on the Domain Controller and NOT the
+secondary Host Controller.
 
 [[host-controller-configuration]]
 == Host Controller Configuration
 
-Once the domain controller is configured correctly you can proceed with
-any host that should join the domain. The host controller configuration
+Once the Domain Controller is configured correctly you can proceed with
+any host that should join the domain. The Host Controller configuration
 requires three steps:
 
 * The logical host name (within the domain) needs to be distinct
-* The host controller needs to know the domain controller IP address
+* The Host Controller needs to know the Domain Controller IP address
 
 Provide a distinct, logical name for the host. In the following example
-we simply name it "slave":
+we simply name it "secondary":
 
 [source,xml,options="nowrap"]
 ----
 <host xmlns="urn:jboss:domain:3.0"
-     name="slave">
+     name="secondary">
 [...]
 </host>
 ----
@@ -127,19 +127,18 @@ to contain the identity of the host controller.
     <authentication-client>
         <authentication-configuration sasl-mechanism-selector="DIGEST-MD5"
                                       name="hostAuthConfig"
-                                      authentication-name="slave"
+                                      authentication-name="secondary"
                                       realm="ManagementRealm">
             <credential-reference clear-text="host_us3r_password"/>
         </authentication-configuration>
         <authentication-context name="hcAuthContext">
-            <match-rule match-host="${jboss.test.host.master.address}" 
-                        authentication-configuration="hostAuthConfig"/>
+            <match-rule authentication-configuration="hostAuthConfig"/>
         </authentication-context>
     </authentication-client>
 ....
 ----
 
-Tell it how to find the domain controller so it can register itself with
+Tell it how to find the Domain Controller, so it can register itself with
 the domain:
 
 [source,xml,options="nowrap"]
@@ -150,7 +149,7 @@ the domain:
 ----
 
 Since we have also exposed the HTTP management interface we could also
-use :
+use:
 
 [source,xml,options="nowrap"]
 ----
@@ -164,13 +163,13 @@ use :
 [TIP]
 
 The name of each host needs to be unique when registering with the
-domain controller, however the username does not - using the username
+Domain Controller, however the username does not - using the username
 attribute allows the same account to be used by multiple hosts if this
 makes sense in your environment.
 
 === Ignoring domain wide resources
 
-WildFly 10 and later make it easy for slave host controllers to "ignore"
+WildFly 10 and later make it easy for secondary Host Controllers to "ignore"
 parts of the domain wide configuration. What does the mean and why is it
 useful?
 
@@ -180,39 +179,39 @@ wide configuration (i.e. those resources whose address does not begin
 with `/host=*`, i.e. those that are persisted in `domain.xml`. Having
 that local copy allows a user to do the following things:
 
-* Ask the slave to launch its already configured servers, even if the
+* Ask the secondary Host Controller to launch its already configured servers, even if the
 Domain Controller is not running.
 * Configured new servers, using different server groups from those
-current running, and ask the slave to launch them, even if the Domain
+current running, and ask the secondary Host Controller to launch them, even if the Domain
 Controller is not running.
-* Reconfigure the slave to act as the Domain Controller, allowing it to
-take over as the master if the previous master has failed or been shut
+* Reconfigure the secondary Host Controller to act as the Domain Controller, allowing it to
+take over as the Domain Controller if the previous Domain Controller has failed or been shut
 down.
 
 However, of these three things only the latter two require that the
-slave maintain a _complete_ copy of the domain wide configuration. The
-first only requires the slave to have the _portion_ of the domain wide
+secondary Host Controller maintain a _complete_ copy of the domain wide configuration. The
+first only requires the secondary Host Controller to have the _portion_ of the domain wide
 configuration that is relevant to its current servers. And the first use
-case is the most common one. A slave that is only meant to support the
+case is the most common one. A secondary Host Controller that is only meant to support the
 first use case can safely "ignore" portions of the domain wide
 configuration. And there are benefits to ignoring some resources:
 
 * If a server group is ignored, and the deployments mapped to that
-server group aren't mapped to other non-ignored groups, then the slave
+server group aren't mapped to other non-ignored groups, then the secondary Host Controller
 does not need to pull down a copy of the deployment content from the
-master. That can save disk space on the slave, improve the speed of
+Domain Controller. That can save disk space on the secondary Host Controller, improve the speed of
 starting new hosts and reduce network traffic.
 * WildFly supports "mixed domains" where a later version Domain
-Controller can manage slaves running previous versions. But those
-"legacy" slaves cannot understand configuration resources, attributes
+Controller can manage secondary Host Controllers running previous versions. But those
+"legacy" secondary Host Controllers cannot understand configuration resources, attributes
 and operations introduced in newer versions. So any attempt to use newer
 things in the domain wide configuration will fail unless the legacy
-slaves are ignoring the relevant resources. But ignoring resources will
-allow the legacy slaves to work fine managing servers using profiles
+secondary Host Controllers are ignoring the relevant resources. But ignoring resources will
+allow the legacy secondary Host Controllers to work fine managing servers using profiles
 without new concepts, while other hosts can run servers with profiles
 that take advantage of the latest features.
 
-Prior to WildFly 10, a slave could be configured to ignore some
+Prior to WildFly 10, a secondary Host Controller could be configured to ignore some
 resources, but the mechanism was not particularly user friendly:
 
 * The resources to be ignored had to be listed in a fair amount of
@@ -222,12 +221,12 @@ that needs to ignore that must be updated to record that.
 
 Starting with WildFly 10, this kind of detailed configuration is no
 longer required. Instead, with the standard versions of `host.xml`, the
-slave will behave as follows:
+secondary Host Controller will behave as follows:
 
-* If the slave was started with the `--backup` command line parameter,
+* If the secondary Host Controller was started with the `--backup` command line parameter,
 the behavior will be the same as releases prior to 10; i.e. only
 resources specifically configured to be ignored will be ignored.
-* Otherwise, the slave will "ignore unused resources".
+* Otherwise, the secondary Host Controller will "ignore unused resources".
 
 What does "ignoring unused resources" mean?
 
@@ -243,9 +242,9 @@ server-group, is ignored
 non-ignored profile uses the extension. Ignoring an extension requires
 explicit configuration. Perhaps in a future release extensions will be
 explicitly ignored.
-* If a change is made to the slave host's configuration or to the domain
+* If a change is made to the secondary Host Controller host's configuration or to the domain
 wide configuration that reduces the set of ignored resources, then as
-part of handling that change the slave will contact the master to pull
+part of handling that change the secondary Host Controller will contact the Domain Controller to pull
 down the missing pieces of configuration and will integrate those pieces
 in its local copy of the management model. Examples of such changes
 include adding a new server-config that references a previously ignored
@@ -275,8 +274,8 @@ The "ignore unused resources" behavior can be used in combination with
 the pre-WildFly 10 detailed specification of what to ignore. If that is
 done both the unused resources and the explicitly declared resources
 will be ignored. Here's an example of such a configuration, one where
-the slave cannot use the "org.example.foo" extension that has been
-installed on the Domain Controller and on some slaves, but not this one:
+the secondary Host Controller cannot use the "org.example.foo" extension that has been
+installed on the Domain Controller and on some secondary Host Controllers, but not this one:
 
 [source,xml,options="nowrap"]
 ----
@@ -295,8 +294,8 @@ installed on the Domain Controller and on some slaves, but not this one:
 [[server-groups]]
 == Server groups
 
-The domain controller defines one or more server groups and associates
-each of these with a profile and a socket binding group, and also :
+The Domain Controller defines one or more server groups and associates
+each of these with a profile and a socket binding group, and also:
 
 [source,xml,options="nowrap"]
 ----
@@ -319,7 +318,7 @@ each of these with a profile and a socket binding group, and also :
 
 ~(See domain/configuration/domain.xml)~
 
-The domain controller also defines the socket binding groups and the
+The Domain Controller also defines the socket binding groups and the
 profiles. The socket binding groups define the default socket bindings
 that are used:
 
@@ -371,7 +370,7 @@ implement the functionality people expect of an application server.
 
 ~(See domain/configuration/domain.xml)~ +
 Here we have two profiles. The `bigger` profile contains all the same
-subsystems as the `default` profile (athough the parameters for the
+subsystems as the `default` profile (although the parameters for the
 various subsystems could be different in each profile), and adds the
 `fictional-example` subsystem which references the `unique-to-bigger`
 socket binding.
@@ -379,7 +378,7 @@ socket binding.
 [[servers]]
 == Servers
 
-The host controller defines one or more servers:
+The Host Controller defines one or more servers:
 
 [source,xml,options="nowrap"]
 ----
@@ -426,7 +425,7 @@ group.
 [[jvm]]
 === JVM
 
-The host controller contains the main `jvm` definitions with arguments:
+The Host Controller contains the main `jvm` definitions with arguments:
 
 [source,xml,options="nowrap"]
 ----
@@ -438,17 +437,17 @@ The host controller contains the main `jvm` definitions with arguments:
 ----
 
 ~(See domain/configuration/host.xml)~ +
-From the preceeding examples we can see that we also had a `jvm`
-reference at server group level in the domain controller. The jvm's name
-*must* match one of the definitions in the host controller. The values
-supplied at domain controller and host controller level are combined,
-with the host controller taking precedence if the same parameter is
+From the preceding examples we can see that we also had a `jvm`
+reference at server group level in the Domain Controller. The jvm's name
+*must* match one of the definitions in the Host Controller. The values
+supplied at Domain Controller and Host Controller level are combined,
+with the Host Controller taking precedence if the same parameter is
 given in both places.
 
 Finally, as seen, we can also override the `jvm` at server level. Again,
-the jvm's name *must* match one of the definitions in the host
-controller. The values are combined with the ones coming in from domain
-controller and host controller level, this time the server definition
+the jvm's name *must* match one of the definitions in the Host Controller.
+The values are combined with the ones coming in from Domain
+Controller and Host Controller level, this time the server definition
 takes precedence if the same parameter is given in all places.
 
 Following these rules the jvm parameters to start each server would be

--- a/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
@@ -136,8 +136,8 @@ Details on how to use the CLI can be found in the
 
 WildFly stores its configuration in centralized XML configuration files,
 one per server for standalone servers and, for managed domains, one per
-host with an additional domain wide policy controlled by the master
-host. These files are meant to be human-readable and human editable.
+host with an additional domain wide policy controlled by the Domain Controller.
+These files are meant to be human-readable and human editable.
 
 [TIP]
 
@@ -176,7 +176,7 @@ with the _[line-through]*c*_ or _-server-config_ command line argument:
 In a managed domain, the XML files are found in the
 `domain/configuration` directory. There are two types of configuration
 files – one per host, and then a single domain-wide file managed by the
-master host, aka the Domain Controller. (For more on the types of
+primary Host Controller, aka the Domain Controller. (For more on the types of
 processes in a managed domain, see <<Operating_modes,Operating
 Modes>>.)
 
@@ -210,7 +210,7 @@ and what server groups they belong to.
 
 |host.xml |The default host configuration, tailored for an easy out of
 the box experience experimenting with a managed domain. This
-configuration specifies the Host Controller should become the master,
+configuration specifies the Host Controller should become the primary Host Controller,
 aka the Domain Controller, but it also launches a couple of servers.
 |=======================================================================
 
@@ -226,7 +226,7 @@ $ bin/domain.sh --host-config=host-primary.xml
 ==== Domain Wide Configuration – domain.xml
 
 Once a Host Controller has processed its host-specific configuration, it
-knows whether it is configured to act as the master Domain Controller.
+knows whether it is configured to act as the Domain Controller.
 If it is, it must parse the domain wide configuration file, by default
 located at `domain/configuration/domain.xml`. This file contains the
 bulk of the settings that should be applied to the servers in the domain
@@ -243,16 +243,16 @@ $ bin/domain.sh --domain-config=domain-production.xml
 ----
 
 That argument is only relevant for hosts configured to act as the
-master.
+Domain Controller.
 
-A slave Host Controller does not usually parse the domain wide
-configuration file. A slave gets the domain wide configuration from the
-remote master Domain Controller when it registers with it. A slave also
+A secondary Host Controller does not usually parse the domain wide
+configuration file. A secondary Host Controller gets the domain wide configuration from the
+remote Domain Controller when it registers with it. A secondary Host Controller also
 will not persist changes to a `domain.xml` file if one is present on the
 filesystem. For that reason it is recommended that no `domain.xml` be
-kept on the filesystem of hosts that will only run as slaves.
+kept on the filesystem of hosts that will only run as secondary Host Controllers.
 
-A slave can be configured to keep a locally persisted copy of the domain
-wide configuration and then use it on boot (in case the master is not
+A secondary Host Controller can be configured to keep a locally persisted copy of the domain
+wide configuration and then use it on boot (in case the Domain Controller is not
 available.) See _--backup and --cached-dc_ under
 <<Command_line_parameters,Command line parameters>>.

--- a/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
@@ -507,9 +507,9 @@ what's in `domain.xml`, the host specific configuration for each host
 application server. The Host Controller processes in a managed domain
 provide access to all or part of the overall resource tree. How much is
 available depends on whether the management client is interacting with
-the Host Controller that is acting as the master Domain Controller. If
-the Host Controller is the master Domain Controller, then the section of
-the tree for each host is available. If the Host Controller is a slave
+the Host Controller that is acting as the Domain Controller. If
+the Host Controller is the Domain Controller, then the section of
+the tree for each host is available. If the Host Controller is a secondary Host Controller
 to a remote Domain Controller, then only the portion of the tree
 associated with that host is available.
 

--- a/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
@@ -197,7 +197,7 @@ to take effect.
 
 In a managed domain, the access control configuration is part of the
 domain wide configuration, so the resource address is the same as above,
-but the CLI is connected to the master Domain Controller:
+but the CLI is connected to the Domain Controller:
 
 [source,options="nowrap"]
 ----
@@ -210,7 +210,7 @@ but the CLI is connected to the master Domain Controller:
         "process-state" => "reload-required"
     },
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {
             "outcome" => "success",
             "response-headers" => {
@@ -227,12 +227,12 @@ but the CLI is connected to the master Domain Controller:
         }}
     }}}}
 }
-[domain@localhost:9990 access=authorization] reload --host=master
+[domain@localhost:9990 access=authorization] reload --host=primary
 ----
 
 As with a standalone server, a reload or restart is required for the
 change to take effect. In this case, all hosts and servers in the domain
-will need to be reloaded or restarted, starting with the master Domain
+will need to be reloaded or restarted, starting with the Domain
 Controller, so be sure to plan well before making this change.
 
 [[mapping-users-and-groups-to-roles]]
@@ -267,7 +267,7 @@ role.
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -282,7 +282,7 @@ Once this is done, map a user to the role:
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -332,7 +332,7 @@ individual user mapping is the value of the `type` attribute should be
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -367,7 +367,7 @@ The same change can be made using the CLI:
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -396,7 +396,7 @@ address element:
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -488,7 +488,7 @@ But you can also use the CLI to create a server-group scoped role.
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -530,11 +530,11 @@ But you can also use the CLI to create a host scoped role.
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /core-service=management/access=authorization/host-scoped-role=MasterOperators:add(base-role=Operator,hosts=[master]}
+[domain@localhost:9990 /] /core-service=management/access=authorization/host-scoped-role=DCOperators:add(base-role=Operator,hosts=[primary]}
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -644,7 +644,7 @@ setting:
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -661,14 +661,14 @@ classification applies:
 {
     "outcome" => "success",
     "result" => {
-        "/host=master" => {
-            "address" => "/host=master",
+        "/host=primary" => {
+            "address" => "/host=primary",
             "attributes" => [],
             "entire-resource" => false,
             "operations" => ["resolve-internet-address"]
         },
-        "/host=master/core-service=host-environment" => {
-            "address" => "/host=master/core-service=host-environment",
+        "/host=primary/core-service=host-environment" => {
+            "address" => "/host=primary/core-service=host-environment",
             "attributes" => [
                 "host-controller-port",
                 "host-controller-address",
@@ -678,8 +678,8 @@ classification applies:
             "entire-resource" => false,
             "operations" => []
         },
-        "/host=master/core-service=management/management-interface=http-interface" => {
-            "address" => "/host=master/core-service=management/management-interface=http-interface",
+        "/host=primary/core-service=management/management-interface=http-interface" => {
+            "address" => "/host=primary/core-service=management/management-interface=http-interface",
             "attributes" => [
                 "port",
                 "secure-interface",
@@ -689,8 +689,8 @@ classification applies:
             "entire-resource" => false,
             "operations" => []
         },
-        "/host=master/core-service=management/management-interface=native-interface" => {
-            "address" => "/host=master/core-service=management/management-interface=native-interface",
+        "/host=primary/core-service=management/management-interface=native-interface" => {
+            "address" => "/host=primary/core-service=management/management-interface=native-interface",
             "attributes" => [
                 "port",
                 "interface"
@@ -698,14 +698,14 @@ classification applies:
             "entire-resource" => false,
             "operations" => []
         },
-        "/host=master/interface=*" => {
-            "address" => "/host=master/interface=*",
+        "/host=primary/interface=*" => {
+            "address" => "/host=primary/interface=*",
             "attributes" => [],
             "entire-resource" => true,
             "operations" => ["resolve-internet-address"]
         },
-        "/host=master/server-config=*/interface=*" => {
-            "address" => "/host=master/server-config=*/interface=*",
+        "/host=primary/server-config=*/interface=*" => {
+            "address" => "/host=primary/server-config=*/interface=*",
             "attributes" => [],
             "entire-resource" => true,
             "operations" => []
@@ -831,7 +831,7 @@ expressions to be security sensitive, you can change that setting:
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}
@@ -912,7 +912,7 @@ Deployer role, set the `configured-application` attribute to true.
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {
         "server-one" => {"response" => {"outcome" => "success"}},
         "server-two" => {"response" => {"outcome" => "success"}}
     }}}}

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
@@ -4,7 +4,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 A detailed description of the resources, attributes and operations that
 make up the management model provided by an individual WildFly instance
-or by any Domain Controller or slave Host Controller process can be
+or by any Domain Controller or secondary Host Controller process can be
 queried using the `read-resource-description`, `read-operation-names`,
 `read-operation-description` and `read-child-types` operations described
 in the <<Global_operations,Global operations>> section. In this
@@ -479,7 +479,7 @@ handling, the handlers for management operations will not restart any
 service without some form of explicit instruction from the end user
 indicating a service restart is desired. In a few cases, simply
 executing the operation is an indication the user wants services to
-restart (e.g. a `/host=master/server-config=server-one:restart`
+restart (e.g. a `/host=primary/server-config=server-one:restart`
 operation in a managed domain, or a `/:reload` operation on a standalone
 server.) For all other cases, if an operation (or attribute write)
 cannot be performed without restarting a service, the metadata
@@ -500,7 +500,7 @@ operation and to any subsequent operation will include a response header
 restart of all services can be accomplished by executing the `reload`
 CLI command. For a server in a managed domain, restarting all services
 is done via a reload operation targeting the particular server (e.g.
-`/host=master/server=server-one:reload`).
+`/host=primary/server=server-one:reload`).
 * `jvm` --The operation can only immediately update the persistent
 configuration; applying the operation to the runtime will require a full
 process restart (i.e. stop the JVM and launch a new JVM). Executing the

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
@@ -17,7 +17,7 @@ complete information about child resources, recursively.
 resources should be included if `recursive` is `true`. If not set, the
 depth will be unlimited; i.e. all descendant resources will be included.
 * `proxies` – (boolean, default is `false`) – whether to include remote
-resources in a recursive query (i.e. host level resources from slave
+resources in a recursive query (i.e. host level resources from secondary
 Host Controllers in a query of the Domain Controller; running server
 resources in a query of a host).
 * `include-runtime` – (boolean, default is `false`) – whether to include
@@ -172,7 +172,7 @@ following parameters, none of which are required:
 * `recursive` – (boolean, default is `false`) – whether to include
 information about child resources, recursively.
 * `proxies` – (boolean, default is `false`) – whether to include remote
-resources in a recursive query (i.e. host level resources from slave
+resources in a recursive query (i.e. host level resources from secondary
 Host Controllers in a query of the Domain Controller; running server
 resources in a query of a host)
 * `operations` – (boolean, default is `false`) – whether to include
@@ -248,7 +248,7 @@ resources should be included if `recursive` is \{\{true}. If not set,
 the depth will be unlimited; i.e. all descendant resources will be
 included.
 * `proxies` – (boolean, default is `false`) – whether to include remote
-resources in a recursive query (i.e. host level resources from slave
+resources in a recursive query (i.e. host level resources from secondary
 Host Controllers in a query of the Domain Controller; running server
 resources in a query of a host)
 * `include-runtime` – (boolean, default is `false`) – whether to include

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
@@ -90,14 +90,14 @@ WWW-Authenticate: Digest realm="ManagementRealm",domain="/management",nonce="P80
 Content-Length: 77
 Content-Type: text/html
 Date: Fri, 01 Aug 2014 11:49:50 GMT
- 
+
 HTTP/1.1 200 OK
 Connection: keep-alive
 Authentication-Info: nextnonce="M+h9aADejeINMTQwNjg5Mzc5MDQ2OPQbHKdAS8pRE8BbGEDY5uI="
 Content-Type: application/json; charset=utf-8
 Content-Length: 55
 Date: Fri, 01 Aug 2014 11:49:50 GMT
- 
+
 {
     "outcome" : "success",
     "result" : "running"
@@ -106,19 +106,19 @@ Date: Fri, 01 Aug 2014 11:49:50 GMT
 
 * Here's an example of an operation on a resource with a nested address
 and passed parameters. This is same as if you would run
-*/host=master/server=server-01:read-attribute(name=server-state)*
+*/host=primary/server=server-01:read-attribute(name=server-state)*
 
 [source,options="nowrap"]
 ----
-$ curl --digest -L -D - http://localhost:9990/management --header "Content-Type: application/json" -d '{"operation":"read-attribute","address":[{"host":"master"},{"server":"server-01"}],"name":"server-state","json.pretty":1}'
+$ curl --digest -L -D - http://localhost:9990/management --header "Content-Type: application/json" -d '{"operation":"read-attribute","address":[{"host":"primary"},{"server":"server-01"}],"name":"server-state","json.pretty":1}'
 HTTP/1.1 200 OK
 Transfer-encoding: chunked
 Content-type: application/json
 Date: Tue, 17 Apr 2012 04:02:24 GMT
- 
+
 {
-    "outcome" : "success",
-    "result" : "running"
+ "outcome" : "success",
+ "result" : "running"
 }
 ----
 
@@ -132,7 +132,7 @@ in CLI
 [source,options="nowrap"]
 ----
 http://localhost:9990/management/subsystem/undertow/server/default-server?operation=resource&recursive=true&json.pretty=1
- 
+
 {
     "default-host" : "default-host",
     "servlet-container" : "default",
@@ -192,14 +192,14 @@ WWW-Authenticate: Digest realm="ManagementRealm",domain="/management",nonce="a3p
 Content-Length: 77
 Content-Type: text/html
 Date: Fri, 01 Aug 2014 13:25:44 GMT
- 
+
 HTTP/1.1 200 OK
 Connection: keep-alive
 Authentication-Info: nextnonce="nTOSJd3ufO4NMTQwNjg5OTU0NDk5MeUsRw5rKXUT4Qvk1nbrG5c="
 Content-Type: application/json; charset=utf-8
 Content-Length: 1729
 Date: Fri, 01 Aug 2014 13:25:45 GMT
- 
+
 {
     "outcome" : "success",
     "result" : {
@@ -293,7 +293,7 @@ String response = managementResource.request(MediaType.APPLICATION_JSON_TYPE)
     .header("Content-type", MediaType.APPLICATION_JSON)
     .post(operation, String.class);
 System.out.println(response);
- 
- 
+
+
 {"outcome" : "success", "result" : {"default-host" : "default-host", "servlet-container" : "default", "ajp-listener" : null, "host" : {"default-host" : {"alias" : ["localhost"], "default-web-module" : "ROOT.war", "filter-ref" : {"server-header" : {"predicate" : null}, "x-powered-by-header" : {"predicate" : null}}, "location" : {"/" : {"handler" : "welcome-content", "filter-ref" : null}}, "setting" : null}}, "http-listener" : {"default" : {"allow-encoded-slash" : false, "allow-equals-in-cookie-value" : false, "always-set-keep-alive" : true, "buffer-pipelined-data" : true, "buffer-pool" : "default", "certificate-forwarding" : false, "decode-url" : true, "enabled" : true, "max-buffered-request-size" : 16384, "max-cookies" : 200, "max-header-size" : 51200, "max-headers" : 200, "max-parameters" : 1000, "max-post-size" : 10485760, "proxy-address-forwarding" : false, "read-timeout" : null, "receive-buffer" : null, "record-request-start-time" : false, "redirect-socket" : "https", "send-buffer" : null, "socket-binding" : "http", "tcp-backlog" : null, "tcp-keep-alive" : null, "url-charset" : "UTF-8", "worker" : "default", "write-timeout" : null}}, "https-listener" : null}}
 ----

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
@@ -2,7 +2,7 @@
 = The native management API
 
 A standalone WildFly process, or a managed domain Domain Controller or
-slave Host Controller process can be configured to listen for remote
+secondary Host Controller process can be configured to listen for remote
 management requests using its "native management interface":
 
 [source,xml,options="nowrap"]
@@ -74,7 +74,7 @@ Python or some other language.)
 
 The `org.jboss.as.controller.client.ModelControllerClient` class is the
 main class a custom client would use to manage a WildFly server instance
-or a Domain Controller or slave Host Controller.
+or a Domain Controller or secondary Host Controller.
 
 The custom client must have maven artifact
 `org.jboss.as:jboss-as-controller-client` and its dependencies on the
@@ -689,7 +689,7 @@ Simple responses are provided by the following types of operations:
 
 * Non-composite operations that target a single server. (See below for
 more on composite operations).
-* Non-composite operations that target a Domain Controller or slave Host
+* Non-composite operations that target a Domain Controller or secondary Host
 Controller and don't require the responder to apply the operation on
 multiple servers and aggregate their results (e.g. a simple read of a
 domain configuration property.)
@@ -822,7 +822,7 @@ Basic composite responses are provided by the following types of
 operations:
 
 * Composite operations that target a single server.
-* Composite operations that target a Domain Controller or a slave Host
+* Composite operations that target a Domain Controller or a secondary Host
 Controller and don't require the responder to apply the operation on
 multiple servers and aggregate their results (e.g. a list of simple
 reads of domain configuration properties.)
@@ -959,7 +959,7 @@ rollback of the others:
 === Multi-Server Responses
 
 Multi-server responses are provided by operations that target a Domain
-Controller or slave Host Controller and require the responder to apply
+Controller or secondary Host Controller and require the responder to apply
 the operation on multiple servers and aggregate their results (e.g.
 nearly all domain or host configuration updates.)
 
@@ -982,7 +982,7 @@ automatically rolled back, with a response like this:
 ----
 
 If the operation was addressed to the domain model, in the next stage
-the Domain Controller will ask each slave Host Controller to apply it to
+the Domain Controller will ask each secondary Host Controller to apply it to
 its local copy of the domain model. If any Host Controller fails to do
 so, the Domain Controller will tell all Host Controllers to revert the
 change, and it will revert the change locally as well. The response to

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Audit_logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Audit_logging.adoc
@@ -137,8 +137,8 @@ operation has been logged via the CLI on the same machine as the running
 server, so the special $local user is used
 
 |domainUUID |An ID to link together all operations as they are
-propagated from the Doman Controller to it servers, slave Host
-Controllers, and slave Host Controller servers
+propagated from the Domain Controller to its servers, secondary Host
+Controllers, and secondary Host Controller servers
 
 |access |This can have one of the following values:*NATIVE - The
 operation came in through the native management interface, for example
@@ -421,7 +421,7 @@ is the default configuration:
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master/core-service=management/access=audit:read-resource(recursive=true)
+[domain@localhost:9990 /] /host=primary/core-service=management/access=audit:read-resource(recursive=true)
 {
     "outcome" => "success",
     "result" => {

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
@@ -185,7 +185,7 @@ available in standalone and domain mode.
 
 |--admin-only |- |Set the server's running type to ADMIN_ONLY causing it
 to open administrative interfaces and accept management requests but not
-start other runtime services oraccept end user requests.
+start other runtime services or accept end user requests.
 
 |--server-config -c |standalone.xml |A relative path which is interpreted
 to be relative to jboss.server.config.dir. The name of the configuration
@@ -193,8 +193,8 @@ file to use.
 
 |--read-only-server-config |- |A relative path which is interpreted to
 be relative to jboss.server.config.dir. This is similar to
---server-config but if this alternative is specified the server willnot
-overwrite the file when the management model is changed. However a full
+--server-config but if this alternative is specified the server will not
+overwrite the file when the management model is changed. However, a full
 versioned history is maintained of the file.
 
 |--graceful-startup | true | Start the servers in gracefully, queuing or cleanly rejecting incoming requests until the server is fully started.
@@ -213,10 +213,10 @@ versioned history is maintained of the file.
 |=======================================================================
 |Name |Default if absent |Value
 
-|--admin-only |- |Set the server's running type to ADMIN_ONLY causing it
-to open administrative interfaces and accept management requests but not
-start servers or, if this host controlleris the master for the domain,
-accept incoming connections from slave host controllers.
+|--admin-only |- |Set the host controller's running type to ADMIN_ONLY causing it to open
+administrative interfaces and accept management requests but not start servers or, if this
+host controller is the primary for the domain, accept incoming connections from secondary
+host controllers.
 
 |--domain-config -c |domain.xml |A relative path which is interpreted to
 be relative to jboss.domain.config.dir. The name of the domain wide
@@ -225,8 +225,8 @@ configuration file to use.
 |--read-only-domain-config |- |A relative path which is interpreted to
 be relative to jboss.domain.config.dir. This is similar to
 --domain-config but if this alternative is specified the host
-controllerwill not overwrite the file when the management model is
-changed. However a full versioned history is maintained of the file.
+controller will not overwrite the file when the management model is
+changed. However, a full versioned history is maintained of the file.
 
 |--host-config |host.xml |A relative path which is interpreted to be
 relative to jboss.domain.config.dir. The name of the host-specific
@@ -234,12 +234,12 @@ configuration file to use.
 
 |--read-only-host-config |- |A relative path which is interpreted to be
 relative to jboss.domain.config.dir. This is similar to --host-config
-but if this alternative is specified the host controller willnot
-overwrite the file when the management model is changed. However a full
+but if this alternative is specified the host controller will not
+overwrite the file when the management model is changed. However, a full
 versioned history is maintained of the file.
 |=======================================================================
 
-The following parameters take no value and are only usable on slave host
+The following parameters take no value and are only usable on secondary host
 controllers (i.e. hosts configured to connect to a `remote` domain
 controller.)
 
@@ -247,29 +247,29 @@ controller.)
 |=======================================================================
 |Name |Function
 
-|--backup |Causes the slave host controller to create and maintain a
+|--backup |Causes the secondary host controller to create and maintain a
 local copy (domain.cached-remote.xml) of the domain configuration. If
 ignore-unused-configuration is unset in host.xml,a complete copy of the
 domain configuration will be stored locally, otherwise the configured
 value of ignore-unused-configuration in host.xml will be used. (See
 ignore-unused-configuration for more details.)
 
-|--cached-dc |If the slave host controller is unable to contact the
-master domain controller to get its configuration at boot, this option
-will allow the slave host controller to boot and becomeoperational using
+|--cached-dc |If the secondary host controller is unable to contact the
+domain controller to get its configuration at boot, this option
+will allow the secondary host controller to boot and become operational using
 a previously cached copy of the domain configuration
 (domain.cached-remote.xml.) If the cached configuration is not present,
-this boot will fail. This file is created using using one ofthe
-following methods:- A previously successful connection to the master
+this boot will fail. This file is created using one of the
+following methods:- A previously successful connection to the
 domain controller using --backup or --cached-dc.- Copying the domain
 configuration from an alternative host to
-domain/configuration/domain.cached-remote.xml.The unavailable master
+domain/configuration/domain.cached-remote.xml.The unavailable
 domain controller will be polled periodically for availability, and once
-becoming available, the slave host controller will reconnect to the
-master host controller and synchronize the domainconfiguration. During
-the interval the master domain controller is unavailable, the slave host
-controller will not be able make any modifications to the domain
-configuration, but it may launch servers and handlerequests to deployed
+becoming available, the secondary host controller will reconnect to the
+domain controller and synchronize the domain configuration. During
+the interval the domain controller is unavailable, the secondary host
+controller will not be able to make any modifications to the domain
+configuration, but it may launch servers and handle requests to deployed
 applications etc.
 |=======================================================================
 

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
@@ -38,7 +38,7 @@ The parameter for `--git-repo` can be a URL or a remote alias provided you have 
 
 If a `--git-branch` parameter is added then the branch will be pulled, otherwise it will default to `master`.
 
-For example this is an elytron configuration file that you could use to connect to Github via the `--git-auth` parameter:
+For example this is an elytron configuration file that you could use to connect to GitHub via the `--git-auth` parameter:
 
 [source,xml,options="nowrap"]
 ----
@@ -260,6 +260,6 @@ When using PKCS formatted keys, the keys should not be encrypted with a passphra
 === Credential Store Reference
 
 It is possible to specify your SSH credentials as a reference to a credential store entry.
-See: https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#adding-a-credential[Adding a Credential]
-to a credential store and https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#referencing-credentials[Referencing Credentials]
+See: https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#adding-a-credential[Adding a Credential]
+to a credential store and https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#referencing-credentials[Referencing Credentials]
 stored in a credential store.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
@@ -64,7 +64,7 @@ is created. These timestamped folders are kept for 30 days.
 == Snapshots
 
 In addition to the backups taken by the server as described above you
-can manually take take snapshots which will be stored in the `snapshot`
+can manually take snapshots which will be stored in the `snapshot`
 folder under the `_xml_history` folder, the automatic backups described
 above are subject to automatic house keeping so will eventually be
 automatically removed, the snapshots on the other hand can be entirely
@@ -124,7 +124,7 @@ to navigate to the host in question:
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master:list-snapshots
+[domain@localhost:9990 /] /host=primary:list-snapshots
 {
     "outcome" => "success",
     "result" => {
@@ -149,7 +149,7 @@ items an abbreviated reverence to the file can be used:
 
 [cols=",,",options="header"]
 |=======================================================================
-|Abreviation |Parameter |Description
+|Abbreviation |Parameter |Description
 
 |initial |--server-config=initial |This will start the server using the
 initial configuration first used to start the server.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/JVM_settings.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/JVM_settings.adoc
@@ -91,11 +91,11 @@ This ability is useful when you need to configure JVM settings without specifyin
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master/jvm=default:add-jvm-option(jvm-option="-Xlog:gc:file=${jboss.server.log.dir}/gc.log")
+[domain@localhost:9990 /] /host=primary/jvm=default:add-jvm-option(jvm-option="-Xlog:gc:file=${jboss.server.log.dir}/gc.log")
 {
     "outcome" => "success",
     "result" => undefined,
-    "server-groups" => {"main-server-group" => {"host" => {"master" => {"server-two" => {"response" => {
+    "server-groups" => {"main-server-group" => {"host" => {"primary" => {"server-two" => {"response" => {
         "outcome" => "success",
         "response-headers" => {
             "operation-requires-restart" => true,

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
@@ -192,19 +192,19 @@ applied at global, server group, server and host levels:
 
 *Server*
 
-`/host=master/server-config=server-one:suspend(suspend-timeout=x)`
+`/host=primary/server-config=server-one:suspend(suspend-timeout=x)`
 
-`/host=master/server-config=server-one:resume`
+`/host=primary/server-config=server-one:resume`
 
-`/host=master/server-config=server-one:stop(suspend-timeout=x)`
+`/host=primary/server-config=server-one:stop(suspend-timeout=x)`
 
 *Host level*
 
-`/host=master:suspend-servers(suspend-timeout=x)`
+`/host=primary:suspend-servers(suspend-timeout=x)`
 
-`/host=master:resume-servers`
+`/host=primary:resume-servers`
 
-`/host=master:shutdown(suspend-timeout=x)`
+`/host=primary:shutdown(suspend-timeout=x)`
 
 Note that even though the host controller itself is being shut down, the suspend-timeout attribute for the shutdown operation at host level is applied to the servers only and not to the host controller itself.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
@@ -68,7 +68,7 @@ Here is an example of an `oidc.json` configuration file:
    "min-time-between-jwks-requests" : 10,
    "public-key-cache-ttl": 86400,
    "redirect-rewrite-rules" : {
-   "^/wsmaster/api/(.*)$" : "/api/$1"
+   "^/wsmain/api/(.*)$" : "/api/$1"
    }
 }
 ----
@@ -88,7 +88,7 @@ The following example shows how to add configuration to the _elytron-oidc-client
         <provider-url>http://localhost:8180/auth/realms/demo</provider-url>
         <ssl-required>external</ssl-required>
         <credential name="secret" secret="0aa31d98-e0aa-404c-b6e0-e771dba1e798" />
-    </secure-deployment
+    </secure-deployment>
 </subsystem>
 ----
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Server_Faces.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Server_Faces.adoc
@@ -32,9 +32,9 @@ WILDFLY_HOME/modules/com/sun/jsf-impl/mojarra-2.2.11
 * Place the Jakarta Server Faces implementation JAR in the <JSF_IMPL_NAME>-<JSF_VERSION>
 subdirectory. In the same subdirectory, add a `module.xml` file similar
 to the
-https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml[Mojarra]
+https://github.com/wildfly/wildfly/blob/main/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml[Mojarra]
 or
-https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml[MyFaces]
+https://github.com/wildfly/wildfly/blob/main/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml[MyFaces]
 template examples. Change the `resource-root-path` to the name of your
 Jakarta Server Faces implementation JAR and fill in appropriate values for $\{
 `jsf-impl-name`} and $\{ `jsf-version`}.
@@ -49,9 +49,9 @@ WILDFLY_HOME/modules/javax/faces/api/<JSF_IMPL_NAME>-<JSF_VERSION>
 * Place the JSF API JAR in the <JSF_IMPL_NAME>-<JSF_VERSION>
 subdirectory. In the same subdirectory, add a `module.xml` file similar
 to the
-https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml[Mojarra]
+https://github.com/wildfly/wildfly/blob/main/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml[Mojarra]
 or
-https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml[MyFaces]
+https://github.com/wildfly/wildfly/blob/main/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml[MyFaces]
 template examples. Change the `resource-root-path` to the name of your
 Jakarta Server Faces API JAR and fill in appropriate values for $\{ `jsf-impl-name`} and
 $\{ `jsf-version`}.
@@ -89,7 +89,7 @@ WILDFLY_HOME/modules/org/apache/commons/digester/main
 http://search.maven.org/remotecontent?filepath=commons-digester/commons-digester/1.8/commons-digester-1.8.jar[commons-digester]
 JAR in WILDFLY_HOME/modules/org/apache/commons/digester/main. In the
 `main` subdirectory, add a `module.xml` file similar to this
-https://github.com/wildfly/wildfly/blob/master/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml[template].
+https://github.com/wildfly/wildfly/blob/main/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml[template].
 Fill in the appropriate value for $\{ `version.commons-digester`}.
 
 [[start-the-server]]

--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -654,7 +654,7 @@ The following attributes are used to define the masked password:
 
 `algorithm`:: The algorithm that was used to encrypt the password. If this attribute is not specified, the default value is "masked-MD5-DES".
 A list of the supported algorithm types can be found in
-link:https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Passwords.adoc#masked-password-types[Masked Password Type]
+link:https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_elytron/Passwords.adoc#masked-password-types[Masked Password Type]
 `key-material`:: The initial key material that was used to encrypt the password. If this attribute is not specified, the default value is "somearbitrarycrazystringthatdoesnotmatter".
 `iteration-count`:: The iteration count that was used to encrypt the password. This attribute is required.
 `salt`:: The salt that was used to encrypt the password. This attribute is required.

--- a/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
@@ -354,7 +354,7 @@ ear deployment is as follows:
 [IMPORTANT]
 
 The xsd for jboss-deployment-structure.xml is available at
-https://github.com/wildfly/wildfly-core/blob/master/server/src/main/resources/schema/jboss-deployment-structure-1_2.xsd[https://github.com/wildfly/wildfly/blob/master/build/src/main/resources/docs/schema/jboss-deployment-structure-1_2.xsd]
+https://github.com/wildfly/wildfly-core/blob/master/server/src/main/resources/schema/jboss-deployment-structure-1_2.xsd[https://github.com/wildfly/wildfly-core/blob/main/server/src/main/resources/schema/jboss-deployment-structure-1_2.xsd]
 
 [[accessing-jdk-classes]]
 == Accessing JDK classes

--- a/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
@@ -479,12 +479,12 @@ If you are running WildFly in domain mode, this operation is available via the s
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master/server=server-one/deployment=test-application.war:list-modules
+[domain@localhost:9990 /] /host=primary/server=server-one/deployment=test-application.war:list-modules
 ----
 
 [source,options="nowrap"]
 ----
-[domain@localhost:9990 /] /host=master/server=server-one/deployment=test-application.ear/subdeployment=test-application.war:list-modules
+[domain@localhost:9990 /] /host=primary/server=server-one/deployment=test-application.ear/subdeployment=test-application.war:list-modules
 ----
 
 By default, the _list-modules_ operation shows the list of dependencies in a compact view, including only the module name. You can control this output using the attribute _verbose=[false*|true]_ to enable/disable a detailed response.

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
@@ -237,7 +237,9 @@ you type 'y' if you've been ask
 
 [source,java,options="nowrap"]
 ----
-Is this new user going to be used for one AS process to connect to another AS process e.g. slave domain controller?
+Is this new user going to be used for one AS process to connect to another AS process?
+e.g. for a secondary host controller connecting to the primary or for a Remoting connection for server to server Jakarta Enterprise Beans calls.
+yes/no?
 ----
 
 Now that we have generated that base64 encoded password, let's use in

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Predefined_client_and_endpoint_configurations.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Predefined_client_and_endpoint_configurations.adoc
@@ -179,7 +179,7 @@ documentation] for details on managing the _webservices_ subsystem such
 as adding, removing and modifying handlers and properties.
 
 The allowed contents in the _webservices_ subsystem are defined by the
-https://github.com/jbossas/jboss-as/blob/7.2.0.Final/build/src/main/resources/docs/schema/jboss-as-webservices_1_2.xsd[schema]
+https://github.com/wildfly/wildfly/blob/main/webservices/server-integration/src/main/resources/schema/jboss-as-webservices_1_2.xsd[schema]
 included in the application server.
 
 [[standard-configurations]]
@@ -306,19 +306,19 @@ extension provided by JBossWS:
 [source,java,options="nowrap"]
 ----
 import org.jboss.ws.api.configuration.ClientConfigFeature;
- 
+
 ...
- 
+
 Service service = Service.create(wsdlURL, serviceName);
 Endpoint port = service.getPort(Endpoint.class, new ClientConfigFeature("META-INF/my-client-config.xml", "Custom Client Config"));
 port.echo("Kermit");
- 
+
 ... or ....
- 
+
 port = service.getPort(Endpoint.class, new ClientConfigFeature("META-INF/my-client-config.xml", "Custom Client Config"), true); //setup properties too from the configuration
 port.echo("Kermit");
 ... or ...
- 
+
 port = service.getPort(Endpoint.class, new ClientConfigFeature(null, testConfigName)); //reads from current container configurations if available
 port.echo("Kermit");
 ----
@@ -341,29 +341,28 @@ from client configurations as follows:
 ----
 import org.jboss.ws.api.configuration.ClientConfigUtil;
 import org.jboss.ws.api.configuration.ClientConfigurer;
- 
+
 ...
- 
+
 Service service = Service.create(wsdlURL, serviceName);
 Endpoint port = service.getPort(Endpoint.class);
 BindingProvider bp = (BindingProvider)port;
 ClientConfigUtil.setConfigHandlers(bp, "META-INF/my-client-config.xml", "Custom Client Config 1");
 port.echo("Kermit");
- 
+
 ...
- 
+
 ClientConfigurer configurer = ClientConfigUtil.resolveClientConfigurer();
 configurer.setConfigHandlers(bp, "META-INF/my-client-config.xml", "Custom Client Config 2");
 port.echo("Kermit");
- 
+
 ...
- 
+
 configurer.setConfigHandlers(bp, "META-INF/my-client-config.xml", "Custom Client Config 3");
 port.echo("Kermit");
- 
- 
+
 ...
- 
+
 configurer.setConfigHandlers(bp, null, "Container Custom Client Config"); //reads from current container configurations if available
 port.echo("Kermit");
 ----
@@ -375,29 +374,28 @@ follows:
 ----
 import org.jboss.ws.api.configuration.ClientConfigUtil;
 import org.jboss.ws.api.configuration.ClientConfigurer;
- 
+
 ...
- 
+
 Service service = Service.create(wsdlURL, serviceName);
 Endpoint port = service.getPort(Endpoint.class);
- 
+
 ClientConfigUtil.setConfigProperties(port, "META-INF/my-client-config.xml", "Custom Client Config 1");
 port.echo("Kermit");
- 
+
 ...
- 
+
 ClientConfigurer configurer = ClientConfigUtil.resolveClientConfigurer();
 configurer.setConfigProperties(port, "META-INF/my-client-config.xml", "Custom Client Config 2");
 port.echo("Kermit");
- 
+
 ...
- 
+
 configurer.setConfigProperties(port, "META-INF/my-client-config.xml", "Custom Client Config 3");
 port.echo("Kermit");
- 
- 
+
 ...
- 
+
 configurer.setConfigProperties(port, null, "Container Custom Client Config"); //reads from current container configurations if available
 port.echo("Kermit");
 

--- a/docs/src/main/asciidoc/_developer-guide/Web_(Undertow)_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Web_(Undertow)_Reference_Guide.adoc
@@ -26,6 +26,6 @@ ear:
 This element is used to configure the shared session manager that will
 be used by all wars in the ear. For full details of all the options
 provided by this file please see the schema at
-https://github.com/wildfly/wildfly/blob/master/undertow/src/main/resources/schema/shared-session-config_2_0.xsd,
+https://github.com/wildfly/wildfly/blob/main/undertow/src/main/resources/schema/shared-session-config_2_0.xsd,
 however in general it mimics the options that are available in
 jboss-web.xml for configuring the session.

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
@@ -89,7 +89,6 @@ container interceptor(s) can be configured in jboss-ejb3.xml:
 <jboss xmlns="http://www.jboss.com/xml/ns/javaee"
        xmlns:jee="http://java.sun.com/xml/ns/javaee"
        xmlns:ci ="urn:container-interceptors:1.0">
- 
     <jee:assembly-descriptor>
         <ci:container-interceptors>
             <!-- Default interceptor -->
@@ -134,14 +133,14 @@ bindings
 * The interceptor bindings themselves are the same elements as what the
 EJB3.1 xsd allows for standard Jakarta Interceptors
 * The interceptors can be bound either to all EJBs in the deployment
-(using the the * wildcard) or individual bean level (using the specific
+(using the * wildcard) or individual bean level (using the specific
 EJB name) or at specific method level for the EJBs.
 
 [IMPORTANT]
 
 The xsd for the urn:container-interceptors:1.0 namespace is available
 here
-https://github.com/jbossas/jboss-as/blob/master/ejb3/src/main/resources/jboss-ejb-container-interceptors_1_0.xsd
+https://github.com/wildfly/wildfly/blob/main/ejb3/src/main/resources/schema/jboss-ejb-container-interceptors_1_0.xsd
 
 The interceptor classes themselves are simple POJOs and use the
 `@javax.annotation.AroundInvoke` to mark the around invoke method which
@@ -157,7 +156,6 @@ public class ClassLevelContainerInterceptor {
     private Object iAmAround(final InvocationContext invocationContext) throws Exception {
         return this.getClass().getName() + " " + invocationContext.proceed();
     }
- 
 }
 ----
 
@@ -185,6 +183,6 @@ the EJB components are setup or instantiated.
 
 This testcase in the WildFly codebase can be used for reference for
 implementing container interceptors in user applications
-https://github.com/wildfly/wildfly/blob/master/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
+https://github.com/wildfly/wildfly/blob/main/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
 
 NOTE: References in this document to Enterprise JavaBeans(EJB) refer to the Jakarta Enterprise Beans unless otherwise noted.

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Message_Driven_Beans_Controlled_Delivery.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Message_Driven_Beans_Controlled_Delivery.adoc
@@ -32,16 +32,16 @@ deployed:
 <?xml version="1.1" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xmlns:d="urn:delivery-active:1.2"
-               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"                version="3.1"
-               impl-version="2.0">
-    <assembly-descriptor>
-        <d:delivery>
-            <ejb-name>HelloWorldQueueMDB</ejb-name>
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:d="urn:delivery-active:1.2"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"                version="3.1"
+               impl-version="2.0">
+    <assembly-descriptor>
+        <d:delivery>
+            <ejb-name>HelloWorldQueueMDB</ejb-name>
             <d:active>false</d:active>
-        </d:delivery>
-    </assembly-descriptor>
+        </d:delivery>
+    </assembly-descriptor>
 </jboss:ejb-jar>
 ----
 
@@ -56,15 +56,15 @@ annotation, as in the example below:
 [source,java,options="nowrap"]
 ----
 @MessageDriven(name = "HelloWorldMDB", activationConfig = {
- 
+
  @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
- 
+
  @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
- 
+
  @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
- 
+
 @DeliveryActive(false)
- 
+
 public class HelloWorldMDB implements MessageListener {
     public void onMessage(Message rcvMessage) {
       // ...
@@ -83,10 +83,10 @@ path of the MDB you want to manage delivery for:
 [source,options="nowrap"]
 ----
 [standalone@localhost:9990 /] cd deployment=jboss-helloworld-mdb.war/subsystem=ejb3/message-driven-bean=HelloWorldMDB
- 
+
 [standalone@localhost:9990 message-driven-bean=HelloWorldMDB] :stop-delivery
 {"outcome" => "success"}
- 
+
 [standalone@localhost:9990 message-driven-bean=HelloWorldMDB] :start-delivery
 {"outcome" => "success"}
 ----
@@ -111,7 +111,7 @@ standalone.xml)
 ----
 <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
     ...
-    <mdb>
+    <mdb>
         ...
         <delivery-groups>
             <delivery-group name="mdb-group-name" active="true"/>
@@ -158,7 +158,7 @@ with a false value:
 ----
 [standalone@localhost:9990 /] ./subsystem=ejb3/mdb-delivery-group=mdb-group-name:write-attribute(name=active,value=false)
 {"outcome" => "success"}
- 
+
 [standalone@localhost:9990 /] ./subsystem=ejb3/mdb-delivery-group=mdb-group-name:read-attribute(name=active)
 { "outcome" => "success", "result" => false }
 ----
@@ -169,7 +169,7 @@ To make it active again, write the attribute with a true value:
 ----
 [standalone@localhost:9990 /] ./subsystem=ejb3/mdb-delivery-group=mdb-group-name:write-attribute(name=active,value=true)
 {"outcome" => "success"}
- 
+
 [standalone@localhost:9990 /] ./subsystem=ejb3/mdb-delivery-group=mdb-group-name:read-attribute(name=active)
 { "outcome" => "success", "result" => true }
 ----
@@ -183,7 +183,7 @@ jboss-ejb3.xml file:
 [source,xml,options="nowrap"]
 ----
 <?xml version="1.1" encoding="UTF-8"?>
- 
+
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -237,9 +237,9 @@ annotation on each MDB class belonging to a group:
  @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
  @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
  @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
- 
+
 @DeliveryGroup("group2")
- 
+
 public class HelloWorldMDB implements MessageListener {
     ...
 }
@@ -249,7 +249,7 @@ A MDB can belong to more than one delivery group. See the following example:
 [source,xml]
 ----
 <?xml version="1.1" encoding="UTF-8"?>
- 
+
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -289,10 +289,10 @@ The same could be specified using the @DeliveryGroup annotation:
  @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
  @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
  @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
- 
+
 @DeliveryGroup("mdb-delivery-group2")
 @DeliveryGroup("mdb-delivery-group3")
- 
+
 public class HelloWorldMDB implements MessageListener {
     ...
 }
@@ -314,7 +314,7 @@ except for the MDBs that are marked as clustered singleton. For those
 MDBs, only one cluster node will be processing their messages. In case
 that node stops, another node will have delivery activated, guaranteeing
 that there is always one node processing the messages. This node is what
-we call the MDB clustered singleton master node.
+we call primary singleton provider of the MDB.
 
 Notice that applications using clustered singleton delivery can only be
 deployed in clustered WildFly servers (i.e., servers that are using the
@@ -359,9 +359,9 @@ to mark an MDB as clustered singleton:
  @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
  @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/HELLOWORLDMDBQueue"),
  @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
- 
+
 @ClusteredSingleton
- 
+
 public class HelloWorldMDB implements MessageListener { ... }
 ----
 
@@ -375,7 +375,7 @@ delivery to be active in a MDB.
 For example, if an MDB belongs to one or more delivery groups and is also a
 clustered singleton MDB, the delivery will be active for that MDB only
 if the delivery groups are active in the cluster node that was elected as
-the singleton master.
+the primary singleton provider.
 
 Also, if you use jboss-cli to stopDelivery on a MDB that belongs to one or more
 delivery groups, the MDB will stop receiving messages in case all groups
@@ -386,9 +386,9 @@ operation is executed to revert the previously executed stopDelivery operation.
 
 Invoking stopDelivery on an MDB that is marked as clustered singleton
 will work in a similar way: no visible effect if the current node is not
-the clustered singleton master; but it will stop delivery of messages
-for that MDB if the current node is the clustered singleton master. If
-the current node is not the master, but eventually becomes so, the
+the primary singleton provider; but it will stop delivery of messages
+for that MDB if the current node is the primary singleton provider. If
+the current node is not the primary singleton provider, but eventually becomes so, the
 delivery of messages will not be active for that MDB, unless a
 startDelivery operation is invoked.
 
@@ -401,12 +401,12 @@ needs to be active and the delivery needs to be restarted (via start-delivery) i
 for that MDB to start receiving messages;
 
 * * MDB belongs to one delivery-group + MDB is clustered singleton*: the delivery group
-needs to be active and the current node needs to be the clustered singleton master
+needs to be active and the current node needs to be the primary singleton provider
 node in order for that MDB to start receiving messages;
 
 * * MDB belongs to one delivery-group + MDB is clustered singleton + stop-delivery was invoked*:
 as above, the delivery-group has to be active, the current cluster node must be the
-clustered singleton master node, plus, start-delivery needs to be invoked on that MDB,
+primary singleton provider node, plus, start-delivery needs to be invoked on that MDB,
 only with these three factors being true the MDB will start receiving messages.
 
 * * MDB belongs to multiple delivery-groups + stop-delivery was invoked*: all the delivery
@@ -414,10 +414,10 @@ groups need to be active and the delivery needs to be restarted (via start-deliv
 order for that MDB to start receiving messages;
 
 * * MDB belongs to multiple delivery-groups + MDB is clustered singleton*: all the delivery
-groups need to be active and the current node needs to be the clustered singleton
-master node in order for that MDB to start receiving messages;
+groups need to be active and the current node needs to be the primary singleton
+provider node in order for that MDB to start receiving messages;
 
 * * MDB belongs to multiple delivery-groups + MDB is clustered singleton + stop-delivery was
 invoked*: as above, all delivery-groups must be active, and current cluster node has to be the
-clustered singleton master node, plus, start-delivery needs to be invoked on that MDB, only
+primary singleton provider node, plus, start-delivery needs to be invoked on that MDB, only
 with these three factors being true the MDB will start receiving messages.

--- a/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
@@ -4,12 +4,12 @@
 [abstract]
 
 A WildFly domain may consist of a new Domain Controller (DC) controlling
-slave Host Controllers (HC) running older versions. Each slave HC
+secondary Host Controllers (HC) running older versions. Each secondary HC
 maintains a copy of the centralized domain configuration, which they use
-for controlling their own servers. In order for the slave HCs to
+for controlling their own servers. In order for the secondary HCs to
 understand the configuration from the DC, transformation is needed,
 whereby the DC translates the configuration and operations into
-something the slave HCs can understand.
+something the secondary HCs can understand.
 
 [[background]]
 == Background
@@ -17,7 +17,7 @@ something the slave HCs can understand.
 WildFly comes with a link:Admin_Guide{outfilesuffix}#Domain_Setup[domain mode] which allows
 you to have one Host Controller acting as the Domain Controller. The
 Domain Controller's job is to maintain the centralized domain
-configuration. Another term for the DC is 'Master Host Controller'.
+configuration. Another term for the DC is 'Primary Host Controller'.
 Before explaining why transformers are important and when they should be
 used, we will revisit how the domain configuration is used in domain
 mode.
@@ -51,7 +51,7 @@ marshalling of the subsystem xml]. These operations build up the model
 on the DC.
 
 A HC wishing to join the domain and use the DC's centralized
-configuration is known as a 'slave HC'. A slave HC maintains a copy of
+configuration is known as a 'secondary HC'. A secondary HC maintains a copy of
 the DC's centralized domain configuration. This copy of the domain
 configuration is used to start its servers. This is done by asking the
 domain model to `describe` itself, which in turn asks the subsystems to
@@ -62,7 +62,7 @@ takes place on the DC (bear in mind that the DC is also a HC, which can
 have its own servers), although of course its copy of the domain
 configuration is the centralized one.
 
-There are two steps involved in keeping the keeping the slave HC's
+There are two steps involved in keeping the secondary HC's
 domain configuration in sync with the centralized domain configuration.
 
 * getting the initial domain model
@@ -73,7 +73,7 @@ Let's look a bit closer at what happens in each of these steps.
 [[getting-the-initial-domain-model]]
 === Getting the initial domain model
 
-When a slave HC connects to the DC it obtains a copy of the domain model
+When a secondary HC connects to the DC it obtains a copy of the domain model
 from the DC. This is done in a simpler serialized format, different from
 the operations that built up the model on the DC, or the operations
 resulting from the `describe` step used to bootstrap the servers. They
@@ -136,7 +136,7 @@ looks like this:
 --SNIP---
 ----
 
-The slave HC then applies these one at a time and builds up the initial
+The secondary HC then applies these one at a time and builds up the initial
 domain model. It needs to do this before it can start any of its
 servers.
 
@@ -145,7 +145,7 @@ servers.
 
 Once a domain is up and running we can still change things in the domain
 configuration. These changes must happen when connected to the DC, and
-are then propagated to the slave HCs, which then in turn propagate the
+are then propagated to the secondary HCs, which then in turn propagate the
 changes to any servers running in a server group affected by the changes
 made. In this example:
 
@@ -157,7 +157,7 @@ made. In this example:
     "outcome" => "success",
     "result" => undefined,
     "server-groups" => {"main-server-group" => {"host" => {
-        "slave" => {"server-one" => {"response" => {
+        "secondary" => {"server-one" => {"response" => {
             "outcome" => "success",
             "result" => undefined,
             "response-headers" => {
@@ -165,7 +165,7 @@ made. In this example:
                 "process-state" => "restart-required"
             }
         }}},
-        "master" => {
+        "primary" => {
             "server-one" => {"response" => {
                 "outcome" => "success",
                 "response-headers" => {
@@ -185,10 +185,10 @@ made. In this example:
 }
 ----
 
-the DC propagates the changes to itself `host=master`, which in turn
+the DC propagates the changes to itself `host=primary`, which in turn
 propagates it to its two servers belonging to `main-server-group` which
 uses the `full` profile. More interestingly, it also propagates it to
-`host=slave` which updates its local copy of the domain model, and then
+`host=secondary` which updates its local copy of the domain model, and then
 propagates the change to its `server-one` which belongs to
 `main-server-group` which uses the `full` profile.
 
@@ -196,7 +196,7 @@ propagates the change to its `server-one` which belongs to
 == Versions and backward compatibility
 
 A HC and its servers will always be the same version of WildFly (they
-use the same module path and jars). However, the DC and the slave HCs do
+use the same module path and jars). However, the DC and the secondary HCs do
 not necessarily need to be the same version. One of the points in the
 original specification for WildFly is that
 
@@ -204,11 +204,11 @@ Important
 
 [IMPORTANT]
 
-A Domain Controller should be able to manage slave Host Controllers
+A Domain Controller should be able to manage secondary Host Controllers
 older than itself.
 
 This means that for example a WildFly 10.1 DC should be able to work
-with slave HCs running WildFly 10. The opposite is not true, the DC must
+with secondary HCs running WildFly 10. The opposite is not true, the DC must
 be the same or the newest version in the domain.
 
 [[versioning-of-subsystems]]
@@ -302,22 +302,22 @@ domain@localhost:9990 /] /extension=org.jboss.as.clustering.infinispan:read-reso
 [[the-role-of-transformers]]
 == The role of transformers
 
-Now that we have mentioned the slave HCs registration process with the
+Now that we have mentioned the secondary HCs registration process with the
 DC, and know about ModelVersions, it is time to mention that when
-registering with the DC, the slave HC will send across a list of all its
+registering with the DC, the secondary HC will send across a list of all its
 subsystem ModelVersions. The DC maintains this information in a registry
-for each slave HC, so that it knows which transformers (if any) to
-invoke for a legacy slave. We will see how to write and register
+for each secondary HC, so that it knows which transformers (if any) to
+invoke for a legacy secondary. We will see how to write and register
 transformers later on in
 <<how-do-i-write-a-transformer,#How
-do I write a transformer>>. Slave HCs from version 7.2.0 onwards will
+do I write a transformer>>. secondary HCs from version 7.2.0 onwards will
 also include a list of resources that they ignore (see
 <<ignoring-resources-on-legacy-hosts,#Ignoring
 resources on legacy hosts>>), and the DC will maintain this information
 in its registry. The DC will not send across any resources that it knows
-a slave ignores during the initial domain model transfer. When
-forwarding operations onto the slave HCs, the DC will skip forwarding
-those to slave HCs ignoring those resources.
+a secondary ignores during the initial domain model transfer. When
+forwarding operations onto the secondary HCs, the DC will skip forwarding
+those to secondary HCs ignoring those resources.
 
 There are two kinds of transformers:
 
@@ -325,10 +325,10 @@ There are two kinds of transformers:
 * operation transformers
 
 The main function of transformers is to transform a subsystem to
-something that the legacy slave HC can understand, or to aggressively
-reject things that the legacy slave HC will not understand. Rejection,
+something that the legacy secondary HC can understand, or to aggressively
+reject things that the legacy secondary HC will not understand. Rejection,
 in this context, essentially means, that the resource or operation
-cannot safely be transformed to something valid on the slave, so the
+cannot safely be transformed to something valid on the secondary HC, so the
 transformation fails. We will see later how to reject attributes in
 <<rejecting-attributes,#Rejecting
 attributes>>, and child resources in
@@ -429,7 +429,7 @@ attributes, `require-bean-descriptor` and `non-portable` mode:
 
 In the rest of this section we will assume that we are running a DC
 running WildFly {wildflyVersion} so it will have ModelVersion 2.0.0 of the weld
-subsystem, and that we are running a slave using ModelVersion 1.0.0 of
+subsystem, and that we are running a secondary HC using ModelVersion 1.0.0 of
 the weld subsystem.
 
 Important
@@ -438,7 +438,7 @@ Important
 
 Transformation always takes place on the Domain Controller, and is done
 when sending across the initial domain model AND forwarding on
-operations to legacy slave HCs.
+operations to legacy secondary HCs.
 
 [[resource-transformers]]
 === Resource transformers
@@ -446,11 +446,11 @@ operations to legacy slave HCs.
 When copying over the centralized domain configuration as mentioned in
 <<getting-the-initial-domain-model,#Getting
 the initial domain model>>, we need to make sure that the copy of the
-domain model is something that the servers running on the legacy slave
+domain model is something that the servers running on the legacy secondary
 HC understand. So if the centralized domain configuration had any of the
 two new attributes set, we would need to reject the transformation in
 the transformers. One reason for this is to keep things consistent, it
-doesn't look good if you connect to the slave HC and find attributes
+doesn't look good if you connect to the secondary HC and find attributes
 and/or child resources when doing `:read-resource` which are not there
 when you do `:read-resource-description`. Also, to make life easier for
 subsystem writers, most instances of the `describe` operation use a
@@ -468,34 +468,34 @@ use color:
 ----
 
 This ' `%K{...`}' however was introduced in JBoss AS < 7.1.3
-(ModelVersion 1.2.0), so if that makes it across to a slave HC running
+(ModelVersion 1.2.0), so if that makes it across to a secondary HC running
 an older version, the servers *will* fail to start up. So the logging
 extension registers transformers to strip out the ' `%K{...`}' from the
 attribute value (leaving ' `%-5p` `%c` `(%t) %s%E%n"`') so that the old
-slave HC's servers can understand it.
+secondary HC's servers can understand it.
 
 [[rejection-in-resource-transformers]]
 ==== Rejection in resource transformers
 
-Only slave HCs from JBoss AS 7.2.0 and newer inform the DC about their
+Only secondary HCs from JBoss AS 7.2.0 and newer inform the DC about their
 ignored resources (see
 <<ignoring-resources-on-legacy-hosts,#Ignoring
 resources on legacy hosts>>). This means that if a transformer on the DC
-rejects transformation for a legacy slave HC, exactly what happens to
-the slave HC depends on the version of the slave HC. If the slave HC is:
+rejects transformation for a legacy secondary HC, exactly what happens to
+the secondary HC depends on the version of the secondary HC. If the secondary HC is:
 
-* _older than 7.2.0_ - the DC has no means of knowing if the slave HC
+* _older than 7.2.0_ - the DC has no means of knowing if the secondary HC
 has ignored the resource being rejected or not. So we log a warning on
 the DC, and send over the serialized part of that model anyway. If the
-slave HC has ignored the resource in question, it does not apply it. If
-the slave HC has not ignored the resource in question, it will apply it,
+secondary HC has ignored the resource in question, it does not apply it. If
+the secondary HC has not ignored the resource in question, it will apply it,
 but no failure will happen until it tries to start a server which
 references this bad configuration.
-* _7.2.0 or newer_ - If a resource is ignored on the slave HC, the DC
+* _7.2.0 or newer_ - If a resource is ignored on the secondary HC, the DC
 knows about this, and will not attempt to transform or send the resource
-across to the slave HC. If the resource transformation is rejected, we
-know the resource was not ignored on the slave HC and so we can
-aggressively fail the transformation, which in turn will cause the slave
+across to the secondary HC. If the resource transformation is rejected, we
+know the resource was not ignored on the secondary HC and so we can
+aggressively fail the transformation, which in turn will cause the secondary
 HC to fail to start up.
 
 [[operation-transformers]]
@@ -504,8 +504,8 @@ HC to fail to start up.
 When
 <<an-operation-changes-something-in-the-domain-configuration,#An
 operation changes something in the domain configuration>> the operation
-gets sent across to the slave HCs to update their copies of the domain
-model. The slave HCs then forward this operation onto the affected
+gets sent across to the secondary HCs to update their copies of the domain
+model. The secondary HCs then forward this operation onto the affected
 servers. The same considerations as in
 <<resource-transformers,#Resource
 transformers>> are true, although operation transformers give you quicker
@@ -516,7 +516,7 @@ transformers>> are true, although operation transformers give you quicker
 /profile=full/subsystem=weld:write-attribute(name=require-bean-descriptor, value=false)
 ----
 
-This will fail on the legacy slave HC since its version of the subsystem
+This will fail on the legacy secondary HC since its version of the subsystem
 does not contain any such attribute. However, it is best to aggressively
 reject in such cases.
 
@@ -524,14 +524,14 @@ reject in such cases.
 ==== Rejection in operation transformers
 
 For transformed operations we can always know if the operation is on an
-ignored resource in the legacy slave HC. In 7.2.0 onwards, we know this
-through the DC's registry of ignored resources on the slave. In older
-versions of slaves, we send the operation across to the slave, which
+ignored resource in the legacy secondary HC. In 7.2.0 onwards, we know this
+through the DC's registry of ignored resources on the secondary HC. In older
+versions of secondary HCs, we send the operation across to the secondary HC, which
 tries to invoke the operation. If the operation is against an ignored
 resource we inform the DC about this fact. So as part of the
 transformation process, if something gets rejected we can (and do!) fail
 the transformation aggressively. If the operation invoked on the DC
-results in the operation being sent across to 10 slave HCs and one of
+results in the operation being sent across to 10 secondary HCs and one of
 them has a legacy version which ends up rejecting the transformation, we
 rollback the operation across the whole domain.
 
@@ -549,7 +549,7 @@ not tweakable, and with the way the subsystem in JBoss AS 7.x worked is
 similar to if they are set to `true`.
 
 The above discussion implies that to use the weld subsystem on a legacy
-slave HC, the `domain.xml` configuration for it must look like:
+secondary HC, the `domain.xml` configuration for it must look like:
 
 [source,xml,options="nowrap"]
 ----
@@ -559,16 +559,16 @@ slave HC, the `domain.xml` configuration for it must look like:
 ----
 
 We will see the exact mechanics for how this is actually done later but
-in short when pushing this to a legacy slave DC we register transformers
+in short when pushing this to a legacy secondary HC we register transformers
 which reject the transformation if these attributes are not set to
 `true` since that implies some behavior not supported on the legacy
-slave DC. If they are `true`, all is well, and the transformers discard,
+secondary HC. If they are `true`, all is well, and the transformers discard,
 or remove, these attributes since they don't exist in the legacy model.
 This removal is fine since they have the values which would result in
-the behavior assumed on the legacy slave HC.
+the behavior assumed on the legacy secondary HC.
 
-That way the older slave HCs will work fine. However, we might also have
-WildFly {wildflyVersion} slave HCs in our domain, and they are missing out on the new
+That way the older secondary HCs will work fine. However, we might also have
+WildFly {wildflyVersion} secondary HCs in our domain, and they are missing out on the new
 features introduced by the attributes introduced in ModelVersion 2.0.0.
 If we do
 
@@ -621,27 +621,27 @@ server group.
 ==== Ignoring resources on legacy hosts
 
 Booting the above configuration will still cause problems on legacy
-slave HCs, especially if they are JBoss AS 7.2.0 or later. The reason
+secondary HCs, especially if they are JBoss AS 7.2.0 or later. The reason
 for this is that when they register themselves with the DC it lets the
 DC know which `ignored resources` they have. If the DC comes to
-transform something it should reject for a slave HC and it is not part
+transform something it should reject for a secondary HC and it is not part
 of its ignored resources it will aggressively fail the transformation.
 Versions of JBoss AS older than 7.2.0 still have this ignored resources
 mechanism, but don't let the DC know about what they have ignored so the
 DC cannot reject aggressively - instead it will log some warnings.
 However, it is still good practice to ignore resources you are not
-interested in regardless of which legacy version the slave HC is
+interested in regardless of which legacy version the secondary HC is
 running.
 
 To ignore the profile we cannot understand we do the following in the
-legacy slave HC's `host.xml`
+legacy secondary HC's `host.xml`
 
 [source,xml,options="nowrap"]
 ----
-<host xmlns="urn:jboss:domain:1.3" name="slave">
+<host xmlns="urn:jboss:domain:1.3" name="secondary">
 ...
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm">
+       <remote host="${jboss.test.host.primary.address}" port="${jboss.domain.primary.port:9999}" security-realm="ManagementRealm">
             <ignored-resources type="profile">
                 <instance name="full-legacy"/>
             </ignored-resources>
@@ -920,7 +920,7 @@ or
 ----
 
 or any other combination (the default values for these attributes if
-undefined is `false`) we will reject the transformation for the slave
+undefined is `false`) we will reject the transformation for the secondary
 legacy HC.
 
 If the resource has true for these attributes:
@@ -988,10 +988,10 @@ discard a child resource, we can do
 ----
 
 This means that any usage of `/subsystem=my-subsystem/child=discarded`
-never make it to the legacy slave HC running ModelVersion 1.0.0. During
+never make it to the legacy secondary HC running ModelVersion 1.0.0. During
 the initial domain model transfer, that part of the serialized domain
 model is stripped out, and any operations on this address are not
-forwarded on to the legacy slave HCs running that version of the
+forwarded on to the legacy secondary HCs running that version of the
 subsystem. (For brevity this section will leave out the leading
 `/profile=xxx` part used in domain mode, and use
 `/subsystem=my-subsystem` as the 'top-level' address).
@@ -1004,10 +1004,10 @@ Note that discarding, although the simplest option in theory, is *rarely
 the right thing to do*.
 
 The presence of the defined child normally implies some behaviour on the
-DC, and that behaviour is not available on the legacy slave HC, so
+DC, and that behaviour is not available on the legacy secondary HC, so
 normally rejection is a better policy for those cases. Remember we can
 have different profiles targeting different groups of versions of legacy
-slave HCs.
+secondary HCs.
 
 [[reject-child-resource]]
 ==== Reject child resource
@@ -1020,9 +1020,9 @@ do
     subsystemBuilder.rejectChildResource(PathElement.pathElement("child", "reject"));
 ----
 
-Now, if there are any legacy slaves running ModelVersion 1.0.0, any
+Now, if there are any legacy secondary HCs running ModelVersion 1.0.0, any
 usage of `/subsystem=my-subsystem/child=reject` will get rejected for
-those slaves. Both during the initial domain model transfer, and if any
+those secondary HCs. Both during the initial domain model transfer, and if any
 operations are invoked on that address. For example the `remoting`
 subsystem did not have a `http-connector=*` child until ModelVersion
 2.0.0, so it is set up to reject that child when transforming to legacy
@@ -1052,7 +1052,7 @@ Now, in the initial domain transfer
 `/subsystem=my-subsystem/newChild=test` becomes
 `/subsystem=my-subsystem/oldChild=test`. Similarly all operations
 against the former address get mapped to the latter when executing
-operations on the DC before sending them to the legacy slave HC running
+operations on the DC before sending them to the legacy secondary HC running
 ModelVersion 1.1.0 of the subsystem.
 
 We can also rename a specific named child:
@@ -1065,7 +1065,7 @@ We can also rename a specific named child:
 
 Now, `/subsystem=my-subsystem/newChild=newName` becomes
 `/subsystem=my-subsystem/oldChild=oldName` both in the initial domain
-transfer, and when mapping operations to the legacy slave. For example,
+transfer, and when mapping operations to the legacy secondary HC. For example,
 under the `web` subsystem `ssl=configuration` got renamed to
 `configuration=ssl` in later versions, meaning we need a redirect from
 `configuration=ssl` to `ssl=configuration` in its transformers.
@@ -1156,7 +1156,7 @@ operation that have been registered for a discard check, are checked to
 see if the attribute should be discarded. If an attribute should be
 discarded, it is removed from the resource's attributes/operation's
 parameters and it does not get passed to the next phases. Once discarded
-it does not get sent to the legacy slave HC.
+it does not get sent to the legacy secondary HC.
 2.  `reject` - All attributes that have been registered for a reject
 check (and which not have been discarded) are checked to see if the
 attribute should be rejected. As explained in
@@ -1165,13 +1165,13 @@ in resource transformers>> and
 <<rejection-in-operation-transformers,#Rejection
 in operation transformers>> exactly what happens when something is
 rejected varies depending on whether we are transforming a resource or
-an operation, and the version of the legacy slave HC we are transforming
+an operation, and the version of the legacy secondary HC we are transforming
 for. If a transformer rejects an attribute, all other reject
 transformers still get invoked, and the next phases also get invoked.
 This is because we don't know in all cases what will happen if a reject
 happens. Although this might sound cumbersome, in practice it actually
 makes it easier to write transformers since you only need one kind
-regardless of if it is a resource, an operation, and legacy slave HC
+regardless of if it is a resource, an operation, and legacy secondary HC
 version. However, as we will see in
 <<common-transformation-use-cases,Common
 transformation use-cases>>, it means some extra checks are needed when
@@ -1180,7 +1180,7 @@ writing reject and convert transformers.
 are checked to see if the attribute should be converted. If the
 attribute does not exist in the original operation/resource it may be
 introduced. This is useful for setting default values for the target
-legacy slave HC.
+legacy secondary HC.
 4.  `rename` - All attributes registered for renaming are renamed.
 
 Next, let us have a look at how to register attributes for each of these
@@ -1190,7 +1190,7 @@ phases.
 ==== Discarding attributes
 
 The general idea behind a discard is that we remove attributes which do
-not exist in the legacy slave HC's model. However, as hopefully
+not exist in the legacy secondary HC's model. However, as hopefully
 described below, we normally can't simply discard everything, we need to
 check the values first.
 
@@ -1373,10 +1373,10 @@ We will come back to the reject checks in the
 attributes>> section. We are saying that we should discard the
 `JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE` attribute if it
 has the value `deep`. The reasoning here is that this attribute did not
-exist in the old model, but the legacy slave HCs _implied behaviour_ is
+exist in the old model, but the legacy secondary HCs _implied behaviour_ is
 that this was `deep`. In the current version we added the possibility to
 toggle this setting, but only `deep` is consistent with what is
-available in the legacy slave HC. In this case we are using the
+available in the legacy secondary HC. In this case we are using the
 constructor for `DiscardAttributeChecker.DiscardAttributeValueChecker`
 which says don't discard if it uses expressions, and discard if it is
 `undefined`. If it is `undefined` in the current model, looking at the
@@ -1384,7 +1384,7 @@ default value of
 `JPADefinition.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE`, it is `deep`,
 so a discard is in line with the implied legacy behaviour. If an
 expression is used, we cannot discard since we have no idea what the
-expression will resolve to on the slave HC.
+expression will resolve to on the secondary HC.
 
 [[discardattributechecker.always]]
 ====== DiscardAttributeChecker.ALWAYS
@@ -1393,8 +1393,8 @@ expression will resolve to on the slave HC.
 this sparingly, since normally the presence of an attribute in the
 current model implies some behaviour should be turned on, and if that
 does not exist in the legacy model it implies that that behaviour does
-not exist in the legacy slave HC and its servers. Normally the legacy
-slave HC's subsystem has some implied behaviour which is better checked
+not exist in the legacy secondary HC and its servers. Normally the legacy
+secondary HC's subsystem has some implied behaviour which is better checked
 for by using a `DiscardAttributeChecker.DiscardAttributeValueChecker`.
 One valid use for `DiscardAttributeChecker.ALWAYS` can be found in the
 `ejb3` subsystem:
@@ -1406,13 +1406,13 @@ One valid use for `DiscardAttributeChecker.ALWAYS` can be found in the
                 .getAttributeBuilder()
                  ...
                 // We can always discard this attribute, because it's meaningless without the security-manager subsystem, and
-                // a legacy slave can't have that subsystem in its profile.
+                // a legacy secondary HC can't have that subsystem in its profile.
                 .setDiscard(DiscardAttributeChecker.ALWAYS, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
    ...
 ----
 
 As the comment says, this attribute only makes sense with the
-security-manager susbsystem, which does not exist on legacy slaves
+security-manager susbsystem, which does not exist on legacy secondary HCs
 running ModelVersion 1.1.0 of the `ejb3` subsystem.
 
 [[discardattributechecker.undefined]]
@@ -1422,14 +1422,14 @@ running ModelVersion 1.1.0 of the `ejb3` subsystem.
 `undefined`. This is normally safer than
 `DiscardAttributeChecker.ALWAYS` since the attribute is not set in the
 current model, we don't need to send it to the legacy model. However,
-you should check that this attribute not existing in the legacy slave
+you should check that this attribute not existing in the legacy secondary
 HC, implies the same functionality as being undefined in the current DC.
 
 [[rejecting-attributes]]
 ==== Rejecting attributes
 
 The next step is to check attributes and values which we know for sure
-will not work on the target legacy slave HC.
+will not work on the target legacy secondary HC.
 
 To reject an attribute we need an instance of
 `org.jboss.as.controller.transform.description.RejectAttributeChecker`,
@@ -1596,7 +1596,7 @@ transformed operation, in the case of operation transformation.
 
 `RejectAttributeChecker.DEFINED` is used to reject any attribute that
 has a defined value. Normally this is because the attribute does not
-exist on the target legacy slave HC. A typical use case for these is for
+exist on the target legacy secondary HC. A typical use case for these is for
 the _implied behavior_ example we looked at in the `jpa` subsystem in
 <<discardattributechecker.discardattributevaluechecker,#DiscardAttributeChecker.DiscardAttributeValueChecker>>
 
@@ -1756,7 +1756,7 @@ A hypothetical example is if the current and legacy subsystems both
 contain an attribute called `timeout`. In the legacy model this was
 specified to be milliseconds, however in the current model it has been
 changed to be seconds, hence we need to convert the value when sending
-it to slave HCs using the legacy model:
+it to secondary HCs using the legacy model:
 
 [source,java,options="nowrap"]
 ----
@@ -1812,7 +1812,7 @@ Say both the current and the legacy models have an attribute called
 the default xml configuration had `1234` for its value. In the current
 version this attribute has been made optional with a default value of
 `1234` so that it does not need to be specified. When transforming to a
-slave HC using the old version we will need to introduce this attribute
+secondary HC using the old version we will need to introduce this attribute
 if the new model does not contain it:
 
 [source,java,options="nowrap"]
@@ -1838,7 +1838,7 @@ To rename an attribute, you simply do
     attributeBuilder.addRename("my-name", "legacy-name");
 ----
 
-Now, in the initial domain transfer to the legacy slave HC, we rename
+Now, in the initial domain transfer to the legacy secondary HC, we rename
 `/subsystem=my-subsystem`'s `my-name` attribute to `legacy-name`. Also,
 the operations involving this attribute are affected, so
 
@@ -1882,7 +1882,7 @@ found in `AttributeTransformationBuilder`:
 
 You can also rename operations, in this case the operation
 `some-operation` gets renamed to `legacy-operation` before getting sent
-to the legacy slave HC.
+to the legacy secondary HC.
 
 [source,java,options="nowrap"]
 ----
@@ -2335,7 +2335,7 @@ help testing rejection of other scenarios.
 Most transformations are quite similar, so this section covers some of
 the actual transformation patterns found in the WildFly codebase. We
 will look at the output of CompareModelVersionsUtil, and see what can be
-done to transform for the older slave HCs. The examples come from the
+done to transform for the older secondary HCs. The examples come from the
 WildFly codebase but are stripped down to focus solely on the use-case
 being explained in an attempt to keep things as clear/simple as
 possible.
@@ -2357,7 +2357,7 @@ Missing child types in current: []; missing in legacy [http-connector]
 So our current model has added a child type called `http-connector`
 which was not there in 7.2.0. This is configurable, and adds new
 behavior, so it can not be part of a configuration sent across to a
-legacy slave running version 1.2.0. So we add the following to
+legacy secondary HC running version 1.2.0. So we add the following to
 `RemotingExtension` to reject all instances of that child type against
 ModelVersion 1.2.0.
 
@@ -2371,15 +2371,15 @@ ModelVersion 1.2.0.
             registerTransformers_1_2(registration);
         }
     }
- 
+
     private void registerTransformers_1_2(SubsystemRegistration registration) {
         TransformationDescription.Tools.register(get1_2_0_1_3_0Description(), registration, VERSION_1_2);
     }
- 
+
     private static TransformationDescription get1_2_0_1_3_0Description() {
         ResourceTransformationDescriptionBuilder builder = ResourceTransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder.rejectChildResource(HttpConnectorResource.PATH);
- 
+
         return builder.build();
     }
 ----
@@ -2417,7 +2417,7 @@ introduced in WildFly {wildflyVersion}, meaning that the _implied behaviour_ in 
 7.2.0 and earlier is the `remote` protocol. Since this attribute does
 not exist in the legacy model we want to discard this attribute if it is
 `undefined` or if it has the value `remote`, both of which are in line
-with what the legacy slave HC is hardwired to use. Also we want to
+with what the legacy secondary HC is hardwired to use. Also we want to
 reject it if it has a value different from `remote`. So what we need to
 do when registering transformers against ModelVersion 1.2.0 to handle
 this attribute:

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -30,36 +30,35 @@ or they will cause network problems).
 
 Here are some details on what we are going to do:
 
-* Let's call one host as 'master', the other one as 'slave'.
+* Let's call one host as 'primary', the other one as 'secondary'.
 
-* Both master and slave will run WildFly, and master will run as
-domain controller, slave will under the domain management of master.
+* Both primary and secondary hosts will run WildFly, and the primary host
+will run as a domain controller, the secondary host will under the domain management of primary host.
 
-* Apache httpd will be run on master, and in httpd we will enable the
-mod_cluster module. The WildFly on master and slave will form a
+* Apache httpd will be run on the primary host, and in httpd we will enable the
+mod_cluster module. The WildFly on primary and secondary hosts will form a
 cluster and discovered by httpd.
 
 image:clustering/Clustering.jpg[images/clustering/Clustering.jpg]
 
-* We will deploy a demo project into domain, and verify that the project
-is deployed into both master and slave by domain controller. Thus we
-could see that domain management provide us a single point to manage the
+* We will deploy a demo project into the domain, and verify that the project
+is deployed into both primary and secondary Host Controllers by the domain controller.
+Thus we could see that domain management provide us a single point to manage the
 deployments across multiple hosts in a single domain.
 
 * We will access the cluster URL and verify that httpd has distributed
-the request to one of the WildFly host. So we could see the cluster is
+the request to one of the WildFly hosts. So we could see the cluster is
 working properly.
 
 * We will try to make a request on cluster, and if the request is
-forwarded to master, we then kill the WildFly process on master. After
+forwarded to the Domain Controller, we then kill the WildFly process on the primary host. After
 that we will go on requesting cluster and we should see the request is
-forwarded to slave, but the session is not lost. Our goal is to verify
+forwarded to the secondary Host Controller, but the session is not lost. Our goal is to verify
 the HA is working and sessions are replicated.
 
-* After previous step finished, we reconnect the master by restarting
-it. We should see the master is registered back into cluster, also we
-should see slave sees master as domain controller again and connect to
-it.
+* After previous step finished, we reconnect the Domain Controller by restarting
+it. We should see the Domain Controller is registered back into cluster, also we
+should see the secondary Host Controller sees the primary Host Controller as a domain controller again and connect to it.
 
 image:clustering/test_scenario.jpg[images/clustering/test_scenario.jpg]
 
@@ -71,7 +70,7 @@ move on and you will get the points step by step.
 
 First we should download WildFly from the http://wildfly.org/downloads/[WildFly website].
 
-Then I unzipped the package to master and try to make a test run:
+Then I unzipped the package to the primary host and try to make a test run:
 
 [source,subs="verbatim,attributes"]
 ----
@@ -87,35 +86,35 @@ mode:
 ----
 wildfly-{wildflyVersion}.0.0.Final/bin$ ./domain.sh
 =========================================================================
- 
+
   JBoss Bootstrap Environment
- 
+
   JBOSS_HOME: /Users/weli/Downloads/wildfly-{wildflyVersion}.0.0.Final
- 
+
   JAVA: /Library/Java/Home/bin/java
- 
+
   JAVA_OPTS: -Xms64m -Xmx512m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Dorg.jboss.resolver.warning=true -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
- 
+
 =========================================================================
 ...
- 
+
 [Server:server-two] 14:46:12,375 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: WildFly {wildflyVersion}.0.0.Final "Kenny" started in 8860ms - Started 210 of 258 services (8{wildflyVersion} services are lazy, passive or on-demand)
 ----
 
-Now exit master and let's repeat the same steps on slave host. Finally
-we get WildFly run on both master and slave, then we could move on to
+Now exit from the primary host and let's repeat the same steps on the secondary host. Finally,
+we get WildFly run on both primary and secondary hosts, then we could move on to
 next step.
 
 [[domain-configuration]]
 == Domain Configuration
 
-[[interface-config-on-master]]
-=== Interface config on master
+[[interface-config-on-primary-hc]]
+=== Interface config on the Primary Host Controller
 
-In this section we'll setup both master and slave for them to run in
-domain mode. And we will configure master to be the domain controller.
+In this section we'll setup both the primary and secondary hosts for them to run in
+domain mode. And we will configure the primary host to be the domain controller.
 
-First open the host.xml in master for editing:
+First open the host.xml in the primary host for editing:
 
 [source,options="nowrap"]
 ----
@@ -133,62 +132,62 @@ The default settings for interface in this file is like:
     <interface name="public">
        <inet-address value="${jboss.bind.address:127.0.0.1}"/>
     </interface>
-    <interface name="unsecured">       
-       <inet-address value="127.0.0.1" />    
+    <interface name="unsecured">
+       <inet-address value="127.0.0.1" />
     </interface>
 </interfaces>
 ----
 
-We need to change the address to the management interface so slave could
-connect to master. The public interface allows the application to be
+We need to change the address to the management interface so the secondary Host Controller could
+connect to the primary Host Controller. The public interface allows the application to be
 accessed by non-local HTTP, and the unsecured interface allows remote
-RMI access. My master's ip address is 10.211.55.7, so I change the
+RMI access. My primary host's ip address is 10.211.55.7, so I change the
 config to:
 
 [source,xml,options="nowrap"]
 ----
 <interfaces>
-    <interface name="management"
+    <interface name="management">
         <inet-address value="${jboss.bind.address.management:10.211.55.7}"/>
     </interface>
     <interface name="public">
        <inet-address value="${jboss.bind.address:10.211.55.7}"/>
-    </interface>    
-    <interface name="unsecured">
-       <inet-address value="10.211.55.7" />    
     </interface>
-</interfaces> 
+    <interface name="unsecured">
+       <inet-address value="10.211.55.7" />
+    </interface>
+</interfaces>
 ----
 
-[[interface-config-on-slave]]
-=== Interface config on slave
+[[interface-config-on-secondary-hc]]
+=== Interface config on the Secondary Host Controller
 
-Now we will setup interfaces on slave. Let's edit host.xml. Similar to
-the steps on master, open host.xml first:
+Now we will setup interfaces on the secondary host. Let's edit host.xml. Similar to
+the steps on the primary host, open host.xml first:
 
 [source,options="nowrap"]
 ----
 vi domain/configuration/host.xml
 ----
 
-The configuration we'll use on slave is a little bit different, because
-we need to let slave connect to master. First we need to set the
+The configuration we'll use on the secondary host is a little bit different, because
+we need to let the secondary Host Controller connect to the primary Host Controller. First we need to set the
 hostname. We change the name property from:
 
 [source,xml,options="nowrap"]
 ----
-<host name="master" xmlns="urn:jboss:domain:3.0">
+<host name="primary" xmlns="urn:jboss:domain:3.0">
 ----
 
 to:
 
 [source,xml,options="nowrap"]
 ----
-<host name="slave" xmlns="urn:jboss:domain:3.0">
+<host name="secondary" xmlns="urn:jboss:domain:3.0">
 ----
 
-Then we need to modify domain-controller section so slave can connect to
-master's management port:
+Then we need to modify domain-controller section so the secondary Host Controller can connect to
+primary Host Controller management port:
 
 [source,xml,options="nowrap"]
 ----
@@ -197,19 +196,19 @@ master's management port:
 </domain-controller>
 ----
 
-As we know, 10.211.55.7 is the ip address of master.
+As we know, 10.211.55.7 is the ip address of the primary host.
 You may use discovery options to define multiple mechanisms to connect
-to the remote domain controller :
+to the remote domain controller:
 
 [source,xml,options="nowrap"]
 ----
 <domain-controller>
  <remote authentication-context="hcAuthContext" >
    <discovery-options>
-     <static-discovery name="master-native" protocol="remote"  host="10.211.55.7" port="9999" />
-     <static-discovery name="master-https" protocol="https-remoting" host="10.211.55.7" port="9993" 
+     <static-discovery name="primary-native" protocol="remote"  host="10.211.55.7" port="9999" />
+     <static-discovery name="primary-https" protocol="https-remoting" host="10.211.55.7" port="9993"
                        authentication-context="hcAuthContext"/>
-     <static-discovery name="master-http" protocol="http-remoting" host="10.211.55.7" port="9990" />
+     <static-discovery name="primary-http" protocol="http-remoting" host="10.211.55.7" port="9990" />
    </discovery-options>
  </remote>
 </domain-controller>
@@ -227,13 +226,13 @@ management ports to public address:
     <interface name="public">
        <inet-address value="${jboss.bind.address:10.211.55.2}"/>
     </interface>
-    <interface name="unsecured">       
-       <inet-address value="10.211.55.2" />    
+    <interface name="unsecured">
+       <inet-address value="10.211.55.2" />
     </interface>
 </interfaces>
 ----
 
-10.211.55.2 is the ip address of the slave. Refer to the domain
+10.211.55.2 is the ip address of the secondary host. Refer to the domain
 controller configuration above for an explanation of the management,
 public, and unsecured interfaces.
 
@@ -248,11 +247,11 @@ you need to enable the firewall and allow access to the following ports:
 
 Now everything is set for the two hosts to run in domain mode. Let's
 start them by running domain.sh on both hosts. If everything goes fine,
-we could see from the log on master:
+we could see from the log on the primary Host Controller:
 
 [source,options="nowrap"]
 ----
-[Host Controller] 21:30:52,042 INFO  [org.jboss.as.domain] (management-handler-threads - 1) JBAS010918: Registered remote slave host slave
+[Host Controller] 21:30:52,042 INFO  [org.jboss.as.domain] (management-handler-threads - 1) JBAS010918: Registered remote secondary host "secondary"
 ----
 
 That means all the configurations are correct and two hosts are run in
@@ -303,8 +302,8 @@ The time is <%= session.getAttribute("current.time") %>
 
 It's an extremely simple project but it could help us to test the
 cluster later: We will access put.jsp from cluster and see the request
-are distributed to master, then we disconnect master and access get.jsp.
-We should see the request is forwarded to slave but the 'current.time'
+are distributed to the primary host, then we disconnect the primary Host Controller and access get.jsp.
+We should see the request is forwarded to secondary host but the 'current.time'
 value is held by session replication. We'll cover more details on this
 one later.
 
@@ -318,7 +317,7 @@ mvn package
 
 It will generate cluster-demo.war. Then we need to deploy the war into
 domain. First we should access the http management console on
-master(Because master is acting as domain controller):
+primary host (Because primary host is acting as domain controller):
 
 [source,options="nowrap"]
 ----
@@ -340,7 +339,7 @@ We could see server-one and server-two are in running status and they
 belong to main-server-group; server-three is in idle status, and it
 belongs to other-server-group.
 
-All these servers and server groups are set in domain.xml on master as7.
+All these servers and server groups are set in domain.xml on the primary host.
 What we are interested in is the 'other-server-group' in domain.xml:
 
 [source,xml,options="nowrap"]
@@ -354,8 +353,8 @@ What we are interested in is the 'other-server-group' in domain.xml:
 ----
 
 We could see this server-group is using 'ha' profile, which then uses
-'ha-sockets' socket binding group. It enable all the modules we need to
-establish cluster later(including infinispan, jgroup and mod_cluster
+'ha-sockets' socket binding group. It enables all the modules we need to
+establish cluster later (including infinispan, jgroup and mod_cluster
 modules). So we will deploy our demo project into a server that belongs
 to 'other-server-group', so 'server-three' is our choice.
 
@@ -379,26 +378,26 @@ Now server-three is not running, so let's click on 'server-three' and
 then click the 'start' button at bottom right of the server list. Wait a
 moment and server-three should start now.
 
-Now we should also enable 'server-three' on slave: From the top of menu
-list on left side of the page, we could see now we are managing master
-currently. Click on the list, and click 'slave', then choose
-'server-three', and we are in slave host management page now.
+Now we should also enable 'server-three' on the secondary Host Controller: From the top of menu
+list on left side of the page, we could see now we are managing the primary Host Controller
+currently. Click on the list, and click 'secondary', then choose
+'server-three', and we are in secondary Host Controller management page now.
 
-Then repeat the steps we've done on master to start 'server-three' on
-slave.
+Then repeat the steps we've done on the primary host to start 'server-three' on
+secondary host.
 
 [TIP]
 
-server-three on master and slave are two different hosts, their names
+server-three on primary and secondary host are two different hosts, their names
 can be different.
 
-After server-three on both master and slave are started, we will add our
+After server-three on both primary and secondary hosts are started, we will add our
 cluster-demo.war for deployment. Click on the 'Manage Deployments' link
 at the bottom of left menu list.
 
 image:clustering/JBoss_Management.png[images/clustering/JBoss_Management.png] +
-(We should ensure the server-three should be started on both master and
-slave)
+(We should ensure the server-three should be started on both primary and
+secondary hosts)
 
 After enter 'Manage Deployments' page, click 'Add Content' at top right
 corner. Then we should choose our cluster-demo.war, and follow the
@@ -413,11 +412,11 @@ deployed into 'other-server-group'.：
 image:clustering/JBoss_Management_2.png[images/clustering/JBoss_Management_2.png]
 
 Please note we have two hosts participate in this server group, so the
-project should be deployed in both master and slave now - that's the
+project should be deployed in both primary and secondary hosts now - that's the
 power of domain management.
 
-Now let's verify this, trying to access cluster-demo from both master
-and slave, and they should all work now:
+Now let's verify this, trying to access cluster-demo from both primary
+and secondary hosts, and they should all work now:
 
 [source,options="nowrap"]
 ----
@@ -440,7 +439,7 @@ establish a cluster icon:smile-o[role="yellow"]
 [IMPORTANT]
 
 Why is the port number 8330 instead of 8080? Please check the settings
-in host.xml on both master and slave:
+in host.xml on both primary and secondary hosts:
 
 [source,xml,options="nowrap"]
 ----
@@ -453,8 +452,8 @@ in host.xml on both master and slave:
 
 The port-offset is set to 250, so 8080 + 250 = 8330
 
-Now we quit the WildFly process on both master and slave. We have some
-work left on host.xml configurations. Open the host.xml of master, and
+Now we quit the WildFly process on both primary and secondary hosts. We have some
+work left on host.xml configurations. Open the host.xml of primary host, and
 do some modifications the servers section from:
 
 [source,xml,options="nowrap"]
@@ -478,12 +477,12 @@ to:
 ----
 
 We've set auto-start to true so we don't need to enable it in management
-console each time WildFly restart. Now open slave's host.xml, and modify
+console each time WildFly restart. Now open secondary's host.xml, and modify
 the server-three section:
 
 [source,xml,options="nowrap"]
 ----
-<server name="server-three-slave" group="other-server-group" auto-start="true">
+<server name="server-three-secondary" group="other-server-group" auto-start="true">
     <!-- server-three avoids port conflicts by incrementing the ports in
          the default socket-group declared in the server-group -->
     <socket-bindings port-offset="250"/>
@@ -491,7 +490,7 @@ the server-three section:
 ----
 
 Besides setting auto-start to true, we've renamed the 'server-three' to
-'server-three-slave'. We need to do this because mod_cluster will fail
+'server-three-secondary'. We need to do this because mod_cluster will fail
 to register the hosts with same name in a single server group. It will
 cause name conflict.
 
@@ -501,14 +500,14 @@ go on cluster configuration.
 [[cluster-configuration]]
 == Cluster Configuration
 
-We will use mod_cluster + apache httpd on master as our cluster
+We will use mod_cluster + apache httpd on primary host as our cluster
 controller here. Because WildFly has been configured to support
 mod_cluster out of box so it's the easiest way.
 
 [IMPORTANT]
 
 The WildFly domain controller and httpd are not necessary to be on
-same host. But in this article I just install them all on master for
+same host. But in this article I just install them all on primary host for
 convenience.
 
 First we need to ensure that httpd is installed:
@@ -574,7 +573,7 @@ Please note we should comment out:
 
 This is conflicted with cluster module. And then we need to make httpd
 to listen to public address so we could do the testing. Because we
-installed httpd on master host so we know the ip address of it:
+installed httpd on primary host so we know the ip address of it:
 
 [source,options="nowrap"]
 ----
@@ -591,16 +590,16 @@ Listen 10.211.55.7:10001
 # This directive only applies to Red Hat Enterprise Linux. It prevents the temmporary
 # files from being written to /etc/httpd/logs/ which is not an appropriate location.
 MemManagerFile /var/cache/httpd
- 
+
 <VirtualHost 10.211.55.7:10001>
- 
+
   <Directory />
     Order deny,allow
     Deny from all
     Allow from 10.211.55.
   </Directory>
- 
- 
+
+
   # This directive allows you to view mod_cluster status at URL http://10.211.55.4:10001/mod_cluster-manager
   <Location /mod_cluster-manager>
    SetHandler mod_cluster-manager
@@ -608,13 +607,13 @@ MemManagerFile /var/cache/httpd
    Deny from all
    Allow from 10.211.55.
   </Location>
- 
+
   KeepAliveTimeout 60
   MaxKeepAliveRequests 0
- 
+
   ManagerBalancerName other-server-group
   AdvertiseFrequency 5
- 
+
 </VirtualHost>
 ----
 
@@ -646,16 +645,16 @@ http://10.211.55.7/cluster-demo/put.jsp
 
 image:clustering/http---10.211.55.7-cluster-demo-put.jsp.png[images/clustering/http---10.211.55.7-cluster-demo-put.jsp.png]
 
-We should see the request is distributed to one of the hosts(master or
-slave) from the WildFly log. For me the request is sent to master:
+We should see the request is distributed to one of the hosts (primary or
+secondary) from the WildFly log. For me the request is sent to primary host:
 
 [source,options="nowrap"]
 ----
 [Server:server-three] 16:06:22,256 INFO  [stdout] (http-10.211.55.7-10.211.55.7-8330-4) Putting date now
 ----
 
-Now I disconnect master by using the management interface. Select
-'runtime' and the server 'master' in the upper corners.
+Now I disconnect the Domain Controller by using the management interface. Select
+'runtime' and the server 'primary' in the upper corners.
 
 Select 'server-three' and kick the stop button, the active-icon should
 change.
@@ -672,26 +671,26 @@ http://10.211.55.7/cluster-demo/get.jsp
 
 image:clustering/http---10.211.55.7-cluster-demo-get.jsp.png[images/clustering/http---10.211.55.7-cluster-demo-get.jsp.png]
 
-Now the request should be served by slave and we should see the log from
-slave:
+Now the request should be served by the secondary host and we should see the log from
+the secondary Host Controller:
 
 [source,options="nowrap"]
 ----
-[Server:server-three-slave] 16:08:29,860 INFO  [stdout] (http-10.211.55.2-10.211.55.2-8330-1) Getting date now
+[Server:server-three-secondary] 16:08:29,860 INFO  [stdout] (http-10.211.55.2-10.211.55.2-8330-1) Getting date now
 ----
 
 And from the get.jsp we should see that the time we get is the same
 we've put by 'put.jsp'. Thus it's proven that the session is correctly
-replicated to slave.
+replicated to the secondary host.
 
-Now we restart master and should see the host is registered back to
+Now we restart the primary Host Controller and should see the host is registered back to
 cluster.
 
 [TIP]
 
-It doesn't matter if you found the request is distributed to slave at
-first time. Then just disconnect slave and do the testing, the request
-should be sent to master instead. The point is we should see the request
+It doesn't matter if you found the request is distributed to the secondary host at
+first time. Then just disconnect the secondary Host Controller and do the testing, the request
+should be sent to the primary host instead. The point is we should see the request
 is redirect from one host to another and the session is held.
 
 [[special-thanks]]

--- a/docs/src/main/asciidoc/_high-availability/ha-singleton/Singleton_subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/ha-singleton/Singleton_subsystem.adoc
@@ -55,7 +55,7 @@ service and will typically use a replicated-cache configuration.
 WildFly includes two singleton election policy implementations:
 
 * *simple* +
-Elects the provider (a.k.a. master) of a singleton service based on a
+Elects the provider (a.k.a. primary provider) of a singleton service based on a
 specified position in a circular linked list of eligible nodes sorted by
 descending age. Position=0, the default value, refers to the oldest
 node, 1 is second oldest, etc. ; while position=-1 refers to the

--- a/docs/src/main/asciidoc/_testsuite/Pre-requisites_-_test_quality_standards.adoc
+++ b/docs/src/main/asciidoc/_testsuite/Pre-requisites_-_test_quality_standards.adoc
@@ -94,7 +94,7 @@ spotted along the way - do another pull request for such.
 which are difficult to merge.
 * Keep the code consistent across commits - e.g. when renaming
 something, be sure to update all references to it.
-* Describe your commits properly as they will appear in master's linear
+* Describe your commits properly as they will appear in main's linear
 history.
 * If you're working on a jira issue, include it's ID in the commit
 message(s).

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
@@ -26,7 +26,7 @@ final ModelNode operation = new ModelNode();
 operation.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
 operation.get(ModelDescriptionConstants.OP_ADDR).set(address);
 operation.get(ModelDescriptionConstants.RECURSIVE).set(true);
- 
+
 final ModelNode result = managementClient.getControllerClient().execute(operation);
 Assert.assertEquals(ModelDescriptionConstants.SUCCESS, result.get(ModelDescriptionConstants.OUTCOME).asString());
 ----
@@ -57,7 +57,7 @@ ModelControllerClient client = managementClient.getControllerClient();
 [source,java,options="nowrap"]
 ----
 @ArquillianResource ContainerController cc;
- 
+
 @Test
 public void test() {
     cc.setup("test", ...properties..)
@@ -172,7 +172,7 @@ optionally you might be able to catch it using the manual deployer
 [source,java,options="nowrap"]
 ----
 @Deployment(name = "X", managed = false) ...
- 
+
 @Test
 public void shouldFail(@ArquillianResource Deployer deployer) throws Exception {
   try {
@@ -196,33 +196,33 @@ And then you have tests that run against each.
 @Deployment(name = "deplA", testable = false)
     @TargetsContainer("serverB")
     public static Archive<?> deployment()
- 
+
     @Deployment(name = "deplB", testable = false)
     @TargetsContainer("serverA")
     public static Archive<?> deployment(){ ... }
- 
+
     @Test
     @OperateOnDeployment("deplA")
     public void testA(){ ... }
- 
+
     @Test
     @OperateOnDeployment("deplA")
     public void testA() {...}
 ----
 
-[[how-to-get-the-tests-to-master]]
-== How to get the tests to master
+[[how-to-get-the-tests-to-main]]
+== How to get the tests to main branch
 
 * First of all, *be sure to read the "Before you add a test" section*.
 * *Fetch* the newest mater:
 `git fetch upstream # Provided you have the jbossas/jbossas GitHub repo`
 `as a remote called 'upstream'.`
 * *Rebase* your branch: git checkout WFLY-1234-your-branch; git rebase
-upstream/master
+upstream/main
 * *Run* *_whole_* *testsuite* (integration-tests -DallTests). You may
 use
 https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/wildfly-as-testsuite-RHEL-matrix-openJDK7/lastCompletedBuild/testReport/.
-** If any tests fail and they do not fail in master, fix it and go back
+** If any tests fail and they do not fail in main, fix it and go back
 to the "Fetch" step.
 * *Push* to a new branch in your GitHub repo:
 `git push origin WFLY-1234-new-XY-tests`
@@ -245,7 +245,7 @@ mail from GitHub.
 * You may also check if it was merged by the following:
 `git fetch upstream; git cherry` `<branch> ## Or` git branch
 --contains\{\{<branch> - see}} `here`
-* Your commits will appear in master. They will have the same hash as in
+* Your commits will appear in main. They will have the same hash as in
 your branch.
 ** You are now safe to delete both your local and remote branches:
 `git branch -D WFLY-1234-your-branch; git push origin :WFLY-1234-your-branch`


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-16146

Mostly replacements of master/slave words by primary/secondary related to Domain Mode configuration.
Replacements of "master" branch by "main" where possible.
Review of "master" term on Singleton Provider documentation.