### PR TITLE
[WFLY-17206] Fix NetworkHealthTestCase failures on Windows with IPv4

### DIFF
--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -107,6 +107,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-commons</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17206

PR CI jobs use -Dipv6 so I ran a custom job without that:

https://ci.wildfly.org/viewLog.html?buildId=333038&buildTypeId=WF_MasterWindowsJdk11
