### PR TITLE
WFLY-17221 Upgrade jboss-ejb-client from 5.0.0.Final to 5.0.1.Final, legacy javax version from 4.0.48.Final to 4.0.49.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,8 +515,8 @@
         <version.org.jboss.activemq.artemis.integration>1.0.6</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.7.0.Alpha12</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <legacy.version.org.jboss.ejb-client>4.0.48.Final</legacy.version.org.jboss.ejb-client>
-        <version.org.jboss.ejb-client>5.0.0.Final</version.org.jboss.ejb-client>
+        <legacy.version.org.jboss.ejb-client>4.0.49.Final</legacy.version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>5.0.1.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17221