### PR TITLE
[WFLY-16992]: WFLYJCA0073: Failed to load module for RA [org.jboss.genericjms].

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<connector xmlns="http://java.sun.com/xml/ns/j2ee"
+<!-- TODO Upgrade to 2.1 once https://issues.redhat.com/browse/WFLY-16991 is fixed -->
+<connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
-           http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
-           version="1.5">
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           https://jakarta.ee/xml/ns/jakartaee/connector_2_0.xsd"
+           version="2.0">
 
     <description>JBoss Generic JMS JCA Resource Adapter</description>
     <display-name>Generic JMS Adapter</display-name>
@@ -102,13 +102,13 @@
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>org.jboss.resource.adapter.jms.JmsConnectionFactoryImpl
                 </connectionfactory-impl-class>
-                <connection-interface>javax.jms.Session</connection-interface>
+                <connection-interface>jakarta.jms.Session</connection-interface>
                 <connection-impl-class>org.jboss.resource.adapter.jms.JmsSession</connection-impl-class>
             </connection-definition>
             <transaction-support>XATransaction</transaction-support>
             <authentication-mechanism>
                 <authentication-mechanism-type>BasicPassword</authentication-mechanism-type>
-                <credential-interface>javax.resource.spi.security.PasswordCredential</credential-interface>
+                <credential-interface>jakarta.resource.spi.security.PasswordCredential</credential-interface>
             </authentication-mechanism>
             <reauthentication-support>false</reauthentication-support>
         </outbound-resourceadapter>
@@ -116,7 +116,7 @@
         <inbound-resourceadapter>
             <messageadapter>
                 <messagelistener>
-                    <messagelistener-type>javax.jms.MessageListener</messagelistener-type>
+                    <messagelistener-type>jakarta.jms.MessageListener</messagelistener-type>
                     <activationspec>
                         <activationspec-class>org.jboss.resource.adapter.jms.inflow.JmsActivationSpec
                         </activationspec-class>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -3180,6 +3180,9 @@
                                         <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/messaging/**/*TestCase.java</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/messaging/mgmt/GenericJmsResourceAdpterTestCase.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                             <!-- Tests against the install with ejb and remote broker-->
@@ -3210,6 +3213,7 @@
                                     </includes>
                                     <excludes>
                                         <exclude>org/jboss/as/test/integration/messaging/mgmt/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/mgmt/GenericJmsResourceAdpterTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/jms/definitions/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/xmldeployment/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/GenericJmsResourceAdpterTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/GenericJmsResourceAdpterTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.messaging.mgmt;
+
+import java.io.IOException;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test trying to deploy the Generic JMS Resource Adapter
+ *
+ * @author Emmanuel Hugonnet (c) 2022 Red Hat, Inc.
+ */
+@RunAsClient()
+@RunWith(Arquillian.class)
+public class GenericJmsResourceAdpterTestCase {
+    private static final Logger LOGGER = Logger.getLogger(GenericJmsResourceAdpterTestCase.class);
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Test
+    public void testAddResourceAdapter() throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(ClientConstants.OP_ADDR).add("subsystem", "resource-adapters");
+        op.get(ClientConstants.OP_ADDR).add("resource-adapter", "MyResourceAdapter");
+        op.get(ClientConstants.OP).set(ClientConstants.ADD);
+        op.get("module").set("org.jboss.genericjms");
+        execute(op, true);
+        op = new ModelNode();
+        op.get(ClientConstants.OP_ADDR).add("subsystem", "resource-adapters");
+        op.get(ClientConstants.OP_ADDR).add("resource-adapter", "MyResourceAdapter");
+        op.get(ClientConstants.OP).set(ClientConstants.REMOVE_OPERATION);
+        execute(op, true);
+    }
+
+    private ModelNode execute(final ModelNode op, final boolean expectSuccess) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        final String outcome = response.get("outcome").asString();
+        if (expectSuccess) {
+            if (!"success".equals(outcome)) {
+                LOGGER.trace(response);
+            }
+            Assert.assertEquals("success", outcome);
+            return response.get("result");
+        } else {
+            if ("success".equals(outcome)) {
+                LOGGER.trace(response);
+            }
+            Assert.assertEquals("failed", outcome);
+            return response.get("failure-description");
+        }
+    }
+}


### PR DESCRIPTION
* Updating the ra.xml to JakartaEE 9 while waiting for IronJacamar to support JakartaEE 10.
* Related Jira: https://issues.redhat.com/browse/WFLY-16991

Jira; https://issues.redhat.com/browse/WFLY-16992

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>