### PR TITLE
[WFLY-16880]: Using SSL with a netty-acceptor is failing.

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/netty-handler/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/netty/netty-handler/main/module.xml
@@ -35,6 +35,7 @@
         <module name="io.netty.netty-common" />
         <module name="io.netty.netty-buffer" />
         <module name="io.netty.netty-transport" />
+        <module name="io.netty.netty-transport-native-unix-common"/>
         <module name="io.netty.netty-codec" />
         <module name="io.netty.netty-resolver" />
     </dependencies>


### PR DESCRIPTION
* Adding the missing dependency to "io.netty.netty-transport-native-unix-common".

Jira: https://issues.redhat.com/browse/WFLY-16880
Upstream https://issues.redhat.com/browse/WFLY-16879

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>
Upstream PR: https://github.com/wildfly/wildfly/pull/15984