### PR TITLE
WFLY-17313 Distributed TimerService fails when cache is configured with jdbc-store

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerIndexKeyFormatter.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerIndexKeyFormatter.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan.timer;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.marshalling.spi.DelimitedFormatter;
+import org.wildfly.clustering.marshalling.spi.Formatter;
+
+/**
+ * Formatter for a {@link TimerIndexKey}.
+ * @author Paul Ferraro
+ */
+@MetaInfServices(Formatter.class)
+public class TimerIndexKeyFormatter extends DelimitedFormatter<TimerIndexKey> {
+
+    public TimerIndexKeyFormatter() {
+        super(TimerIndexKey.class, "#", TimerIndexKeyFormatter::fromStrings, TimerIndexKeyFormatter::toStrings);
+    }
+
+    static TimerIndexKey fromStrings(String[] values) {
+        String className = values[0];
+        String methodName = values[1];
+        int parameters = (values.length == 3) ? 0 : 1;
+        int index = Integer.parseInt(values[values.length - 1]);
+        return new TimerIndexKey(new TimerIndex(className, methodName, parameters, index));
+    }
+
+    static String[] toStrings(TimerIndexKey key) {
+        TimerIndex index = key.getId();
+        int parameters = index.getParameters();
+        String indexValue = Integer.toString(index.getIndex());
+        return (parameters == 0) ? new String[] { index.getDeclaringClassName(), index.getMethodName(), indexValue } : new String[] { index.getDeclaringClassName(), index.getMethodName(), "", indexValue };
+    }
+}

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerKeySerializer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerKeySerializer.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan.timer;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.ee.Key;
+import org.wildfly.clustering.marshalling.spi.BinaryFormatter;
+import org.wildfly.clustering.marshalling.spi.Formatter;
+import org.wildfly.clustering.marshalling.spi.Serializer;
+import org.wildfly.clustering.marshalling.spi.util.UUIDSerializer;
+
+/**
+ * Serializer for timer keys.
+ * @author Paul Ferraro
+ */
+public class TimerKeySerializer<K extends Key<UUID>> implements Serializer<K> {
+
+    private final Function<UUID, K> factory;
+
+    TimerKeySerializer(Function<UUID, K> factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public void write(DataOutput output, K value) throws IOException {
+        UUIDSerializer.INSTANCE.write(output, value.getId());
+    }
+
+    @Override
+    public K read(DataInput input) throws IOException {
+        return this.factory.apply(UUIDSerializer.INSTANCE.read(input));
+    }
+
+    @MetaInfServices(Formatter.class)
+    public static class TimerCreationMetaDataKeyFormatter extends BinaryFormatter<TimerCreationMetaDataKey<UUID>> {
+        @SuppressWarnings("unchecked")
+        public TimerCreationMetaDataKeyFormatter() {
+            super((Class<TimerCreationMetaDataKey<UUID>>) (Class<?>) TimerCreationMetaDataKey.class, new TimerKeySerializer<>(TimerCreationMetaDataKey::new));
+        }
+    }
+
+    @MetaInfServices(Formatter.class)
+    public static class TimerAccessMetaDataKeyFormatter extends BinaryFormatter<TimerAccessMetaDataKey<UUID>> {
+        @SuppressWarnings("unchecked")
+        public TimerAccessMetaDataKeyFormatter() {
+            super((Class<TimerAccessMetaDataKey<UUID>>) (Class<?>) TimerAccessMetaDataKey.class, new TimerKeySerializer<>(TimerAccessMetaDataKey::new));
+        }
+    }
+}

--- a/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/timer/TimerKeyMapperTestCase.java
+++ b/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/timer/TimerKeyMapperTestCase.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan.timer;
+
+import java.util.UUID;
+
+import org.junit.Test;
+import org.wildfly.clustering.ejb.infinispan.KeyMapper;
+import org.wildfly.clustering.infinispan.persistence.KeyMapperTester;
+
+/**
+ * Validates {@link org.infinispan.persistence.keymappers.TwoWayKey2StringMapper} implementations for keys used by distributed timer service.
+ * @author Paul Ferraro
+ */
+public class TimerKeyMapperTestCase {
+    @Test
+    public void test() throws NoSuchMethodException, SecurityException {
+        KeyMapperTester tester = new KeyMapperTester(new KeyMapper());
+
+        UUID id = UUID.randomUUID();
+        tester.test(new TimerCreationMetaDataKey<>(id));
+        tester.test(new TimerAccessMetaDataKey<>(id));
+        tester.test(new TimerIndexKey(new TimerIndex(this.getClass().getDeclaredMethod("test"), 0)));
+        tester.test(new TimerIndexKey(new TimerIndex(this.getClass().getDeclaredMethod("test"), 1)));
+        tester.test(new TimerIndexKey(new TimerIndex(this.getClass().getDeclaredMethod("ejbTimeout", Object.class), 0)));
+        tester.test(new TimerIndexKey(new TimerIndex(this.getClass().getDeclaredMethod("ejbTimeout", Object.class), 2)));
+    }
+
+    void ejbTimeout(Object timer) {
+    }
+}

--- a/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/util/UUIDExternalizer.java
+++ b/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/util/UUIDExternalizer.java
@@ -21,34 +21,20 @@
  */
 package org.wildfly.clustering.marshalling.spi.util;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.util.OptionalInt;
 import java.util.UUID;
 
 import org.wildfly.clustering.marshalling.Externalizer;
+import org.wildfly.clustering.marshalling.spi.SerializerExternalizer;
 
 /**
  * {@link Externalizer} for {@link UUID} instances.
  * @author Paul Ferraro
  */
-public class UUIDExternalizer implements Externalizer<UUID> {
+public class UUIDExternalizer extends SerializerExternalizer<UUID> {
 
-    @Override
-    public void writeObject(ObjectOutput output, UUID uuid) throws IOException {
-        output.writeLong(uuid.getMostSignificantBits());
-        output.writeLong(uuid.getLeastSignificantBits());
-    }
-
-    @Override
-    public UUID readObject(ObjectInput input) throws IOException {
-        return new UUID(input.readLong(), input.readLong());
-    }
-
-    @Override
-    public Class<UUID> getTargetClass() {
-        return UUID.class;
+    public UUIDExternalizer() {
+        super(UUID.class, UUIDSerializer.INSTANCE);
     }
 
     @Override

--- a/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/util/UUIDSerializer.java
+++ b/clustering/marshalling/spi/src/main/java/org/wildfly/clustering/marshalling/spi/util/UUIDSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.marshalling.spi.util;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.wildfly.clustering.marshalling.spi.Serializer;
+
+/**
+ * {@link Serializer} for a {@link UUID}.
+ * @author Paul Ferraro
+ */
+public enum UUIDSerializer implements Serializer<UUID> {
+    INSTANCE;
+
+    @Override
+    public void write(DataOutput output, UUID value) throws IOException {
+        output.writeLong(value.getMostSignificantBits());
+        output.writeLong(value.getLeastSignificantBits());
+    }
+
+    @Override
+    public UUID read(DataInput input) throws IOException {
+        return new UUID(input.readLong(), input.readLong());
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17313

Adds missing key formatters.
