### PR TITLE
[WFLY-17127] Adding --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED to default JPMS settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
             --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
             --add-exports=java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED
             --add-exports=java.naming/com.sun.jndi.url.ldaps=ALL-UNNAMED
+            --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED
             --add-opens=java.base/java.io=ALL-UNNAMED
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17127

Follows up on [WildFly Core PR](https://github.com/wildfly/wildfly-core/pull/5242).
