### PR TITLE
[WFLY-16238] Don't export traces by default

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
@@ -64,7 +64,6 @@ public class TracerAttributes {
 
     public static final SimpleAttributeDefinition SENDER_BINDING = SimpleAttributeDefinitionBuilder.create(TracerConfigurationConstants.SENDER_AGENT_BINDING, ModelType.STRING, true)
             .setAttributeGroup("sender-configuration")
-            .setAllowExpression(true)
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
@@ -22,17 +22,17 @@
 
 package org.wildfly.extension.microprofile.opentracing;
 
-import org.jboss.logging.BasicLogger;
-import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.annotations.Message;
-import org.jboss.logging.annotations.MessageLogger;
-
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFLYTRACEXT", length = 4)
 public interface TracingExtensionLogger extends BasicLogger {
@@ -81,4 +81,7 @@ public interface TracingExtensionLogger extends BasicLogger {
     OperationFailedException seeDownstream();
     */
 
+    @LogMessage(level = WARN)
+    @Message(id = 12, value="No Jaeger endpoint or sender-binding configured. Installing a no-op sender")
+    void senderNotConfigured();
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16238

If no sender endpoint or agent is configured, configure a no-op sender.
