### PR TITLE
Fix for WFLY-17013, Upgrade Galleon plugins to 6.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>8.0.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>3.0.2.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17013
