### PR TITLE
[WFLY-17017] Upgrade Undertow to 2.3.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
         <version.io.smallrye.smallrye-opentracing>3.0.0</version.io.smallrye.smallrye-opentracing>
         <version.io.smallrye.smallrye-reactive-messaging>4.0.0.RC1</version.io.smallrye.smallrye-reactive-messaging>
         <legacy.version.io.undertow>2.2.19.Final</legacy.version.io.undertow>
-        <version.io.undertow>2.3.0.Alpha2</version.io.undertow>
+        <version.io.undertow>2.3.0.Beta1</version.io.undertow>
         <legacy.version.io.undertow.jastow>2.0.11.Final</legacy.version.io.undertow.jastow>
         <version.io.undertow.jastow>2.2.3.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.1</version.io.vertx.vertx>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFLY-17017
WildFly Core PR: https://github.com/wildfly/wildfly-core/pull/5212
WFCORE Jira: https://issues.redhat.com/browse/WFCORE-6056

        Release Notes - Undertow - Version 2.3.0.Beta1
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1902'>UNDERTOW-1902</a>] -         Undertow allows session creation and session ID change after response is committed.
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1934'>UNDERTOW-1934</a>] -         onClose not called when network drops
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1997'>UNDERTOW-1997</a>] -         SecurityPathMatches fails to match default path (&#39;/&#39;) 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2069'>UNDERTOW-2069</a>] -         Filter.destroy can deadlock with running filter on shutdown
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2083'>UNDERTOW-2083</a>] -         bad read timeout message
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2097'>UNDERTOW-2097</a>] -         DMI_RANDOM_USED_ONLY_ONCE error reported by spotbugs
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2109'>UNDERTOW-2109</a>] -         The large file is in unexpected location on JDK17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2112'>UNDERTOW-2112</a>] -         Client Cert Renegotiation Test Case is failing
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2125'>UNDERTOW-2125</a>] -         ReadTimeoutStreamSourceConduit expires when connection is closed
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2140'>UNDERTOW-2140</a>] -         SSLSessionInfo.calculateKeySize(String cipherSuite) doesn&#39;t account for all cipher suits
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2142'>UNDERTOW-2142</a>] -         ChunkedStreamSinkConduit write with a buffer array writes too few buffers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2147'>UNDERTOW-2147</a>] -         race condition between session invalidate and  changeSessionId leads to UT000010
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2160'>UNDERTOW-2160</a>] -         Enhance FileHandlerTestCase.testFileTransferLargeFile
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2117'>UNDERTOW-2117</a>] -         Fix issues found by SonarQube
</li>
</ul>
                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2138'>UNDERTOW-2138</a>] -         Remove JDK8 support from ALPN providers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2145'>UNDERTOW-2145</a>] -         UndertowOutputStream and ServletOutputStreamImpl awaitWritable unnecessarily
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2159'>UNDERTOW-2159</a>] -         InMemorySessionManager#getSession - null check inconsistency
</li>
</ul>
                                                                                                                                            
