### PR TITLE
[WFLY-16854] [WFLY-17023] [WFLY-17024] Update dependencies for Opentelemetry and MicroProfile OpenTracing

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -2052,6 +2052,30 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jgroups</groupId>
                 <artifactId>jgroups</artifactId>
                 <version>${version.org.jgroups}</version>

--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -462,6 +462,12 @@
                 <version>${version.com.fasterxml.jackson}</version>
             </dependency>
 
+	    <dependency>
+                <groupId>com.fasterxml.jackson.jr</groupId>
+                <artifactId>jackson-jr-objects</artifactId>
+                <version>${version.com.fasterxml.jackson.jr.jackson-jr-objects}</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
@@ -610,8 +616,8 @@
 
             <dependency>
                 <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>${version.com.squareup.okio}</version>
+                <artifactId>okio-jvm</artifactId>
+                <version>${version.com.squareup.okio-jvm}</version>
             </dependency>
 
             <dependency>
@@ -2049,6 +2055,42 @@
                 <groupId>org.jctools</groupId>
                 <artifactId>jctools-core</artifactId>
                 <version>${version.org.jctools.jctools-core}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -2083,6 +2083,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk7</artifactId>
+                <version>${version.org.jetbrains.kotlin}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jgroups</groupId>
                 <artifactId>jgroups</artifactId>
                 <version>${version.org.jgroups}</version>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -101,6 +101,17 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.sun.faces</groupId>
             <artifactId>jsf-impl</artifactId>
             <exclusions>
@@ -1688,7 +1699,7 @@
 
         <dependency>
             <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
+            <artifactId>okio-jvm</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -3149,6 +3160,39 @@
         <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -2503,16 +2503,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jctools</groupId>
             <artifactId>jctools-core</artifactId>
         </dependency>
@@ -3164,34 +3154,21 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk7</artifactId>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -2503,6 +2503,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jctools</groupId>
             <artifactId>jctools-core</artifactId>
         </dependency>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -4232,6 +4232,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk7</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups</artifactId>
       <licenses>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -112,6 +112,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.jr</groupId>
+      <artifactId>jackson-jr-objects</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <licenses>
@@ -302,7 +313,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
+      <artifactId>okio-jvm</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>
@@ -4206,6 +4217,39 @@
     <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
@@ -30,10 +30,14 @@
 
     <resources>
         <artifact name="${com.squareup.okhttp3:okhttp}"/>
-        <artifact name="${com.squareup.okio:okio}"/>
+        <artifact name="${com.squareup.okio:okio-jvm}"/>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib}"/>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-common}"/>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-jdk8}"/>
     </resources>
 
     <dependencies>
         <module name="java.logging"/>
     </dependencies>
 </module>
+

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/com/squareup/okhttp3/main/module.xml
@@ -34,6 +34,8 @@
     </resources>
 
     <dependencies>
+        <module name="org.jetbrains.kotlin.kotlin-stdlib"/>
+
         <module name="java.logging"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/trace/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/trace/main/module.xml
@@ -32,18 +32,18 @@
         <artifact name="${io.opentelemetry:opentelemetry-exporter-jaeger}"/>
         <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp-common}"/>
         <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp-trace}"/>
+        <artifact name="${com.fasterxml.jackson.jr:jackson-jr-objects}"/>
     </resources>
 
     <dependencies>
         <module name="io.opentelemetry.api"/>
         <module name="io.opentelemetry.context"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.squareup.okhttp3"/>
         <module name="org.slf4j"/>
-        <module name="io.grpc"/>
-        <module name="com.google.guava" />
-        <module name="com.google.code.gson"/>
 
         <module name="java.logging"/>
         <module name="jdk.unsupported"/>
     </dependencies>
 </module>
+

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jetbrains/kotlin/kotlin-stdlib/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jetbrains/kotlin/kotlin-stdlib/main/module.xml
@@ -26,6 +26,7 @@
         <artifact name="${org.jetbrains.kotlin:kotlin-stdlib}"/>
         <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-common}"/>
         <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-jdk8}"/>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-jdk7}"/>
     </resources>
 
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jetbrains/kotlin/kotlin-stdlib/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jetbrains/kotlin/kotlin-stdlib/main/module.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.jetbrains.kotlin.kotlin-stdlib">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib}"/>
+        <artifact name="${org.jetbrains.kotlin:kotlin-stdlib-common}"/>
+    </resources>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,7 @@
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.jr.jackson-jr-objects>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.jr.jackson-jr-objects>
         <version.com.github.ben-manes.caffeine>2.9.3</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
@@ -316,7 +317,7 @@
         <version.com.nimbus.jose-jwt>9.23</version.com.nimbus.jose-jwt>
         <legacy.version.com.squareup.okhttp>3.14.9</legacy.version.com.squareup.okhttp>
         <version.com.squareup.okhttp>4.10.0</version.com.squareup.okhttp>
-        <version.com.squareup.okio>1.17.5</version.com.squareup.okio>
+        <version.com.squareup.okio-jvm>3.2.0</version.com.squareup.okio-jvm>
         <legacy.version.com.sun.activation.jakarta.activation>1.2.2</legacy.version.com.sun.activation.jakarta.activation>
         <legacy.version.com.sun.faces>2.3.17.SP01</legacy.version.com.sun.faces>
         <version.com.sun.faces>4.0.0.SP01</version.com.sun.faces>
@@ -560,6 +561,7 @@
         <version.org.jboss.ws.spi>4.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
+        <version.org.jetbrains.kotlin>1.7.10</version.org.jetbrains.kotlin>
         <version.org.jgroups>4.2.21.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.3.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.16.Final</version.org.jgroups.kubernetes>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <version.com.nimbus.jose-jwt>9.23</version.com.nimbus.jose-jwt>
         <legacy.version.com.squareup.okhttp>3.14.9</legacy.version.com.squareup.okhttp>
         <version.com.squareup.okhttp>4.10.0</version.com.squareup.okhttp>
-        <version.com.squareup.okio>1.17.5</version.com.squareup.okio>
+        <version.com.squareup.okio>2.8.0</version.com.squareup.okio>
         <legacy.version.com.sun.activation.jakarta.activation>1.2.2</legacy.version.com.sun.activation.jakarta.activation>
         <legacy.version.com.sun.faces>2.3.17.SP01</legacy.version.com.sun.faces>
         <version.com.sun.faces>4.0.0.SP01</version.com.sun.faces>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,7 @@
         <version.org.jboss.ws.spi>4.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
+        <version.org.jetbrains.kotlin>1.7.10</version.org.jetbrains.kotlin>
         <version.org.jgroups>4.2.21.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.3.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.16.Final</version.org.jgroups.kubernetes>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -114,6 +114,10 @@ public class LayersTestCase {
         "org.wildfly.security.jakarta.client.resteasy",
         "org.wildfly.security.jakarta.client.webservices",
         "org.jboss.resteasy.microprofile.config",
+        // TODO see gRPC proposal
+        "io.grpc",
+        // TODO analysis
+        "com.google.protobuf",
     };
     // Packages that are not referenced from the module graph but needed.
     // This is the expected set of un-referenced modules found when scanning
@@ -129,14 +133,12 @@ public class LayersTestCase {
         "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
         "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
         "io.jaegertracing",
-        "io.grpc",
         "io.smallrye.health",
         "io.smallrye.openapi",
         "io.vertx.client",
         "org.eclipse.microprofile.health.api",
         "org.eclipse.microprofile.openapi.api",
         "com.fasterxml.jackson.dataformat.jackson-dataformat-yaml",
-        "com.google.protobuf",
         "org.jboss.resteasy.resteasy-client-microprofile",
         "io.netty.netty-codec-dns",
         "io.netty.netty-codec-http2",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16854
https://issues.redhat.com/browse/WFLY-17023
https://issues.redhat.com/browse/WFLY-17024

This combines these 3 PRs:

#15961
#16089
#16090

It uses the separate module kotlin artifact packaging approach from #16089 instead of the approach in #15961. I did that because it was easiest to pull things together that way. @jasondlee in the discussion at https://github.com/wildfly/wildfly/pull/15961#discussion_r950076537 it sounded like the #15961 approach was preferable. If so, please follow up with a PR moving to that.

