### PR TITLE
[WFLY-17268] Remove the unneeded dependency on org.wildfly:wildfly-we…

### DIFF
--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -82,17 +82,6 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>${ee.maven.groupId}</groupId>
-            <artifactId>wildfly-weld</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Other deps consistent with the jakarta.* from parent module -->
         <dependency>


### PR DESCRIPTION
…ld in the OpenTracing SmallRye module.

https://issues.redhat.com/browse/WFLY-17268
Signed-off-by: James R. Perkins <jperkins@redhat.com>

Minor follow up to #16276