### PR TITLE
WFLY-17133 Ensure server socket channels created by NioServer can rebind to the same port on restart.

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -30,6 +30,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.StandardSocketOptions;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Map;
@@ -163,6 +164,10 @@ public class ManagedSocketFactory implements SocketFactory {
     @Override
     public ServerSocketChannel createServerSocketChannel(String name) throws IOException {
         ServerSocketChannel channel = ServerSocketChannel.open();
+        // Ensure server socket channels created by NioServer can rebind to the same port on restart
+        if (channel.supportedOptions().contains(StandardSocketOptions.SO_LINGER)) {
+            channel.setOption(StandardSocketOptions.SO_LINGER, 1);
+        }
         this.manager.getNamedRegistry().registerChannel(name, channel);
         return channel;
     }

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -60,7 +60,8 @@
         timeout_check_interval="5000"
     />
     <FD_SOCK port_range="0"/>
-    <FD_SOCK2 port_range="0" offset="1"/>
+    <!-- Restore port_range="0" once FD_SOCK2 respects our SocketFactory override -->
+    <FD_SOCK2 offset="1"/>
     <VERIFY_SUSPECT timeout="1000"/>
     <VERIFY_SUSPECT2 timeout="1000"/>
     <pbcast.NAKACK2


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17133

UPDATE: This will require a 5.2.9 JGroups release that contains a fix for https://issues.redhat.com/browse/JGRP-2648