### PR TITLE
[WFLY-17293] Remove use of ClassFileInfo.interfaces()

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
@@ -28,6 +28,7 @@ import java.io.Externalizable;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -66,8 +67,8 @@ class ViewInterfaces {
      * @return A collection of all potential view interfaces
      */
     static Set<DotName> getPotentialViewInterfaces(ClassInfo beanClass) {
-        DotName[] interfaces = beanClass.interfaces();
-        if (interfaces == null) {
+        List<DotName> interfaces = beanClass.interfaceNames();
+        if (interfaces.isEmpty()) {
             return Collections.emptySet();
         }
         final Set<DotName> names = new HashSet<DotName>();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
@@ -43,10 +43,10 @@ class ViewInterfaces {
      */
     static Set<Class<?>> getPotentialViewInterfaces(Class<?> beanClass) {
         Class<?>[] interfaces = beanClass.getInterfaces();
-        if (interfaces == null) {
+        if (interfaces.length == 0) {
             return Collections.emptySet();
         }
-        final Set<Class<?>> potentialBusinessInterfaces = new HashSet<Class<?>>();
+        final Set<Class<?>> potentialBusinessInterfaces = new HashSet<>();
         for (Class<?> klass : interfaces) {
             // Enterprise Beans 3.1 FR 4.9.7 bullet 5.3
             if (klass.equals(Serializable.class) ||
@@ -71,7 +71,7 @@ class ViewInterfaces {
         if (interfaces.isEmpty()) {
             return Collections.emptySet();
         }
-        final Set<DotName> names = new HashSet<DotName>();
+        final Set<DotName> names = new HashSet<>();
         for (DotName dotName : interfaces) {
             String name = dotName.toString();
             // Enterprise Beans 3.1 FR 4.9.7 bullet 5.3

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/WeldClassFileInfo.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/WeldClassFileInfo.java
@@ -283,11 +283,9 @@ public class WeldClassFileInfo implements ClassFileInfo {
             return true;
         }
 
-        if (fromClassInfo.interfaces() != null) {
-            for (DotName interfaceName : fromClassInfo.interfaces()) {
-                if (isAssignableTo(interfaceName, to)) {
-                    return true;
-                }
+        for (DotName interfaceName : fromClassInfo.interfaceNames()) {
+            if (isAssignableTo(interfaceName, to)) {
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17293

Also a minor cleanup in ViewInterfaces.

This is just a minor outgrowth of my work on #16276, where I noticed some use of a deprecated method and decided to clean those up.