### PR TITLE
[26.x][WFLY-16822] Upgrade Hibernate ORM to 5.3.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.24.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.28.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.11.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.23.Final</version.org.hibernate.validator>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16822
Upstream: Not required, but https://github.com/wildfly/wildfly/pull/15922 exists