### PR TITLE
[WFLY-15271]: Update test org.wildfly.test.integration.vdx.standalone…

### DIFF
--- a/testsuite/integration/vdx/src/test/java/org/wildfly/test/integration/vdx/standalone/MessagingTestCase.java
+++ b/testsuite/integration/vdx/src/test/java/org/wildfly/test/integration/vdx/standalone/MessagingTestCase.java
@@ -21,7 +21,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -198,7 +197,6 @@ public class MessagingTestCase extends TestBase {
     @Test
     @ServerConfig(configuration = "standalone-full-ha.xml", xmlTransformationGroovy = "messaging/AddSecurityElementToEndOfSubsystem.groovy",
             subtreeName = "messaging", subsystemName = "messaging-activemq")
-    @Ignore("[WFLY-15271] Update to use a different element as security is in the configuration already.")
     public void testWrongOrderOfElements() throws Exception {
         container().tryStartAndWaitForFail();
         String errorLog = container().getErrorMessageFromServerStart();

--- a/testsuite/integration/vdx/src/test/resources/org/wildfly/test/integration/vdx/transformations/messaging/AddSecurityElementToEndOfSubsystem.groovy
+++ b/testsuite/integration/vdx/src/test/resources/org/wildfly/test/integration/vdx/transformations/messaging/AddSecurityElementToEndOfSubsystem.groovy
@@ -3,5 +3,5 @@ attr = [enabled: 'false']
 def security = {
     security(attr) {}
 }
-
+messaging.server.security.replaceNode({})
 messaging.server.appendNode security


### PR DESCRIPTION
….MessagingTestCase.testWrongOrderOfElements.

* Fixing the groovy scrip to put the security node at the end of the subsystem.

Jira: https://issues.redhat.com/browse/WFLY-15271

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>