### PR TITLE
WFLY-16770 Distributable-web subsystem documentation neglects to mention marshaller attribute

### DIFF
--- a/docs/src/main/asciidoc/High_Availability_Guide.adoc
+++ b/docs/src/main/asciidoc/High_Availability_Guide.adoc
@@ -29,5 +29,6 @@ include::_high-availability/Clustering_API.adoc[]
 
 include::_high-availability/HA_Singleton_Features.adoc[]
 
-include::_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc[]
+include::_high-availability/Marshalling.adoc[]
 
+include::_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc[]

--- a/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
@@ -63,9 +63,12 @@ The available bean management provider is:
 The infinispan-bean-management provider element represents a bean manager implementation based on an Infinispan cache. The
 attributes for the infinispan-bean-manager element are:
 
-* `cache-container` specifies a cache container defined in the Infinispan subsystem used to support the session state cache
-* `cache` specifies the session state cache and its configured properties
-* `max-active-beans` specifies the maximum number of non-passivated session state entries allowed in the cache
+cache-container::
+Specifies a cache container defined in the Infinispan subsystem used to support the session state cache
+cache::
+Specifies the session state cache and its configured properties
+max-active-beans::
+Specifies the maximum number of non-passivated session state entries allowed in the cache
 
 
 [[client-mappings-registries]]
@@ -84,8 +87,11 @@ The available client mappings registry providers are:
 
 The infinispan-client-mappings-registry provider is a provider based on an Infinispan cache and suitable for a clustered server.
 
-* `cache-container` specifies a cache container defined in the Infinispan subsystem used to support the client mappings registry
-* `cache` specifies the cache and its configured properties used to support the client mappings registry
+cache-container::
+Specifies a cache container defined in the Infinispan subsystem used to support the client mappings registry
+cache::
+Specifies the cache and its configured properties used to support the client mappings registry
+
 
 [[local-client-mappings-registry]]
 ==== local-client-mappings-registry
@@ -105,10 +111,19 @@ See link:Developer_Guide{outfilesuffix}#Jakarta_Enterprise_Beans_Distributed_Per
 
 This provider stores timer metadata within an embedded Infinispan cache, and utilizes consistent hashing to distribute timer execution between cluster members.
 
-* `cache-container` specifies a cache container defined in the Infinispan subsystem
-* `cache` specifies the a cache configuration within the specified cache-container
-* `max-active-timers` specifies the maximum number active timers to retain in memory at a time, after which the least recently used will passivate
-* `marshaller` specifies the marshalling implementation used to serialize the timeout context of a timer.
+cache-container::
+Specifies a cache container defined in the Infinispan subsystem
+cache::
+Specifies the a cache configuration within the specified cache-container
+max-active-timers::
+Specifies the maximum number active timers to retain in memory at a time, after which the least recently used will passivate
+marshaller::
+Specifies the marshalling implementation used to serialize the timeout context of a timer.
+JBOSS:::
+Marshals session attributes using <<jboss_marshalling>>.
+PROTOSTREAM:::
+Marshals session attributes using <<protostream>>.
+
 
 To ensure proper functioning, the associated cache configuration, regardless of type, should use:
 

--- a/docs/src/main/asciidoc/_high-availability/Marshalling.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Marshalling.adoc
@@ -1,0 +1,121 @@
+[[marshalling]]
+= Marshalling
+
+In general, the most effective way to improve the scalability of a system with persistent or distributed state is to reducing the number of bytes needed to be sent over the network or persisted to storage.
+Marshalling is the process by which Java objects in heap space are converted to a byte buffer for replication to other JVMs or for persistence to local or shared storage.
+
+WildFly generally supports 2 marshalling mechanisms for use with its clustering modules: JBoss Marshalling and ProtoStream.
+
+[[jboss_marshalling]]
+== JBoss Marshalling
+
+https://jbossmarshalling.jboss.org/[JBoss Marshalling] is a serialization library for objects implementing `java.io.Serializable`.
+
+When configured to use JBoss Marshalling, an application can optimize the marshalling of a given object, either through custom JDK serialization logic, or by implementing a custom externalizer.
+An externalizer is an implementation of the `org.wildfly.clustering.marshalling.Externalizer` interface, which dictates how a given class should be marshalled.
+An externalizer reads/writes the state of an object directly from/to an input/output stream, but also:
+
+. Allows an application to replicate/persist and object that does not implement `java.io.Serializable`
+. Eliminates the need to serialize the class descriptor of an object along with its state
+
+e.g.
+[source,java]
+----
+public class MyObjectExternalizer implements org.wildfly.clustering.marshalling.Externalizer<MyObject> {
+
+    @Override
+    public Class<MyObject> getTargetClass() {
+        return MyObject.class;
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, MyObject object) throws IOException {
+        // Write object state to stream
+    }
+
+    @Override
+    public MyObject readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        // Construct and read object state from stream
+        return ...;
+    }
+}
+----
+
+Externalizers are dynamically loaded during deployment via the service loader mechanism.
+Implementations should be enumerated within a file named:
+`/META-INF/services/org.wildfly.clustering.marshalling.Externalizer`
+
+[[protostream]]
+== ProtoStream
+
+https://github.com/infinispan/protostream[ProtoStream] is serialization library based on the https://developers.google.com/protocol-buffers[Protobuf] data format.
+The nature of the Protobuf data format makes it very easy to evolve classes without breaking serialization compatibility.
+When compared to JBoss Marshalling, ProtoStream is generally more efficient and generates smaller payloads, especially for objects containing fields that are either optional or have a default value.
+Since marshallable classes are explicitly enumerated, ProtoStream is not vulnerable to the same arbitrary code execution exploits that affect JDK serialization.
+
+When configured to use ProtoStream, a web application will need to register ProtoStream marshallers/schemas for *every* application-specific type.
+WildFly initializes its ProtoStream marshaller using all instances of `org.infinispan.protostream.SerializationContextInitializer` that are visible to the deployment classpath.
+Implementations should be enumerated within a file named:
+`/META-INF/services/org.infinispan.protostream.SerializationContextInitializer`
+
+Simple objects can leverage ProtoStream annotations and https://infinispan.org/docs/stable/titles/encoding/encoding.html#adding-protostream-processor_marshalling[auto-generate marshallers and schemas at build time].
+
+e.g.
+[source,java]
+----
+@AutoProtoSchemaBuilder(includeClasses = { Person.class })
+public interface PersonInitalizer extends SerializationContextInitializer {
+}
+
+public class Person {
+    @ProtoField(number = 1)
+    final String name;
+    @ProtoField(number = 2, type = Type.UINT32, defaultValue = "0")
+    final int age;
+    @ProtoField(number = 3)
+    Person parent;
+    @ProtoField(number = 4, collectionImplementation = LinkedList.class)
+    final List<Person> children;
+
+    @ProtoFactory
+    Person(String name, int age, Person parent, List<Person> children) {
+        this.name = name;
+        this.age = age;
+        this.parent = parent;
+        this.children = children;
+    }
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age = age;
+        this.children = new LinkedList<>();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getAge() {
+        return this.age;
+    }
+
+    public Person getParent() {
+        return this.parent;
+    }
+
+    public List<Person> getChildren() {
+        return this.children;
+    }
+
+    public void setParent(Person parent) {
+        this.parent = parent;
+    }
+
+    public void addChild(Person child) {
+        this.children.add(child);
+    }
+}
+----
+
+Sufficiently complex objects may require a custom `org.infinispan.protostream.SerializationContextInitializer` implementation to register custom marshaller implementations and schemas.
+Refer to the https://infinispan.org/docs/stable/titles/encoding/encoding.html#marshalling_user_types[Infinispan documentation] for details.

--- a/docs/src/main/asciidoc/_high-availability/Marshalling.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Marshalling.adoc
@@ -1,7 +1,7 @@
 [[marshalling]]
 = Marshalling
 
-In general, the most effective way to improve the scalability of a system with persistent or distributed state is to reducing the number of bytes needed to be sent over the network or persisted to storage.
+In general, the most effective way to improve the scalability of a system with persistent or distributed state is to reduce the number of bytes needed to be sent over the network or persisted to storage.
 Marshalling is the process by which Java objects in heap space are converted to a byte buffer for replication to other JVMs or for persistence to local or shared storage.
 
 WildFly generally supports 2 marshalling mechanisms for use with its clustering modules: JBoss Marshalling and ProtoStream.
@@ -15,7 +15,7 @@ When configured to use JBoss Marshalling, an application can optimize the marsha
 An externalizer is an implementation of the `org.wildfly.clustering.marshalling.Externalizer` interface, which dictates how a given class should be marshalled.
 An externalizer reads/writes the state of an object directly from/to an input/output stream, but also:
 
-. Allows an application to replicate/persist and object that does not implement `java.io.Serializable`
+. Allows an application to replicate/persist an object that does not implement `java.io.Serializable`
 . Eliminates the need to serialize the class descriptor of an object along with its state
 
 e.g.

--- a/docs/src/main/asciidoc/_high-availability/subsystem-support/Distributable_Web_Applications.adoc
+++ b/docs/src/main/asciidoc/_high-availability/subsystem-support/Distributable_Web_Applications.adoc
@@ -89,6 +89,12 @@ affinity=ranked:::
 Web requests will have an affinity to the first available node in a ranked list comprised of: primary owner, backup nodes, local node (if not a primary nor backup owner).
 Only for use with load balancers that support multiple routes.
 Behaves the same as affinity=local if cache is not distributed nor replicated.
+marshaller::
+Specifies the marshalling implementation used to serialize session attributes.
+JBOSS:::
+Marshals session attributes using <<jboss_marshalling>>.
+PROTOSTREAM:::
+Marshals session attributes using <<protostream>>.
 
 e.g. Creating a new session management profile, using ATTRIBUTE granularity with local session affinity:
 
@@ -134,6 +140,12 @@ This option is intended for use cases where web session state is not maintained 
 affinity=local:::
 Web requests will have an affinity to the server that last handled a request for a given session.
 This option corresponds to traditional sticky session behavior.
+marshaller::
+Specifies the marshalling implementation used to serialize session attributes.
+JBOSS:::
+Marshals session attributes using <<jboss_marshalling>>.
+PROTOSTREAM:::
+Marshals session attributes using <<protostream>>.
 
 e.g. Creating a new session management profile "foo" using the cache configuration "bar" defined on a remote infinispan server "datagrid" with ATTRIBUTE granularity:
 
@@ -353,115 +365,4 @@ e.g.
 === Session attribute marshalling
 
 Minimizing the replication/persistence payload for individual session attributes has a direct impact on performance by reducing the number of bytes sent over the network or persisted to storage.
-
-==== JBoss Marshalling
-
-https://jbossmarshalling.jboss.org/[JBoss Marshalling] is a serialization library for objects implementing `java.io.Serializable`.
-
-When configured to use JBoss Marshalling, a web application can optimize the marshalling of a given session attribute, either through custom JDK serialization logic, or by implementing a custom externalizer.
-An externalizer is an implementation of the `org.wildfly.clustering.marshalling.Externalizer` interface, which dictates how a given class should be marshalled.
-An externalizer reads/writes the state of an object directly from/to an input/output stream, but also:
-
-. Allows an application to store an object in the session that does not implement `java.io.Serializable`
-. Eliminates the need to serialize the class descriptor of an object along with its state
-
-e.g.
-[source,java]
-----
-public class MyObjectExternalizer implements org.wildfly.clustering.marshalling.Externalizer<MyObject> {
-
-    @Override
-    public Class<MyObject> getTargetClass() {
-        return MyObject.class;
-    }
-
-    @Override
-    public void writeObject(ObjectOutput output, MyObject object) throws IOException {
-        // Write object state to stream
-    }
-
-    @Override
-    public MyObject readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-        // Construct and read object state from stream
-        return ...;
-    }
-}
-----
-
-Externalizers are dynamically loaded during deployment via the service loader mechanism.
-Implementations should be enumerated within a file named:
-`/META-INF/services/org.wildfly.clustering.marshalling.Externalizer`
-
-==== ProtoStream
-
-https://github.com/infinispan/protostream[ProtoStream] is serialization library based on the https://developers.google.com/protocol-buffers[Protobuf] data format.
-The nature of the Protobuf data format makes it very easy to evolve classes without breaking serialization compatibility.
-When compared to JBoss Marshalling, ProtoStream is generally more efficient and generates smaller payloads, especially for objects containing fields that are either optional or have a default value.
-Since marshallable classes are explicitly enumerated, ProtoStream is not vulnerable to the same arbitrary code execution exploits that affect JDK serialization.
-
-When configured to use ProtoStream, a web application will need to register ProtoStream marshallers/schemas for any session attribute of a custom type.
-WildFly initializes its ProtoStream marshaller using all instances of `org.infinispan.protostream.SerializationContextInitializer` visible to the deployment classpath.
-Implementations should be enumerated within a file named:
-`/META-INF/services/org.infinispan.protostream.SerializationContextInitializer`
-
-Simple objects can leverage ProtoStream annotations and https://infinispan.org/docs/stable/titles/encoding/encoding.html#adding-protostream-processor_marshalling[auto-generate marshallers and schemas at build time].
-
-e.g.
-[source,java]
-----
-@AutoProtoSchemaBuilder(includeClasses = { Person.class })
-public interface PersonInitalizer extends SerializationContextInitializer {
-}
-
-public class Person {
-    @ProtoField(number = 1)
-    final String name;
-    @ProtoField(number = 2, type = Type.UINT32, defaultValue = "0")
-    final int age;
-    @ProtoField(number = 3)
-    Person parent;
-    @ProtoField(number = 4, collectionImplementation = LinkedList.class)
-    final List<Person> children;
-
-    @ProtoFactory
-    Person(String name, int age, Person parent, List<Person> children) {
-        this.name = name;
-        this.age = age;
-        this.parent = parent;
-        this.children = children;
-    }
-
-    public Person(String name, int age) {
-        this.name = name;
-        this.age = age;
-        this.children = new LinkedList<>();
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    public int getAge() {
-        return this.age;
-    }
-
-    public Person getParent() {
-        return this.parent;
-    }
-
-    public List<Person> getChildren() {
-        return this.children;
-    }
-
-    public void setParent(Person parent) {
-        this.parent = parent;
-    }
-
-    public void addChild(Person child) {
-        this.children.add(child);
-    }
-}
-----
-
-Sufficiently complex objects may require a custom `org.infinispan.protostream.SerializationContextInitializer` implementation to register custom marshaller implementations and schemas.
-Refer to the https://infinispan.org/docs/stable/titles/encoding/encoding.html#marshalling_user_types[Infinispan documentation] for details.
+See the <<marshalling>> section for more details.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16770

Moves marshalling documentation to a generic section, referenced from relevant sections.