### PR TITLE
WFLY-16573 Update remote distributed timer service test case deployment descriptor to jakarta namespace.

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/remote/jboss-ejb3.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/remote/jboss-ejb3.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
-        xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<jboss:ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:jboss="urn:jboss:jakartaee:1.0"
         xmlns:t="urn:timer-service:2.0"
-        xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
-                http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd
-                http://www.jboss.org/j2ee/schema/jboss_5_0.xsd"
-        version="3.1"
-        impl-version="2.0">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd urn:jboss:jakartaee:1.0 https://www.jboss.org/schema/jbossas/jboss-ejb3-4_0.xsd"
+        version="4.0">
     <assembly-descriptor>
         <t:timer-service>
             <ejb-name>*</ejb-name>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16573

This slipped through due to the overlap between this feature implementation and the jakarta namespace transition.
