### PR TITLE
[WFLY-16838] Fix MP RM subsystem name in management model

### DIFF
--- a/microprofile/reactive-messaging-smallrye/extension/src/main/resources/org/wildfly/extension/microprofile/reactive/messaging/LocalDescriptions.properties
+++ b/microprofile/reactive-messaging-smallrye/extension/src/main/resources/org/wildfly/extension/microprofile/reactive/messaging/LocalDescriptions.properties
@@ -20,6 +20,6 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 
-microprofile-reactive-messaging-smallrye=The Microprofile Reactive Streams Operators subsystem implemented by SmallRye
-microprofile-reactive-messaging-smallrye.add=Adds the Microprofile Reactive Streams Operators subsystem
-microprofile-reactive-messaging-smallrye.remove=Removes the Microprofile Reactive Streams Operators subsystem
+microprofile-reactive-messaging-smallrye=The Microprofile Reactive Messaging subsystem implemented by SmallRye
+microprofile-reactive-messaging-smallrye.add=Adds the Microprofile Reactive Messaging subsystem
+microprofile-reactive-messaging-smallrye.remove=Removes the Microprofile Reactive Messaging subsystem


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16838