### PR TITLE
[26.x][WFLY-16830] Upgrade Jackson Core and Databind 2.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,8 @@
         <version.antlr>2.7.7</version.antlr>
         <version.com.beust>1.78</version.com.beust>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>2.12.6.1</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson>2.12.7</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.12.7</version.com.fasterxml.jackson.databind>
         <version.com.github.ben-manes.caffeine>2.9.3</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16830

Upstream https://github.com/wildfly/wildfly/pull/15934
