### PR TITLE
[WFLY-17291] The RTS module needs `org.jboss.resteasy.resteasy-client…

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -31,6 +31,7 @@
     </resources>
 
     <dependencies>
+        <module name="org.jboss.resteasy.resteasy-client"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>


### PR DESCRIPTION
This PR addresses [WFLY-17291](https://issues.redhat.com/browse/WFLY-17291)