### PR TITLE
[WFLY-17254] Add a global client interceptors for EJB deployments that will runAs the current security identity to activate any outflow identities

### DIFF
--- a/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee-9/source-transform/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -206,6 +206,7 @@ public class InterceptorOrder {
 
     public static final class Client {
 
+        public static final int SECURITY_IDENTITY = 0x001;
         public static final int TO_STRING = 0x100;
         public static final int NOT_BUSINESS_METHOD_EXCEPTION = 0x110;
         public static final int LOCAL_ASYNC_LOG_SAVE = 0x180;

--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -206,6 +206,7 @@ public class InterceptorOrder {
 
     public static final class Client {
 
+        public static final int SECURITY_IDENTITY = 0x001;
         public static final int TO_STRING = 0x100;
         public static final int NOT_BUSINESS_METHOD_EXCEPTION = 0x110;
         public static final int LOCAL_ASYNC_LOG_SAVE = 0x180;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityEJBClientInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityEJBClientInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.security;
+
+import static org.jboss.as.ejb3.security.IdentityUtil.getCurrentSecurityDomain;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An {@code EJBClientInterceptor} that will always runAs the current {@code SecurityIdentity}
+ * to activate any outflow identities.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public final class IdentityEJBClientInterceptor implements EJBClientInterceptor {
+
+    public static final IdentityEJBClientInterceptor INSTANCE = new IdentityEJBClientInterceptor();
+
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        final SecurityDomain securityDomain = getCurrentSecurityDomain();
+        if (securityDomain != null) {
+            SecurityIdentity identity = securityDomain.getCurrentSecurityIdentity();
+            identity.runAsSupplierEx(() -> {
+                context.sendRequest();
+                return null;
+            });
+        } else {
+            context.sendRequest();
+        }
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.security;
+
+import static org.jboss.as.ejb3.security.IdentityUtil.getCurrentSecurityDomain;
+
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An {@code Interceptor} that will always runAs the current {@code SecurityIdentity}
+ * to activate any outflow identities.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public final class IdentityInterceptor implements Interceptor {
+
+    public static final IdentityInterceptor INSTANCE = new IdentityInterceptor();
+
+    @Override
+    public Object processInvocation(InterceptorContext context) throws Exception {
+        final SecurityDomain securityDomain = getCurrentSecurityDomain();
+        if (securityDomain != null) {
+            SecurityIdentity identity = securityDomain.getCurrentSecurityIdentity();
+            return identity.runAsSupplierEx(() -> context.proceed());
+        } else {
+            return context.proceed();
+        }
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityUtil.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/IdentityUtil.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.security;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+class IdentityUtil {
+
+    public static SecurityDomain getCurrentSecurityDomain() {
+        if (WildFlySecurityManager.isChecking()) {
+            return AccessController.doPrivileged((PrivilegedAction<SecurityDomain>) SecurityDomain::getCurrent);
+        } else {
+            return SecurityDomain.getCurrent();
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClientInterceptorsBindingsProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClientInterceptorsBindingsProcessor.java
@@ -45,11 +45,14 @@ public class ClientInterceptorsBindingsProcessor implements DeploymentUnitProces
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         try {
-            final List<EJBClientInterceptor> clientInterceptors = new ArrayList<>();
+            final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+            List<EJBClientInterceptor> clientInterceptors = deploymentUnit.getAttachment(org.jboss.as.ejb3.subsystem.Attachments.STATIC_EJB_CLIENT_INTERCEPTORS);
+            if (clientInterceptors == null) {
+                clientInterceptors = new ArrayList<>();
+            }
             for (final Class<? extends EJBClientInterceptor> interceptorClass : clientInterceptorCache.getClientInterceptors()) {
                 clientInterceptors.add(interceptorClass.newInstance());
             }
-            final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
             deploymentUnit.putAttachment(org.jboss.as.ejb3.subsystem.Attachments.STATIC_EJB_CLIENT_INTERCEPTORS, clientInterceptors);
 
         } catch (InstantiationException | IllegalAccessException e) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -435,6 +435,9 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                                 new ServerInterceptorsBindingsProcessor(serverInterceptorCache));
                     }
 
+                    processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_GLOBAL_CLIENT_INTERCEPTORS,
+                            new IdentityInterceptorProcessor());
+
                     if (model.hasDefined(CLIENT_INTERCEPTORS)) {
                         final List<ServerInterceptorMetaData> clientInterceptors = new ArrayList<>();
 
@@ -447,7 +450,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                                 new StaticInterceptorsDependenciesDeploymentUnitProcessor(clientInterceptors));
 
                         final ClientInterceptorCache clientInterceptorCache = new ClientInterceptorCache(clientInterceptors);
-                        processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.POST_MODULE_EJB_SERVER_INTERCEPTORS,
+                        processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_SERVER_INTERCEPTORS,
                                 new ClientInterceptorsBindingsProcessor(clientInterceptorCache));
                     }
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/IdentityInterceptorProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/IdentityInterceptorProcessor.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ejb3.subsystem;
+
+import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
+
+import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.component.ViewConfiguration;
+import org.jboss.as.ee.component.ViewConfigurator;
+import org.jboss.as.ee.component.ViewDescription;
+import org.jboss.as.ee.component.interceptors.InterceptorOrder;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.component.EJBViewDescription;
+import org.jboss.as.ejb3.security.IdentityEJBClientInterceptor;
+import org.jboss.as.ejb3.security.IdentityInterceptor;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.invocation.ImmediateInterceptorFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link DeploymentUnitProcessor} that adds interceptors to EJB deployments that will always
+ * runAs the current {@code SecurityIdentity} to activate any outflow identities.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+class IdentityInterceptorProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        registerIdentityEJBClientInterceptor(deploymentUnit);
+        registerIdentityInterceptor(deploymentUnit);
+    }
+
+    private static void registerIdentityEJBClientInterceptor(final DeploymentUnit deploymentUnit) {
+        // this EJBClientInterceptor will get used when invoking remote EJBs
+        final List<EJBClientInterceptor> clientInterceptors = new ArrayList<>(Arrays.asList(IdentityEJBClientInterceptor.INSTANCE));
+        deploymentUnit.putAttachment(org.jboss.as.ejb3.subsystem.Attachments.STATIC_EJB_CLIENT_INTERCEPTORS, clientInterceptors);
+    }
+
+    private static void registerIdentityInterceptor(final DeploymentUnit deploymentUnit) {
+        // this Interceptor will get used when invoking local EJBs
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(EE_MODULE_DESCRIPTION);
+        if (eeModuleDescription == null) {
+            return;
+        }
+        final Collection<ComponentDescription> componentDescriptions = eeModuleDescription.getComponentDescriptions();
+        if (componentDescriptions == null || componentDescriptions.isEmpty()) {
+            return;
+        }
+        for (ComponentDescription componentDescription : componentDescriptions) {
+            if (componentDescription instanceof EJBComponentDescription) {
+                for (ViewDescription view : componentDescription.getViews()) {
+                    final EJBViewDescription ejbView = (EJBViewDescription) view;
+                    ejbView.getConfigurators().add(new ViewConfigurator() {
+                        @Override
+                        public void configure(final DeploymentPhaseContext context, final ComponentConfiguration componentConfiguration,
+                                              final ViewDescription description, final ViewConfiguration configuration) throws DeploymentUnitProcessingException {
+                            configuration.addClientInterceptor(new ImmediateInterceptorFactory(new IdentityInterceptor()), InterceptorOrder.Client.SECURITY_IDENTITY);
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/IdentityPropagationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/IdentityPropagationTestCase.java
@@ -1,0 +1,663 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.cli.Util.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.operations.common.Util.createAddOperation;
+import static org.jboss.as.controller.operations.common.Util.getUndefineAttributeOperation;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.test.integration.elytron.util.HttpUtil.get;
+
+import java.io.File;
+import java.net.SocketPermission;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
+import org.wildfly.test.integration.elytron.ejb.base.WhoAmIBean;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.ComplexServletLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.EntryBeanLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.EntryLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.ManagementBeanLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.ServletOnlyLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.SimpleServletLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.WhoAmIBeanLocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.local.WhoAmILocal;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.ComplexServletRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryBeanRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.ManagementBeanRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.ServletOnlyRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.SimpleServletRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.WhoAmIBeanRemote;
+import org.wildfly.test.integration.elytron.ejb.propagation.remote.WhoAmIRemote;
+import org.wildfly.test.integration.elytron.util.HttpUtil;
+import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ServletElytronDomainSetup;
+
+/**
+ * Test class to hold the identity propagation scenarios involving different security domains.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ *
+ * NOTE: References in this file to Enterprise JavaBeans(EJB) refer to the Jakarta Enterprise Beans unless otherwise noted.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ IdentityPropagationTestCase.ServletDomainSetupOverride.class, IdentityPropagationTestCase.EJBDomainSetupOverride.class, IdentityPropagationTestCase.PropagationSetup.class, ServletElytronDomainSetup.class})
+public class IdentityPropagationTestCase {
+
+    private static final String SERVLET_SECURITY_DOMAIN_NAME = "elytron-tests";
+    private static final String EJB_SECURITY_DOMAIN_NAME = "ejb-domain";
+    private static final String SINGLE_DEPLOYMENT_LOCAL = "single-deployment-local";
+    private static final String EAR_DEPLOYMENT_WITH_EJB_LOCAL = "ear-ejb-deployment-local";
+    private static final String EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL = "ear-servlet-ejb-deployment-local";
+    private static final String SINGLE_DEPLOYMENT_REMOTE = "single-deployment-remote";
+    private static final String EAR_DEPLOYMENT_WITH_EJB_REMOTE = "ear-ejb-deployment-remote";
+    private static final String EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE = "ear-servlet-ejb-deployment-remote";
+    private static final String EAR_DEPLOYMENT_WITH_SERVLET_REMOTE = "ear-servlet-remote";
+    private static final String EAR_DEPLOYMENT_WITH_SERVLET_LOCAL = "ear-servlet-local";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_EJB_LOCAL, order = 1)
+    public static Archive<?> ejbDeploymentLocal() {
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_EJB_LOCAL + "-ejb.jar")
+                .addClass(WhoAmIBeanLocal.class).addClass(EntryBeanLocal.class)
+                .addClass(WhoAmILocal.class).addClass(EntryLocal.class)
+                .addClass(WhoAmIBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_EJB_LOCAL + ".ear");
+        ear.addAsModule(jar);
+        return ear;
+    }
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_EJB_REMOTE, order = 2)
+    public static Archive<?> ejbDeploymentRemote() {
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_EJB_REMOTE + "-ejb.jar")
+                .addClass(WhoAmIBeanRemote.class).addClass(EntryBeanRemote.class)
+                .addClass(WhoAmIRemote.class).addClass(EntryRemote.class)
+                .addClass(WhoAmIBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_EJB_REMOTE + ".ear");
+        ear.addAsModule(jar);
+        return ear;
+    }
+
+    @Deployment(name= SINGLE_DEPLOYMENT_LOCAL, order = 3)
+    public static Archive<?> singleDeploymentLocal() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, SINGLE_DEPLOYMENT_LOCAL + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(SimpleServletLocal.class, IdentityPropagationTestCase.class)
+                .addClass(Util.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, SINGLE_DEPLOYMENT_LOCAL + "-ejb.jar")
+                .addClass(WhoAmIBeanLocal.class).addClass(EntryBeanLocal.class)
+                .addClass(WhoAmILocal.class).addClass(EntryLocal.class)
+                .addClass(WhoAmIBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, SINGLE_DEPLOYMENT_LOCAL + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL, order = 4)
+    public static Archive<?> servletAndEJBDeploymentLocal() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(ComplexServletLocal.class, IdentityPropagationTestCase.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL + "-ejb.jar")
+                .addClass(ManagementBeanLocal.class)
+                .addClass(Util.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB_LOCAL + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB_LOCAL + "-ejb.jar"), "MANIFEST.MF");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_SERVLET_REMOTE, order = 5)
+    public static Archive<?> servletOnlyRemote() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_REMOTE + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(ServletOnlyRemote.class, IdentityPropagationTestCase.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_REMOTE + "-ejb.jar")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB_REMOTE + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB_REMOTE + "-ejb.jar"), "MANIFEST.MF");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_REMOTE + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_SERVLET_LOCAL, order = 6)
+    public static Archive<?> servletOnlyLocal() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_LOCAL + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(ServletOnlyLocal.class, IdentityPropagationTestCase.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_LOCAL + "-ejb.jar")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB_LOCAL + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB_LOCAL + "-ejb.jar"), "MANIFEST.MF");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_LOCAL + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    @Deployment(name= SINGLE_DEPLOYMENT_REMOTE, order = 7)
+    public static Archive<?> singleDeploymentRemote() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, SINGLE_DEPLOYMENT_REMOTE + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(SimpleServletRemote.class, IdentityPropagationTestCase.class)
+                .addClass(Util.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, SINGLE_DEPLOYMENT_REMOTE + "-ejb.jar")
+                .addClass(WhoAmIBeanRemote.class).addClass(EntryBeanRemote.class)
+                .addClass(WhoAmIRemote.class).addClass(EntryRemote.class)
+                .addClass(WhoAmIBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, SINGLE_DEPLOYMENT_REMOTE + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    @Deployment(name= EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE, order = 8)
+    public static Archive<?> servletAndEJBDeploymentRemote() {
+        final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+        final Package currentPackage = IdentityPropagationTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE + "-web.war")
+                .addClass(HttpUtil.class)
+                .addClasses(ComplexServletRemote.class, IdentityPropagationTestCase.class)
+                .addClasses(ServletDomainSetupOverride.class, EJBDomainSetupOverride.class, PropagationSetup.class,
+                        PropagationSetup.class, ServletElytronDomainSetup.class,
+                        ElytronDomainSetup.class, AbstractMgmtTestBase.class, EjbElytronDomainSetup.class)
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE + "-ejb.jar")
+                .addClass(ManagementBeanRemote.class)
+                .addClass(Util.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB_REMOTE + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB_REMOTE + "-ejb.jar"), "MANIFEST.MF");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE + ".ear");
+        ear.addAsModule(war);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                        // HttpUtil#execute calls ExecutorService#shutdownNow
+                        new RuntimePermission("modifyThread"),
+                        // HttpUtil#execute calls sun.net.www.http.HttpClient#openServer under the hood
+                        new SocketPermission(SERVER_HOST_PORT, "connect,resolve"),
+                        // Util#switchIdentity calls SecurityDomain#getCurrent and SecurityDomain#authenticate
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                ),
+                "permissions.xml");
+        return ear;
+    }
+
+    /**
+     * Servlet -> EJB propagation scenarios involving different security domains within a single deployment.
+     */
+
+    /**
+     * The EAR used in this test case contains:
+     * - a servlet within a WAR
+     * - a local EJB within a JAR
+     *
+     * The servlet attempts to invoke the local EJB.
+     */
+    @Test
+    @OperateOnDeployment(SINGLE_DEPLOYMENT_LOCAL)
+    public void testServletToEjbSingleDeploymentLocal() throws Exception {
+        testServletToEjbInvocation();
+    }
+
+    /**
+     * The EAR used in this test case contains:
+     * - a servlet within a WAR
+     * - a remote EJB within a JAR
+     *
+     * The servlet attempts to invoke the remote EJB.
+     */
+    @Test
+    @OperateOnDeployment(SINGLE_DEPLOYMENT_REMOTE)
+    public void testServletToEjbSingleDeploymentRemote() throws Exception {
+        testServletToEjbInvocation();
+    }
+
+    private void testServletToEjbInvocation() throws Exception {
+        String result = getWhoAmI("?method=whoAmI");
+        assertEquals("user1", result);
+        result = getWhoAmI("?method=doIHaveRole&role=Managers");
+        assertEquals("true", result);
+    }
+
+    /**
+     * The EAR used in this test case contains:
+     * - a servlet within a WAR
+     * - an EJB within a JAR
+     *
+     * The wrong password is used to access the servlet.
+     */
+    @Test
+    @OperateOnDeployment(SINGLE_DEPLOYMENT_REMOTE)
+    public void testWrongPasswordSingleDeployment() throws Exception {
+        testWrongPassword();
+    }
+
+    /**
+     * The EAR used in this test case contains:
+     * - a servlet within a WAR
+     * - a remote EJB within a JAR
+     *
+     * The servlet uses programmatic authentication to switch the identity and invokes the remote EJB
+     * under this new identity.
+     */
+    @Test
+    @OperateOnDeployment(SINGLE_DEPLOYMENT_REMOTE)
+    public void testServletToEjbSingleDeploymentProgrammaticAuthRemote() throws Exception {
+        testServletToEjbSingleDeploymentProgrammaticAuth();
+    }
+
+    /**
+     * The EAR used in this test case contains:
+     * - a servlet within a WAR
+     * - a local EJB within a JAR
+     *
+     * The servlet uses programmatic authentication to switch the identity and invokes the local EJB
+     * under this new identity.
+     */
+    @Test
+    @OperateOnDeployment(SINGLE_DEPLOYMENT_LOCAL)
+    public void testServletToEjbSingleDeploymentProgrammaticAuthLocal() throws Exception {
+        testServletToEjbSingleDeploymentProgrammaticAuth();
+    }
+
+    private void testServletToEjbSingleDeploymentProgrammaticAuth() throws Exception {
+        String result = getWhoAmI("?method=switchWhoAmI&username=user2&password=password2&role=Managers2");
+        assertEquals("user2,true", result);
+    }
+
+    private void testWrongPassword() throws Exception {
+        try {
+            getWhoAmIWrongPassword("?method=whoAmI");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Unauthorized"));
+        }
+    }
+
+    /**
+     * Servlet -> EJB -> EJB propagation scenarios involving different security domains across deployments.
+     */
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     * - an EJB within a JAR
+     *
+     * EAR #2 contains:
+     * - a local EJB within a JAR
+     *
+     * The servlet invokes the EJB from EAR #1 and that EJB attempts to invoke the local EJB in EAR #2.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL)
+    public void testEarToEarLocal() throws Exception {
+        testServletToEjbToEjbInvocation();
+    }
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     * - an EJB within a JAR
+     *
+     * EAR #2 contains:
+     * - a remote EJB within a JAR
+     *
+     * The servlet invokes the EJB from EAR #1 and that EJB attempts to invoke the remote EJB in EAR #2.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE)
+    public void testEarToEarRemote() throws Exception {
+        testServletToEjbToEjbInvocation();
+    }
+
+    private void testServletToEjbToEjbInvocation() throws Exception {
+        String result = getWhoAmI("?method=whoAmI");
+        assertEquals("user1", result);
+        result = getWhoAmI("?method=invokeEntryDoIHaveRole&role=Managers");
+        assertEquals("true", result);
+    }
+
+    /**
+     * The servlet from EAR #1 is accessed using the wrong password.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE)
+    public void testWrongPasswordEarToEar() throws Exception {
+        testWrongPassword();
+    }
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     *
+     * EAR #2 contains:
+     * - a remote EJB within a JAR
+     *
+     * The servlet invokes the remote EJB from EAR #2.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_REMOTE)
+    public void testServletToEjbEarToEarRemote() throws Exception {
+        testServletToEjbInvocation();
+    }
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     *
+     * EAR #2 contains:
+     * - a local EJB within a JAR
+     *
+     * The servlet invokes the local EJB from EAR #2.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_LOCAL)
+    public void testServletToEjbEarToEarLocal() throws Exception {
+        testServletToEjbInvocation();
+    }
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     * - an EJB within a JAR
+     *
+     * EAR #2 contains:
+     * - a remote EJB within a JAR
+     *
+     * The servlet invokes the EJB from EAR #1. That EJB then uses programmatic authentication to switch
+     * the identity and then invokes the remote EJB from EAR #2 under this new identity.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_REMOTE)
+    public void testEarToEarProgrammaticAuthRemote() throws Exception {
+        testEarToEarProgrammaticAuth();
+    }
+
+    /**
+     * Two EARs are used in this test case.
+     * EAR #1 contains:
+     * - a servlet within a WAR
+     * - an EJB within a JAR
+     *
+     * EAR #2 contains:
+     * - a local EJB within a JAR
+     *
+     * The servlet invokes the EJB from EAR #1. That EJB then uses programmatic authentication to switch
+     * the identity and then invokes the local EJB from EAR #2 under this new identity.
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_WITH_SERVLET_AND_EJB_LOCAL)
+    public void testEarToEarProgrammaticAuthLocal() throws Exception {
+        testEarToEarProgrammaticAuth();
+    }
+
+    private void testEarToEarProgrammaticAuth() throws Exception {
+        String result = getWhoAmI("?method=switchThenInvokeEntryDoIHaveRole&username=user2&password=password2&role=Managers2");
+        assertEquals("user2,true", result);
+    }
+
+    private String getWhoAmI(String queryString) throws Exception {
+        return get(url + "whoAmI" + queryString, "user1", "password1", 10, SECONDS);
+    }
+
+    private String getWhoAmIWrongPassword(String queryString) throws Exception {
+        return get(url + "whoAmI" + queryString, "user1", "wrongpassword", 10, SECONDS);
+    }
+
+    static class ServletDomainSetupOverride extends ElytronDomainSetup {
+        public ServletDomainSetupOverride() {
+            super(new File(IdentityPropagationTestCase.class.getResource("users.properties").getFile()).getAbsolutePath(),
+                    new File(IdentityPropagationTestCase.class.getResource("roles.properties").getFile()).getAbsolutePath(),
+                    SERVLET_SECURITY_DOMAIN_NAME);
+        }
+    }
+
+    static class EJBDomainSetupOverride extends ElytronDomainSetup {
+        public EJBDomainSetupOverride() {
+            super(new File(IdentityPropagationTestCase.class.getResource("ejbusers.properties").getFile()).getAbsolutePath(),
+                    new File(IdentityPropagationTestCase.class.getResource("ejbroles.properties").getFile()).getAbsolutePath(),
+                    EJB_SECURITY_DOMAIN_NAME);
+        }
+    }
+
+    static class PropagationSetup extends AbstractMgmtTestBase implements ServerSetupTask {
+        private ManagementClient managementClient;
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            this.managementClient = managementClient;
+            final List<ModelNode> updates = new ArrayList<ModelNode>();
+
+            updates.add(getAddEjbApplicationSecurityDomainOp(EJB_SECURITY_DOMAIN_NAME, EJB_SECURITY_DOMAIN_NAME));
+            updates.add(getAddEjbApplicationSecurityDomainOp(SERVLET_SECURITY_DOMAIN_NAME, SERVLET_SECURITY_DOMAIN_NAME));
+
+            // /subsystem=elytron/security-domain=elytron-tests:write-attribute(name=outflow-security-domains, value=["ejb-domain"])
+            ModelNode op = new ModelNode();
+            op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            op.get(OP_ADDR).add(SUBSYSTEM, "elytron");
+            op.get(OP_ADDR).add("security-domain", SERVLET_SECURITY_DOMAIN_NAME);
+            op.get("name").set("outflow-security-domains");
+            ModelNode outflowDomains = new ModelNode();
+            outflowDomains.add(EJB_SECURITY_DOMAIN_NAME);
+            op.get("value").set(outflowDomains);
+            updates.add(op);
+
+            // /subsystem=elytron/security-domain=ejb-domain:write-attribute(name=trusted-security-domains, value=["elytron-tests"])
+            op = new ModelNode();
+            op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            op.get(OP_ADDR).add(SUBSYSTEM, "elytron");
+            op.get(OP_ADDR).add("security-domain", EJB_SECURITY_DOMAIN_NAME);
+            op.get("name").set("trusted-security-domains");
+            ModelNode trustedDomains = new ModelNode();
+            trustedDomains.add(SERVLET_SECURITY_DOMAIN_NAME);
+            op.get("value").set(trustedDomains);
+            updates.add(op);
+
+            executeOperations(updates);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            final List<ModelNode> updates = new ArrayList<>();
+
+            updates.add(getUndefineAttributeOperation(PathAddress.pathAddress("subsystem", "elytron").append("security-domain", SERVLET_SECURITY_DOMAIN_NAME), "outflow-security-domains"));
+            updates.add(getUndefineAttributeOperation(PathAddress.pathAddress("subsystem", "elytron").append("security-domain", EJB_SECURITY_DOMAIN_NAME), "trusted-security-domains"));
+
+            ModelNode op = ModelUtil.createOpNode(
+                    "subsystem=ejb3/application-security-domain=" + EJB_SECURITY_DOMAIN_NAME, REMOVE);
+            updates.add(op);
+
+            op = ModelUtil.createOpNode(
+                    "subsystem=ejb3/application-security-domain=" + SERVLET_SECURITY_DOMAIN_NAME, REMOVE);
+            updates.add(op);
+            executeOperations(updates);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
+        }
+
+        @Override
+        protected ModelControllerClient getModelControllerClient() {
+            return managementClient.getControllerClient();
+        }
+
+        private static PathAddress getEjbApplicationSecurityDomainAddress(String ejbDomainName) {
+            return PathAddress.pathAddress()
+                    .append(SUBSYSTEM, "ejb3")
+                    .append("application-security-domain", ejbDomainName);
+        }
+
+        private static ModelNode getAddEjbApplicationSecurityDomainOp(String ejbDomainName, String securityDomainName) {
+            ModelNode op = createAddOperation(getEjbApplicationSecurityDomainAddress(ejbDomainName));
+            op.get("security-domain").set(securityDomainName);
+            return op;
+        }
+    }
+
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/ejbroles.properties
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/ejbroles.properties
@@ -1,0 +1,4 @@
+user1=Managers,Role1
+user2=Managers2,Role2
+admin=Users,Admin
+hr=HR

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/ejbusers.properties
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/ejbusers.properties
@@ -1,0 +1,5 @@
+#$REALM_NAME=UsersRoles$
+user1=1password
+user2=2password
+admin=admin
+hr=hr

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ComplexServletLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ComplexServletLocal.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class ComplexServletLocal extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private ManagementBeanLocal bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String username = req.getParameter("username");
+        String password = req.getParameter("password");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("invokeEntryDoIHaveRole".equals(method)) {
+            try {
+            writer.write(String.valueOf(bean.invokeEntryDoIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("switchThenInvokeEntryDoIHaveRole".equals(method)) {
+            try {
+                String[] result = bean.switchThenInvokeEntryDoIHaveRole(username, password, role);
+                writer.write(result[0] + "," + result[1]);
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/EntryBeanLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/EntryBeanLocal.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ejb-domain")
+public class EntryBeanLocal implements EntryLocal {
+
+    @EJB
+    private WhoAmILocal whoAmIBean;
+
+    @Resource
+    private SessionContext context;
+
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    public boolean doIHaveRole(String roleName) {
+        return context.isCallerInRole(roleName);
+    }
+
+}
+

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/EntryLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/EntryLocal.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import jakarta.ejb.Local;
+
+/**
+ * Interface for the bean used as the entry point to verify Enterprise Beans 3 security behaviour.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Local
+public interface EntryLocal {
+
+    /**
+     * @return The name of the Principal obtained from a call to EJBContext.getCallerPrincipal()
+     */
+    String whoAmI();
+
+    /**
+     * @param roleName - The role to check.
+     * @return the response from EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ManagementBeanLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ManagementBeanLocal.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import static org.jboss.as.test.shared.integration.ejb.security.Util.switchIdentity;
+
+import java.util.concurrent.Callable;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * A simple EJB that can be called to obtain the current caller principal and to check the role membership for
+ * that principal.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@SecurityDomain("elytron-tests")
+public class ManagementBeanLocal {
+
+    @Resource
+    private SessionContext context;
+
+    @PermitAll
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    @PermitAll
+    public boolean invokeEntryDoIHaveRole(String role) {
+        EntryLocal entry = lookup(EntryLocal.class, "java:global/ear-ejb-deployment-local/ear-ejb-deployment-local-ejb/EntryBeanLocal!org.wildfly.test.integration.elytron.ejb.propagation.local.EntryLocal");
+        return entry.doIHaveRole(role);
+    }
+
+    @PermitAll
+    public String[] switchThenInvokeEntryDoIHaveRole(String username, String password, String role) {
+        EntryLocal entry = lookup(EntryLocal.class, "java:global/ear-ejb-deployment-local/ear-ejb-deployment-local-ejb/EntryBeanLocal!org.wildfly.test.integration.elytron.ejb.propagation.local.EntryLocal");
+        final Callable<String[]> callable = () -> {
+            String localWho = entry.whoAmI();
+            boolean hasRole = entry.doIHaveRole(role);
+            return new String[] { localWho, String.valueOf(hasRole) };
+        };
+        try {
+            return switchIdentity(username, password, callable);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ServletOnlyLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/ServletOnlyLocal.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class ServletOnlyLocal extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                EntryLocal bean = lookup(EntryLocal.class, "java:global/ear-ejb-deployment-local/ear-ejb-deployment-local-ejb/EntryBeanLocal!org.wildfly.test.integration.elytron.ejb.propagation.local.EntryLocal");
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("doIHaveRole".equals(method)) {
+            try {
+                EntryLocal bean = lookup(EntryLocal.class, "java:global/ear-ejb-deployment-local/ear-ejb-deployment-local-ejb/EntryBeanLocal!org.wildfly.test.integration.elytron.ejb.propagation.local.EntryLocal");
+                writer.write(String.valueOf(bean.doIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/SimpleServletLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/SimpleServletLocal.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import static org.jboss.as.test.shared.integration.ejb.security.Util.switchIdentity;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.concurrent.Callable;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class SimpleServletLocal extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private EntryLocal bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String username = req.getParameter("username");
+        String password = req.getParameter("password");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("switchWhoAmI".equals(method)) {
+            final Callable<String[]> callable = () -> {
+                String localWho = bean.whoAmI();
+                boolean hasRole = bean.doIHaveRole(role);
+                return new String[]{localWho, String.valueOf(hasRole)};
+            };
+            try {
+                String[] result = switchIdentity(username, password, callable);
+                writer.write(result[0] + "," + result[1]);
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+       } else if ("doIHaveRole".equals(method)) {
+            try {
+            writer.write(String.valueOf(bean.doIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/WhoAmIBeanLocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/WhoAmIBeanLocal.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ejb-domain")
+public class WhoAmIBeanLocal extends org.wildfly.test.integration.elytron.ejb.base.WhoAmIBean implements WhoAmILocal {
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/WhoAmILocal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/local/WhoAmILocal.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.local;
+
+import java.security.Principal;
+import jakarta.ejb.Local;
+
+/**
+ * The local interface to the simple WhoAmI bean.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Local
+public interface WhoAmILocal {
+
+    /**
+     * @return the caller principal obtained from the EJBContext.
+     */
+    Principal getCallerPrincipal();
+
+    /**
+     * @param roleName - The role to check.
+     * @return The result of calling EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ComplexServletRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ComplexServletRemote.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class ComplexServletRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private ManagementBeanRemote bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String username = req.getParameter("username");
+        String password = req.getParameter("password");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("invokeEntryDoIHaveRole".equals(method)) {
+            try {
+            writer.write(String.valueOf(bean.invokeEntryDoIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("switchThenInvokeEntryDoIHaveRole".equals(method)) {
+            try {
+                String[] result = bean.switchThenInvokeEntryDoIHaveRole(username, password, role);
+                writer.write(result[0] + "," + result[1]);
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/EntryBeanRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/EntryBeanRemote.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ejb-domain")
+public class EntryBeanRemote implements EntryRemote {
+
+    @EJB
+    private WhoAmIRemote whoAmIBean;
+
+    @Resource
+    private SessionContext context;
+
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    public boolean doIHaveRole(String roleName) {
+        return context.isCallerInRole(roleName);
+    }
+
+}
+

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/EntryRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/EntryRemote.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import jakarta.ejb.Remote;
+
+/**
+ * Interface for the bean used as the entry point to verify Enterprise Beans 3 security behaviour.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Remote
+public interface EntryRemote {
+
+    /**
+     * @return The name of the Principal obtained from a call to EJBContext.getCallerPrincipal()
+     */
+    String whoAmI();
+
+    /**
+     * @param roleName - The role to check.
+     * @return the response from EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ManagementBeanRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ManagementBeanRemote.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import static org.jboss.as.test.shared.integration.ejb.security.Util.switchIdentity;
+
+import java.util.concurrent.Callable;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * A simple EJB that can be called to obtain the current caller principal and to check the role membership for
+ * that principal.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@SecurityDomain("elytron-tests")
+public class ManagementBeanRemote {
+
+    @Resource
+    private SessionContext context;
+
+    @PermitAll
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    @PermitAll
+    public boolean invokeEntryDoIHaveRole(String role) {
+        EntryRemote entry = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote/ear-ejb-deployment-remote-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryRemote");
+        return entry.doIHaveRole(role);
+    }
+
+    @PermitAll
+    public String[] switchThenInvokeEntryDoIHaveRole(String username, String password, String role) {
+        EntryRemote entry = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote/ear-ejb-deployment-remote-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryRemote");
+        final Callable<String[]> callable = () -> {
+            String remoteWho = entry.whoAmI();
+            boolean hasRole = entry.doIHaveRole(role);
+            return new String[] { remoteWho, String.valueOf(hasRole) };
+        };
+        try {
+            return switchIdentity(username, password, callable);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ServletOnlyRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/ServletOnlyRemote.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class ServletOnlyRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                EntryRemote bean = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote/ear-ejb-deployment-remote-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryRemote");
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("doIHaveRole".equals(method)) {
+            try {
+                EntryRemote bean = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote/ear-ejb-deployment-remote-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.ejb.propagation.remote.EntryRemote");
+                writer.write(String.valueOf(bean.doIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/SimpleServletRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/SimpleServletRemote.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import static org.jboss.as.test.shared.integration.ejb.security.Util.switchIdentity;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.concurrent.Callable;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "Users" }))
+@DeclareRoles("Users")
+public class SimpleServletRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private EntryRemote bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+        String method = req.getParameter("method");
+        String username = req.getParameter("username");
+        String password = req.getParameter("password");
+        String role = req.getParameter("role");
+
+        if ("whoAmI".equals(method)) {
+            try {
+                writer.write(bean.whoAmI());
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("switchWhoAmI".equals(method)) {
+            final Callable<String[]> callable = () -> {
+                String remoteWho = bean.whoAmI();
+                boolean hasRole = bean.doIHaveRole(role);
+                return new String[]{remoteWho, String.valueOf(hasRole)};
+            };
+            try {
+                String[] result = switchIdentity(username, password, callable);
+                writer.write(result[0] + "," + result[1]);
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else if ("doIHaveRole".equals(method)) {
+            try {
+            writer.write(String.valueOf(bean.doIHaveRole(role)));
+            } catch (Exception e) {
+                throw new ServletException("Unexpected Failure", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Parameter 'method' either missing or invalid method='" + method + "'");
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/WhoAmIBeanRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/WhoAmIBeanRemote.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ejb-domain")
+public class WhoAmIBeanRemote extends org.wildfly.test.integration.elytron.ejb.base.WhoAmIBean implements WhoAmIRemote {
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/WhoAmIRemote.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/propagation/remote/WhoAmIRemote.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb.propagation.remote;
+
+import java.security.Principal;
+import jakarta.ejb.Remote;
+
+/**
+ * The local interface to the simple WhoAmI bean.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Remote
+public interface WhoAmIRemote {
+
+    /**
+     * @return the caller principal obtained from the EJBContext.
+     */
+    Principal getCallerPrincipal();
+
+    /**
+     * @param roleName - The role to check.
+     * @return The result of calling EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17254

This PR updates the EJB3 subsystem so that it always registers appropriate client interceptors automatically for EJB deployments to ensure that we always runAs the current security identity in order to activate any outflow identities.

In particular, the following changes have been made:

* The EJB3 subsystem automatically registers a global `org.jboss.ejb.client.EJBClientInterceptor` for EJB deployments. This interceptor will be used when invoking remote EJBs.
* The EJB3 subsystem automatically registers a global `org.jboss.invocation.Interceptor` for EJB deployments. This interceptor will be used when invoking local EJBs. Note that the only reason this additional interceptor is needed is because global `EJBClientInterceptors` don't get invoked for local EJBs due to [WFLY-9976](https://issues.redhat.com/browse/WFLY-9976).

Depends on https://github.com/wildfly/wildfly-core/pull/5263