### PR TITLE
[WFLY-16460] Workaround MP JWT TCK regression caused by AES default key size change since JDK19

### DIFF
--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -213,6 +213,7 @@
                     <systemPropertyVariables>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                     </systemPropertyVariables>
+                    <argLine>-Djdk.security.defaultKeySize=AES:128</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16460
