### PR TITLE
WFLY-16862 Hibernate Search engine module should have optional dependencies to other modules

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -33,5 +33,11 @@
 
     <dependencies>
         <module name="org.jboss.logging"/>
+
+        <!-- Optional dependencies to import services (used for resolution of bean references in particular). -->
+        <module name="org.hibernate.search.backend.lucene" optional="true" services="import"/>
+        <module name="org.hibernate.search.backend.elasticsearch" optional="true" services="import"/>
+        <module name="org.hibernate.search.mapper.pojo-base" optional="true" services="import"/>
+        <module name="org.hibernate.search.mapper.orm" optional="true" services="import"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -37,7 +37,7 @@
         <!-- Optional dependencies to import services (used for resolution of bean references in particular). -->
         <module name="org.hibernate.search.backend.lucene" optional="true" services="import"/>
         <module name="org.hibernate.search.backend.elasticsearch" optional="true" services="import"/>
-        <module name="org.hibernate.search.mapper.pojo-base" optional="true" services="import"/>
+        <module name="org.hibernate.search.mapper.pojo" optional="true" services="import"/>
         <module name="org.hibernate.search.mapper.orm" optional="true" services="import"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -36,7 +36,7 @@
         <module name="javax.transaction.api"/>
         <module name="org.jboss.logging" />
         <module name="org.hibernate.search.engine" export="true" />
-        <module name="org.hibernate.search.mapper.pojo-base" export="true" />
+        <module name="org.hibernate.search.mapper.pojo" export="true" />
         <module name="org.hibernate" />
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
@@ -22,7 +22,7 @@
   -->
 
 <!-- Hibernate Search Pojo-base Mapper: base code for mappers such as org.hibernate.search.mapper.orm -->
-<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.pojo-base">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.pojo">
 
     <resources>
         <artifact name="${org.hibernate.search:hibernate-search-mapper-pojo-base}"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/massindexer/HibernateSearchLuceneEarMassIndexerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/massindexer/HibernateSearchLuceneEarMassIndexerTestCase.java
@@ -97,6 +97,7 @@ public class HibernateSearchLuceneEarMassIndexerTestCase {
                 .getOrCreateProperties()
                 .createProperty().name("hibernate.hbm2ddl.auto").value("create").up()
                 .createProperty().name("hibernate.search.schema_management.strategy").value("drop-and-create-and-drop").up()
+                .createProperty().name("hibernate.search.backend.type").value("lucene").up()
                 .createProperty().name("hibernate.search.backend.lucene_version").value("LUCENE_CURRENT").up()
                 .createProperty().name("hibernate.search.backend.directory.type").value("local-heap").up()
                 .createProperty().name("hibernate.search.automatic_indexing.enabled").value("false").up()

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -93,21 +93,16 @@ public class LayersTestCase {
         "org.jboss.resteasy.resteasy-rxjava2",
         // TODO WFLY-16586 microprofile-reactive-streams-operators layer should provision this
         "org.wildfly.reactive.dep.jts",
-        // Used by Hibernate Search 6 TODO remove these entries as part of the big-bang, as they are used, just not in javax Hibernate Search
-        "com.carrotsearch.hppc",
-        "org.elasticsearch.client.rest-client",
-        // Used by Hibernate Search 5 but not part of the jpa layer (aiui they are optional aspects of Hibernate Search)
-        // These modules are dropped with Hibernate Search 6 so no point evaluating whether they should be provisioned
-        // by the jpa layer
-        "org.hibernate.search.backend-jms",
-        "org.hibernate.search.serialization-avro",
-        "org.apache.avro",
-        // Optionally used by Hibernate Search 6 but not provided by the jpa layer
-        // TODO determine if they should be
+        // Optionally used by Hibernate Search but not provided by the jpa layer
+        // TODO they probably should be, see https://github.com/wildfly/wildfly/pull/15965
+        "org.hibernate.search.orm",
         "org.hibernate.search.backend.elasticsearch",
+        "org.elasticsearch.client.rest-client",
         "org.hibernate.search.backend.lucene",
+        "com.carrotsearch.hppc",
         "org.apache.lucene",
-        "org.apache.lucene.internal",
+        // Used by Hibernate Search but only in preview
+        "org.apache.avro", // Will be used by outboxpolling, present only in preview (see https://github.com/wildfly/wildfly/pull/15974)
         // TODO these implement SPIs from RESTEasy or JBoss WS but I don't know how they integrate
         // as there is no ref to them in any module.xml nor any in WF java code.
         // Perhaps via deployment descriptor? In any case, no layer provides them
@@ -196,14 +191,13 @@ public class LayersTestCase {
         "org.jboss.resteasy.resteasy-json-binding-provider",
         // injected by jpa
         "org.hibernate.search.orm",
-        "org.hibernate.search.backend.lucene",
         "org.hibernate.search.backend.elasticsearch",
+        "org.hibernate.search.backend.lucene",
         // Used by the hibernate search that's injected by jpa
-        "org.hibernate.search.serialization-avro",
-        "org.hibernate.search.backend-jms",
-        "org.apache.avro",
+        "org.elasticsearch.client.rest-client",
+        "com.google.code.gson",
+        "com.carrotsearch.hppc",
         "org.apache.lucene",
-        "org.apache.lucene.internal",
         // injected by jsf
         "org.jboss.as.jsf-injection",
         // injected by sar


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16862

I don't think this warrants a dedicated integration test since we're fixing a very exotic use case here.

I also noticed a module had a name that was not aligned with the corresponding Java module, so I took the liberty to fix that. That module was introduced in WF 27, so there's no backward incompatibility to fear.