### PR TITLE
[WFLY-17051] Add a circular dependency on the JSON Binding API to the…

### DIFF
--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -60,8 +60,6 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             ModuleIdentifier.create("javax.rmi.api"),
             ModuleIdentifier.create("javax.xml.bind.api"),
             ModuleIdentifier.create("javax.api"),
-            // (Jakarta JSON Binding) implementation
-            ModuleIdentifier.create("org.eclipse.yasson"),
             ModuleIdentifier.create(GLASSFISH_EL),
             ModuleIdentifier.create("org.glassfish.javax.enterprise.concurrent")
     };

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -35,7 +35,6 @@
     <dependencies>
         <module name="javax.json.bind.api"/>
         <module name="org.apache.commons.io"/>
-        <module name="org.eclipse.yasson" services="import"/>
         <module name="javax.annotation.api"/>
         <module name="javax.json.api"/>
         <module name="javax.enterprise.api"/>

--- a/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/json/bind/api/main/module.xml
+++ b/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/json/bind/api/main/module.xml
@@ -28,5 +28,10 @@
 
     <dependencies>
         <module name="javax.json.api"/>
+        <!-- Circular dependency on the implementation to ensure that:
+             1. The implementation is loaded
+             2. It is done last via the hard-coded class name in the spec API
+         -->
+        <module name="org.eclipse.yasson"/>
     </dependencies>
 </module>

--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -60,8 +60,6 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             ModuleIdentifier.create("javax.rmi.api"),
             ModuleIdentifier.create("javax.xml.bind.api"),
             ModuleIdentifier.create("javax.api"),
-            // (Jakarta JSON Binding) implementation
-            ModuleIdentifier.create("org.eclipse.yasson"),
             ModuleIdentifier.create(GLASSFISH_EL),
             ModuleIdentifier.create("org.glassfish.javax.enterprise.concurrent")
     };

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
@@ -27,11 +27,9 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,11 +53,6 @@ public class JSONBTestCase {
     @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "jsonb10-test.war").addClasses(JSONBServlet.class);
-    }
-
-    @BeforeClass
-    public static void skipSecurityManager() {
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @Test


### PR DESCRIPTION
… implementation, Yasson. This gets around possible service loader issues when the security manager is used. It instead uses the RI which is Yasson by adding the implementation dependency on the API.

https://issues.redhat.com/browse/WFLY-17051
https://issues.redhat.com/browse/WFLY-11365

This is some what of a hack and I'd like to get @bstansberry's approval before this is merged. This works by skipping the `ServiceLoader` finding any implementations and allows for the hard-coded RI to be tried which gets around the issues with the security manager not being able to read the file.