### PR TITLE
[WFLY-17007]:  Upgrade jboss metadata to 15.2.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.metadata>15.2.0.Beta1</version.org.jboss.metadata>
+        <version.org.jboss.metadata>15.2.0.Beta2</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.13.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarManifestDependencyPropagatedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarManifestDependencyPropagatedTestCase.java
@@ -88,10 +88,10 @@ public class EarManifestDependencyPropagatedTestCase {
     private static StringAsset emptyEjbJar() {
         return new StringAsset(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ejb-jar xmlns=\"http://java.sun.com/xml/ns/javaee\" \n" +
+                "<ejb-jar xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" \n" +
                 "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
-                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd\"\n" +
-                "         version=\"3.0\">\n" +
+                "         xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee//ejb-jar_4_0.xsd\"\n" +
+                "         version=\"4.0\">\n" +
                 "   \n" +
                 "</ejb-jar>");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EjbJarCanAccessOtherEjbJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EjbJarCanAccessOtherEjbJarTestCase.java
@@ -70,10 +70,10 @@ public class EjbJarCanAccessOtherEjbJarTestCase {
     private static StringAsset emptyEjbJar() {
         return new StringAsset(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ejb-jar xmlns=\"http://java.sun.com/xml/ns/javaee\" \n" +
+                "<ejb-jar xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" \n" +
                 "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
-                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd\"\n" +
-                "         version=\"3.0\">\n" +
+                "         xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd\"\n" +
+                "         version=\"4.0\">\n" +
                 "   \n" +
                 "</ejb-jar>");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/WarCanAccessEjbJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/WarCanAccessEjbJarTestCase.java
@@ -70,10 +70,10 @@ public class WarCanAccessEjbJarTestCase {
     private static StringAsset emptyEjbJar() {
         return new StringAsset(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ejb-jar xmlns=\"http://java.sun.com/xml/ns/javaee\" \n" +
+                "<ejb-jar xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" \n" +
                 "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
-                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd\"\n" +
-                "         version=\"3.0\">\n" +
+                "         xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd\"\n" +
+                "         version=\"4.0\">\n" +
                 "   \n" +
                 "</ejb-jar>");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app version="2.5"
-         xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.0"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-   http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
     <servlet>
         <servlet-name>Servlet</servlet-name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/application.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/application.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<application xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd"
-	version="6">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+             version="10">
 
-	<initialize-in-order>true</initialize-in-order>
+    <initialize-in-order>true</initialize-in-order>
 
-	<module>
-		<web>
-			<web-uri>staller.war</web-uri>
-			<context-root>staller</context-root>
-		</web>
-	</module>
+    <module>
+        <web>
+            <web-uri>staller.war</web-uri>
+            <context-root>staller</context-root>
+        </web>
+    </module>
 
-	<module>
-		<ejb>hello.jar</ejb>
-	</module>
+    <module>
+        <ejb>hello.jar</ejb>
+    </module>
 
 </application>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/web.xml
@@ -1,8 +1,8 @@
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
-	<listener>
-		<listener-class>org.jboss.as.test.integration.deployment.dependencies.ear.SleeperContextListener</listener-class>
-	</listener>
+    <listener>
+        <listener-class>org.jboss.as.test.integration.deployment.dependencies.ear.SleeperContextListener</listener-class>
+    </listener>
 </web-app>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/override.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/override.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2011, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  -->
-<web-app version="2.5"
-         xmlns="http://java.sun.com/xml/ns/javaee"
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2011, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<web-app version="6.0"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
     <env-entry>
         <env-entry-name>simpleString</env-entry-name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/update.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/update.xml
@@ -21,10 +21,10 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<web-app version="2.5"
-         xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.0"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
     <env-entry>
         <env-entry-name>simpleString</env-entry-name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-ejb3.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>  
-   <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
-                  xmlns="http://java.sun.com/xml/ns/javaee"
+<jboss:ejb-jar xmlns:jboss="urn:jboss:jakartaee:1.0"
+                  xmlns="https://jakarta.ee/xml/ns/jakartaee"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
-                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
-                  version="3.1"
-                  impl-version="2.0">
+                  xsi:schemaLocation="urn:jboss:jakartaee:1.0 https://www.jboss.org/schema/jbossas/jboss-ejb3-4_0.xsd
+                     https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd"
+                  version="4.0">
     <enterprise-beans>
         
-       <session>
+        <session>
             <ejb-name>ResourceRefBean</ejb-name>
             <!-- This resource-ref has no corresponding res-type specified
             neither in ejb-jar.xml nor in the bean as a @Resource (see EJBTHREE-1823
@@ -26,9 +25,9 @@
         <session>
             <ejb-name>ResUrlCheckerBean</ejb-name>
             <resource-ref>
-	        	<res-ref-name>url2</res-ref-name>
-	        	<res-url>http://somewhere/url2</res-url>
-	        </resource-ref>
+                <res-ref-name>url2</res-ref-name>
+                <res-url>http://somewhere/url2</res-url>
+            </resource-ref>
         </session>
         
     </enterprise-beans>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+<jboss-web xmlns="urn:jboss:jakartaee:1.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_7_2.xsd"
-           version="7.2">
+           xsi:schemaLocation="urn:jboss:jakartaee:1.0 https://www.jboss.org/schema/jbossas/jboss-web_15_0.xsd"
+           version="15.0">
 
     <resource-ref>
         <res-ref-name>ds-ignored</res-ref-name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/jboss-ejb3.xml
@@ -21,11 +21,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<jboss:jboss
-        xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+<jboss:ejb-jar
+        xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:jboss="urn:jboss:jakartaee:1.0"
         xmlns:s="urn:security:1.1"
-        version="3.1" impl-version="2.0">
+        version="4.0" >
 
     <assembly-descriptor>
         <s:security>
@@ -33,4 +33,4 @@
             <s:missing-method-permissions-deny-access>false</s:missing-method-permissions-deny-access>
         </s:security>
     </assembly-descriptor>
-</jboss:jboss>
+</jboss:ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/jboss-ejb3.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss:jboss
-        xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+<jboss:ejb-jar 
+        xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:jboss="urn:jboss:jakartaee:1.0"
         xmlns:s="urn:security:1.1"
-        version="3.1" impl-version="2.0">
+        version="4.0">
 
     <assembly-descriptor>
         <s:security>
@@ -11,4 +11,4 @@
             <s:missing-method-permissions-deny-access>false</s:missing-method-permissions-deny-access>
         </s:security>
     </assembly-descriptor>
-</jboss:jboss>
+</jboss:ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-ejb3.xml
@@ -1,8 +1,8 @@
-<jboss:jboss
-        xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+<jboss:ejb-jar
+        xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:jboss="urn:jboss:jakartaee:1.0"
         xmlns:s="urn:security:1.1"
-        version="3.1" impl-version="2.0">
+        version="4.0" >
 
     <assembly-descriptor>
         <s:security>
@@ -10,4 +10,4 @@
             <s:missing-method-permissions-deny-access>false</s:missing-method-permissions-deny-access>
         </s:security>
     </assembly-descriptor>
-</jboss:jboss>
+</jboss:ejb-jar>

--- a/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/weld/builtinBeans/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/weld/builtinBeans/jboss-ejb3.xml
@@ -15,11 +15,11 @@
  ~ limitations under the License.
   -->
 
-<jboss:jboss
-        xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+<jboss:ejb-jar
+        xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:jboss="urn:jboss:jakartaee:1.0"
         xmlns:s="urn:security:1.1"
-        version="3.1" impl-version="2.0">
+        version="4.0">
 
     <assembly-descriptor>
         <s:security>
@@ -28,4 +28,4 @@
             <s:run-as-principal>non-anonymous</s:run-as-principal>
         </s:security>
     </assembly-descriptor>
-</jboss:jboss>
+</jboss:ejb-jar>


### PR DESCRIPTION
* Fixing some XML descriptors.
* Updating jboss-metadata to 15.2.0.Beta2

Jira: https://issues.redhat.com/browse/WFLY-17007

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>