### PR TITLE
[WFLY-17107] Upgrade Undertow legacy to 2.2.20.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>2.26.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-opentracing>3.0.0</version.io.smallrye.smallrye-opentracing>
         <version.io.smallrye.smallrye-reactive-messaging>4.0.0.RC3</version.io.smallrye.smallrye-reactive-messaging>
-        <legacy.version.io.undertow>2.2.19.Final</legacy.version.io.undertow>
+        <legacy.version.io.undertow>2.2.20.Final</legacy.version.io.undertow>
         <legacy.version.io.undertow.jastow>2.0.11.Final</legacy.version.io.undertow.jastow>
         <version.io.undertow.jastow>2.2.3.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.3</version.io.vertx.vertx>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFLY-17107


        Release Notes - Undertow - Version 2.2.20.Final
                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2109'>UNDERTOW-2109</a>] -         The large file is in unexpected location on JDK17
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2140'>UNDERTOW-2140</a>] -         SSLSessionInfo.calculateKeySize(String cipherSuite) doesn&#39;t account for all cipher suits
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2142'>UNDERTOW-2142</a>] -         ChunkedStreamSinkConduit write with a buffer array writes too few buffers
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2147'>UNDERTOW-2147</a>] -         race condition between session invalidate and  changeSessionId leads to UT000010
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2159'>UNDERTOW-2159</a>] -         InMemorySessionManager#getSession - null check inconsistency
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2145'>UNDERTOW-2145</a>] -         UndertowOutputStream and ServletOutputStreamImpl awaitWritable unnecessarily
</li>
</ul>
                                                                                                                                            
