### PR TITLE
WFLY-17173 Upgrade ByteBuddy to 1.2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>6.1.4.Final</version.org.hibernate>
+        <version.org.hibernate>6.1.5.Final</version.org.hibernate>
         <legacy.version.org.hibernate.commons.annotations>5.0.5.Final</legacy.version.org.hibernate.commons.annotations>
         <version.org.hibernate.commons.annotations>6.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.7.Final</version.org.hibernate.search>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
         <version.org.apache.xerces>2.12.0.SP04</version.org.apache.xerces>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.bitbucket.jose4j>0.8.0</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.12.9</version.org.bytebuddy>
+        <version.org.bytebuddy>1.12.18</version.org.bytebuddy>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.2.8</version.org.codehaus.woodstox.woodstox-core>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17173

Builds on the https://github.com/wildfly/wildfly/pull/16220 change that upgraded Hibernate ORM to 6.1.5.