### PR TITLE
[WFLY-16841] Use org.glassfish:jakarta.json explicitely on wildfly-me…

### DIFF
--- a/ee-9/source-transform/messaging-activemq/subsystem/pom.xml
+++ b/ee-9/source-transform/messaging-activemq/subsystem/pom.xml
@@ -361,6 +361,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- javax dependencies required to bootstrap the legacy controllers for transformer tests -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1144,7 +1144,7 @@
             </dependency>
 
             <!--
-            TODO used both in both a testsuite/integration/microprofile-tck and in legacy code.
+            TODO used both in testsuite/integration/microprofile-tck, ee-9/source-transform/messaging-activemq/subsystem and in legacy code.
             Once the legacy use is removed, this can become a <scope>test</scope> dependency.
             TODO double-check that the testsuite use is really needed
             -->


### PR DESCRIPTION
…ssaging-activemq-subsystem-jakarta to avoid getting it transitively from wildfly-cli

Jira issue: https://issues.redhat.com/browse/WFLY-16841
