### PR TITLE
[WFLY-17065] Remove the exporting of the services from the circular i…

### DIFF
--- a/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/xml/bind/api/main/module.xml
+++ b/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/xml/bind/api/main/module.xml
@@ -35,7 +35,15 @@
         <module name="jakarta.activation.api" export="true"/>
         <module name="org.eclipse.angus.activation" services="export" export="true"/>
         <module name="javax.xml.stream.api"/>
-        <!-- Export the implementation and services as the TCCL is typically the CL of a deployment -->
-        <module name="org.glassfish.jaxb" services="export" export="true"/>
+        <!-- Export the implementation as the TCCL is typically the CL of a deployment. We do not want to export the
+             services as that would trigger the loading through the service loader. This can be an issue and require
+             special permissions if the security manager is present. Not exporting the services falls back to a default
+             implementation provided by the org.glassfish.jaxb module.
+
+             Please note the comment in WFLY-17065. The org.glassfish.jaxb module includes more than one module. While
+             it is likely not an issue to NOT export the services, it should be noted this currently affects;
+             jaxb-runtime.jar and jaxb-xjc.jar.
+         -->
+        <module name="org.glassfish.jaxb" services="import" export="true"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -3800,10 +3800,6 @@
                                         <!-- Requires the Arquillian Servlet 3.0 protocol to be overridden to Servlet 5.0 -->
                                         <exclude>org/jboss/as/test/integration/logging/config/LoggingProfileSharedTestCase.java</exclude>
 
-                                        <!-- Differences in the API changes for EE 8/9 and EE 10. -->
-                                        <exclude>org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingServicesTestCase.java</exclude>
-
                                     </excludes>
                                 </configuration>
                             </execution>
@@ -3884,9 +3880,6 @@
                                              adapted to rely on Hibernate Search 6 APIs,
                                              so we still test Hibernate Search with EE9. -->
                                         <exclude>org/jboss/as/test/integration/hibernate/search/**</exclude>
-                                        <!-- Differences in the API changes for EE 8/9 and EE 10. -->
-                                        <exclude>org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingServicesTestCase.java</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
…mplementation dependency on the jakarta.xml.bind.api module. This allows the fallback to the hard-coded implementation and works around issues not being able to read files when the security manager is enabled.

Also re-enabled 2 tests that previously had to be ignored due to EE 8/EE 10 conflicts.

https://issues.redhat.com/browse/WFLY-17065