### PR TITLE
[WFLY-16713][WFLY-16552] Upgrade to Hibernate ORM 6.1.3 to address envers test failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <legacy.version.org.hibernate>5.3.28.Final</legacy.version.org.hibernate>
-        <version.org.hibernate>6.0.2.Final</version.org.hibernate>
+        <version.org.hibernate>6.1.3.Final</version.org.hibernate>
         <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
         <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.5.Final</version.org.hibernate.search>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/entitytest/EntityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/entitytest/EntityTestCase.java
@@ -77,7 +77,7 @@ public class EntityTestCase {
     @BeforeClass
     public static void beforeClass() {
 
-        // TODO WFLY-16552
+        // TODO WFLY-16974
         AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         assumeTrue(System.getProperty("ts.ee9") == null && System.getProperty("ts.bootable.ee9") == null);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/AuditJoinTableoverBidirectionalTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/AuditJoinTableoverBidirectionalTest.java
@@ -27,7 +27,6 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -50,9 +49,6 @@ public class AuditJoinTableoverBidirectionalTest {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/AuditJoinTableoverOnetoManyJoinColumnTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/AuditJoinTableoverOnetoManyJoinColumnTest.java
@@ -28,7 +28,6 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -51,9 +50,6 @@ public class AuditJoinTableoverOnetoManyJoinColumnTest {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/basicenverstest/BasicEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/basicenverstest/BasicEnversTestCase.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.jpa.hibernate.envers.Address;
 import org.jboss.as.test.integration.jpa.hibernate.envers.Person;
 import org.jboss.as.test.integration.jpa.hibernate.envers.SLSBPU;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -52,9 +51,6 @@ public class BasicEnversTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/basicselectiveenverstest/BasicSelectiveEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/basicselectiveenverstest/BasicSelectiveEnversTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.jpa.hibernate.envers.Organization;
 import org.jboss.as.test.integration.jpa.hibernate.envers.SLSBOrg;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -52,9 +51,6 @@ public class BasicSelectiveEnversTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/implementvalidityauditstrategytest/ImplementValidityAuditStrategyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/implementvalidityauditstrategytest/ImplementValidityAuditStrategyTestCase.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.jpa.hibernate.envers.Organization;
 import org.jboss.as.test.integration.jpa.hibernate.envers.SLSBValidityStrategyOrg;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -57,9 +56,6 @@ public class ImplementValidityAuditStrategyTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/validityauditstrategyoninheritancetest/ValidityAuditStrategyonInheritanceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/validityauditstrategyoninheritancetest/ValidityAuditStrategyonInheritanceTestCase.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.jpa.hibernate.envers.Player;
 import org.jboss.as.test.integration.jpa.hibernate.envers.SLSBAuditInheritance;
 import org.jboss.as.test.integration.jpa.hibernate.envers.SoccerPlayer;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -54,9 +53,6 @@ public class ValidityAuditStrategyonInheritanceTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
-
-        // TODO WFLY-16552
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         iniCtx = new InitialContext();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
@@ -60,7 +60,7 @@ public class SessionFactoryTestCase {
     @BeforeClass
     public static void beforeClass() {
 
-        // TODO WFLY-16552
+        // TODO WFLY-16974
         AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         assumeTrue(System.getProperty("ts.ee9") == null && System.getProperty("ts.bootable.ee9") == null);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16713 (Hibernate ORM 6.1.3 upgrade)
https://issues.redhat.com/browse/WFLY-16552 (Envers failures when run under security manager)

Note that https://issues.redhat.com/browse/WFLY-16974 is the tracker for remaining non-envs test failures when run under security manager that will need to be addressed separately due to (see WFLY-16974 for more complete stack trace):
```
java.security.AccessControlException: WFSM000001: Permission check failed (permission "("java.lang.RuntimePermission" "accessDeclaredMembers")" in code source "(vfs:/content/jpa_sessionfactory.jar <no signer certificates>)" of "ModuleClassLoader for Module "deployment.jpa_sessionfactory.jar" from Service Module Loader")
        at org.wildfly.security.elytron-base@2.0.0.Beta3//org.wildfly.security.manager.WildFlySecurityManager.checkPermission(WildFlySecurityManager.java:309)
        at org.wildfly.security.elytron-base@2.0.0.Beta3//org.wildfly.security.manager.WildFlySecurityManager.checkPermission(WildFlySecurityManager.java:201)
        at java.base/java.lang.Class.checkMemberAccess(Class.java:2847)
        at java.base/java.lang.Class.getDeclaredMethod(Class.java:2471)
        at deployment.jpa_sessionfactory.jar//org.jboss.as.test.integration.jpa.hibernate.Employee$HibernateProxy$oqaPU9Fv.<clinit>(Unknown Source)
```
