### PR TITLE
[WFLY-17018] Upgrade WildFly Core to 19.0.0.Beta18 

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
@@ -171,12 +171,11 @@ available). In general this will not cause any deployment descriptors in
 META-INF to be processed, with the exception of `beans.xml`. If a
 `beans.xml` file is present this module will be scanned by Weld and any
 resulting beans will be available to the application.
-* `annotations` If a jandex index has be created for the module these
+* `annotations` If a Jandex index has be created for the module these
 annotations will be merged into the deployments annotation index. The
-https://github.com/jbossas/jandex[Jandex] index can be generated using
-the
-https://github.com/jbossas/jandex/blob/master/src/main/java/org/jboss/jandex/JandexAntTask.java[Jandex
-ant task], and must be named `META-INF/jandex.idx`. Note that it is not
+https://smallrye.io/jandex[Jandex] index can be generated using
+the Jandex Ant task or the Jandex Maven plugin, and must be named
+`META-INF/jandex.idx`. Note that it is not
 necessary to break open the jar being indexed to add this to the modules
 class path, a better approach is to create a jar containing just this
 index, and adding it as an additional resource root in the `module.xml`

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
@@ -557,7 +557,7 @@ depends on OpenJPA, to deploy on WildFly.
         <module name="javax.xml.bind.api"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
     </dependencies>
 </module>
 ----

--- a/ee-9/source-transform/datasources-agroal/pom.xml
+++ b/ee-9/source-transform/datasources-agroal/pom.xml
@@ -72,7 +72,7 @@
         <!-- Other deps -->
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <exclusions>
                 <exclusion>

--- a/ee-9/source-transform/jpa/spi/pom.xml
+++ b/ee-9/source-transform/jpa/spi/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
 

--- a/ee-9/source-transform/jpa/subsystem/pom.xml
+++ b/ee-9/source-transform/jpa/subsystem/pom.xml
@@ -207,7 +207,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
 

--- a/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
+++ b/ee-9/source-transform/microprofile/jwt-smallrye/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>jboss-dmr</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/ee-9/source-transform/rts/pom.xml
+++ b/ee-9/source-transform/rts/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <!-- skip org.jboss.vfs -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/ee-9/source-transform/weld/webservices/pom.xml
+++ b/ee-9/source-transform/weld/webservices/pom.xml
@@ -58,7 +58,7 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss</groupId>
+         <groupId>io.smallrye</groupId>
          <artifactId>jandex</artifactId>
       </dependency>
 

--- a/ee-9/source-transform/xts/pom.xml
+++ b/ee-9/source-transform/xts/pom.xml
@@ -119,7 +119,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsMethodParameterProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsMethodParameterProcessor.java
@@ -12,6 +12,7 @@ import org.jboss.as.server.deployment.annotation.CompositeIndex;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.modules.Module;
 
@@ -232,10 +233,11 @@ public class JaxrsMethodParameterProcessor implements DeploymentUnitProcessor {
                 }
             }
 
+            Index tmpIndex = indexer.complete();
             List<ClassInfo> paramConverterList =
-                    indexer.complete().getKnownDirectImplementors(PARAM_CONVERTER_DOTNAME);
+                    tmpIndex.getKnownDirectImplementors(PARAM_CONVERTER_DOTNAME);
             List<ClassInfo> paramConverterProviderList =
-                    indexer.complete().getKnownDirectImplementors(PARAM_CONVERTER_PROVIDER_DOTNAME);
+                    tmpIndex.getKnownDirectImplementors(PARAM_CONVERTER_PROVIDER_DOTNAME);
             paramConverterSet.addAll(paramConverterList);
             paramConverterSet.addAll(paramConverterProviderList);
 
@@ -341,12 +343,11 @@ public class JaxrsMethodParameterProcessor implements DeploymentUnitProcessor {
         ArrayList<String> classNameArr = new ArrayList<>();
 
         if (isFromUnitTest) {
-            Indexer indexer = new Indexer();
             for (String className : knownResourceClasses) {
                 try {
                     String pathName = className.replace(".", File.separator);
                     InputStream stream = classLoader.getResourceAsStream(pathName + ".class");
-                    ClassInfo classInfo = indexer.index(stream);
+                    ClassInfo classInfo = Index.singleClass(stream);
 
                     List<AnnotationInstance> defaultValuesList =
                             classInfo.annotationsMap().get(DEFAULT_VALUE_DOTNAME);

--- a/jpa/spi/pom.xml
+++ b/jpa/spi/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
 

--- a/microprofile/fault-tolerance-smallrye/extension/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/extension/pom.xml
@@ -70,7 +70,7 @@
             <artifactId>jboss-dmr</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/jwt-smallrye/pom.xml
+++ b/microprofile/jwt-smallrye/pom.xml
@@ -66,7 +66,7 @@
             <artifactId>jboss-dmr</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta17</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta18</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.15.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.5</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.open-api>3.0.0-RC4</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>3.0.0</version.io.smallrye.open-api>
         <legacy.version.io.smallrye.opentracing>2.0.0</legacy.version.io.smallrye.opentracing>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <legacy.version.io.smallrye.smallrye-common>1.12.0</legacy.version.io.smallrye.smallrye-common>
@@ -1712,6 +1712,8 @@
                                             <exclude>trove:trove</exclude>
                                             <exclude>woodstox:wstx-lgpl</exclude>
                                             <exclude>xml-apis:xml-apis</exclude>
+                                            <!-- Jandex moved to SmallRye -->
+                                            <exclude>org.jboss:jandex</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                     <dependencyConvergence></dependencyConvergence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarManifestDependencyPropagatedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarManifestDependencyPropagatedTestCase.java
@@ -48,7 +48,7 @@ public class EarManifestDependencyPropagatedTestCase {
         JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class,"ejbmodule.jar");
         ejbJar.addClasses(EarManifestDependencyPropagatedTestCase.class);
         ejbJar.addAsManifestResource(emptyEjbJar(), "ejb-jar.xml");
-        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jandex\n"),"MANIFEST.MF");
+        ejbJar.addAsManifestResource(new StringAsset("Dependencies: io.smallrye.jandex\n"),"MANIFEST.MF");
         ear.addAsModule(ejbJar);
 
         JavaArchive earLib = ShrinkWrap.create(JavaArchive.class, "libjar.jar");

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/ExternalBeanArchiveProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/ExternalBeanArchiveProcessor.java
@@ -66,7 +66,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.Indexer;
 import org.jboss.modules.DependencySpec;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleDependencySpec;
@@ -308,10 +307,9 @@ public class ExternalBeanArchiveProcessor implements DeploymentUnitProcessor {
                 };
             } else {
                 // Build ClassInfo on the fly
-                Indexer indexer = new Indexer();
                 consumer = (name, classFile) -> {
                     try (InputStream in = classFile.openStream()) {
-                        ClassInfo classInfo = indexer.index(in);
+                        ClassInfo classInfo = Index.singleClass(in);
                         allKnownClasses.add(name);
                         if (classInfo != null && hasBeanDefiningAnnotation(classInfo, beanDefiningAnnotations)) {
                             discoveredBeanClasses.add(name);

--- a/weld/webservices/pom.xml
+++ b/weld/webservices/pom.xml
@@ -29,7 +29,7 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss</groupId>
+         <groupId>io.smallrye</groupId>
          <artifactId>jandex</artifactId>
       </dependency>
 


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17018

Includes:
https://issues.redhat.com/browse/WFLY-16917

Supersedes:
https://github.com/wildfly/wildfly/pull/15987

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Beta18
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta17...19.0.0.Beta18

---

<details>
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6048'>WFCORE-6048</a>] -         Add license entries for the artifacts that are fully driven by WildFly Core
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6055'>WFCORE-6055</a>] -         Make Galleon provisioning content zips unique per release
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6026'>WFCORE-6026</a>] -         Upgrade Elytron to 2.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6027'>WFCORE-6027</a>] -         Upgrade Elytron Web to 3.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6037'>WFCORE-6037</a>] -         Upgrade Jandex to 3.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6046'>WFCORE-6046</a>] -         Upgrade snakeyaml to 1.31 (resolves CVE-2022-25857)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6047'>WFCORE-6047</a>] -         Upgrade Jakarta JSON Processing to 2.1.1 and Eclipse Parsson to 1.1.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6049'>WFCORE-6049</a>] -         Upgrade WildFly Elytron EE to 3.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6051'>WFCORE-6051</a>] -         Upgrade legacy Elytron Web to 1.10.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6053'>WFCORE-6053</a>] -         [CVE-2022-0084] Upgrade XNIO to 3.8.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6054'>WFCORE-6054</a>] -         Upgrade Galleon plugins to 6.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6056'>WFCORE-6056</a>] -         Upgrade Undertow to 2.3.0.Beta1
</li>
</ul>
</details>