### PR TITLE
WFLY-16253 Undertow subsystem model for WF27 should be 12.0.0, not 13.0.0.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostSingleSignOnDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostSingleSignOnDefinition.java
@@ -43,7 +43,7 @@ public class HostSingleSignOnDefinition extends SingleSignOnDefinition {
 
     public HostSingleSignOnDefinition() {
         super();
-        setDeprecated(ModelVersion.create(13));
+        setDeprecated(ModelVersion.create(12));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
@@ -79,7 +79,7 @@ public class UndertowExtension implements Extension {
     static final AccessConstraintDefinition LISTENER_CONSTRAINT = new SensitiveTargetAccessConstraintDefinition(
                     new SensitivityClassification(SUBSYSTEM_NAME, "web-connector", false, false, false));
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(13, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(12);
 
 
     public static StandardResourceDescriptionResolver getResolver(final String... keyPrefix) {


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16253

TLDR
* WF 26 is using model version 11 = https://github.com/wildfly/wildfly/blob/26.0.0.Final/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java#L82
* So WF 27 should be using version 12 (and not 13.)

Issue introduced in https://github.com/wildfly/wildfly/commit/a1f9ad78f6c960e824a2ca007a40593706c2d060#diff-b60dca0e646d43bf2678414de075f93e39a0550ab0ad7564b774e8e8615f5340R82