### PR TITLE
WFLY-16951 Add necessary individual elytron component jars to jboss-client.jar

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -341,6 +341,67 @@
             <artifactId>remoting-jmx</artifactId>
         </dependency>
 
+        <!-- additional elytron dependencies that are not brought in by the above dependencies -->
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-digest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-mechanism-digest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-digest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-mechanism-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-mechanism-scram</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-scram</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-entity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-gs2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-mechanism-gssapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-gssapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-otp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-sasl-plain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-x500</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This is a follow-up of 26.x PR https://github.com/wildfly/wildfly/pull/15962 in the main branch.

https://issues.redhat.com/browse/WFLY-16951

It was reported in the above jira that jboss-client.jar worked in 26.0.0 but failed in 26.1.1 for this user's application. In 26.0.0, jboss-client.jar includes everything in wildfly-elytron.jar, which is an uber jar including many of its dependencies and submodules. In 26.1.1, some components like jboss-ejb-client and wildfly-naming-client split their dependency on wildfly-elytron into its more modular individual submodules. Therefore, when building jboss-client.jar, these individual elytron-* submodules are bundled in jboss-client.jar, which omits some artifacts unreachable via transitive dependency.

In order to maintain some kind of compatibility with 26.0.0, this PR proposes to add some additional elytron-* submodules to jboss-client.jar. Even though those additional artifacts are not required at each component client level (e.g., jboss-ejb-client, or wildfly-naming-client), they are needed to support a wide range of non-maven-based applications with various security mechanisms.

The following artifacts are not added to jboss-client.jar in this PR, as they appear not applicable on the client side, but I may be wrong:

elytron-audit
elytron-jacc
elytron-oidc
wildfly-elytron-jose-util
wildfly-elytron-jose-jwk
elytron-*-deprecated
elytron-*-http-*

Comment from Farah copied here for easy reference:

>@chengfang Thanks for working on this! To make sure that we aren't accidentally missing anything here, I'm wondering if for WildFly 26.1.2, it would be safer to just add a dependency on org.wildfly.security:wildfly-elytron to mimic the behaviour that was present in WildFly 26.0.0.Final? What do you think? That would preserve compatibility.

>We can then working on fixing this properly in the main branch. As a starting point, I've added some comments about dependencies that I think can be removed.

I've incorporated Farah's suggestions in the other PR (https://github.com/wildfly/wildfly/pull/15962).