### PR TITLE
Remove duplicate dependency on jboss-invocation causing build warnings.

### DIFF
--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -127,10 +127,6 @@
             <artifactId>wildfly-request-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -211,11 +211,6 @@ vi:ts=4:sw=4:expandtab
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>


### PR DESCRIPTION
Introduced over the weekend via https://github.com/wildfly/wildfly/pull/15913 (FYI @yersan)