### PR TITLE
[27.x][WFLY-17341] Upgrade Woodstox from 6.2.8 to 6.4.0  (CVE-2022-40152)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
         <version.org.bytebuddy>1.12.18</version.org.bytebuddy>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
-        <version.org.codehaus.woodstox.woodstox-core>6.2.8</version.org.codehaus.woodstox.woodstox-core>
+        <version.org.codehaus.woodstox.woodstox-core>6.4.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.eclipse.angus.angus-activation>1.0.0</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>1.0.0</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.31.0</version.org.eclipse.jdt>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17341
Upstream: #16324