### PR TITLE
[WFLY-16970] ValueManagedReferenceFactory must use j.u.f.Supplier instead of o.j.m.v.Value

### DIFF
--- a/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationFactoryDeployer.java
+++ b/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationFactoryDeployer.java
@@ -44,7 +44,6 @@ import org.jboss.as.weld.WeldCapability;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Creates a Jakarta Bean Validation factory and adds it to the deployment and binds it to JNDI.
@@ -102,7 +101,7 @@ public class BeanValidationFactoryDeployer implements DeploymentUnitProcessor {
     private void bindServices(LazyValidatorFactory factory, ServiceTarget serviceTarget, EEModuleDescription description, String componentName, ServiceName contextServiceName) {
 
         BinderService validatorFactoryBindingService = new BinderService("ValidatorFactory");
-        validatorFactoryBindingService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(factory)));
+        validatorFactoryBindingService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(factory));
         serviceTarget.addService(contextServiceName.append("ValidatorFactory"), validatorFactoryBindingService)
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, validatorFactoryBindingService.getNamingStoreInjector())
             .install();

--- a/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationFactoryResourceReferenceProcessor.java
+++ b/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationFactoryResourceReferenceProcessor.java
@@ -33,7 +33,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Handled resource injections for the Validator Factory
@@ -61,7 +60,7 @@ public class BeanValidationFactoryResourceReferenceProcessor implements EEResour
         @Override
         public void getResourceValue(final ResolutionContext resolutionContext, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
             final ClassLoader classLoader = phaseContext.getDeploymentUnit().getAttachment(Attachments.MODULE).getClassLoader();
-            injector.inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(new LazyValidatorFactory(classLoader))));
+            injector.inject(new ValueManagedReferenceFactory(new LazyValidatorFactory(classLoader)));
         }
     }
 }

--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/component/EnvEntryInjectionSource.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/component/EnvEntryInjectionSource.java
@@ -28,7 +28,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * A description of an env-entry.
@@ -48,7 +47,7 @@ public final class EnvEntryInjectionSource extends InjectionSource {
     }
 
     public void getResourceValue(final ResolutionContext resolutionContext, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
-        injector.inject(new ValueManagedReferenceFactory(new ImmediateValue(value)));
+        injector.inject(new ValueManagedReferenceFactory(value));
     }
 
     public boolean equals(final Object injectionSource) {

--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/ApplicationContextProcessor.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/ApplicationContextProcessor.java
@@ -34,7 +34,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Deployment processor that deploys a naming context for the current application.
@@ -62,7 +61,7 @@ public class ApplicationContextProcessor implements DeploymentUnitProcessor {
         serviceTarget.addService(applicationContextServiceName, contextService).install();
         final ServiceName appNameServiceName = applicationContextServiceName.append("AppName");
         final BinderService applicationNameBinder = new BinderService("AppName");
-        applicationNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(moduleDescription.getApplicationName())));
+        applicationNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(moduleDescription.getApplicationName()));
         serviceTarget.addService(appNameServiceName, applicationNameBinder)
                 .addDependency(applicationContextServiceName, ServiceBasedNamingStore.class, applicationNameBinder.getNamingStoreInjector())
                 .install();

--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
@@ -41,7 +41,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Processor responsible for binding java:comp/InAppClientContainer
@@ -86,7 +85,7 @@ public class InApplicationClientBindingProcessor implements DeploymentUnitProces
     private void bindServices(DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, ServiceName contextServiceName) {
         BinderService inAppClientContainerService = new BinderService("InAppClientContainer");
         final ServiceName inAppClientServiceName = contextServiceName.append("InAppClientContainer");
-        inAppClientContainerService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(appclient)));
+        inAppClientContainerService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(appclient));
         serviceTarget.addService(inAppClientServiceName, inAppClientContainerService)
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, inAppClientContainerService.getNamingStoreInjector())
             .install();

--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/ModuleContextProcessor.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/naming/ModuleContextProcessor.java
@@ -39,7 +39,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
 import static org.jboss.as.ee.naming.Attachments.MODULE_CONTEXT_CONFIG;
@@ -76,7 +75,7 @@ public class ModuleContextProcessor implements DeploymentUnitProcessor {
 
         final ServiceName moduleNameServiceName = moduleContextServiceName.append("ModuleName");
         final BinderService moduleNameBinder = new BinderService("ModuleName");
-        moduleNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(moduleDescription.getModuleName())));
+        moduleNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(moduleDescription.getModuleName()));
         serviceTarget.addService(moduleNameServiceName, moduleNameBinder)
                 .addDependency(moduleContextServiceName, ServiceBasedNamingStore.class, moduleNameBinder.getNamingStoreInjector())
                 .install();

--- a/ee/src/main/java/org/jboss/as/ee/component/EnvEntryInjectionSource.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/EnvEntryInjectionSource.java
@@ -28,7 +28,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * A description of an env-entry.
@@ -48,7 +47,7 @@ public final class EnvEntryInjectionSource extends InjectionSource {
     }
 
     public void getResourceValue(final ResolutionContext resolutionContext, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
-        injector.inject(new ValueManagedReferenceFactory(new ImmediateValue(value)));
+        injector.inject(new ValueManagedReferenceFactory(value));
     }
 
     public boolean equals(final Object injectionSource) {

--- a/ee/src/main/java/org/jboss/as/ee/naming/ApplicationContextProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/naming/ApplicationContextProcessor.java
@@ -34,7 +34,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Deployment processor that deploys a naming context for the current application.
@@ -62,7 +61,7 @@ public class ApplicationContextProcessor implements DeploymentUnitProcessor {
         serviceTarget.addService(applicationContextServiceName, contextService).install();
         final ServiceName appNameServiceName = applicationContextServiceName.append("AppName");
         final BinderService applicationNameBinder = new BinderService("AppName");
-        applicationNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(moduleDescription.getApplicationName())));
+        applicationNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(moduleDescription.getApplicationName()));
         serviceTarget.addService(appNameServiceName, applicationNameBinder)
                 .addDependency(applicationContextServiceName, ServiceBasedNamingStore.class, applicationNameBinder.getNamingStoreInjector())
                 .install();

--- a/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
@@ -41,7 +41,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Processor responsible for binding java:comp/InAppClientContainer
@@ -86,7 +85,7 @@ public class InApplicationClientBindingProcessor implements DeploymentUnitProces
     private void bindServices(DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, ServiceName contextServiceName) {
         BinderService inAppClientContainerService = new BinderService("InAppClientContainer");
         final ServiceName inAppClientServiceName = contextServiceName.append("InAppClientContainer");
-        inAppClientContainerService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(appclient)));
+        inAppClientContainerService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(appclient));
         serviceTarget.addService(inAppClientServiceName, inAppClientContainerService)
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, inAppClientContainerService.getNamingStoreInjector())
             .install();

--- a/ee/src/main/java/org/jboss/as/ee/naming/ModuleContextProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/naming/ModuleContextProcessor.java
@@ -39,7 +39,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
 import static org.jboss.as.ee.naming.Attachments.MODULE_CONTEXT_CONFIG;
@@ -76,7 +75,7 @@ public class ModuleContextProcessor implements DeploymentUnitProcessor {
 
         final ServiceName moduleNameServiceName = moduleContextServiceName.append("ModuleName");
         final BinderService moduleNameBinder = new BinderService("ModuleName");
-        moduleNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(moduleDescription.getModuleName())));
+        moduleNameBinder.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(moduleDescription.getModuleName()));
         serviceTarget.addService(moduleNameServiceName, moduleNameBinder)
                 .addDependency(moduleContextServiceName, ServiceBasedNamingStore.class, moduleNameBinder.getNamingStoreInjector())
                 .install();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/IIOPJndiBindingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/IIOPJndiBindingProcessor.java
@@ -40,7 +40,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 import org.omg.CORBA.ORB;
 import org.wildfly.iiop.openjdk.deployment.IIOPDeploymentMarker;
 import org.wildfly.iiop.openjdk.service.CorbaORBService;
@@ -105,7 +104,7 @@ public class IIOPJndiBindingProcessor implements DeploymentUnitProcessor {
 
         final ServiceName handleDelegateServiceName = contextServiceName.append("HandleDelegate");
         final BinderService handleDelegateBindingService = new BinderService("HandleDelegate");
-        handleDelegateBindingService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(new HandleDelegateImpl(module.getClassLoader()))));
+        handleDelegateBindingService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new HandleDelegateImpl(module.getClassLoader())));
         serviceTarget.addService(handleDelegateServiceName, handleDelegateBindingService)
                 .addDependency(contextServiceName, ServiceBasedNamingStore.class, handleDelegateBindingService.getNamingStoreInjector())
                 .install();

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaServiceUtil.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaServiceUtil.java
@@ -27,7 +27,6 @@ import org.jboss.as.naming.ValueManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * <p>
@@ -58,7 +57,7 @@ public class CorbaServiceUtil {
      */
     public static void bindObject(final ServiceTarget target, final String contextName, final Object value) {
         final BinderService binderService = new BinderService(contextName);
-        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(value)));
+        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(value));
         target.addService(ContextNames.buildServiceName(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, contextName), binderService)
                 .addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
                 .install();

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -104,7 +104,6 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 import org.jipijapa.plugin.spi.ManagementAdaptor;
 import org.jipijapa.plugin.spi.PersistenceProviderAdaptor;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
@@ -701,12 +700,11 @@ public class PersistenceUnitServiceHandler {
                     public void inject(final PersistenceUnitServiceImpl value) throws
                             InjectionException {
                         binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(
-                                new ImmediateValue<Object>(
                                         new TransactionScopedEntityManager(
                                                 pu.getScopedPersistenceUnitName(),
                                                 Collections.emptyMap(),
                                                 value.getEntityManagerFactory(),
-                                                SynchronizationType.SYNCHRONIZED, transactionSynchronizationRegistry, transactionManager))));
+                                                SynchronizationType.SYNCHRONIZED, transactionSynchronizationRegistry, transactionManager)));
                     }
 
                     @Override
@@ -735,7 +733,7 @@ public class PersistenceUnitServiceHandler {
                     @Override
                     public void inject(final PersistenceUnitServiceImpl value) throws
                             InjectionException {
-                        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value.getEntityManagerFactory())));
+                        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(value.getEntityManagerFactory()));
                     }
 
                     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BinderServiceUtil.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BinderServiceUtil.java
@@ -41,7 +41,6 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * Utility class to install BinderService (either to bind actual objects or create alias on another binding).
@@ -62,7 +61,7 @@ public class BinderServiceUtil {
                                                  final Object obj) {
         final BindInfo bindInfo = ContextNames.bindInfoFor(name);
         final BinderService binderService = new BinderService(bindInfo.getBindName());
-        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue(obj)));
+        binderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(obj));
         serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
                 .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
                 .install();

--- a/naming/src/main/java/org/jboss/as/naming/ManagedReferenceInjector.java
+++ b/naming/src/main/java/org/jboss/as/naming/ManagedReferenceInjector.java
@@ -23,7 +23,6 @@ package org.jboss.as.naming;
 
 import org.jboss.msc.inject.InjectionException;
 import org.jboss.msc.inject.Injector;
-import org.jboss.msc.value.ImmediateValue;
 
 /**
  * A n adaptor between value injectors and ManagedReferenceFactory
@@ -40,7 +39,7 @@ public class ManagedReferenceInjector<T> implements Injector<T> {
 
     @Override
     public void inject(T value) throws InjectionException {
-        injectable.inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
+        injectable.inject(new ValueManagedReferenceFactory(value));
     }
 
     @Override

--- a/naming/src/main/java/org/jboss/as/naming/ValueManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ValueManagedReferenceFactory.java
@@ -23,37 +23,49 @@
 package org.jboss.as.naming;
 
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 import org.jboss.msc.value.Value;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
- * A JNDI injectable which simply uses an MSC {@link Value}
- * to fetch the injected value, and takes no action when the value is returned.
+ * A JNDI injectable which simply uses a value and takes no action when the value is returned.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author Eduardo Martins
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public final class ValueManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
-    private final Value<?> value;
+    private final Supplier<?> value;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param value the value to wrap
+     * @deprecated use {@link ValueManagedReferenceFactory#ValueManagedReferenceFactory(Object)} instead. This constructor will be removed in the future.
+     */
+    @Deprecated
+    public ValueManagedReferenceFactory(final Value<?> value) {
+        this.value = () -> value.getValue();
+    }
 
     /**
      * Construct a new instance.
      *
      * @param value the value to wrap
      */
-    public ValueManagedReferenceFactory(final Value<?> value) {
-        this.value = value;
+    public ValueManagedReferenceFactory(final Object value) {
+        this.value = () -> value;
     }
 
     @Override
     public ManagedReference getReference() {
-        return new ValueManagedReference(value.getValue());
+        return new ValueManagedReference(value.get());
     }
 
     @Override
     public String getInstanceClassName() {
-        final Object instance = value != null ? value.getValue() : null;
+        final Object instance = value != null ? value.get() : null;
         if(instance == null) {
             return ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
         }
@@ -62,7 +74,7 @@ public final class ValueManagedReferenceFactory implements ContextListAndJndiVie
 
     @Override
     public String getJndiViewInstanceValue() {
-        final Object instance = value != null ? value.getValue() : null;
+        final Object instance = value != null ? value.get() : null;
         if (instance == null) {
             return "null";
         }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingAdd.java
@@ -60,7 +60,6 @@ import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -115,7 +114,7 @@ public class NamingBindingAdd extends AbstractAddStepHandler {
 
         Object bindValue = createSimpleBinding(context, model);
 
-        ValueManagedReferenceFactory referenceFactory = new ValueManagedReferenceFactory(new ImmediateValue<Object>(bindValue));
+        ValueManagedReferenceFactory referenceFactory = new ValueManagedReferenceFactory(bindValue);
 
 
         final BinderService binderService = new BinderService(name, bindValue);
@@ -321,7 +320,7 @@ public class NamingBindingAdd extends AbstractAddStepHandler {
             final BindingType type = BindingType.forName(NamingBindingResourceDefinition.BINDING_TYPE.resolveModelAttribute(context, model).asString());
             if (type == BindingType.SIMPLE) {
                 Object bindValue = createSimpleBinding(context, model);
-                factory.setFactory(new ValueManagedReferenceFactory(new ImmediateValue<Object>(bindValue)));
+                factory.setFactory(new ValueManagedReferenceFactory(bindValue));
                 service.setSource(bindValue);
             } else if (type == BindingType.OBJECT_FACTORY) {
                 final ObjectFactory objectFactoryClassInstance = createObjectFactory(context, model);

--- a/naming/src/test/java/org/jboss/as/naming/ServiceBasedNamingStoreTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/ServiceBasedNamingStoreTestCase.java
@@ -41,7 +41,6 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.ImmediateValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -410,7 +409,7 @@ public class ServiceBasedNamingStoreTestCase {
             }
 
             public ManagedReferenceFactory getValue() throws IllegalStateException, IllegalArgumentException {
-                return new ValueManagedReferenceFactory(new ImmediateValue(value));
+                return new ValueManagedReferenceFactory(value);
             }
         }).install();
         latch.await();

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -90,7 +90,6 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.value.ImmediateValue;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.tm.ExtendedJBossXATerminator;
 import org.jboss.tm.JBossXATerminator;
@@ -276,7 +275,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         tmBuilder.addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
             @Override
             public void inject(final javax.transaction.TransactionManager value) throws InjectionException {
-                tmBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
+                tmBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(value));
             }
 
             @Override
@@ -292,7 +291,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         tmLegacyBuilder.addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
             @Override
             public void inject(final javax.transaction.TransactionManager value) throws InjectionException {
-                tmLegacyBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
+                tmLegacyBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(value));
             }
 
             @Override
@@ -308,7 +307,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         tsrBuilder.addDependency(TransactionSynchronizationRegistryService.INTERNAL_SERVICE_NAME, TransactionSynchronizationRegistry.class, new Injector<TransactionSynchronizationRegistry>() {
             @Override
             public void inject(final TransactionSynchronizationRegistry value) throws InjectionException {
-                tsrBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
+                tsrBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(value));
             }
 
             @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16970

Is related to https://github.com/wildfly/wildfly/pull/16071
