### PR TITLE
[WFLY-17112]: Can't load a custom load balancing policy on a pooled connection factory.

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -54,6 +54,6 @@
         <!-- WFLY-6301 This module can be used to load user-created classes that are
              used by Artemis resources (e.g. connector-service, transformers, etc.)
         -->
-        <module name="org.apache.activemq.artemis.addons" optional="true" />
+        <module name="org.apache.activemq.artemis.addons" optional="true" export="true"/>
     </dependencies>
 </module>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ActivemqServerAddonsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ActivemqServerAddonsTestCase.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2022 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.manualmode.messaging;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.nio.file.Paths;
+import java.util.PropertyPermission;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.manualmode.messaging.deployment.MessagingServlet;
+import org.jboss.as.test.manualmode.messaging.deployment.QueueMDB;
+import org.jboss.as.test.manualmode.messaging.deployment.TopicMDB;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2022 Red Hat, Inc.
+ */
+@RunAsClient()
+@RunWith(Arquillian.class)
+@ServerControl(manual = true)
+public class ActivemqServerAddonsTestCase {
+
+    private static final String DEFAULT_FULL_JBOSSAS = "default-full-jbossas";
+
+    @ArquillianResource
+    protected static ContainerController container;
+    @ArquillianResource
+    private Deployer deployer;
+
+    private final TestModule module = new TestModule("org.apache.activemq.artemis.addons", "org.apache.activemq.artemis");
+
+    private static final String LB_CLASS_ATT = "connection-load-balancing-policy-class-name";
+    private static final String QUEUE_LOOKUP = "java:/jms/DependentMessagingDeploymentTestCase/myQueue";
+    private static final String TOPIC_LOOKUP = "java:/jms/DependentMessagingDeploymentTestCase/myTopic";
+
+    private static final String QUEUE_NAME = "myQueue";
+    private static final String TOPIC_NAME = "myTopic";
+    private static final String DEPLOYMENT = "addons-deployment";
+
+    @Before
+    public void setup() throws Exception {
+        try ( ManagementClient managementClient = createManagementClient()) {
+            if (container.isStarted(DEFAULT_FULL_JBOSSAS)) {
+                container.stop(DEFAULT_FULL_JBOSSAS);
+            }
+            final JavaArchive jar = module.addResource("artemis-lb-policy.jar");
+            jar.addClasses(OrderedLoadBalancingPolicy.class);
+            System.setProperty("module.path", Paths.get("target" ,"wildfly", "modules").toAbsolutePath().toString());
+            module.create(true);
+            if (!container.isStarted(DEFAULT_FULL_JBOSSAS)) {
+                container.start(DEFAULT_FULL_JBOSSAS);
+            }
+            ModelNode address = new ModelNode();
+            address.add("subsystem", "messaging-activemq");
+            address.add("server", "default");
+            address.add("pooled-connection-factory", "activemq-ra");
+            ModelNode op = Operations.createWriteAttributeOperation(address, LB_CLASS_ATT, OrderedLoadBalancingPolicy.class.getName());
+            execute(managementClient, op, true);
+            JMSOperations jmsOperations = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
+            jmsOperations.createJmsQueue(QUEUE_NAME, QUEUE_LOOKUP);
+            jmsOperations.createJmsTopic(TOPIC_NAME, TOPIC_LOOKUP);
+            jmsOperations.close();
+            deployer.deploy(DEPLOYMENT);
+        }
+    }
+
+    private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        final boolean success = Operations.isSuccessfulOutcome(response);
+        if (expectSuccess) {
+            assertTrue(response.toString(), success);
+            return Operations.readResult(response);
+        } else {
+            assertFalse(response.toString(), success);
+            return Operations.getFailureDescription(response);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deployer.undeploy(DEPLOYMENT);
+        try ( ManagementClient managementClient = createManagementClient()) {
+            JMSOperations jmsOperations = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
+            jmsOperations.removeJmsQueue(QUEUE_NAME);
+            jmsOperations.removeJmsTopic(TOPIC_NAME);
+            jmsOperations.close();
+            ModelNode address = new ModelNode();
+            address.add("subsystem", "messaging-activemq");
+            address.add("server", "default");
+            address.add("pooled-connection-factory", "activemq-ra");
+            ModelNode op = Operations.createUndefineAttributeOperation(address, LB_CLASS_ATT);
+            execute(managementClient, op, true);
+        }
+        container.stop(DEFAULT_FULL_JBOSSAS);
+        module.remove();
+        System.clearProperty("module.path");
+    }
+
+    private static ManagementClient createManagementClient() throws UnknownHostException {
+        return new ManagementClient(
+                TestSuiteEnvironment.getModelControllerClient(),
+                TestSuiteEnvironment.formatPossibleIpv6Address(TestSuiteEnvironment.getServerAddress()),
+                TestSuiteEnvironment.getServerPort(),
+                "remote+http");
+    }
+
+    @Deployment(name = DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(DEFAULT_FULL_JBOSSAS)
+    public static WebArchive createArchive() {
+        return create(WebArchive.class, DEPLOYMENT +".war")
+                .addClasses(MessagingServlet.class, TimeoutUtil.class)
+                .addClasses(QueueMDB.class, TopicMDB.class)
+                .addAsWebInfResource(new StringAsset("<beans xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd\"\n"
+                        + "bean-discovery-mode=\"all\">\n"
+                        + "</beans>"), "beans.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")
+                ), "permissions.xml");
+    }
+
+    @Test
+    public void testQueue() throws Exception {
+        String destination = "queue";
+        String text = UUID.randomUUID().toString();
+        URL servletUrl = new URL(TestSuiteEnvironment.getHttpUrl().toExternalForm() + '/' + DEPLOYMENT + "/DependentMessagingDeploymentTestCase?destination=" + destination + "&text=" + text);
+        String reply = HttpRequest.get(servletUrl.toExternalForm(), 10, TimeUnit.SECONDS);
+        assertNotNull(reply);
+        assertEquals(text, reply);
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/OrderedLoadBalancingPolicy.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/OrderedLoadBalancingPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.manualmode.messaging;
+
+import org.apache.activemq.artemis.api.core.client.loadbalance.ConnectionLoadBalancingPolicy;
+
+/**
+ * Simple add-on for Activemq Artemis.
+ * @author Emmanuel Hugonnet (c) 2022 Red Hat, Inc.
+ */
+public class OrderedLoadBalancingPolicy implements ConnectionLoadBalancingPolicy {
+
+    private int pos = -1;
+
+    @Override
+    public int select(final int max) {
+        pos++;
+        if (pos >= max) {
+            pos = 0;
+        }
+        return pos;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/MessagingServlet.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/MessagingServlet.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.messaging.deployment;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+
+import java.io.IOException;
+
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@WebServlet("/DependentMessagingDeploymentTestCase")
+public class MessagingServlet extends HttpServlet {
+
+    @Resource(lookup = "java:/jms/DependentMessagingDeploymentTestCase/myQueue")
+    private Queue queue;
+
+    @Resource(lookup = "java:/jms/DependentMessagingDeploymentTestCase/myTopic")
+    private Topic topic;
+
+    @Inject
+    private JMSContext context;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        boolean useTopic = req.getParameterMap().containsKey("topic");
+        final Destination destination = useTopic ? topic : queue;
+        final String text = req.getParameter("text");
+
+        String reply = sendAndReceiveMessage(destination, text);
+
+        resp.getWriter().write(reply);
+    }
+
+    private String sendAndReceiveMessage(Destination destination, String text) {
+            Destination replyTo = context.createTemporaryQueue();
+
+            JMSConsumer consumer = context.createConsumer(replyTo);
+
+            context.createProducer()
+                    .setJMSReplyTo(replyTo)
+                    .send(destination, text);
+
+            return consumer.receiveBody(String.class, TimeoutUtil.adjust(5000));
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/QueueMDB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/QueueMDB.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.messaging.deployment;
+
+
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.inject.Inject;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import jakarta.jms.TextMessage;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@MessageDriven(
+        activationConfig = {
+                @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "java:/jms/DependentMessagingDeploymentTestCase/myQueue")
+        }
+)
+public class QueueMDB implements MessageListener {
+
+    @Inject
+    private JMSContext context;
+
+    @Override
+    public void onMessage(final Message m) {
+        try {
+            TextMessage message = (TextMessage) m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, message.getText());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/TopicMDB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/deployment/TopicMDB.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.messaging.deployment;
+
+
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.inject.Inject;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import jakarta.jms.TextMessage;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@MessageDriven(
+        activationConfig = {
+                @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "java:/jms/DependentMessagingDeploymentTestCase/myTopic")
+        }
+)
+public class TopicMDB implements MessageListener {
+
+    @Inject
+    private JMSContext context;
+
+    @Override
+    public void onMessage(final Message m) {
+        try {
+            TextMessage message = (TextMessage) m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, message.getText());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
* Exporting "org.apache.activemq.artemis.addons" so that the class can be found by Artemis classes.
* Adding a test to cover this.

Jira: https://issues.redhat.com/browse/WFLY-17112

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>