### PR TITLE
WFLY-16781 Allow use of ProtoStream for marshalling timeout context of a distributed timer.

### DIFF
--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanTimerManagementResourceDefinition.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanTimerManagementResourceDefinition.java
@@ -32,12 +32,14 @@ import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceRegistration;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
+import org.jboss.as.clustering.controller.validation.EnumValidator;
 import org.jboss.as.clustering.controller.validation.IntRangeValidatorBuilder;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.ejb.timer.TimerServiceRequirement;
 import org.wildfly.clustering.infinispan.service.InfinispanCacheRequirement;
@@ -90,6 +92,14 @@ public class InfinispanTimerManagementResourceDefinition extends ChildResourceDe
             @Override
             public SimpleAttributeDefinitionBuilder apply(SimpleAttributeDefinitionBuilder builder) {
                 return builder.setValidator(new IntRangeValidatorBuilder().min(1).configure(builder).build());
+            }
+        },
+        MARSHALLER("marshaller", ModelType.STRING) {
+            @Override
+            public SimpleAttributeDefinitionBuilder apply(SimpleAttributeDefinitionBuilder builder) {
+                return builder.setDefaultValue(new ModelNode(TimerContextMarshallerFactory.JBOSS.name()))
+                        .setValidator(new EnumValidator<>(TimerContextMarshallerFactory.class))
+                        ;
             }
         },
         ;

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanTimerManagementServiceConfigurator.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanTimerManagementServiceConfigurator.java
@@ -22,9 +22,7 @@
 
 package org.wildfly.extension.clustering.ejb;
 
-import static org.wildfly.extension.clustering.ejb.InfinispanTimerManagementResourceDefinition.Attribute.CACHE;
-import static org.wildfly.extension.clustering.ejb.InfinispanTimerManagementResourceDefinition.Attribute.CACHE_CONTAINER;
-import static org.wildfly.extension.clustering.ejb.InfinispanTimerManagementResourceDefinition.Attribute.MAX_ACTIVE_TIMERS;
+import static org.wildfly.extension.clustering.ejb.InfinispanTimerManagementResourceDefinition.Attribute.*;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -55,6 +53,7 @@ public class InfinispanTimerManagementServiceConfigurator extends CapabilityServ
     private volatile String containerName;
     private volatile String cacheName;
     private volatile Integer maxActiveTimers;
+    private volatile Function<Module, ByteBufferMarshaller> marshallerFactory;
 
     public InfinispanTimerManagementServiceConfigurator(PathAddress address) {
         super(InfinispanTimerManagementResourceDefinition.Capability.TIMER_MANAGEMENT_PROVIDER, address);
@@ -65,6 +64,7 @@ public class InfinispanTimerManagementServiceConfigurator extends CapabilityServ
         this.containerName = CACHE_CONTAINER.resolveModelAttribute(context, model).asString();
         this.cacheName = CACHE.resolveModelAttribute(context, model).asStringOrNull();
         this.maxActiveTimers = MAX_ACTIVE_TIMERS.resolveModelAttribute(context, model).asIntOrNull();
+        this.marshallerFactory = TimerContextMarshallerFactory.valueOf(MARSHALLER.resolveModelAttribute(context, model).asString());
         return this;
     }
 
@@ -78,7 +78,7 @@ public class InfinispanTimerManagementServiceConfigurator extends CapabilityServ
 
     @Override
     public Function<Module, ByteBufferMarshaller> getMarshallerFactory() {
-        return TimerContextMarshallerFactory.JBOSS;
+        return this.marshallerFactory;
     }
 
     @Override

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/TimerContextMarshallerFactory.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/TimerContextMarshallerFactory.java
@@ -30,6 +30,9 @@ import org.jboss.modules.Module;
 import org.wildfly.clustering.marshalling.jboss.DynamicExternalizerObjectTable;
 import org.wildfly.clustering.marshalling.jboss.JBossByteBufferMarshaller;
 import org.wildfly.clustering.marshalling.jboss.SimpleMarshallingConfigurationRepository;
+import org.wildfly.clustering.marshalling.protostream.ModuleClassLoaderMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamByteBufferMarshaller;
+import org.wildfly.clustering.marshalling.protostream.SerializationContextBuilder;
 import org.wildfly.clustering.marshalling.spi.ByteBufferMarshaller;
 
 /**
@@ -44,6 +47,13 @@ public enum TimerContextMarshallerFactory implements Function<Module, ByteBuffer
             config.setClassResolver(ModularClassResolver.getInstance(module.getModuleLoader()));
             config.setObjectTable(new DynamicExternalizerObjectTable(module.getClassLoader()));
             return new JBossByteBufferMarshaller(new SimpleMarshallingConfigurationRepository(config), module.getClassLoader());
+        }
+    },
+    PROTOSTREAM() {
+        @Override
+        public ByteBufferMarshaller apply(Module module) {
+            SerializationContextBuilder builder = new SerializationContextBuilder(new ModuleClassLoaderMarshaller(module.getModuleLoader())).load(module.getClassLoader());
+            return new ProtoStreamByteBufferMarshaller(builder.build());
         }
     },
     ;

--- a/clustering/ejb/extension/src/main/resources/org/wildfly/extension/clustering/ejb/LocalDescriptions.properties
+++ b/clustering/ejb/extension/src/main/resources/org/wildfly/extension/clustering/ejb/LocalDescriptions.properties
@@ -26,3 +26,4 @@ distributable-ejb.infinispan-timer-management.remove=Removes an Infinispan-based
 distributable-ejb.infinispan-timer-management.cache-container=The name of the cache container associated with this provider
 distributable-ejb.infinispan-timer-management.cache=The name of the cache associated with this provider
 distributable-ejb.infinispan-timer-management.max-active-timers=The maximum number of active timers to retain in memory before triggering passivation.
+distributable-ejb.infinispan-timer-management.marshaller=Indicates the marshalling implementation used for serializing the timeout context of a timer.

--- a/clustering/ejb/extension/src/main/resources/schema/wildfly-distributable-ejb_1_0.xsd
+++ b/clustering/ejb/extension/src/main/resources/schema/wildfly-distributable-ejb_1_0.xsd
@@ -112,9 +112,33 @@
                 <xs:documentation>The maximum number active timers to retain in memory at a time, after which the least recently used will passivate.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="marshaller" type="tns:marshaller" default="JBOSS">
+            <xs:annotation>
+                <xs:documentation>Indicates the marshalling implementation used for serializing the timeout context of a timer.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="empty">
         <xs:sequence/>
     </xs:complexType>
+
+    <xs:simpleType name="marshaller">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="JBOSS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Marshaller based on JBoss Marshalling.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PROTOSTREAM">
+                <xs:annotation>
+                    <xs:documentation>
+                        Marshaller based on ProtoStream.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
@@ -108,6 +108,7 @@ This provider stores timer metadata within an embedded Infinispan cache, and uti
 * `cache-container` specifies a cache container defined in the Infinispan subsystem
 * `cache` specifies the a cache configuration within the specified cache-container
 * `max-active-timers` specifies the maximum number active timers to retain in memory at a time, after which the least recently used will passivate
+* `marshaller` specifies the marshalling implementation used to serialize the timeout context of a timer.
 
 To ensure proper functioning, the associated cache configuration, regardless of type, should use:
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/ejb/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/clustering/ejb/main/module.xml
@@ -46,6 +46,7 @@
         <module name="org.wildfly.clustering.ejb.spi"/>
         <module name="org.wildfly.clustering.infinispan.embedded.service"/>
         <module name="org.wildfly.clustering.marshalling.jboss"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.server.api"/>
         <module name="org.wildfly.clustering.server.service"/>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/remote/HotRodPersistentTimerServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/remote/HotRodPersistentTimerServiceTestCase.java
@@ -66,7 +66,7 @@ public class HotRodPersistentTimerServiceTestCase extends AbstractTimerServiceTe
                             .add("/subsystem=infinispan/cache-container=ejb/invalidation-cache=hotrod-persistent/component=locking:add(isolation=REPEATABLE_READ)")
                             .add("/subsystem=infinispan/cache-container=ejb/invalidation-cache=hotrod-persistent/component=transaction:add(mode=BATCH)")
                             .add("/subsystem=infinispan/cache-container=ejb/invalidation-cache=hotrod-persistent/store=hotrod:add(remote-cache-container=ejb, cache-configuration=default, fetch-state=false, shared=true)")
-                            .add("/subsystem=distributable-ejb/infinispan-timer-management=hotrod:add(cache-container=ejb, cache=hotrod-persistent)")
+                            .add("/subsystem=distributable-ejb/infinispan-timer-management=hotrod:add(cache-container=ejb, cache=hotrod-persistent, marshaller=PROTOSTREAM)")
                         .endBatch()
                         .build())
                     .tearDownScript(createScriptBuilder()


### PR DESCRIPTION
Follows up on WFLY-16781, adding ability to marshal Timer info using ProtoStream.

https://issues.redhat.com/browse/WFLY-16781