### PR TITLE
[WFLY-16296] Re-enable the testsuite/integration/legacy-ejb-client EJ…

### DIFF
--- a/testsuite/integration/legacy-ejb-client/pom.xml
+++ b/testsuite/integration/legacy-ejb-client/pom.xml
@@ -30,6 +30,9 @@
         <!-- Use the legacy javax.* testsuite/shared as it's used client-side and client-side is currently javax.* -->
         <wildfly-testsuite-shared.artifactId>wildfly-testsuite-shared</wildfly-testsuite-shared.artifactId>
 
+        <!-- Tell the server to run in javax<->jakarta interop mode -->
+        <extra.server.jvm.args>-Dorg.wildfly.ee.namespace.interop=true</extra.server.jvm.args>
+
     </properties>
 
     <dependencies>

--- a/testsuite/integration/legacy-ejb-client/src/test/java/org/jboss/as/test/integration/legacy/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
+++ b/testsuite/integration/legacy-ejb-client/src/test/java/org/jboss/as/test/integration/legacy/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
@@ -49,7 +49,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -249,7 +248,6 @@ public class EJBClientAPIUsageTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("WFLY-16646")
     public void testNonExistentViewForEJB() throws Exception {
         final StatelessEJBLocator<NotAnEJBInterface> locator = new StatelessEJBLocator<NotAnEJBInterface>(NotAnEJBInterface.class, APP_NAME, MODULE_NAME, EchoBean.class.getSimpleName(), "");
         final NotAnEJBInterface nonExistentBean = EJBClient.createProxy(locator);
@@ -292,7 +290,6 @@ public class EJBClientAPIUsageTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("WFLY-16646")
     public void testSystemExceptionOnSLSBMethod() throws Exception {
         final StatelessEJBLocator<ExceptionThrowingRemote> locator = new StatelessEJBLocator<ExceptionThrowingRemote>(ExceptionThrowingRemote.class, APP_NAME, MODULE_NAME, ExceptionThrowingBean.class.getSimpleName(), "");
         final ExceptionThrowingRemote exceptionThrowingBean = EJBClient.createProxy(locator);


### PR DESCRIPTION
…BClientAPIUsageTestCase tests that test propagation of EE exception types

https://issues.redhat.com/browse/WFLY-16296

This is a follow-up to #16078 to re-enable a couple tests that the WFLY-16296 work now allows to pass, and which serve as a test of one aspect of EE 8<->10 interop.

This is the main thing discussed on WFLY-16646, but I didn't use that JIRA for it, as that one mentions a couple other less important things that @chengfang may (or may not) plan on looking into.

@fl4via @ropalka @tadamski @msve FYI.