### PR TITLE
[26.x][WFLY-16829] Upgrade Apache cxf to 3.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
         <version.org.apache.activemq.artemis>2.19.1</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.10.2</version.org.apache.avro>
-        <version.org.apache.cxf>3.4.7</version.org.apache.cxf>
+        <version.org.apache.cxf>3.4.8</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.3.1</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16829

Upstream 
1. https://github.com/wildfly/wildfly/pull/15467 (3.5.2)
2. https://github.com/wildfly/wildfly/commit/61c1db90ddacf1faf3978dc9fcd8ff4400be5bde#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8 (3.5.2-jbossorg)
3. https://github.com/wildfly/wildfly/commit/78d2a0fbaec760e8b946b3c505a95015ff1348d1 (3.5.2-jbossorg-1)
