### PR TITLE
[WFLY-16808] Upgrade RESTEasy MicroProfile dependencies to 2.0.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
         <version.org.jboss.openjdk-orb>8.1.9.Final</version.org.jboss.openjdk-orb>
         <legacy.version.org.jboss.resteasy>4.7.4.Final</legacy.version.org.jboss.resteasy>
         <version.org.jboss.resteasy>6.2.0.Beta1</version.org.jboss.resteasy>
-        <version.org.jboss.resteasy.microprofile>2.0.0.Beta1</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.microprofile>2.0.0.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.0.Beta1</version.org.jboss.resteasy.spring>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16808
Signed-off-by: James R. Perkins <jperkins@redhat.com>

---
Tag: https://github.com/resteasy/resteasy-microprofile/releases/tag/2.0.0.Final
Diff: https://github.com/resteasy/resteasy-microprofile/compare/2.0.0.Beta1...2.0.0.Final