### PR TITLE
[WFLY-17105] Upgrade WildFly Core to 19.0.0.Final 

### DIFF
--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -522,10 +522,6 @@
                     <artifactId>jboss-invocation</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-elytron-integration</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.wildfly.security</groupId>
                     <artifactId>wildfly-elytron-jacc</artifactId>
                 </exclusion>
@@ -573,12 +569,6 @@
             <artifactId>wildfly-core-feature-pack-galleon-common</artifactId>
             <type>pom</type>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-elytron-integration</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -3174,7 +3174,7 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -4469,7 +4469,7 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
-      <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+      <artifactId>wildfly-elytron-integration</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 or later</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -33,7 +33,7 @@
     </exports>
 
     <resources>
-        <artifact name="${org.wildfly.core:wildfly-elytron-integration-jakarta}"/>
+        <artifact name="${org.wildfly.core:wildfly-elytron-integration}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Beta18</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.http-client>1.1.15.Final</legacy.version.org.wildfly.http-client>
         <version.org.wildfly.http-client>2.0.0.Final</version.org.wildfly.http-client>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/EEConcurrencyExecutorShutdownTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/EEConcurrencyExecutorShutdownTestCase.java
@@ -87,7 +87,7 @@ public class EEConcurrencyExecutorShutdownTestCase {
     @BeforeClass
     public static void setupDomain() {
         testSupport = createAndStartDefaultEESupport(EEConcurrencyExecutorShutdownTestCase.class.getSimpleName());
-        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainMasterLifecycleUtil = testSupport.getDomainPrimaryLifecycleUtil();
         masterClient = domainMasterLifecycleUtil.getDomainClient();
     }
 
@@ -95,10 +95,10 @@ public class EEConcurrencyExecutorShutdownTestCase {
         try {
             final DomainTestSupport.Configuration configuration;
             if (Boolean.getBoolean("wildfly.master.debug")) {
-                configuration = DomainTestSupport.Configuration.createDebugMaster(testName,
+                configuration = DomainTestSupport.Configuration.createDebugPrimary(testName,
                         "domain-configs/domain-standard-ee.xml", "host-configs/host-primary.xml", null);
             } else if (Boolean.getBoolean("wildfly.slave.debug")) {
-                configuration = DomainTestSupport.Configuration.createDebugSlave(testName,
+                configuration = DomainTestSupport.Configuration.createDebugSecondary(testName,
                         "domain-configs/domain-standard-ee.xml", "host-configs/host-primary.xml", null);
             } else {
                 configuration = DomainTestSupport.Configuration.create(testName,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
@@ -112,7 +112,7 @@ public class JVMServerPropertiesTestCase {
 
         testSupport = DomainTestSupport.create(configuration);
 
-        masterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        masterLifecycleUtil = testSupport.getDomainPrimaryLifecycleUtil();
 
         // Prepares the application deployment file
         WebArchive deployment = createDeployment();
@@ -169,7 +169,7 @@ public class JVMServerPropertiesTestCase {
         final Path serverDataDir = BY_SERVER.equals(directoryGrouping) ? serverBaseDir.resolve("data") : serverHome.resolve("data").resolve("servers").resolve(server);
         final Path serverTmpDir = BY_SERVER.equals(directoryGrouping) ? serverBaseDir.resolve("tmp") : serverHome.resolve("tmp").resolve("servers").resolve(server);
 
-        String response = performHttpCall(DomainTestSupport.masterAddress, port, PROP_SERVLET_APP_URL);
+        String response = performHttpCall(DomainTestSupport.primaryAddress, port, PROP_SERVLET_APP_URL);
         Properties p = new Properties();
         try (StringReader isr = new StringReader(response.replace("\\", "\\\\"))) {
             p.load(isr);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CloneProfileTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CloneProfileTestCase.java
@@ -63,9 +63,9 @@ public class CloneProfileTestCase extends AbstractCliTestBase {
     @BeforeClass
     public static void before() throws Exception {
         DomainTestSupport domainSupport = CLITestSuite.createSupport(CloneProfileTestCase.class.getSimpleName());
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
 
-        File masterDir = new File(domainSupport.getDomainMasterConfiguration().getDomainDirectory());
+        File masterDir = new File(domainSupport.getDomainPrimaryConfiguration().getDomainDirectory());
         domainCfg = new File(masterDir, "configuration"
                 + File.separator + "testing-domain-standard.xml");
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DataSourceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DataSourceTestCase.java
@@ -57,7 +57,7 @@ public class DataSourceTestCase extends AbstractCliTestBase {
     public static void before() throws Exception {
 
         CLITestSuite.createSupport(DataSourceTestCase.class.getSimpleName());
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllServerGroupsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllServerGroupsTestCase.java
@@ -64,7 +64,7 @@ public class DeployAllServerGroupsTestCase extends AbstractCliTestBase {
 
         new ZipExporterImpl(war).exportTo(warFile, true);
 
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
@@ -70,7 +70,7 @@ public class DeploySingleServerGroupTestCase extends AbstractCliTestBase {
 
         serverGroups = CLITestSuite.serverGroups.keySet().toArray(new String[CLITestSuite.serverGroups.size()]);
 
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
@@ -68,7 +68,7 @@ public class DomainDeployWithRuntimeNameTestCase extends AbstractCliTestBase {
         List<String> groups = new ArrayList<>(CLITestSuite.serverGroups.keySet());
         Collections.sort(groups);
         serverGroups = groups.toArray(new String[groups.size()]);
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
     }
 
    private File createWarFile(String content) throws IOException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -138,7 +138,7 @@ public class DomainDeploymentOverlayTestCase {
 
     @Before
     public void setUp() throws Exception {
-        client = testSupport.getDomainMasterLifecycleUtil().createDomainClient();
+        client = testSupport.getDomainPrimaryLifecycleUtil().createDomainClient();
         ctx = CLITestUtil.getCommandContext(testSupport);
         ctx.connectController();
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/JmsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/JmsTestCase.java
@@ -44,7 +44,7 @@ public class JmsTestCase extends AbstractCliTestBase {
     public static void before() throws Exception {
 
         CLITestSuite.createSupport(JmsTestCase.class.getSimpleName());
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
@@ -74,7 +74,7 @@ public class RolloutPlanTestCase extends AbstractCliTestBase {
         warFile = new File(tempDir + File.separator + "RolloutPlanTestCase.war");
         new ZipExporterImpl(war).exportTo(warFile, true);
 
-        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+        AbstractCliTestBase.initCLI(DomainTestSupport.primaryAddress);
 
         // add another server group to default profile
         cli.sendLine("/server-group=test-server-group:add(profile=default,socket-binding-group=standard-sockets)");

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -105,8 +105,8 @@ public class CLITestSuite {
         hostServers.put("primary", new String[]{"main-one", "main-two", "other-one"});
         hostServers.put("secondary", new String[]{"main-three", "main-four", "other-two"});
 
-        hostAddresses.put("primary", DomainTestSupport.masterAddress);
-        hostAddresses.put("secondary", DomainTestSupport.slaveAddress);
+        hostAddresses.put("primary", DomainTestSupport.primaryAddress);
+        hostAddresses.put("secondary", DomainTestSupport.secondaryAddress);
 
         serverGroups.put("main-server-group", new String[]{"main-one", "main-two", "main-three", "main-four"});
         serverGroups.put("other-server-group", new String[]{"other-one", "other-two"});

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DatasourceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DatasourceTestCase.java
@@ -69,8 +69,8 @@ public class DatasourceTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {
         testSupport = DomainTestSuite.createSupport(DatasourceTestCase.class.getSimpleName());
-        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
-        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+        domainMasterLifecycleUtil = testSupport.getDomainPrimaryLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSecondaryLifecycleUtil();
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
@@ -191,13 +191,13 @@ public class DeploymentManagementTestCase {
         assertEquals("Deployments are removed from the domain", 0, deploymentList.size());
 
         try {
-            performHttpCall(DomainTestSupport.masterAddress, 8080);
+            performHttpCall(DomainTestSupport.primaryAddress, 8080);
             fail(TEST + " is available on main-one");
         } catch (IOException good) {
             // good
         }
         try {
-            performHttpCall(DomainTestSupport.slaveAddress, 8630);
+            performHttpCall(DomainTestSupport.secondaryAddress, 8630);
             fail(TEST + " is available on other-three");
         } catch (IOException good) {
             // good
@@ -233,8 +233,8 @@ public class DeploymentManagementTestCase {
         ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -247,8 +247,8 @@ public class DeploymentManagementTestCase {
 
         executeOnMaster(builder.build());
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
 
@@ -282,8 +282,8 @@ public class DeploymentManagementTestCase {
         ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -309,8 +309,8 @@ public class DeploymentManagementTestCase {
         ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -322,8 +322,8 @@ public class DeploymentManagementTestCase {
 
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class DeploymentManagementTestCase {
         // Thread.sleep(1000);
 
         try {
-            performHttpCall(DomainTestSupport.slaveAddress, 8630);
+            performHttpCall(DomainTestSupport.secondaryAddress, 8630);
             fail("Webapp still accessible following undeploy");
         } catch (IOException good) {
             // desired result
@@ -393,7 +393,7 @@ public class DeploymentManagementTestCase {
         ModelNode op = getEmptyOperation("redeploy", OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(op);
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -411,8 +411,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -429,8 +429,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -447,8 +447,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -465,8 +465,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -483,8 +483,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -502,8 +502,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
     @Test
     public void testFullReplaceViaStream() throws Exception {
@@ -520,8 +520,8 @@ public class DeploymentManagementTestCase {
 
         // Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
 
@@ -539,8 +539,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -562,13 +562,13 @@ public class DeploymentManagementTestCase {
         executeOnMaster(op);
 
         // Check that the original content got removed!
-        testRemovedContent(testSupport.getDomainMasterLifecycleUtil(), original);
-        testRemovedContent(testSupport.getDomainSlaveLifecycleUtil(), original);
+        testRemovedContent(testSupport.getDomainPrimaryLifecycleUtil(), original);
+        testRemovedContent(testSupport.getDomainSecondaryLifecycleUtil(), original);
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -586,8 +586,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
 
@@ -605,8 +605,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -623,8 +623,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -641,8 +641,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -659,8 +659,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -678,8 +678,8 @@ public class DeploymentManagementTestCase {
 
         //Thread.sleep(1000);
 
-        performHttpCall(DomainTestSupport.masterAddress, 8080);
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
     }
 
     @Test
@@ -694,7 +694,7 @@ public class DeploymentManagementTestCase {
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
 
         executeOnMaster(builder.build());
-        performHttpCall(DomainTestSupport.slaveAddress, 8630, "test1");
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630, "test1");
     }
 
     @Test
@@ -707,9 +707,9 @@ public class DeploymentManagementTestCase {
 
         executeOnMaster(builder.build());
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
         try {
-            performHttpCall(DomainTestSupport.masterAddress, 8080);
+            performHttpCall(DomainTestSupport.primaryAddress, 8080);
             fail("Webapp deployed to unselected server group");
         } catch (IOException ioe) {
             // good
@@ -806,17 +806,17 @@ public class DeploymentManagementTestCase {
 //
 //        executeOnMaster(builder.build());
 //
-//        performHttpCall(DomainTestSupport.masterAddress, 8080);
-//        performHttpCall(DomainTestSupport.slaveAddress, 8630);
+//        performHttpCall(DomainTestSupport.primaryAddress, 8080);
+//        performHttpCall(DomainTestSupport.secondaryAddress, 8630);
 //
 //    }
 
     private static ModelNode executeOnMaster(ModelNode op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private static ModelNode executeOnMaster(Operation op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private static ModelNode createDeploymentOperation(ModelNode content, ModelNode... serverGroupAddressses) {
@@ -864,7 +864,7 @@ public class DeploymentManagementTestCase {
         ModelNode op = getEmptyOperation("read-children-names", address);
         op.get("child-type").set("deployment");
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         ModelNode result = validateResponse(response);
         return result.isDefined() ? result.asList() : Collections.<ModelNode>emptyList();
     }
@@ -874,7 +874,7 @@ public class DeploymentManagementTestCase {
         deplAddr.set(address);
         deplAddr.add("deployment", deploymentName);
         ModelNode op = getEmptyOperation(REMOVE, deplAddr);
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         validateResponse(response);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -295,7 +295,7 @@ public class DeploymentOverlayTestCase {
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
         executeOnMaster(builder.build());
 
-        DomainClient client = testSupport.getDomainMasterLifecycleUtil().createDomainClient();
+        DomainClient client = testSupport.getDomainPrimaryLifecycleUtil().createDomainClient();
         Assert.assertEquals("OVERRIDDEN", performHttpCall(client, "primary", "main-one", "standard-sockets", "/test/servlet"));
         Assert.assertEquals("OVERRIDDEN", performHttpCall(client, "secondary", "main-three", "standard-sockets", "/test/servlet"));
         Assert.assertEquals("new file", performHttpCall(client, "primary", "main-one", "standard-sockets", "/test/wildcard-new-file.txt"));
@@ -354,11 +354,11 @@ public class DeploymentOverlayTestCase {
     }
 
     private static ModelNode executeOnMaster(ModelNode op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private static ModelNode executeOnMaster(Operation op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private static ModelNode createDeploymentOperation(ModelNode content, ModelNode... serverGroupAddressses) {
@@ -380,7 +380,7 @@ public class DeploymentOverlayTestCase {
         ModelNode op = getEmptyOperation("read-children-names", address);
         op.get("child-type").set("deployment");
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         ModelNode result = validateResponse(response);
         return result.isDefined() ? result.asList() : Collections.<ModelNode>emptyList();
     }
@@ -390,7 +390,7 @@ public class DeploymentOverlayTestCase {
         deplAddr.set(address);
         deplAddr.add("deployment", deploymentName);
         ModelNode op = getEmptyOperation(REMOVE, deplAddr);
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         validateResponse(response);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/GlobalDirectoryDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/GlobalDirectoryDomainTestCase.java
@@ -250,8 +250,8 @@ public class GlobalDirectoryDomainTestCase {
         registerGlobalDirectory(GLOBAL_DIRECTORY_NAME, "default");
         registerGlobalDirectory(GLOBAL_DIRECTORY_NAME, "other");
 
-        reloadServerGroup(testSupport.getDomainMasterLifecycleUtil(), PathAddress.pathAddress(MAIN_SERVER_GROUP_ADDRESS));
-        reloadServerGroup(testSupport.getDomainMasterLifecycleUtil(), PathAddress.pathAddress(OTHER_SERVER_GROUP_ADDRESS));
+        reloadServerGroup(testSupport.getDomainPrimaryLifecycleUtil(), PathAddress.pathAddress(MAIN_SERVER_GROUP_ADDRESS));
+        reloadServerGroup(testSupport.getDomainPrimaryLifecycleUtil(), PathAddress.pathAddress(OTHER_SERVER_GROUP_ADDRESS));
 
         verifyProperlyRegistered(GLOBAL_DIRECTORY_NAME, GLOBAL_DIRECTORY_PATH.toString(), "default");
         verifyProperlyRegistered(GLOBAL_DIRECTORY_NAME, GLOBAL_DIRECTORY_PATH.toString(), "other");
@@ -262,10 +262,10 @@ public class GlobalDirectoryDomainTestCase {
         ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        String response = performHttpCall(DomainTestSupport.masterAddress, 8080, "test/global-directory/library");
+        String response = performHttpCall(DomainTestSupport.primaryAddress, 8080, "test/global-directory/library");
         assertEquals("HELLO WORLD", response);
 
-        response = performHttpCall(DomainTestSupport.slaveAddress, 8630, "test/global-directory/library");
+        response = performHttpCall(DomainTestSupport.secondaryAddress, 8630, "test/global-directory/library");
         assertEquals("HELLO WORLD", response);
 
         removeGlobalDirectory(GLOBAL_DIRECTORY_NAME, "default");
@@ -274,8 +274,8 @@ public class GlobalDirectoryDomainTestCase {
         verifyDoesNotExist(GLOBAL_DIRECTORY_NAME, "default");
         verifyDoesNotExist(GLOBAL_DIRECTORY_NAME, "other");
 
-        reloadServerGroup(testSupport.getDomainMasterLifecycleUtil(), PathAddress.pathAddress(MAIN_SERVER_GROUP_ADDRESS));
-        reloadServerGroup(testSupport.getDomainMasterLifecycleUtil(), PathAddress.pathAddress(OTHER_SERVER_GROUP_ADDRESS));
+        reloadServerGroup(testSupport.getDomainPrimaryLifecycleUtil(), PathAddress.pathAddress(MAIN_SERVER_GROUP_ADDRESS));
+        reloadServerGroup(testSupport.getDomainPrimaryLifecycleUtil(), PathAddress.pathAddress(OTHER_SERVER_GROUP_ADDRESS));
     }
 
     private void copyLibraryToGlobalDirectory(String name) throws IOException {
@@ -319,7 +319,7 @@ public class GlobalDirectoryDomainTestCase {
         operation.get(INCLUDE_RUNTIME).set(true);
         operation.get(OP_ADDR).set(address);
 
-        return testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(operation);
+        return testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(operation);
     }
 
     /**
@@ -364,7 +364,7 @@ public class GlobalDirectoryDomainTestCase {
         operation.get(OP_ADDR).set(address);
         operation.get(PATH).set(path);
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(operation);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(operation);
         ModelNode outcome = response.get(OUTCOME);
         if (expectSuccess) {
             assertThat("Registration of global directory " + name + " failure!", outcome.asString(), is(SUCCESS));
@@ -389,14 +389,14 @@ public class GlobalDirectoryDomainTestCase {
         operation.get(INCLUDE_RUNTIME).set(true);
         operation.get(OP_ADDR).set(address);
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(operation);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(operation);
         ModelNode outcome = response.get(OUTCOME);
         assertThat("Remove of global directory " + name + "  failure!", outcome.asString(), is(SUCCESS));
         return response;
     }
 
     private static ModelNode executeOnMaster(ModelNode op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private static ModelNode createDeploymentOperation(ModelNode content, ModelNode... serverGroupAddressses) {
@@ -418,7 +418,7 @@ public class GlobalDirectoryDomainTestCase {
         ModelNode op = getEmptyOperation("read-children-names", address);
         op.get("child-type").set("deployment");
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         ModelNode result = validateResponse(response);
         return result.isDefined() ? result.asList() : Collections.<ModelNode>emptyList();
     }
@@ -428,7 +428,7 @@ public class GlobalDirectoryDomainTestCase {
         deplAddr.set(address);
         deplAddr.add("deployment", deploymentName);
         ModelNode op = getEmptyOperation(REMOVE, deplAddr);
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         validateResponse(response);
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/JcaCCMRuntimeOnlyProfileOpsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/JcaCCMRuntimeOnlyProfileOpsTestCase.java
@@ -58,7 +58,7 @@ public class JcaCCMRuntimeOnlyProfileOpsTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {
         testSupport = DomainTestSuite.createSupport(JcaCCMRuntimeOnlyProfileOpsTestCase.class.getSimpleName());
-        client = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        client = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient();
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ModelPersistenceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ModelPersistenceTestCase.java
@@ -97,11 +97,11 @@ public class ModelPersistenceTestCase {
     @BeforeClass
     public static void initDomain() throws Exception {
         domainSupport = DomainTestSuite.createSupport(ModelPersistenceTestCase.class.getSimpleName());
-        domainMasterLifecycleUtil = domainSupport.getDomainMasterLifecycleUtil();
-        domainSlaveLifecycleUtil = domainSupport.getDomainSlaveLifecycleUtil();
+        domainMasterLifecycleUtil = domainSupport.getDomainPrimaryLifecycleUtil();
+        domainSlaveLifecycleUtil = domainSupport.getDomainSecondaryLifecycleUtil();
 
-        File masterDir = new File(domainSupport.getDomainMasterConfiguration().getDomainDirectory());
-        File slaveDir = new File(domainSupport.getDomainSlaveConfiguration().getDomainDirectory());
+        File masterDir = new File(domainSupport.getDomainPrimaryConfiguration().getDomainDirectory());
+        File slaveDir = new File(domainSupport.getDomainSecondaryConfiguration().getDomainDirectory());
         domainCurrentCfgDir = new File(masterDir, CONFIG_DIR
                 + File.separator + DOMAIN_HISTORY_DIR + File.separator + CURRENT_DIR);
         masterCurrentCfgDir = new File(masterDir,  CONFIG_DIR

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadEnvironmentVariablesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadEnvironmentVariablesTestCase.java
@@ -74,8 +74,8 @@ public class ReadEnvironmentVariablesTestCase {
     public static void setupDomain() throws Exception {
         testSupport = DomainTestSuite.createSupport(ReadEnvironmentVariablesTestCase.class.getSimpleName());
 
-        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
-        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+        domainMasterLifecycleUtil = testSupport.getDomainPrimaryLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSecondaryLifecycleUtil();
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/resources/host-configs/host-secondary-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secondary-elytron.xml
@@ -63,7 +63,7 @@
     </management>
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.primary.address}" port="9999" authentication-context="slaveHostAContext"/>
+        <remote host="${jboss.test.host.primary.address}" port="9999" authentication-context="secondaryHostAContext"/>
     </domain-controller>
     <interfaces>
         <interface name="management">
@@ -92,11 +92,11 @@
         </subsystem>
         <subsystem xmlns="urn:wildfly:elytron:1.0" initial-providers="combined-providers">
             <authentication-client>
-                <authentication-configuration allow-sasl-mechanisms="DIGEST-MD5" name="slaveHostAConfiguration" authentication-name="slave" realm="ManagementRealm">
-                    <credential-reference clear-text="slave_us3r_password"/>
+                <authentication-configuration allow-sasl-mechanisms="DIGEST-MD5" name="secondaryHostAConfiguration" authentication-name="secondary" realm="ManagementRealm">
+                    <credential-reference clear-text="secondary_us3r_password"/>
                 </authentication-configuration>
-                <authentication-context name="slaveHostAContext">
-                    <match-rule match-host="${jboss.test.host.primary.address}" authentication-configuration="slaveHostAConfiguration"/>
+                <authentication-context name="secondaryHostAContext">
+                    <match-rule match-host="${jboss.test.host.primary.address}" authentication-configuration="secondaryHostAConfiguration"/>
                 </authentication-context>
             </authentication-client>
             <providers>

--- a/testsuite/domain/src/test/resources/host-configs/host-secondary.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secondary.xml
@@ -66,7 +66,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.primary.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" authentication-context="slaveHostAContext">
+        <remote host="${jboss.test.host.primary.address}" protocol="${jboss.domain.primary.protocol:remote+http}" port="${jboss.domain.primary.port:9990}" authentication-context="secondaryHostAContext">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>
@@ -136,11 +136,11 @@
         <subsystem xmlns="urn:wildfly:elytron:15.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <authentication-client>
                 <!-- corresponding secret: <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" /> -->
-                <authentication-configuration sasl-mechanism-selector="DIGEST-MD5" name="slaveHostAConfiguration" authentication-name="slave" realm="ManagementRealm">
-                    <credential-reference clear-text="slave_us3r_password"/>
+                <authentication-configuration sasl-mechanism-selector="DIGEST-MD5" name="secondaryHostAConfiguration" authentication-name="secondary" realm="ManagementRealm">
+                    <credential-reference clear-text="secondary_us3r_password"/>
                 </authentication-configuration>
-                <authentication-context name="slaveHostAContext">
-                    <match-rule match-host="${jboss.test.host.primary.address}" authentication-configuration="slaveHostAConfiguration"/>
+                <authentication-context name="secondaryHostAContext">
+                    <match-rule match-host="${jboss.test.host.primary.address}" authentication-configuration="secondaryHostAConfiguration"/>
                 </authentication-context>
             </authentication-client>
             <providers>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -272,7 +272,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration-jakarta</artifactId>
+            <artifactId>wildfly-elytron-integration</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Required for Java 11 -->

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
@@ -74,7 +74,7 @@ public abstract class LegacyConfigTest {
     @Test
     public void testServerLaunching() throws IOException, MgmtOperationException, InterruptedException {
 
-        DomainClient client = support.getDomainMasterLifecycleUtil().getDomainClient();
+        DomainClient client = support.getDomainPrimaryLifecycleUtil().getDomainClient();
         for (Map.Entry<String, String> entry : getProfilesToTest().entrySet()) {
             String profile = entry.getKey();
             String sbg = entry.getValue();
@@ -129,7 +129,7 @@ public abstract class LegacyConfigTest {
 
     private void verifyHttp(String profile) {
         try {
-            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
+            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.secondaryAddress) + ":8080").openConnection();
             connection.connect();
         } catch (IOException e) {
             Assert.fail("Cannot connect to profile " + profile + " " + e.toString());

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
@@ -144,13 +144,13 @@ public abstract class MixedDomainDeploymentTest {
         assertEquals("Deployments are removed from the domain", 0, deploymentList.size());
 
         try {
-            performHttpCall(DomainTestSupport.masterAddress, 8080);
+            performHttpCall(DomainTestSupport.primaryAddress, 8080);
             fail(TEST + " is available on main-one");
         } catch (IOException good) {
             // good
         }
         try {
-            performHttpCall(DomainTestSupport.slaveAddress, 8630);
+            performHttpCall(DomainTestSupport.secondaryAddress, 8630);
             fail(TEST + " is available on other-three");
         } catch (IOException good) {
             // good
@@ -165,7 +165,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode composite = createDeploymentOperation(content, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
     }
 
     @Test
@@ -178,7 +178,7 @@ public abstract class MixedDomainDeploymentTest {
 
         executeOnMaster(builder.build());
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
 
     }
 
@@ -190,7 +190,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode composite = createDeploymentOperation(content, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
     }
 
     @Test
@@ -202,7 +202,7 @@ public abstract class MixedDomainDeploymentTest {
 
         executeOnMaster(composite);
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
     }
 
     protected boolean supportManagedExplodedDeployment() {
@@ -258,7 +258,7 @@ public abstract class MixedDomainDeploymentTest {
         builder.addInputStream(tccl.getResourceAsStream("helloWorld/index2.html"));
         if (supportManagedExplodedDeployment()) {
             executeOnMaster(builder.build());
-            performHttpCall(DomainTestSupport.slaveAddress, 8080);
+            performHttpCall(DomainTestSupport.secondaryAddress, 8080);
         } else {
             ModelNode failure = executeForFailureOnMaster(builder.build());
             assertTrue(failure.toJSONString(true), failure.toJSONString(true).contains("WFLYCTL0421:"));
@@ -326,14 +326,14 @@ public abstract class MixedDomainDeploymentTest {
 
         executeOnMaster(builder.build());
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
     }
 
     private void redeployTest() throws IOException {
         ModelNode op = createEmptyOperation("redeploy", OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
         executeOnMaster(op);
 
-        performHttpCall(DomainTestSupport.slaveAddress, 8080);
+        performHttpCall(DomainTestSupport.secondaryAddress, 8080);
     }
 
 
@@ -344,7 +344,7 @@ public abstract class MixedDomainDeploymentTest {
         // Thread.sleep(1000);
 
         try {
-            performHttpCall(DomainTestSupport.slaveAddress, 8080);
+            performHttpCall(DomainTestSupport.secondaryAddress, 8080);
             fail("Webapp still accessible following undeploy");
         } catch (IOException good) {
             // desired result
@@ -372,19 +372,19 @@ public abstract class MixedDomainDeploymentTest {
     }
 
     private ModelNode executeOnMaster(ModelNode op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private ModelNode executeOnMaster(Operation op) throws IOException {
-        return validateResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private ModelNode executeForFailureOnMaster(ModelNode op) throws IOException {
-        return validateFailedResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateFailedResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private ModelNode executeForFailureOnMaster(Operation op) throws IOException {
-        return validateFailedResponse(testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op));
+        return validateFailedResponse(testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op));
     }
 
     private ModelNode createDeploymentOperation(ModelNode content, PathAddress... serverGroupAddressses) {
@@ -425,7 +425,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode op = createEmptyOperation("read-children-names", address);
         op.get("child-type").set("deployment");
 
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         ModelNode result = validateResponse(response);
         return result.isDefined() ? result.asList() : Collections.<ModelNode>emptyList();
     }
@@ -459,7 +459,7 @@ public abstract class MixedDomainDeploymentTest {
 
     private void removeDeployment(String deploymentName, PathAddress address) throws IOException {
         ModelNode op = createRemoveOperation(address.append(DEPLOYMENT, deploymentName));
-        ModelNode response = testSupport.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = testSupport.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         validateResponse(response);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
@@ -131,7 +131,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
     }
 
     private void startSlaveServer() {
-        DomainClient client = getDomainMasterLifecycleUtil().getDomainClient();
+        DomainClient client = getDomainPrimaryLifecycleUtil().getDomainClient();
         PathElement hostElement = PathElement.pathElement("host", "secondary");
 
         try {
@@ -178,7 +178,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
         }
 
         if (javaHome != null) {
-            WildFlyManagedConfiguration  cfg = getDomainSlaveConfiguration();
+            WildFlyManagedConfiguration  cfg = getDomainSecondaryConfiguration();
             cfg.setJavaHome(javaHome);
             cfg.setControllerJavaHome(javaHome);
             System.out.println("Set legacy host controller to use " + javaHome + " as JAVA_HOME");
@@ -198,7 +198,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
             //strip down the domain model to something more workable. The domain
             //adjusters will also make adjustments for the legacy version being
             //tested.
-            DomainLifecycleUtil masterUtil = getDomainMasterLifecycleUtil();
+            DomainLifecycleUtil masterUtil = getDomainPrimaryLifecycleUtil();
             masterUtil.getConfiguration().setAdminOnly(true);
             //masterUtil.getConfiguration().addHostCommandLineProperty("-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y");
             masterUtil.start();
@@ -214,7 +214,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
             masterUtil.awaitHostController(System.currentTimeMillis());
 
             //Start the secondary hosts
-            DomainLifecycleUtil slaveUtil = getDomainSlaveLifecycleUtil();
+            DomainLifecycleUtil slaveUtil = getDomainSecondaryLifecycleUtil();
             if (slaveUtil != null) {
                 //slaveUtil.getConfiguration().addHostCommandLineProperty("-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y");
                 slaveUtil.start();

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/RBACConfigTestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/RBACConfigTestCase.java
@@ -76,8 +76,8 @@ public class RBACConfigTestCase {
     @Before
     public void init() throws Exception {
         DomainTestSupport support = KernelBehaviorTestSuite.getSupport(this.getClass());
-        masterClient = support.getDomainMasterLifecycleUtil().getDomainClient();
-        slaveClient = support.getDomainSlaveLifecycleUtil().getDomainClient();
+        masterClient = support.getDomainPrimaryLifecycleUtil().getDomainClient();
+        slaveClient = support.getDomainSecondaryLifecycleUtil().getDomainClient();
     }
 
     @AfterClass

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -102,20 +102,20 @@ public abstract class SimpleMixedDomainTest  {
 
     @Test
     public void test00001_ServerRunning() throws Exception {
-        URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
+        URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.secondaryAddress) + ":8080").openConnection();
         connection.connect();
     }
 
     @Test
     public void test00002_Versioning() throws Exception {
-        DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
+        DomainClient masterClient = support.getDomainPrimaryLifecycleUtil().createDomainClient();
         ModelNode masterModel;
         try {
             masterModel = readDomainModelForVersions(masterClient);
         } finally {
             IoUtils.safeClose(masterClient);
         }
-        DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
+        DomainClient slaveClient = support.getDomainSecondaryLifecycleUtil().createDomainClient();
         ModelNode slaveModel;
         try {
             slaveModel = readDomainModelForVersions(slaveClient);
@@ -131,7 +131,7 @@ public abstract class SimpleMixedDomainTest  {
 
     @Test
     public void test00010_JgroupsTransformers() throws Exception {
-        final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
+        final DomainClient masterClient = support.getDomainPrimaryLifecycleUtil().createDomainClient();
         try {
             // Check composite operation
             final ModelNode compositeOp = new ModelNode();
@@ -157,7 +157,7 @@ public abstract class SimpleMixedDomainTest  {
         PathAddress exampleDSAddress = PathAddress.pathAddress(PathElement.pathElement(HOST, "secondary"),
                 PathElement.pathElement(RUNNING_SERVER, "server-one"), PathElement.pathElement(SUBSYSTEM, "datasources"),
                 PathElement.pathElement("data-source", "ExampleDS"));
-        DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
+        DomainClient masterClient = support.getDomainPrimaryLifecycleUtil().createDomainClient();
         try {
             ModelNode op = Util.createOperation("test-connection-in-pool", PathAddress.pathAddress(exampleDSAddress));
             ModelNode response = masterClient.execute(op);
@@ -184,8 +184,8 @@ public abstract class SimpleMixedDomainTest  {
         //For an EAP 7 slave we will need another test since EAP 7 allows the clone operation.
         // However EAP 7 will need to take into account the ignore-unused-configuration
         // setting which does not exist in 6.x
-        final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
-        final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
+        final DomainClient masterClient = support.getDomainPrimaryLifecycleUtil().createDomainClient();
+        final DomainClient slaveClient = support.getDomainSecondaryLifecycleUtil().createDomainClient();
         try {
             final PathAddress newProfileAddress = PathAddress.pathAddress(PROFILE, "new-profile");
 
@@ -205,7 +205,7 @@ public abstract class SimpleMixedDomainTest  {
             DomainTestUtils.executeForResult(ignoreNewProfile, slaveClient);
 
             //Reload slave so ignore takes effect
-            reloadHost(support.getDomainSlaveLifecycleUtil(), "secondary");
+            reloadHost(support.getDomainSecondaryLifecycleUtil(), "secondary");
 
             //Clone should work now that the new profile is ignored
             DomainTestUtils.executeForResult(clone, masterClient);
@@ -214,7 +214,7 @@ public abstract class SimpleMixedDomainTest  {
             DomainTestUtils.executeForFailure(Util.createAddOperation(PathAddress.pathAddress(PROFILE, "cloned").append(SUBSYSTEM, "jmx")), masterClient);
 
             //Reload slave
-            reloadHost(support.getDomainSlaveLifecycleUtil(), "secondary");
+            reloadHost(support.getDomainSecondaryLifecycleUtil(), "secondary");
 
             //Reloading should have brought over the cloned profile, so adding a subsystem should now work
             DomainTestUtils.executeForResult(Util.createAddOperation(PathAddress.pathAddress(PROFILE, "cloned").append(SUBSYSTEM, "jmx")), masterClient);
@@ -229,8 +229,8 @@ public abstract class SimpleMixedDomainTest  {
         // EAP 7 allows the clone operation.
         // However EAP 7 will need to take into account the ignore-unused-configuration
         // setting which does not exist in 6.x
-        final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
-        final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
+        final DomainClient masterClient = support.getDomainPrimaryLifecycleUtil().createDomainClient();
+        final DomainClient slaveClient = support.getDomainSecondaryLifecycleUtil().createDomainClient();
         try {
             final PathAddress newProfileAddress = PathAddress.pathAddress(PROFILE, "new-profile");
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/WildcardReadsTestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/WildcardReadsTestCase.java
@@ -120,7 +120,7 @@ public class WildcardReadsTestCase {
 
     private static String readMasterServerOneState() throws IOException {
         ModelNode op = Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE), "server-state");
-        ModelNode response = support.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+        ModelNode response = support.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
         if (SUCCESS.equals(response.get(OUTCOME).asString())) {
             return response.get(RESULT).asString();
         }
@@ -682,7 +682,7 @@ public class WildcardReadsTestCase {
 
     private static ModelNode executeForResult(ModelNode op, ModelType expectedType) {
         try {
-            ModelNode response = support.getDomainMasterLifecycleUtil().getDomainClient().execute(op);
+            ModelNode response = support.getDomainPrimaryLifecycleUtil().getDomainClient().execute(op);
             assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
             ModelNode result = response.get(RESULT);
             assertEquals(result.toString(), expectedType, result.getType());


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17105

Includes:
https://issues.redhat.com/browse/WFLY-15863 (via jboss-logmanager component upgrade: https://issues.redhat.com/browse/WFCORE-6078)

Supersedes:
https://github.com/wildfly/wildfly/pull/16184
https://github.com/wildfly/wildfly/pull/16065

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/19.0.0.Beta18...19.0.0.Final

---

 
<details>       
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5899'>WFCORE-5899</a>] -         primary/secondary] Problematic Language usage deprecation and replacement of Java docs/variable names
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5903'>WFCORE-5903</a>] -         Cannot register a secondary host controller after restarting it when admin-policy is fetch-from-domain-controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6038'>WFCORE-6038</a>] -         The org.wildfly.core:wildfly-cli:client artifact has unneeded dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6058'>WFCORE-6058</a>] -         host-secondary.xml missing example to specify password for connection to primary
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6062'>WFCORE-6062</a>] -         Remoting subsystem contains security-realm references which have not been deprecated.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6068'>WFCORE-6068</a>] -         CliCommandBuilder.of method must be added back
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6087'>WFCORE-6087</a>] -         Add --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED to default JPMS settings
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6040'>WFCORE-6040</a>] -         Update MappersTestCase to use assertNull where appropriate
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6061'>WFCORE-6061</a>] -         [Primary/Secondary]Problematic Language usage deprecation and replacement of unit test cases. 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6063'>WFCORE-6063</a>] -         Bump the Remoting subsystem model to 6 and the schema to 5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6067'>WFCORE-6067</a>] -         Allocate Phase ID for Metrics module in WFLY
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6079'>WFCORE-6079</a>] -         Make protected AttributeDefinition fields private
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6082'>WFCORE-6082</a>] -         Verify the path when unzipping zip files
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6091'>WFCORE-6091</a>] -         Remove &quot;-jakarta&quot; suffix from source-transformed artifacts and instead add new suffix to the original artifacts
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6034'>WFCORE-6034</a>] -         Upgrade log4j2 2.19.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6057'>WFCORE-6057</a>] -         Upgrade Undertow to 2.3.0.Final (CVE-2022-2764)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6059'>WFCORE-6059</a>] -         Upgrade Jandex to 3.0.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6071'>WFCORE-6071</a>] -         Upgrade snakeyaml to 1.33 (resolves CVE-2022-38752)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6072'>WFCORE-6072</a>] -         Upgrade JBoss Marshalling to 2.1.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6076'>WFCORE-6076</a>] -         Upgrade JBoss Remoting to 5.0.26.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6078'>WFCORE-6078</a>] -         Upgrade jboss-logmanager to 2.1.19.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6083'>WFCORE-6083</a>] -         Upgrade Google guava to 31.1-jre
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6085'>WFCORE-6085</a>] -         Upgrade Jackson to 2.13.4 (CVE-2022-42004)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6088'>WFCORE-6088</a>] -         Upgrade Jackson Databind to 2.13.4.1 (CVE-2022-42003)
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3373'>WFCORE-3373</a>] -         Add an HC reload API to DomainLifecycleUtil
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6064'>WFCORE-6064</a>] -         SubDeploymentUnitService wasn&#39;t intended to be a public class
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6065'>WFCORE-6065</a>] -         Eliminate unused AbstractDeploymentUnitService.deployerChainsInjector field
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6066'>WFCORE-6066</a>] -         Rewrite DeploymentUnitServices to use new MSC values API
</li>
</ul>
</details>
