### PR TITLE
[WFLY-17298]: Replace uses of ServiceName OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME with use of the capability.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -94,7 +94,7 @@ public class Capabilities {
      *
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/network/socket-binding/capability.adoc">documentation</a>
      */
-    static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.network.socket-binding", true, SocketBinding.class)
+    public static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.network.socket-binding", true, SocketBinding.class)
             .build();
 
     /**
@@ -102,6 +102,6 @@ public class Capabilities {
      *
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/network/outbound-socket-binding/capability.adoc">Capability documentation</a>
      */
-    static final RuntimeCapability<Void> OUTBOUND_SOCKET_BINDING_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.network.outbound-socket-binding", true, OutboundSocketBinding.class)
+    public static final RuntimeCapability<Void> OUTBOUND_SOCKET_BINDING_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.network.outbound-socket-binding", true, OutboundSocketBinding.class)
             .build();
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -27,11 +27,13 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
 import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ACTIVEMQ_SERVER_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.DATA_SOURCE_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ELYTRON_DOMAIN_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME;
 import static org.wildfly.extension.messaging.activemq.Capabilities.JMX_CAPABILITY;
+import static org.wildfly.extension.messaging.activemq.Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.PATH_MANAGER_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ADDRESS_SETTING;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.BINDINGS_DIRECTORY;
@@ -352,7 +354,7 @@ class ServerAdd extends AbstractAddStepHandler {
 
             Map<String, Supplier<SocketBinding>> socketBindings = new HashMap<>();
             for (final String socketBindingName : socketBindingNames) {
-                Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SocketBinding.JBOSS_BINDING_NAME.append(socketBindingName));
+                Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(socketBindingName));
                 socketBindings.put(socketBindingName, socketBinding);
             }
 
@@ -364,13 +366,13 @@ class ServerAdd extends AbstractAddStepHandler {
             for (final String connectorSocketBinding : connectorsSocketBindings) {
                 // find whether the connectorSocketBinding references a SocketBinding or an OutboundSocketBinding
                 if (outbounds.get(connectorSocketBinding)) {
-                    final ServiceName outboundSocketName = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(connectorSocketBinding);
+                    final ServiceName outboundSocketName = OUTBOUND_SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding);
                     Supplier<OutboundSocketBinding> outboundSocketBinding = serviceBuilder.requires(outboundSocketName);
                     outboundSocketBindings.put(connectorSocketBinding, outboundSocketBinding);
                 } else {
                     // check if the socket binding has not already been added by the acceptors
                     if (!socketBindings.containsKey(connectorSocketBinding)) {
-                        Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding));
+                        Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding));
                         socketBindings.put(connectorSocketBinding, socketBinding);
                     }
                 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketBroadcastGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketBroadcastGroupAdd.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.CONNECTOR_REFS;
 import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.validateConnectors;
 
@@ -104,7 +105,7 @@ public class SocketBroadcastGroupAdd extends AbstractAddStepHandler {
             final String name = context.getCurrentAddressValue();
             final ServiceTarget target = context.getServiceTarget();
                 ServiceBuilder builder = target.addService(GroupBindingService.getBroadcastBaseServiceName(serviceName).append(name));
-                builder.setInstance(new GroupBindingService(builder.requires(SocketBinding.JBOSS_BINDING_NAME.append(model.get(SOCKET_BINDING).asString()))));
+                builder.setInstance(new GroupBindingService(builder.requires(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(model.get(SOCKET_BINDING).asString()))));
                 builder.install();
         }
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketDiscoveryGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SocketDiscoveryGroupAdd.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
 
 import java.util.HashMap;
@@ -93,7 +94,7 @@ public class SocketDiscoveryGroupAdd extends AbstractAddStepHandler {
                     serviceName = MessagingServices.getActiveMQServiceName((String) null);
                 }
                 ServiceBuilder builder = target.addService(GroupBindingService.getDiscoveryBaseServiceName(serviceName).append(name));
-                builder.setInstance(new GroupBindingService(builder.requires(SocketBinding.JBOSS_BINDING_NAME.append(model.get(SOCKET_BINDING).asString()))));
+                builder.setInstance(new GroupBindingService(builder.requires(SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(model.get(SOCKET_BINDING).asString()))));
                 builder.install();
             }
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
@@ -15,6 +15,8 @@
  */
 package org.wildfly.extension.messaging.activemq.jms;
 
+import static org.wildfly.extension.messaging.activemq.Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY;
+import static org.wildfly.extension.messaging.activemq.Capabilities.SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_DISCOVERY_GROUP;
@@ -125,11 +127,11 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
             for (final String connectorSocketBinding : connectorsSocketBindings) {
                 // find whether the connectorSocketBinding references a SocketBinding or an OutboundSocketBinding
                 if (outbounds.get(connectorSocketBinding)) {
-                    final ServiceName outboundSocketName = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(connectorSocketBinding);
+                    final ServiceName outboundSocketName = OUTBOUND_SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding);
                     Supplier<OutboundSocketBinding> outboundSupplier = builder.requires(outboundSocketName);
                     outboundSocketBindings.put(connectorSocketBinding, outboundSupplier);
                 } else {
-                    final ServiceName socketName = SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding);
+                    final ServiceName socketName = SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding);
                     Supplier<SocketBinding> socketBindingsSupplier = builder.requires(socketName);
                     socketBindings.put(connectorSocketBinding, socketBindingsSupplier);
                 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
@@ -16,6 +16,8 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 import static org.jboss.as.naming.deployment.ContextNames.BindInfo;
+import static org.wildfly.extension.messaging.activemq.Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY;
+import static org.wildfly.extension.messaging.activemq.Capabilities.SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS_PROP_NAME;
 
 import java.io.InputStream;
@@ -288,11 +290,11 @@ public class ExternalPooledConnectionFactoryService implements Service<ExternalP
         for (final String connectorSocketBinding : connectorsSocketBindings) {
             // find whether the connectorSocketBinding references a SocketBinding or an OutboundSocketBinding
             if (outbounds.get(connectorSocketBinding)) {
-                final ServiceName outboundSocketName = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(connectorSocketBinding);
+                final ServiceName outboundSocketName = OUTBOUND_SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding);
                 Supplier<OutboundSocketBinding> outboundSocketBindingSupplier = serviceBuilder.requires(outboundSocketName);
                 service.outboundSocketBindings.put(connectorSocketBinding, outboundSocketBindingSupplier);
             } else {
-                final ServiceName socketName = SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding);
+                final ServiceName socketName = SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(connectorSocketBinding);
                 Supplier<SocketBinding> socketBindingSupplier = serviceBuilder.requires(socketName);
                 service.socketBindings.put(connectorSocketBinding, socketBindingSupplier);
             }


### PR DESCRIPTION
- Replace OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME with use of the capability
- Replace SocketBinding.JBOSS_BINDING_NAME with use of the capability

Jira: https://issues.redhat.com/browse/WFLY-17298
      https://issues.redhat.com/browse/WFLY-17297

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>