### PR TITLE
[26.x][WFLY-16849] Upgrade JGroups to 4.2.21.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <version.org.jboss.ws.spi>3.3.1.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
-        <version.org.jgroups>4.2.20.Final</version.org.jgroups>
+        <version.org.jgroups>4.2.21.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.3.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.16.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-16849

Upstream https://github.com/wildfly/wildfly/pull/15424