### PR TITLE
[WFLY-16810] Remove Glassfish Jakarta EL from dependency management

### DIFF
--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -1859,18 +1859,6 @@
 
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${version.org.glassfish.jakarta.el}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.enterprise.concurrent</artifactId>
                 <version>${version.org.glassfish.jakarta.enterprise.concurrent}</version>
                 <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,6 @@
         <version.org.eclipselink.version>3.0.2</version.org.eclipselink.version>
         <version.org.glassfish.expressly>5.0.0-M2</version.org.glassfish.expressly>
         <legacy.version.org.glassfish.jakarta.el>3.0.3.jbossorg-4</legacy.version.org.glassfish.jakarta.el>
-        <version.org.glassfish.jakarta.el>5.0.0-M1</version.org.glassfish.jakarta.el>
         <legacy.version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</legacy.version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <legacy.version.org.glassfish.jakarta.json>1.1.6</legacy.version.org.glassfish.jakarta.json>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16810

Unused dep replaced by Eclipse Expressly.