### PR TITLE
[WFLY-17350] Custom mail providers are not loaded

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -168,14 +168,7 @@ class SessionProviderFactory {
 
         @Override
         public Session getSession() {
-            final Session session;
-            final ClassLoader current = Thread.currentThread().getContextClassLoader();
-            try {
-                Thread.currentThread().setContextClassLoader(Session.class.getClassLoader());
-                session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
-            } finally {
-                Thread.currentThread().setContextClassLoader(current);
-            }
+            final Session session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
             return session;
         }
     }

--- a/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/servlet-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -51,5 +51,14 @@
         <!-- It is used only if org.wildfly.undertow.http-invoker capability is available -->
         <module name="io.undertow.core" optional="true"/>
         <module name="sun.jdk" />
+        <!--
+        The Angus Mail services are required to be able to load the Jakarta Mail Session from this Module context classloader
+        when listing the Mail context stored in the JNDI tree.
+        -->
+        <module name="org.eclipse.angus.mail" services="import" optional="true">
+            <imports>
+                <include path="META-INF"/>
+            </imports>
+        </module>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionCustomProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionCustomProviderTestCase.java
@@ -1,0 +1,68 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2022, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.mail.providers;
+
+import jakarta.annotation.Resource;
+import jakarta.mail.Provider;
+import jakarta.mail.Session;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MailSessionCustomProviderTestCase {
+
+    @Resource(lookup = "java:jboss/mail/Default")
+    private Session session;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(MailSessionCustomProviderTestCase.class.getPackage(),"javamail.providers", "META-INF/javamail.providers")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testCustomProvidersInApplication() {
+        Assert.assertNotNull(session);
+
+        Provider[] providers = session.getProviders();
+
+        int found = 0;
+        for (Provider p : providers) {
+            if (p.toString().equals("jakarta.mail.Provider[TRANSPORT,CustomTransport,org.jboss.qa.management.mail.custom.CustomTransport,JBoss QE]")) {
+                found++;
+            }
+            if (p.toString().equals("jakarta.mail.Provider[STORE,CustomStore,org.jboss.qa.management.mail.custom.CustomStore,JBoss QE]")) {
+                found++;
+            }
+        }
+
+        Assert.assertTrue("The expected custom providers cannot be found on the default Mail Session", found == 2);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/javamail.providers
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/javamail.providers
@@ -1,0 +1,2 @@
+protocol=CustomTransport; type=transport; class=org.jboss.qa.management.mail.custom.CustomTransport; vendor=JBoss QE;
+protocol=CustomStore; type=store; class=org.jboss.qa.management.mail.custom.CustomStore; vendor=JBoss QE;


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-17350

The getSession() method was changed to use the ~~"org.jboss.as.mail"~~ "jakarta.mail.api" classloader to prevent any caller module be able to load the session. In our Jakarta EE development cycle, we found "org.jboss.as.naming" was under this category. 

However, changing the TCCL in getSession left the application classloader outside without being able to provide other Mail providers.

Now we change the strategy and add the Mail API providers available on "org.jboss.as.naming" and roll back the TCCL changes. 