### PR TITLE
[WFLY-17170] Drop suffix from transformed wildfly-elytron-integration artifact

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -522,10 +522,6 @@
                     <artifactId>jboss-invocation</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-elytron-integration</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.wildfly.security</groupId>
                     <artifactId>wildfly-elytron-jacc</artifactId>
                 </exclusion>
@@ -573,12 +569,6 @@
             <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
             <type>pom</type>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-elytron-integration</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -3174,7 +3174,7 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -4469,7 +4469,7 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
-      <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+      <artifactId>wildfly-elytron-integration</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 or later</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -33,7 +33,7 @@
     </exports>
 
     <resources>
-        <artifact name="${org.wildfly.core:wildfly-elytron-integration-jakarta}"/>
+        <artifact name="${org.wildfly.core:wildfly-elytron-integration}"/>
     </resources>
 
     <dependencies>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -272,7 +272,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Required for Java 11 -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17170

Drop -jakarta suffix from the transformed artifact and use new suffix for original artifact instead, until it is properly migrated to Jakarta namespace.

This PR is blocked by https://github.com/wildfly/wildfly-core/pull/5245 and corresponding update in this repo - so I expect CI will fail for now.