### PR TITLE
WFLY-16928: Upgrade HAL to 3.6.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>
-        <version.org.jboss.hal.console>3.6.3.Final</version.org.jboss.hal.console>
+        <version.org.jboss.hal.console>3.6.4.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.5.7.Final</version.org.jboss.ironjacamar>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16928

HAL 3.6.4.Final doesn't contain new features or bug fixes but only pulls in new translations. 