### PR TITLE
[WFLY-17286] Eliminating unused version.org.jboss.byteman property from clustering TS pom.xml

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -44,7 +44,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>5400</surefire.forked.process.timeout>
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
-        <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.org.infinispan.server>${version.org.infinispan}</version.org.infinispan.server>
         <version.org.infinispan.server.driver>${version.org.infinispan}</version.org.infinispan.server.driver>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17286
