### PR TITLE
[WFLY-17226][WFLY-17227] Upgrading JBoss Invocation version to 2.0.0.Final (Jakarta EE API) and legacy version to 1.7.1.Final (Java EE API)

### DIFF
--- a/boms/legacy-ee/pom.xml
+++ b/boms/legacy-ee/pom.xml
@@ -763,7 +763,7 @@
             <dependency>
                 <groupId>org.jboss.invocation</groupId>
                 <artifactId>jboss-invocation</artifactId>
-                <version>${version.org.jboss.invocation}</version>
+                <version>${legacy.version.org.jboss.invocation}</version>
             </dependency>
 
             <dependency>

--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -2240,7 +2240,7 @@
 
             <dependency>
                 <groupId>org.jboss.invocation</groupId>
-                <artifactId>jboss-invocation-jakarta</artifactId>
+                <artifactId>jboss-invocation</artifactId>
                 <version>${version.org.jboss.invocation}</version>
                 <exclusions>
                     <exclusion>

--- a/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
+++ b/ee-9/common/src/main/resources/license/preview-feature-pack-common-licenses.xml
@@ -149,7 +149,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.invocation</groupId>
-      <artifactId>jboss-invocation-jakarta</artifactId>
+      <artifactId>jboss-invocation</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/ee-9/source-transform/connector/pom.xml
+++ b/ee-9/source-transform/connector/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>

--- a/ee-9/source-transform/ee/pom.xml
+++ b/ee-9/source-transform/ee/pom.xml
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
 
         <dependency>

--- a/ee-9/source-transform/weld/common/pom.xml
+++ b/ee-9/source-transform/weld/common/pom.xml
@@ -66,7 +66,7 @@
 
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -494,7 +494,7 @@
 
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -3491,7 +3491,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.invocation</groupId>
-      <artifactId>jboss-invocation-jakarta</artifactId>
+      <artifactId>jboss-invocation</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -62,7 +62,7 @@ vi:ts=4:sw=4:expandtab
         </dependency>
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.resource</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,8 @@
         <version.org.jboss.genericjms>2.0.10.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.6.4.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
-        <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
+        <legacy.version.org.jboss.invocation>1.7.1.Final</legacy.version.org.jboss.invocation>
+        <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.5.9.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.metadata</groupId>

--- a/weld/ejb/pom.xml
+++ b/weld/ejb/pom.xml
@@ -48,7 +48,7 @@
 
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
 
         <dependency>

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -103,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.invocation</groupId>
-            <artifactId>jboss-invocation-jakarta</artifactId>
+            <artifactId>jboss-invocation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17226
https://issues.redhat.com/browse/WFLY-17227
