### PR TITLE
Revert "[WFLY-17209] jboss-client.jar is missing jboss-modules classes which are required by jboss-ejb-client"

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -81,11 +81,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>
@@ -93,11 +88,6 @@
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.modules</groupId>
-            <artifactId>jboss-modules</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reverts wildfly/wildfly#16223

See https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers/topic/JBoss.20Modules.20in.20jboss-client.2Ejar