### PR TITLE
[WFLY-17230] Upgrade WildFly Core to 20.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,7 +597,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.http-client>1.1.15.Final</legacy.version.org.wildfly.http-client>
         <version.org.wildfly.http-client>2.0.0.Final</version.org.wildfly.http-client>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17230

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/19.0.0.Final...20.0.0.Beta1

---

<details>       
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6090'>WFCORE-6090</a>] -         Unexpected NullPointerException in Elytron tests when init capabilities are missing
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5979'>WFCORE-5979</a>] -         Move com.google.guava:guava and com.google.guava:failureaccess to testbom
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6092'>WFCORE-6092</a>] -         Remove deprecation of ExtensibleHttpManagement
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6093'>WFCORE-6093</a>] -         Remove Seam2 integration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6101'>WFCORE-6101</a>] -         Remove the deprecated OperationFailedException(ModelNode) constructor
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6102'>WFCORE-6102</a>] -         org.jboss.as.test.layers.Scanner cannot handle dependencies with explicit slots
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6106'>WFCORE-6106</a>] -         Bump the kernel management API version to 21.0.0
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6039'>WFCORE-6039</a>] -         Upgrade JBoss MSC to 1.5.0.Beta3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6070'>WFCORE-6070</a>] -         Upgrade JBoss Modules to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6084'>WFCORE-6084</a>] -         Upgrade bouncycastle from 1.71 to 1.72
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6100'>WFCORE-6100</a>] -         -D[Server:XXX] JVM parameter is out of order
</li>
</ul>
</details>
