### PR TITLE
[WFLY-17019] Remove build.shibboleth.net from the repository set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1471,15 +1471,6 @@
             <url>${maven.repository.url}</url>
             <layout>default</layout>
         </repository>
-        <!-- Remove below repo after opensaml 4.2.0 is accessible from maven central repo-->
-        <repository>
-            <id>opensaml-repo</id>
-            <name>opensaml</name>
-            <url>https://build.shibboleth.net/nexus/content/groups/public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17019

The repository.jboss.org public repository group now proxies build.shibboleth.net so we no longer need to declare it.