### PR TITLE
[WFLY-16988] Limit the JPMS setting needed by AbstactUnmarshallingFil…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,23 @@
         <!-- TarArchiver behavior -->
         <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
 
-        <!-- Modularized JDK support (various workarounds) - activated via profile -->
+        <!--
+            Modularized JDK support. These are our recommended client-side JPMS settings.
+            This list should only be modified if we are making a change to our general
+            recommendation of what settings an external *client* application should use
+            *in order to utilize our client-side libraries*. It is not meant to cover
+            settings a client app might need to support it's own code.
+
+            This list is not meant to control server-side JPMS settings.
+
+            DO NOT add entries here just to support JPMS needs for specialized tests.
+            The testsuite/pom.xml declares a 'modular.jdk.testsuite.args' property that
+            defaults to ${modular.jdk.args}, i.e. this list. If particular tests need
+            additional settings to support client-side behavior in their test code,
+            then that property should be overridden in as fine-grained a location as
+            practical, and no more coarse-grained than the global config of the pom
+            for the maven module that includes the test.
+         -->
         <modular.jdk.args>
             --add-exports=java.desktop/sun.awt=ALL-UNNAMED
             --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
@@ -166,7 +182,6 @@
             --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
             --add-opens=java.management/javax.management=ALL-UNNAMED
             --add-opens=java.naming/javax.naming=ALL-UNNAMED
-            --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED
         </modular.jdk.args>
         <modular.jdk.props></modular.jdk.props>
 

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -34,7 +34,7 @@
         <!-- Disable the default surefire test execution. -->
         <surefire.default-test.phase>none</surefire.default-test.phase>
 
-        <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.base/sun.security.validator=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED</modular.jdk.testsuite.args>
+        <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/javax.crypto=ALL-UNNAMED --add-opens=java.base/sun.security.validator=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED  --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED</modular.jdk.testsuite.args>
     </properties>
 
     <dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -159,6 +159,13 @@
         <surefire.memory.args>-Xmx512m -XX:MetaspaceSize=128m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
+        <!-- The JPMS settings needed by the client side of a portion of the testsuite.
+             Defaults to ${modular.jdk.args}, i.e. the standard list of recommended
+             client side JPMS settings for users of our client-side libraries.
+             If particular tests need additional settings to support client-side behavior
+             in their test code, then this property should be overridden in as fine-grained
+             a location as is practical; no more coarse-grained than the global config of
+             the pom for the maven module that includes the test. -->
         <modular.jdk.testsuite.args>${modular.jdk.args}</modular.jdk.testsuite.args>
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />


### PR DESCRIPTION
…terTestCase to testsuite/integration/basic

https://issues.redhat.com/browse/WFLY-16988

Follow up to #16067 to adjust something I overlooked in code review. Plus adds some missing documentation to better explain how testsuite JPMS config is meant to work.