### PR TITLE
[WFLY-17086] Warning message WFLYWELD0052 in ee-security quickstart

### DIFF
--- a/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
+++ b/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
@@ -41,5 +41,11 @@
         <module name="javax.annotation.api" />
         <module name="javax.inject.api" />
         <module name="javax.json.api" />
+        <!--TODO remove the WELD dependencies from this module, see comments on https://github.com/wildfly/wildfly/pull/16155 for more details
+        soteria overrides the beanClass in CDIExtension, which makes weld not load them from appropriate module
+         -->
+        <module name="org.jboss.weld.api"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Add weld dependency to module jakarta.security.enterprise.api in order to remove warning message WFLYWELD0052 in ee-security quickstart

issue: https://issues.redhat.com/browse/WFLY-17086
