### PR TITLE
[WFLY-16784] Upgrade legacy Undertow version to 2.2.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>2.23.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-opentracing>3.0.0-RC1</version.io.smallrye.smallrye-opentracing>
         <version.io.smallrye.smallrye-reactive-messaging>4.0.0.RC1</version.io.smallrye.smallrye-reactive-messaging>
-        <legacy.version.io.undertow>2.2.18.Final</legacy.version.io.undertow>
+        <legacy.version.io.undertow>2.2.19.Final</legacy.version.io.undertow>
         <version.io.undertow>2.3.0.Alpha2</version.io.undertow>
         <legacy.version.io.undertow.jastow>2.0.10.Final</legacy.version.io.undertow.jastow>
         <version.io.undertow.jastow>2.2.2.Final</version.io.undertow.jastow>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

https://issues.redhat.com/browse/WFLY-16784


        Release Notes - Undertow - Version 2.2.19.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1790'>UNDERTOW-1790</a>] -         UT000010: Session is invalid due to concurrent calls changeSessionId() calls on same session
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1900'>UNDERTOW-1900</a>] -         InMemorySessionManager#SessionImpl.changeSessionId does not check if session exist before replacing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1934'>UNDERTOW-1934</a>] -         onClose not called when network drops
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1997'>UNDERTOW-1997</a>] -         SecurityPathMatches fails to match default path (&#39;/&#39;) 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2031'>UNDERTOW-2031</a>] -         protocol error with HTTP/2 and Expect: 100-continue 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2064'>UNDERTOW-2064</a>] -         Revert HTTP2 Fix for  UT005085, it is causing issues with WildFly HTTP Client
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2083'>UNDERTOW-2083</a>] -         bad read timeout message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2112'>UNDERTOW-2112</a>] -         Client Cert Renegotiation Test Case is failing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2113'>UNDERTOW-2113</a>] -         Read Timeout Test Case Fail on Windows with JDK17 due to different exception message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2116'>UNDERTOW-2116</a>] -         ServletOutputStreamImpl incorrectly sets Content-Length to 0
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2124'>UNDERTOW-2124</a>] -         ProgramaticLazyEndpointTest and BinaryEndpointTest failures with JDK-17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2125'>UNDERTOW-2125</a>] -         ReadTimeoutStreamSourceConduit expires when connection is closed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2130'>UNDERTOW-2130</a>] -         Classes with annotation RunWith are triggered as TestCase.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2133'>UNDERTOW-2133</a>] -         CVE-2022-2053: Large AJP request may cause DoS
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2135'>UNDERTOW-2135</a>] -         Properly handle HTTP Continue with HTTP2 upgrade
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2063'>UNDERTOW-2063</a>] -         Review fix for UT005085, it is causing RST messages to be sent to client sometimes
</li>
</ul>
                                                                                                                                                                                                                                                        