### PR TITLE
[WFLY-17166] Correct use of MSC Service Registry in Micrometer Extension

### DIFF
--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerDependencyProcessor.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerDependencyProcessor.java
@@ -30,7 +30,7 @@ import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
 
-public class MicrometerDependencyProcessor implements DeploymentUnitProcessor {
+class MicrometerDependencyProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {
         addDependencies(phaseContext.getDeploymentUnit());

--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerParser.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerParser.java
@@ -24,10 +24,10 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.micrometer.model.MicrometerSchema;
 
-public class MicrometerParser extends PersistentResourceXMLParser {
+class MicrometerParser extends PersistentResourceXMLParser {
     private final MicrometerSchema schema;
 
-    public MicrometerParser(MicrometerSchema schema) {
+    MicrometerParser(MicrometerSchema schema) {
         this.schema = schema;
     }
 

--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerSubsystemDefinition.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerSubsystemDefinition.java
@@ -43,7 +43,7 @@ class MicrometerSubsystemDefinition extends PersistentResourceDefinition {
     static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
     static final String MANAGEMENT_EXECUTOR = "org.wildfly.management.executor";
     static final String PROCESS_STATE_NOTIFIER = "org.wildfly.management.process-state-notifier";
-    private static final RuntimeCapability<Void> MICROMETER_COLLECTOR_RUNTIME_CAPABILITY =
+    static final RuntimeCapability<Void> MICROMETER_COLLECTOR_RUNTIME_CAPABILITY =
             RuntimeCapability.Builder.of(MICROMETER_MODULE + ".wildfly-collector", MicrometerCollector.class)
                     .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR, PROCESS_STATE_NOTIFIER)
                     .build();


### PR DESCRIPTION
Provide suppliers to subsystem code that they can use to access objects installed by the subsystem.

Remove use of the deprecated org.jboss.msc.service.Service

Use CapabilityServiceTarget to install services.

While I was at it I reduced visiblility of classes and methods in the root org.wildfly.extension.micrometer package and cleaned up a few minor IDE warns.

https://issues.redhat.com/browse/WFLY-17166