### PR TITLE
WFLY-17010 Upgrade to Hibernate Search 6.1.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
         <version.org.hibernate>6.1.3.Final</version.org.hibernate>
         <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
         <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.search>6.1.5.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>6.1.7.Final</version.org.hibernate.search>
         <legacy.version.org.hibernate.validator>6.0.23.Final</legacy.version.org.hibernate.validator>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17010

This version has been tested to work with Hibernate ORM 6.1 (which WildFly recently upgraded to).

https://in.relation.to/2022/08/04/hibernate-search-6-1-6-Final
https://in.relation.to/2022/09/16/hibernate-search-6-1-7-Final
