### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -19,6 +19,7 @@ env:
   RESULT_POLL_WAIT_SECONDS: 300
   #   Maximum number of polls before we time out
   RESULT_MAX_POLL_ATTEMPTS: 10
+permissions: {}
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/dep-diff-workflow_run.yml
+++ b/.github/workflows/dep-diff-workflow_run.yml
@@ -13,8 +13,12 @@ env:
   DEPS_CHANGED_LABEL_NAME: deps-changed
   # People/teams to mention in the PR comment if dependencies changed
   CHANGE_MENTIONS: '@wildfly/prod'
+permissions: {}
 jobs:
   compare:
+    permissions:
+      actions: read # to download a workflow artifact
+      pull-requests: write # for commenting on and labeling pull requests
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.