### PR TITLE
WFLY-17119 Distributed session metadata only needs millisecond precision

### DIFF
--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SimpleSessionAccessMetaData.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SimpleSessionAccessMetaData.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.web.cache.session;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * @author Paul Ferraro
@@ -44,11 +45,14 @@ public class SimpleSessionAccessMetaData implements SessionAccessMetaData {
 
     @Override
     public void setLastAccessDuration(Duration sinceCreation, Duration lastAccess) {
-        int nano = sinceCreation.getNano();
-        // Only retain millisecond precision
-        this.sinceCreation = (nano % 1_000_000) > 0 ? sinceCreation.withNanos((nano / 1_000_000) + 1) : sinceCreation;
-        // Only retain second precision
-        this.lastAccess = (lastAccess.getNano() > 0) ? Duration.ofSeconds(lastAccess.getSeconds() + 1) : lastAccess;
+        this.sinceCreation = normalize(sinceCreation);
+        this.lastAccess = normalize(lastAccess);
+    }
+
+    private static Duration normalize(Duration duration) {
+        // Only retain millisecond precision, rounding up to nearest millisecond
+        Duration truncatedDuration = duration.truncatedTo(ChronoUnit.MILLIS);
+        return !duration.equals(truncatedDuration) ? truncatedDuration.plusMillis(1) : duration;
     }
 
     @Override

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SimpleSessionCreationMetaData.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SimpleSessionCreationMetaData.java
@@ -24,7 +24,7 @@ package org.wildfly.clustering.web.cache.session;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -38,13 +38,13 @@ public class SimpleSessionCreationMetaData implements SessionCreationMetaData {
     private final AtomicBoolean valid = new AtomicBoolean(true);
 
     public SimpleSessionCreationMetaData() {
-        this.creationTime = Instant.now();
+        // Only retain millisecond precision
+        this.creationTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         this.newSession = true;
     }
 
     public SimpleSessionCreationMetaData(Instant creationTime) {
-        // Only retain millisecond precision
-        this.creationTime = (creationTime.getNano() % 1_000_000 > 0) ? creationTime.with(ChronoField.MILLI_OF_SECOND, creationTime.get(ChronoField.MILLI_OF_SECOND)) : creationTime;
+        this.creationTime = creationTime;
         this.newSession = false;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17119