### PR TITLE
[26.x] [WFLY-16859] Upgrade WildFly Core to 18.1.2.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>18.1.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>18.1.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.11.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16859

Tag: https://github.com/wildfly/wildfly-core/releases/tag/18.1.2.Final
Diff: https://github.com/wildfly/wildfly-core/compare/18.1.1.Final...18.1.12.Final
