### PR TITLE
[WFLY-16976]: Upgrade jboss metadata to 15.2.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.metadata>15.1.0.Final</version.org.jboss.metadata>
+        <version.org.jboss.metadata>15.2.0.Beta1</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.13.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>


### PR DESCRIPTION
* Upgrade jboss metadata to 15.2.0.Beta1 to have jboss descriptors using jakartaee 10 namespace

Jira: https://issues.redhat.com/browse/WFLY-16976

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>

