### PR TITLE
[WFLY-16734] Add the wildfly-elytron dependency to ensure all classes…

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -327,7 +327,12 @@
         <dependency>
             <groupId>org.jboss.remotingjmx</groupId>
             <artifactId>remoting-jmx</artifactId>
-        </dependency>
+        </dependency>   
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency> 
 
     </dependencies>
 


### PR DESCRIPTION
… present in WF 26.0.0 are included

https://issues.redhat.com/browse/WFLY-16734

This implements the possible approach discussed at https://github.com/wildfly/wildfly/pull/15962#pullrequestreview-1080891670. I want to get CI for this so it can be merged tomorrow if @chengfang / @fjuma decide to use this approach.