### PR TITLE
WFLY-16974 Upgrade to Hibernate ORM 6.1.4 to resolve test failures with security manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <legacy.version.org.hibernate>5.3.28.Final</legacy.version.org.hibernate>
-        <version.org.hibernate>6.1.3.Final</version.org.hibernate>
+        <version.org.hibernate>6.1.4.Final</version.org.hibernate>
         <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
         <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.7.Final</version.org.hibernate.search>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/entitytest/EntityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/entitytest/EntityTestCase.java
@@ -40,7 +40,6 @@ import org.jboss.as.test.integration.jpa.hibernate.entity.Company;
 import org.jboss.as.test.integration.jpa.hibernate.entity.Customer;
 import org.jboss.as.test.integration.jpa.hibernate.entity.Flight;
 import org.jboss.as.test.integration.jpa.hibernate.entity.Ticket;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -76,9 +75,6 @@ public class EntityTestCase {
     // This test needs to be recompiled against Hibernate ORM 6 (WFLY-16178) in order to pass.
     @BeforeClass
     public static void beforeClass() {
-
-        // TODO WFLY-16974
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         assumeTrue(System.getProperty("ts.ee9") == null && System.getProperty("ts.bootable.ee9") == null);
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.as.test.integration.jpa.hibernate.Employee;
 import org.jboss.as.test.integration.jpa.hibernate.SFSB1;
 import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSession;
 import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSessionFactory;
-import org.jboss.as.test.shared.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -59,9 +58,6 @@ public class SessionFactoryTestCase {
     // This test needs to be recompiled against Hibernate ORM 6 (WFLY-16178) in order to pass.
     @BeforeClass
     public static void beforeClass() {
-
-        // TODO WFLY-16974
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
 
         assumeTrue(System.getProperty("ts.ee9") == null && System.getProperty("ts.bootable.ee9") == null);
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16974

This change enables to tests that were previously excluded when run with the Java security manager.

To run tests that previously failed with earlier Hibernate ORM versions:
```
cd wildfly/testsuite/integration/basic
mvn clean test -Dtest=SessionFactoryTestCase -Dsecurity.manager
mvn clean test -Dtest=EntityTestCase -Dsecurity.manager
```
