### PR TITLE
[WFLY-17209] jboss-client.jar is missing jboss-modules classes which are required by jboss-ejb-client

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>
@@ -88,6 +93,11 @@
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17209