### PR TITLE
[WFLY-17014] Make Galleon provisioning content zips unique per release

### DIFF
--- a/ee-9/common-microprofile/assembly.xml
+++ b/ee-9/common-microprofile/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-9/common/assembly.xml
+++ b/ee-9/common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -109,6 +109,9 @@
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
+                            <!-- The feature pack build seems to ignore such things anyway, but to be
+                                 robust exclude artifact metadata content -->
+                            <excludes>**/pom.xml,META-INF,META-INF/**</excludes>
                             <outputDirectory>${basedir}/target/unpacked-wildfly-core-galleon-resources</outputDirectory>
                         </configuration>
                     </execution>

--- a/ee-9/galleon-content-microprofile/assembly.xml
+++ b/ee-9/galleon-content-microprofile/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-9/galleon-content/assembly.xml
+++ b/ee-9/galleon-content/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-feature-pack/common/assembly.xml
+++ b/ee-feature-pack/common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-feature-pack/ee-10-api/assembly.xml
+++ b/ee-feature-pack/ee-10-api/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-feature-pack/galleon-common/assembly.xml
+++ b/ee-feature-pack/galleon-common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-feature-pack/galleon-content/assembly.xml
+++ b/ee-feature-pack/galleon-content/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -100,6 +100,9 @@
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
+                            <!-- The feature pack build seems to ignore such things anyway, but to be
+                                 robust exclude artifact metadata content -->
+                            <excludes>**/pom.xml,META-INF,META-INF/**</excludes>
                             <outputDirectory>${basedir}/target/unpacked-wildfly-core-galleon-resources</outputDirectory>
                         </configuration>
                     </execution>

--- a/ee-feature-pack/pruned/assembly.xml
+++ b/ee-feature-pack/pruned/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/galleon-pack/galleon-content/assembly.xml
+++ b/galleon-pack/galleon-content/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/servlet-feature-pack/common/assembly.xml
+++ b/servlet-feature-pack/common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/servlet-feature-pack/galleon-common/assembly.xml
+++ b/servlet-feature-pack/galleon-common/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>

--- a/servlet-feature-pack/galleon-pruned/assembly.xml
+++ b/servlet-feature-pack/galleon-pruned/assembly.xml
@@ -12,4 +12,10 @@
             <outputDirectory/>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
 </assembly>


### PR DESCRIPTION
This change does this by adding the maven module pom to the zip.

A reasonable alternative when we have a bit more time would be to convert these modules jar packaging.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.redhat.com/browse/WFLY-17014

Related PR: https://github.com/wildfly/wildfly-core/pull/5211 
A WF Core release with that PR merged is not required before this can be merged.