### PR TITLE
[WFLY-17306]: Cleanup the messaging subsystem poms.

### DIFF
--- a/messaging-activemq/injection/pom.xml
+++ b/messaging-activemq/injection/pom.xml
@@ -83,10 +83,6 @@
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-impl</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -129,7 +125,6 @@
         <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-common-jakarta</artifactId>
-            <type>jar</type>
         </dependency>
 
         <!-- test -->

--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -182,6 +182,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-jakarta-client</artifactId>
             <exclusions>
@@ -287,6 +292,7 @@
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-impl</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -364,11 +370,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>failureaccess</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -414,11 +415,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.resource</groupId>
-            <artifactId>jakarta.resource-api</artifactId>
-            <type>jar</type>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
* Removing weld-core-impl from the injection submodule.
* Removing guava failureaccess from the subsytem module.
* Moving weld-core-impl to the 'test' scope in the subsytem module.

Jira: https://issues.redhat.com/browse/WFLY-17306

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>
