### PR TITLE
WFLY-16819 Upgrade SmallRye Fault Tolerance to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <version.io.smallrye.smallrye-common>2.0.0</version.io.smallrye.smallrye-common>
         <legacy.version.io.smallrye.smallrye-config>2.10.1</legacy.version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-config>3.0.0</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.0.0-RC4</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.0.0</version.io.smallrye.smallrye-fault-tolerance>
         <legacy.version.io.smallrye.smallrye-health>3.3.0</legacy.version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-health>4.0.0</version.io.smallrye.smallrye-health>
         <legacy.version.io.smallrye.smallrye-jwt>3.1.1</legacy.version.io.smallrye.smallrye-jwt>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16819