### PR TITLE
[WFLY-17177] Configure surefire plugin's 'reportNameSuffix' when test will be executed multiple times

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1544,6 +1544,7 @@
                                     <additionalClasspathElements>
                                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
                                     </additionalClasspathElements>
+                                    <reportNameSuffix>basic-integration-default-web</reportNameSuffix>
                                 </configuration>
                             </execution>
 

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -219,6 +219,7 @@
                             <systemPropertyVariables>
                                 <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                             </systemPropertyVariables>
+                            <reportNameSuffix>standalone-enabled-elytron-oidc-client-test</reportNameSuffix>
                         </configuration>
                     </execution>
                 </executions>
@@ -318,6 +319,9 @@
                             <execution>
                                 <id>layers-test</id>
                                 <phase>test</phase>
+                                <configuration>
+                                    <reportNameSuffix>layers-test</reportNameSuffix>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>default-test</id>
@@ -432,6 +436,9 @@
                             <execution>
                                 <id>layers-test</id>
                                 <phase>test</phase>
+                                <configuration>
+                                    <reportNameSuffix>layers-test</reportNameSuffix>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>default-test</id>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -445,6 +445,7 @@
                                 <!-- The enable-microprofile.cli script does not enable the reactive extensions/subsystems -->
                                 <exclude>org/wildfly/test/integration/microprofile/reactive/**</exclude>
                             </excludes>
+                            <reportNameSuffix>standalone-enabled-microprofile-test</reportNameSuffix>
                         </configuration>
                     </execution>
                 </executions>
@@ -575,6 +576,9 @@
                             <execution>
                                 <id>layers-test</id>
                                 <phase>test</phase>
+                                <configuration>
+                                    <reportNameSuffix>layers-test</reportNameSuffix>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>default-test</id>
@@ -714,6 +718,9 @@
                             <execution>
                                 <id>layers-test</id>
                                 <phase>test</phase>
+                                <configuration>
+                                    <reportNameSuffix>layers-test</reportNameSuffix>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>default-test</id>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/converter/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/converter/SetupTask.java
@@ -23,6 +23,7 @@
 package org.wildfly.test.integration.microprofile.config.smallrye.converter;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
@@ -67,7 +68,9 @@ public class SetupTask implements ServerSetupTask {
                 }
             }
         } else {
-            configSourceServiceLoad.as(ZipExporter.class).exportTo(moduleFile);
+            try (FileOutputStream target = new FileOutputStream(moduleFile)) {
+                configSourceServiceLoad.as(ZipExporter.class).exportTo(target);
+            }
         }
         testModule = new TestModule(TEST_MODULE_NAME, moduleXmlFile);
         testModule.addJavaArchive(moduleFile);

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_class/SetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_class/SetupTask.java
@@ -50,6 +50,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashSet;
@@ -97,7 +98,9 @@ public class SetupTask implements ServerSetupTask {
                 .addClass(CustomConfigSourceAServiceLoader.class)
                 .addAsServiceProvider(ConfigSource.class,
                         CustomConfigSourceAServiceLoader.class, CustomConfigSourceServiceLoader.class);
-        configSourceServiceLoad.as(ZipExporter.class).exportTo(moduleFile);
+        try(FileOutputStream target = new FileOutputStream(moduleFile)) {
+            configSourceServiceLoad.as(ZipExporter.class).exportTo(target);
+        }
         url = ConfigSourceFromClassTestCase.class.getResource("module_service_loader.xml");
         moduleXmlFile = new File(url.toURI());
         testModule = new TestModule(TEST_MODULE_NAME_SERVICE_LOADER, moduleXmlFile);

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -555,6 +555,9 @@
                                 <goals>
                                     <goal>test</goal>
                                 </goals>
+                                <configuration>
+                                    <reportNameSuffix>microprofile.surefire</reportNameSuffix>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -875,6 +878,7 @@
                                         <!-- requires https -->
                                         <exclude>org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java</exclude>
                                     </excludes>
+                                    <reportNameSuffix>web-profile-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -904,6 +908,7 @@
                                              where elytron is configured but -Delytron is not set. -->
                                         <!--include>org/jboss/as/test/integration/web/security/**/TransportGuaranteeTestCase.java</include-->
                                     </includes>
+                                    <reportNameSuffix>legacy-https-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -933,6 +938,7 @@
                                         <!-- requires https -->
                                         <exclude>org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java</exclude>
                                     </excludes>
+                                    <reportNameSuffix>jaxrs-server-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -955,6 +961,7 @@
                                         <module.path>${project.build.directory}/wildfly-cloud/modules${path.separator}${basedir}/target/modules</module.path>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
+                                    <reportNameSuffix>microprofile.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1066,6 +1073,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-web-profile-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1093,6 +1101,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-legacy-security-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1120,6 +1129,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>ts.bootable.bootable-jar-legacy-https-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1151,6 +1161,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-jaxrs-server-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1182,6 +1193,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-cloud-server-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1294,6 +1306,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-web-profile-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1321,6 +1334,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-legacy-https-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1355,6 +1369,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-jaxrs-server-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -1389,6 +1404,7 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <reportNameSuffix>bootable-jar-cloud-server-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -191,7 +191,7 @@
                                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
                                     </additionalClasspathElements>
 
-                                    <!--<reportNameSuffix>tests-basic-integration-default</reportNameSuffix>-->
+                                    <reportNameSuffix>basic-preview-default-full.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -222,6 +222,7 @@
                                     <additionalClasspathElements>
                                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
                                     </additionalClasspathElements>
+                                    <reportNameSuffix>basic-preview-default-web.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -381,6 +382,7 @@
                                         <!-- Dummy test used to validate this pom -->
                                         <include>org/wildfly/test/preview/util/TestsuiteModuleTestCase.java</include>
                                     </includes>
+                                    <reportNameSuffix>cloud-server.layer.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -407,6 +409,7 @@
                                     <includes>
                                         <include>org/wildfly/test/preview/hibernate/search/**/*TestCase.java</include>
                                     </includes>
+                                    <reportNameSuffix>hibernate-search.layer.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -582,6 +585,7 @@
                                         <!-- Dummy test used to validate this pom -->
                                         <include>org/wildfly/test/preview/util/TestsuiteModuleTestCase.java</include>
                                     </includes>
+                                    <reportNameSuffix>cloud.server.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
 
@@ -607,6 +611,7 @@
                                         <!-- Dummy test used to validate this pom -->
                                         <include>org/wildfly/test/preview/util/TestsuiteModuleTestCase.java</include>
                                     </includes>
+                                    <reportNameSuffix>jpa-layers.surefire</reportNameSuffix>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17177

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

If this PR is not for the 'main' branch you must add a link to the equivalent change in 'main'.

Remember to use the Jira issue ID in the PR title and any commits.


This PR tries to add `reportNameSuffix>EXECUTION-ID</reportNameSuffix>` to some execution configuration of `maven-surefire-plugin` to avoid the test report being overridden if the test gets executed multiple times.
