### PR TITLE
[WFLY-17116] Upgrade Jakarta Activation to 2.1.1.jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
         <version.io.undertow.jastow>2.2.3.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.4</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>${version.io.vertx.vertx}</version.io.vertx.vertx-kafka-client>
-        <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
+        <version.jakarta.activation.jakarta.activation-api>2.1.1.jbossorg-1</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-17116
