### PR TITLE
WFLY-17199 Replace hsqldb with h2 for Elytron OCSP test and drop hsqldb dependency

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -56,7 +56,6 @@
              Remove pinning with WFLY-15867 upgrading org.xipki.pki tests
              and change to org.bouncycastle:*-jdk18on -->
         <version.org.bouncycastle>1.69</version.org.bouncycastle>
-        <version.org.hsqldb.hsqldb>2.5.0</version.org.hsqldb.hsqldb>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>
         <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
@@ -368,13 +367,6 @@
             <artifactId>mockserver</artifactId>
             <version>${version.org.mock-server.mockserver}</version>
             <type>pom</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <version>${version.org.hsqldb.hsqldb}</version>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/certs/ocsp/ocsp-db.properties
+++ b/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/certs/ocsp/ocsp-db.properties
@@ -5,9 +5,9 @@
 
 ################## H2 #################
 
-dataSourceClassName = org.hsqldb.jdbc.JDBCDataSource
+dataSourceClassName = org.h2.jdbcx.JdbcDataSource
 
-dataSource.url = jdbc:hsqldb:mem:ocspdb
+dataSource.url = jdbc:h2:mem:ocspdb
 dataSource.user = root
 dataSource.password = 123456
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17199