### PR TITLE
[26.x][WFLY-16847] Upgrade Eclipse Yasson to 1.0.11/2.0.4

### DIFF
--- a/ee-9/pom.xml
+++ b/ee-9/pom.xml
@@ -86,7 +86,7 @@
         <version.org.eclipse.microprofile.opentracing>3.0</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>3.0</version.org.eclipse.microprofile.rest.client.api>
         <!-- MP5 - END -->
-        <version.org.eclipse.yasson>2.0.3</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>2.0.4</version.org.eclipse.yasson>
         <version.org.glassfish.jakarta.el>4.0.0</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>2.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@
         <version.org.eclipse.microprofile.reactive-messaging.api>2.0.1</version.org.eclipse.microprofile.reactive-messaging.api>
         <version.org.eclipse.microprofile.reactive-streams-operators.api>2.0</version.org.eclipse.microprofile.reactive-streams-operators.api>
         <version.org.eclipse.microprofile.rest.client.api>2.0</version.org.eclipse.microprofile.rest.client.api>
-        <version.org.eclipse.yasson>1.0.10</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>1.0.11</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.10</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>3.0.3.jbossorg-4</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16847

Upstream https://github.com/wildfly/wildfly/pull/15953
