### PR TITLE
[WFLY-17328] Remove uses of deprecated AbstractAddStepHandler methods

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -24,7 +24,6 @@ package org.wildfly.extension.batch.jberet;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
-import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -175,7 +174,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
         private final ContextClassLoaderJobOperatorContextSelector selector;
 
         private BatchSubsystemAdd() {
-            super(Collections.singleton(Capabilities.BATCH_CONFIGURATION_CAPABILITY), DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME, SECURITY_DOMAIN);
+            super(DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME, SECURITY_DOMAIN);
             selector = new ContextClassLoaderJobOperatorContextSelector(() -> JobOperatorContext.create(DefaultBatchEnvironment.INSTANCE));
             JobOperatorContext.setJobOperatorContextSelector(selector);
         }

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
@@ -54,7 +54,7 @@ public class InMemoryJobRepositoryDefinition extends SimpleResourceDefinition {
         super(
                 new Parameters(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME))
                         .setAddHandler(new InMemoryAddHandler())
-                        .setRemoveHandler(new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY))
+                        .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                         .setCapabilities(Capabilities.JOB_REPOSITORY_CAPABILITY)
         );
     }
@@ -68,7 +68,7 @@ public class InMemoryJobRepositoryDefinition extends SimpleResourceDefinition {
 
     private static class InMemoryAddHandler extends AbstractAddStepHandler {
         InMemoryAddHandler() {
-            super(Capabilities.JOB_REPOSITORY_CAPABILITY, CommonAttributes.EXECUTION_RECORDS_LIMIT);
+            super(CommonAttributes.EXECUTION_RECORDS_LIMIT);
         }
 
         @Override

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
@@ -71,7 +71,7 @@ public class JdbcJobRepositoryDefinition extends SimpleResourceDefinition {
         super(
                 new Parameters(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME))
                         .setAddHandler(new JdbcRepositoryAddHandler())
-                        .setRemoveHandler(new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY))
+                        .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                         .setCapabilities(Capabilities.JOB_REPOSITORY_CAPABILITY)
         );
     }
@@ -88,7 +88,7 @@ public class JdbcJobRepositoryDefinition extends SimpleResourceDefinition {
     private static class JdbcRepositoryAddHandler extends AbstractAddStepHandler {
 
         JdbcRepositoryAddHandler() {
-            super(Capabilities.JOB_REPOSITORY_CAPABILITY, DATA_SOURCE, CommonAttributes.EXECUTION_RECORDS_LIMIT);
+            super(DATA_SOURCE, CommonAttributes.EXECUTION_RECORDS_LIMIT);
         }
 
         @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -106,7 +106,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
     private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
 
     AbstractDataSourceAdd(Collection<AttributeDefinition> attributes) {
-        super(Capabilities.DATA_SOURCE_CAPABILITY, attributes);
+        super(attributes);
     }
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
@@ -39,8 +39,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_INVA
 import static org.jboss.as.connector.subsystems.datasources.Constants.RECOVERY_CREDENTIAL_REFERENCE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.TEST_CONNECTION;
 
-import java.util.List;
-
 import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.subsystems.common.pool.PoolConfigurationRWHandler;
 import org.jboss.as.connector.subsystems.common.pool.PoolOperations;
@@ -51,8 +49,8 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
@@ -66,21 +64,26 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
     private final boolean registerRuntimeOnly;
     private final boolean deployed;
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     private DataSourceDefinition(final boolean registerRuntimeOnly, final boolean deployed) {
-        super(PATH_DATASOURCE,
-                DataSourcesExtension.getResourceDescriptionResolver(DATA_SOURCE),
-                deployed ? null : DataSourceAdd.INSTANCE,
-                deployed ? null : DataSourceRemove.INSTANCE);
+        super(new Parameters(PATH_DATASOURCE, DataSourcesExtension.getResourceDescriptionResolver(DATA_SOURCE))
+                .setAddHandler(deployed ? null : DataSourceAdd.INSTANCE)
+                .setRemoveHandler(deployed ? null : DataSourceRemove.INSTANCE)
+                .setAccessConstraints(
+                        new ApplicationTypeAccessConstraintDefinition(
+                                new ApplicationTypeConfig(DataSourcesExtension.SUBSYSTEM_NAME, DATA_SOURCE)))
+                .setCapabilities(getCapabilities(deployed))
+        );
         this.registerRuntimeOnly = registerRuntimeOnly;
         this.deployed = deployed;
-        ApplicationTypeConfig atc = new ApplicationTypeConfig(DataSourcesExtension.SUBSYSTEM_NAME, DATA_SOURCE);
-        accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
     }
 
     public static DataSourceDefinition createInstance(final boolean registerRuntimeOnly, final boolean deployed) {
         return new DataSourceDefinition(registerRuntimeOnly, deployed);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static RuntimeCapability[] getCapabilities(boolean deployed) {
+        return deployed ? new RuntimeCapability[0] : new RuntimeCapability[] {Capabilities.DATA_SOURCE_CAPABILITY};
     }
 
     @Override
@@ -100,13 +103,6 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerOperationHandler(FLUSH_GRACEFULLY_CONNECTION, PoolOperations.FlushGracefullyConnectionInPool.DS_INSTANCE);
             resourceRegistration.registerOperationHandler(TEST_CONNECTION, PoolOperations.TestConnectionInPool.DS_INSTANCE);
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-        if (!deployed)
-            resourceRegistration.registerCapability(Capabilities.DATA_SOURCE_CAPABILITY);
     }
 
     @Override
@@ -155,10 +151,5 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
         } else {
             resourceRegistration.registerSubModel(ConnectionPropertyDefinition.INSTANCE);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
@@ -37,7 +37,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATASOU
 import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATASOURCE_ATTRIBUTE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATASOURCE_PROPERTIES_ATTRIBUTES;
 
-import java.util.List;
+import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.subsystems.common.pool.PoolConfigurationRWHandler;
 import org.jboss.as.connector.subsystems.common.pool.PoolOperations;
 import org.jboss.as.controller.PathElement;
@@ -47,8 +47,8 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
@@ -64,21 +64,24 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
     private final boolean registerRuntimeOnly;
     private final boolean deployed;
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     private XaDataSourceDefinition(final boolean registerRuntimeOnly, final boolean deployed) {
-        super(PATH_XA_DATASOURCE,
-                DataSourcesExtension.getResourceDescriptionResolver(XA_DATASOURCE),
-                deployed ? null : XaDataSourceAdd.INSTANCE,
-                deployed ? null : DataSourceRemove.XA_INSTANCE);
+        super(new Parameters(PATH_XA_DATASOURCE, DataSourcesExtension.getResourceDescriptionResolver(XA_DATASOURCE))
+                .setAddHandler(deployed ? null : XaDataSourceAdd.INSTANCE)
+                .setRemoveHandler(deployed ? null : DataSourceRemove.XA_INSTANCE)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig(DataSourcesExtension.SUBSYSTEM_NAME, XA_DATASOURCE)))
+                .setCapabilities(getCapabilities(deployed))
+        );
         this.registerRuntimeOnly = registerRuntimeOnly;
         this.deployed = deployed;
-        ApplicationTypeConfig atc = new ApplicationTypeConfig(DataSourcesExtension.SUBSYSTEM_NAME, XA_DATASOURCE);
-        accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
     }
 
     public static XaDataSourceDefinition createInstance(final boolean registerRuntimeOnly, final boolean deployed) {
         return new XaDataSourceDefinition(registerRuntimeOnly, deployed);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static RuntimeCapability[] getCapabilities(boolean deployed) {
+        return deployed ? new RuntimeCapability[0] : new RuntimeCapability[] {Capabilities.DATA_SOURCE_CAPABILITY};
     }
 
     @Override
@@ -97,14 +100,6 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerOperationHandler(FLUSH_GRACEFULLY_CONNECTION, PoolOperations.FlushGracefullyConnectionInPool.DS_INSTANCE);
             resourceRegistration.registerOperationHandler(TEST_CONNECTION, PoolOperations.TestConnectionInPool.DS_INSTANCE);
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-
-        if (!deployed)
-            resourceRegistration.registerCapability(org.jboss.as.connector._private.Capabilities.DATA_SOURCE_CAPABILITY);
     }
 
     @Override
@@ -150,10 +145,5 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
         } else {
             resourceRegistration.registerSubModel(XaDataSourcePropertyDefinition.INSTANCE);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/IdentityResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/IdentityResourceDefinition.java
@@ -90,7 +90,7 @@ public class IdentityResourceDefinition extends SimpleResourceDefinition {
         super(new SimpleResourceDefinition.Parameters(EJB3SubsystemModel.IDENTITY_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.IDENTITY))
                 .setAddHandler(new AddHandler())
                 // .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
-                .setRemoveHandler(new ReloadRequiredRemoveStepHandler(IDENTITY_CAPABILITY))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setCapabilities(IDENTITY_CAPABILITY));
     }
@@ -107,7 +107,7 @@ public class IdentityResourceDefinition extends SimpleResourceDefinition {
     private static class AddHandler extends AbstractAddStepHandler {
 
         private AddHandler() {
-            super(IDENTITY_CAPABILITY, OUTFLOW_SECURITY_DOMAINS);
+            super(OUTFLOW_SECURITY_DOMAINS);
         }
 
         @Override

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingAdd.java
@@ -44,7 +44,6 @@ public class RemoteNamingAdd extends AbstractAddStepHandler {
     static final RemoteNamingAdd INSTANCE = new RemoteNamingAdd();
 
     private RemoteNamingAdd() {
-        super(RemoteNamingResourceDefinition.REMOTE_NAMING_CAPABILITY);
     }
 
     @Override

--- a/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
+++ b/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
@@ -41,7 +41,6 @@ public class SarSubsystemAdd extends AbstractBoottimeAddStepHandler {
     static final SarSubsystemAdd INSTANCE = new SarSubsystemAdd();
 
     private SarSubsystemAdd() {
-        super(SarExtension.SAR_CAPABILITY);
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) {

--- a/security/subsystem/src/main/java/org/jboss/as/security/elytron/ElytronIntegrationResourceDefinitions.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/elytron/ElytronIntegrationResourceDefinitions.java
@@ -20,16 +20,12 @@ import static org.jboss.as.security.elytron.Capabilities.KEY_STORE_RUNTIME_CAPAB
 import static org.jboss.as.security.elytron.Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY;
 import static org.jboss.as.security.elytron.Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY;
 
-import java.util.Collections;
-import java.util.HashSet;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.security.Constants;
@@ -79,7 +75,7 @@ public class ElytronIntegrationResourceDefinitions {
     public static ResourceDefinition getElytronRealmResourceDefinition() {
 
         final AttributeDefinition[] attributes = new AttributeDefinition[] {LEGACY_JAAS_CONFIG, APPLY_ROLE_MAPPERS};
-        final AbstractAddStepHandler addHandler = createAddHandler(attributes, SECURITY_REALM_RUNTIME_CAPABILITY);
+        final AbstractAddStepHandler addHandler = new AbstractAddStepHandler(attributes);
 
         return new BasicResourceDefinition(Constants.ELYTRON_REALM, addHandler, attributes, SECURITY_REALM_RUNTIME_CAPABILITY);
     }
@@ -98,7 +94,7 @@ public class ElytronIntegrationResourceDefinitions {
      */
     public static ResourceDefinition getElytronKeyStoreResourceDefinition() {
         final AttributeDefinition[] attributes = new AttributeDefinition[] {LEGACY_JSSE_CONFIG};
-        final AbstractAddStepHandler addHandler = createAddHandler(attributes, KEY_STORE_RUNTIME_CAPABILITY);
+        final AbstractAddStepHandler addHandler = new AbstractAddStepHandler(attributes);
 
         return new BasicResourceDefinition(Constants.ELYTRON_KEY_STORE, addHandler, attributes, KEY_STORE_RUNTIME_CAPABILITY);
     }
@@ -126,7 +122,7 @@ public class ElytronIntegrationResourceDefinitions {
      */
     public static ResourceDefinition getElytronTrustStoreResourceDefinition() {
         final AttributeDefinition[] attributes = new AttributeDefinition[] {LEGACY_JSSE_CONFIG};
-        final AbstractAddStepHandler addHandler = createAddHandler(attributes, KEY_STORE_RUNTIME_CAPABILITY);
+        final AbstractAddStepHandler addHandler = new AbstractAddStepHandler(attributes);
 
         return new BasicResourceDefinition(Constants.ELYTRON_TRUST_STORE, addHandler, attributes, KEY_STORE_RUNTIME_CAPABILITY);
     }
@@ -145,7 +141,7 @@ public class ElytronIntegrationResourceDefinitions {
      */
     public static ResourceDefinition getElytronKeyManagersResourceDefinition() {
         final AttributeDefinition[] attributes = new AttributeDefinition[] {LEGACY_JSSE_CONFIG};
-        final AbstractAddStepHandler addHandler = createAddHandler(attributes, KEY_MANAGER_RUNTIME_CAPABILITY);
+        final AbstractAddStepHandler addHandler = new AbstractAddStepHandler(attributes);
 
         return new BasicResourceDefinition(Constants.ELYTRON_KEY_MANAGER, addHandler, attributes, KEY_MANAGER_RUNTIME_CAPABILITY);
     }
@@ -169,15 +165,8 @@ public class ElytronIntegrationResourceDefinitions {
      */
     public static ResourceDefinition getElytronTrustManagersResourceDefinition() {
         final AttributeDefinition[] attributes = new AttributeDefinition[] {LEGACY_JSSE_CONFIG};
-        final AbstractAddStepHandler addHandler = createAddHandler(attributes, TRUST_MANAGER_RUNTIME_CAPABILITY);
+        final AbstractAddStepHandler addHandler = new AbstractAddStepHandler(attributes);
 
         return new BasicResourceDefinition(Constants.ELYTRON_TRUST_MANAGER, addHandler, attributes, TRUST_MANAGER_RUNTIME_CAPABILITY);
-    }
-
-    private static AbstractAddStepHandler createAddHandler(AttributeDefinition[] attributes, RuntimeCapability<?> runtimeCapability) {
-        // Don't use wildfly-common for these as it would be the only use in the entire maven module
-        assert attributes != null;
-        assert runtimeCapability != null;
-        return new AbstractAddStepHandler(new HashSet<>(Collections.singletonList(runtimeCapability)), attributes);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17328

This consists of ensuring that the capabilities provided by a resource are registered via its ResourceDefinition, i.e. via the SimpleResourceDefinition.Parameters object used to construct the ResourceDefinition. If that is done, having the add handler record the capability is redundant.

In most of the cases here, the ResourceDefinition was already recording the capability, so the redundant recording by the add handler could simply be removed.