### PR TITLE
WFLY-16362 Upgrade to Hibernate ORM 6.1.5 to remove internal CacheKeyValueDescriptor uses from API Type/JavaType classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>6.1.4.Final</version.org.hibernate>
+        <version.org.hibernate>6.1.5.Final</version.org.hibernate>
         <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
         <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.7.Final</version.org.hibernate.search>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>
https://issues.redhat.com/browse/WFLY-17173

Upgrade to Hibernate ORM 6.1.5.Final to resolve incorrect use of internal class as super class for API Type/JavaType classes.