### PR TITLE
Move cloud tests trigger to use pull_request_target

### DIFF
--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -1,6 +1,6 @@
 name: Cloud Tests Trigger
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 env:
@@ -38,9 +38,11 @@ jobs:
           FILENAME="$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT.json"
           echo "FILENAME=$FILENAME" >> $GITHUB_ENV
           
+          REFERENCE="refs/pull/${{github.event.number}}/merge"
+          
           CLIENT_PAYLOAD=$( jq -n \
                   --arg tr "$GITHUB_REPOSITORY" \
-                  --arg ref "$GITHUB_REF" \
+                  --arg ref "$REFERENCE" \
                   --arg sf "$FILENAME" \
                   '{triggerRepo: $tr, ref: $ref, statusFile: $sf}' )
           


### PR DESCRIPTION
With the old pull_request trigger, we were not able to access the required secrets.

Follows up on #15921