### PR TITLE
[WFLY-17218] Don't shade JBoss Logmanager into the jboss-client jar

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -81,11 +81,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17218