### PR TITLE
[WFLY-17359] Update protobuf to 3.19.6 (resolves CVE-2022-3171)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
         <version.com.google.guava>31.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.j2objc>1.3</version.com.google.j2objc>
-        <version.com.google.protobuf>3.19.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
         <version.com.h2database>2.1.210</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17359