### PR TITLE
[WFLY-16762]: JMSQueueService uses wrong prefix.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueService.java
@@ -22,7 +22,6 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 import static org.jboss.as.server.Services.addServerExecutorDependency;
-import static org.wildfly.extension.messaging.activemq.jms.JMSTopicService.JMS_TOPIC_PREFIX;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -62,8 +61,8 @@ public class JMSQueueService implements Service<Queue> {
     private Queue queue;
 
     public JMSQueueService(final String name, String selectorString, boolean durable) {
-        if (name.startsWith(JMS_TOPIC_PREFIX)) {
-            this.queueName = name.substring(JMS_TOPIC_PREFIX.length());
+        if (name.startsWith(JMS_QUEUE_PREFIX)) {
+            this.queueName = name.substring(JMS_QUEUE_PREFIX.length());
         } else {
             this.queueName = name;
         }


### PR DESCRIPTION
* Updating JMSQueueService to use jms queue prefix instead of jms topic
  prefix.

Jira: https://issues.redhat.com/browse/WFLY-16762

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>