### PR TITLE
WFLY-16927 Update the OIDC tests to use the 19.0.1 version of quay.io/keycloak/keycloak

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
@@ -32,7 +32,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public static final String ADMIN_USER = "admin";
     public static final String ADMIN_PASSWORD = "admin";
 
-    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:latest";
+    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:19.0.1";
     private static final String SSO_IMAGE = System.getProperty("testsuite.integration.oidc.rhsso.image",KEYCLOAK_IMAGE);
     private static final int STARTUP_ATTEMPTS = Integer.parseInt(
             System.getProperty("testsuite.integration.oidc.container.startup.attempts", "5"));


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16927