### PR TITLE
[WFLY-17370] Upgrade WildFly Core to 20.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>20.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.http-client>1.1.15.Final</legacy.version.org.wildfly.http-client>
         <version.org.wildfly.http-client>2.0.0.Final</version.org.wildfly.http-client>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17370

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/20.0.0.Beta3...20.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5780'>WFCORE-5780</a>] -         ClientAgainstOldServerTestCase doesn&#39;t work
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6125'>WFCORE-6125</a>] -         Stuck server after invoking update-key-pair on filesystem-realm
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6130'>WFCORE-6130</a>] -         Bootstrap Exceptions unchained
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6138'>WFCORE-6138</a>] -         RealmsTestCase.testFilesystemRealmIntegrity() fails when run twice with no clean
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6141'>WFCORE-6141</a>] -         OtherServicesSubsystemTestCase.testOtherService and testPath fail intermittently
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6144'>WFCORE-6144</a>] -         JmxFacadeRbacEnabledTestCase tests fail intermittently due to an NPE
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6145'>WFCORE-6145</a>] -         Unbound SocketChannels do not correctly register with SocketBindingManager
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6146'>WFCORE-6146</a>] -         Socket binding &quot;bind-address&quot; and &quot;bind-port&quot; runtime attributes throw NPE if network channel is unbound
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4902'>WFCORE-4902</a>] -         Console availability message should be printed always before the boot statistics
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6108'>WFCORE-6108</a>] -         Add a new Phase constant to install global EJB client interceptors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6118'>WFCORE-6118</a>] -         Remove deprecated SocketBindingManager.SOCKET_BINDING_MANAGER
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6126'>WFCORE-6126</a>] -         Remove deprecated code in the org.jboss.as.controller.operations.validation package
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6133'>WFCORE-6133</a>] -         Remove deprecated Extension API members
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6137'>WFCORE-6137</a>] -         Remove LoggingExtension use of deprecated ChainedTransformationDescriptionBuilder.buildAndRegister
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6139'>WFCORE-6139</a>] -         CurrentOperationIdHolder cleanup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6140'>WFCORE-6140</a>] -         SuspendController service name cleanup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6152'>WFCORE-6152</a>] -         Implement Support for MicroProfile Telemetry
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6132'>WFCORE-6132</a>] -         Upgrade sshd-common from 2.8.0 to 2.9.2 to address CVE-2022-45047 
</li>
</ul>
</details>