### PR TITLE
[WFLY-17365] Failed deployment is not removed from Undertow ServletContainer's deployments map

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentService.java
@@ -106,6 +106,9 @@ public class UndertowDeploymentService implements Service<UndertowDeploymentServ
                 HttpHandler handler = deploymentManager.start();
                 Deployment deployment = deploymentManager.getDeployment();
                 host.get().registerDeployment(deployment, handler);
+            } catch (Throwable e ) {
+                container.get().getServletContainer().removeDeployment(deploymentInfo);
+                throw e;
             } finally {
                 StartupContext.setInjectionContainer(null);
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17365