### PR TITLE
WFLY-16952 JsonSchemaValidationTest failed with a java.lang.NoClassDefFoundError

### DIFF
--- a/testsuite/integration/microprofile-tck/health/pom.xml
+++ b/testsuite/integration/microprofile-tck/health/pom.xml
@@ -75,6 +75,13 @@
         </dependency>
 
         <dependency>
+            <!-- This is a transitive dep of com.google.guava -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <!-- WFLY-15265. This is a workaround for an unclear dep tree pollution problem.
                  TODO Remove this if elytron aligns its version with WF or some other solution is found. -->
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16952

This PR needs to be merged before merging the PR: https://github.com/wildfly/wildfly-core/pull/5190 for issue: https://issues.redhat.com/browse/WFCORE-5979