### PR TITLE
[WFLY-17052]: Upgrade Apache Artemis to 2.26.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
         <version.jsoup>1.15.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.25.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.26.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.11.0</version.org.apache.avro>
         <version.org.apache.cxf>3.5.2-jbossorg-3</version.org.apache.cxf>
@@ -444,7 +444,7 @@
         <version.org.apache.myfaces.core>3.0.2</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>3.1.2</version.org.apache.openjpa>
-        <version.org.apache.qpid.proton>0.33.10</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.34.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.0</version.org.apache.santuario>
         <version.org.apache.thrift>0.14.1</version.org.apache.thrift>
         <version.org.apache.velocity>2.3</version.org.apache.velocity>


### PR DESCRIPTION
- Upgrading Apache Artemis to 2.26.0
- Upgrading qpid proton-j to 0.34.0

Jira: https://issues.redhat.com/browse/WFLY-17052

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>