### PR TITLE
WFLY-17287 default-data-store requires thread-pool-name.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TimerServiceResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TimerServiceResourceDefinition.java
@@ -75,6 +75,7 @@ public class TimerServiceResourceDefinition extends SimpleResourceDefinition {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setRequired(true)
                     .setAlternatives(EJB3SubsystemModel.DEFAULT_PERSISTENT_TIMER_MANAGEMENT)
+                    .setRequires(EJB3SubsystemModel.THREAD_POOL_NAME)
                     .setCapabilityReference(TIMER_PERSISTENCE_CAPABILITY_NAME, TIMER_SERVICE_CAPABILITY)
                     .build();
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
@@ -81,8 +81,8 @@ public class DomainAdjuster740 extends DomainAdjuster {
 
     private static void adjustEjb3(List<ModelNode> operations, PathAddress subsystemAddress) {
         PathAddress timerServiceAddress = subsystemAddress.append("service", "timer-service");
-        operations.add(Util.createCompositeOperation(Arrays.asList(Util.getUndefineAttributeOperation(timerServiceAddress, "default-persistent-timer-management"), Util.getWriteAttributeOperation(timerServiceAddress, "default-data-store", "default-file-store"))));
         operations.add(Util.createCompositeOperation(Arrays.asList(Util.getUndefineAttributeOperation(timerServiceAddress, "default-transient-timer-management"), Util.getWriteAttributeOperation(timerServiceAddress, "thread-pool-name", "default"))));
+        operations.add(Util.createCompositeOperation(Arrays.asList(Util.getUndefineAttributeOperation(timerServiceAddress, "default-persistent-timer-management"), Util.getWriteAttributeOperation(timerServiceAddress, "default-data-store", "default-file-store"))));
     }
 
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17287
