### PR TITLE
[WFLY-16755] Update javax.* uses in JPA docs

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
@@ -9,7 +9,7 @@ requirements. Deploys the persistence unit definitions, the persistence
 unit/context annotations and persistence unit/context references in the
 deployment descriptor. JPA Applications use the Hibernate (version 5.3)
 persistence provider, which is included with WildFly. The JPA subsystem
-uses the standard SPI (javax.persistence.spi.PersistenceProvider) to
+uses the standard SPI (jakarta.persistence.spi.PersistenceProvider) to
 access the Hibernate persistence provider and some additional extensions
 as well.
 
@@ -19,7 +19,7 @@ dependencies into the application deployment. This makes it easy to
 deploy JPA applications.
 
 In the remainder of this documentation, "entity manager" refers to an
-instance of the _javax.persistence.EntityManager_ class.
+instance of the _jakarta.persistence.EntityManager_ class.
 https://javaee.github.io/javaee-spec/javadocs/overview-summary.html[Javadoc
 for the JPA interfaces]and https://jcp.org/en/jsr/detail?id=338[JPA 2.2
 specification].
@@ -43,7 +43,7 @@ Or remove the persistence provider class name from your persistence.xml
 [[entity-manager]]
 == Entity manager
 
-The entity manager (javax.persistence.EntityManager class) is similar to
+The entity manager (jakarta.persistence.EntityManager class) is similar to
 the Hibernate Session class; applications use it to
 create/read/update/delete data (and related operations). Applications
 can use application-managed or container-managed entity managers. Keep
@@ -68,7 +68,7 @@ EntityManager instance, if not found, a new EntityManager instance is
 created and associated with the current JTA transaction, to be reused
 for the next EntityManager invocation. Use the @PersistenceContext
 annotation, to inject a container-managed entity manager into a
-javax.persistence.EntityManager variable.
+jakarta.persistence.EntityManager variable.
 
 [[application-managed-entity-manager]]
 == Application-managed entity manager
@@ -77,7 +77,7 @@ An application-managed entity manager is kept around until the
 application closes it. The scope of the application-managed entity
 manager is from when the application creates it and lasts until the
 application closes it. Use the _@PersistenceUnit_ annotation, to inject
-a persistence unit into a _javax.persistence.EntityManagerFactory
+a persistence unit into a _jakarta.persistence.EntityManagerFactory
 variable_. The EntityManagerFactory can return an application-managed
 entity manager.
 
@@ -542,25 +542,25 @@ that depends on EclipseLink, to deploy on WildFly.
 ----
  <module xmlns="urn:jboss:module:1.9" name="org.eclipse.persistence">
     <resources>
-        <resource-root path="jipijapa-eclipselink-10.0.0.Final.jar"/>
+        <resource-root path="jipijapa-eclipselink-jakarta-27.0.0.Final.jar"/>
         <resource-root path="eclipselink.jar">           <filter>
-              <exclude path="javax/**" />
+              <exclude path="jakarta/**" />
            </filter>
         </resource-root>
     </resources>
  
     <dependencies>
-        <module name="asm.asm"/>
-        <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="javax.persistence.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.xml.bind.api"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="jakarta.annotation.api"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.json.api" optional="true"/>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
+        <module name="jakarta.xml.bind.api"/>
         <module name="org.antlr"/>
-        <module name="org.apache.commons.collections"/>
-        <module name="org.dom4j"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
@@ -880,7 +880,7 @@ persistence.xml
 public class ExampleSFSB {
   public void createSomeEntityWithTransactionScopedEM(String name) {
     Context context = new InitialContext();
-    javax.persistence.EntityManager entityManager = (javax.persistence.EntityManager) context.lookup("java:/myEntityManager");
+    jakarta.persistence.EntityManager entityManager = (javax.persistence.EntityManager) context.lookup("java:/myEntityManager");
     SomeEntity someEntity = new SomeEntity();
     someEntity.setName(name);    entityManager.persist(name);
   }

--- a/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
@@ -55,7 +55,7 @@ Spring applications using Jakarta Persistence may choose between:
 
 Applications that use a server-deployed persistence unit must observe
 the typical Jakarta EE rules in what concerns dependency management, i.e.
-the javax.persistence classes and persistence provider (Hibernate) are
+the jakarta.persistence classes and persistence provider (Hibernate) are
 contained in modules which are added automatically by the application
 when the persistence unit is deployed.
 
@@ -87,7 +87,7 @@ to be looked up in JNDI, as follows:
 [source,xml,options="nowrap"]
 ----
 <jee:jndi-lookup id="entityManager" jndi-name="java:comp/env/persistence/petclinic-em" 
-            expected-type="javax.persistence.EntityManager"/>
+            expected-type="jakarta.persistence.EntityManager"/>
 ----
 
 or
@@ -95,7 +95,7 @@ or
 [source,xml,options="nowrap"]
 ----
 <jee:jndi-lookup id="entityManagerFactory" jndi-name="java:comp/env/persistence/petclinic-emf" 
-            expected-type="javax.persistence.EntityManagerFactory"/>
+            expected-type="jakarta.persistence.EntityManagerFactory"/>
 ----
 
 JNDI binding

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
@@ -36,13 +36,13 @@
         <module name="java.logging"/>
         <module name="java.management"/>
         <module name="java.naming"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="javax.json.api" optional="true"/>
-        <module name="javax.persistence.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.xml.bind.api"/>
+        <module name="jakarta.annotation.api"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.json.api" optional="true"/>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
+        <module name="jakarta.xml.bind.api"/>
         <module name="org.antlr"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
I also update the org.eclipse.persistence EE API module deps to the jakarta.* names. In general I'm not in favor of doing that piecemeal but in this case the docs duplicate the file so I want it to match and I don't want to have to edit the docs later when we update all the module.xml files for javax->jakarta.

https://issues.redhat.com/browse/WFLY-16755 (JPA docs part)

@scottmarlow FYI