### PR TITLE
[WFLY-16855] Upgrade Elytron MP to 2.0.0.Beta4

### DIFF
--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -3250,7 +3250,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.security</groupId>
+                <groupId>org.wildfly.security.mp</groupId>
                 <artifactId>wildfly-elytron-jwt</artifactId>
                 <version>${version.org.wildfly.security.elytron-mp}</version>
             </dependency>

--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -796,7 +796,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.security</groupId>
+            <groupId>org.wildfly.security.mp</groupId>
             <artifactId>wildfly-elytron-jwt</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
@@ -865,7 +865,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly.security</groupId>
+      <groupId>org.wildfly.security.mp</groupId>
       <artifactId>wildfly-elytron-jwt</artifactId>
       <licenses>
         <license>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-jwt/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-jwt/main/module.xml
@@ -25,7 +25,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.wildfly.security:wildfly-elytron-jwt}"/>
+        <artifact name="${org.wildfly.security.mp:wildfly-elytron-jwt}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
         <legacy.version.org.wildfly.security.elytron>1.20.1.Final</legacy.version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron>2.0.0.Beta3</version.org.wildfly.security.elytron>
         <legacy.version.org.wildfly.security.elytron-mp>1.20.1.Final</legacy.version.org.wildfly.security.elytron-mp>
-        <version.org.wildfly.security.elytron-mp>2.0.0.Beta3</version.org.wildfly.security.elytron-mp>
+        <version.org.wildfly.security.elytron-mp>2.0.0.Beta4</version.org.wildfly.security.elytron-mp>
         <legacy.version.org.wildfly.security.elytron-web>1.10.1.Final</legacy.version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron-web>3.0.0.Beta1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>


### PR DESCRIPTION
This update includes an adjustment to the group ID to avoid intersecting
with the ranges used by WildFly Elytron.

https://issues.redhat.com/browse/WFLY-16855