### PR TITLE
[WFLY-17198] Add the org.jboss.resteasy.microprofile.config module de…

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
@@ -102,7 +102,6 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
         addDependency(moduleSpecification, moduleLoader, RESTEASY_CRYPTO, true, false);
         addDependency(moduleSpecification, moduleLoader, JACKSON_DATATYPE_JDK8, true, false);
         addDependency(moduleSpecification, moduleLoader, JACKSON_DATATYPE_JSR310, true, false);
-        addDependency(moduleSpecification, moduleLoader, MP_REST_CLIENT, true, false);
 
         final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         if (support.hasCapability(WELD_CAPABILITY_NAME)) {
@@ -110,6 +109,10 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
             if (api.isPartOfWeldDeployment(deploymentUnit)) {
                 addDependency(moduleSpecification, moduleLoader, RESTEASY_CDI, true, false);
             }
+        }
+        if (support.hasCapability("org.wildfly.microprofile.config")) {
+            addDependency(moduleSpecification, moduleLoader, MP_REST_CLIENT, true, false);
+            addDependency(moduleSpecification, moduleLoader, "org.jboss.resteasy.microprofile.config", true, false);
         }
     }
 
@@ -129,6 +132,11 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
 
     private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
                                ModuleIdentifier moduleIdentifier, boolean optional, boolean deploymentBundelesClientBuilder) {
+        addDependency(moduleSpecification, moduleLoader, moduleIdentifier.toString(), optional, deploymentBundelesClientBuilder);
+    }
+
+    private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
+                               String moduleIdentifier, boolean optional, boolean deploymentBundelesClientBuilder) {
         ModuleDependency dependency = new ModuleDependency(moduleLoader, moduleIdentifier, optional, false, true, false);
         if(deploymentBundelesClientBuilder) {
             dependency.addImportFilter(PathFilters.is(CLIENT_BUILDER), false);

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
@@ -26,5 +26,6 @@
     </dependencies>
     <packages>
         <package name="org.jboss.resteasy.resteasy-client-microprofile"/>
+        <package name="org.jboss.resteasy.microprofile.config" optional="true"/>
     </packages>
 </layer-spec>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
@@ -32,6 +32,8 @@
         <module name="org.eclipse.microprofile.restclient"/>
         <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.jboss.logging"/>
+        <!--This will add additional configuration lookups if available, however it's not required -->
+        <module name="org.jboss.resteasy.microprofile.config" services="import" optional="true"/>
         <module name="org.jboss.resteasy.resteasy-cdi" services="import"/>
         <module name="org.jboss.resteasy.resteasy-client-api"/>
         <module name="org.jboss.resteasy.resteasy-client" services="import"/>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -73,6 +73,8 @@ public class LayersTestCase {
             // Perhaps via deployment descriptor? In any case, no layer provides them
             "org.wildfly.security.jakarta.client.resteasy",
             "org.wildfly.security.jakarta.client.webservices",
+            // This is added in the jaxrs subsystem to deployments if the MP config capability is met. The package is
+            // added in the microprofile-rest-client as well.
             "org.jboss.resteasy.microprofile.config",
             // Temporarily provided to not break the wildfly-extras gRPC feature pack
             // until it provides it itself.


### PR DESCRIPTION
…pendency to deployments. User should be able to set some RESTEasy specific configuration options with the MP Config API.

https://issues.redhat.com/browse/WFLY-17198
Signed-off-by: James R. Perkins <jperkins@redhat.com>