### PR TITLE
Update Jastow version to 2.0.11.Final to include fix for UNDERTOW-2104 (WFLY-16745)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
         <version.io.smallrye.smallrye-mutiny>1.1.2</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>2.15.1</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-reactive-messaging>3.13.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.undertow.jastow>2.0.10.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.0.11.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.io.vertx.vertx>4.2.1</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>${version.io.vertx.vertx}</version.io.vertx.vertx-kafka-client>


### PR DESCRIPTION
Pull request for WFLY-16745 to update Jastow version in 26.x branch from 2.0.10.Final to 2.0.11.Final in order to incorporate fix for UNDERTOW-2104 in 26.1.x version.

This pull request is intended to replace https://github.com/wildfly/wildfly/pull/15882 for 26.1.x branch, as original PR was created with target branch 'main' instead of 26.x.