### PR TITLE
Revert "[WFLY-17086] Warning message WFLYWELD0052 in ee-security quickstart"

### DIFF
--- a/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
+++ b/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/security/enterprise/api/main/module.xml
@@ -41,11 +41,5 @@
         <module name="javax.annotation.api" />
         <module name="javax.inject.api" />
         <module name="javax.json.api" />
-        <!--TODO remove the WELD dependencies from this module, see comments on https://github.com/wildfly/wildfly/pull/16155 for more details
-        soteria overrides the beanClass in CDIExtension, which makes weld not load them from appropriate module
-         -->
-        <module name="org.jboss.weld.api"/>
-        <module name="org.jboss.weld.core"/>
-        <module name="org.jboss.weld.spi"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Reverts wildfly/wildfly#16155

These changes appear to be preventing the Soteria implementations of the APIs from being loaded correctly resulting in ClassNotFoundException when running the TCK.

The following is proposed as a fix for the original issue but we also need to ensure it is accepted by Soteria as it is in code we have temporarily forked:
    https://github.com/wildfly-security/wildfly-elytron-ee/pull/22

If merged please reopen https://issues.redhat.com/browse/WFLY-17086