### PR TITLE
[WFLY-17382] Upgrade legacy Undertow to 2.2.22.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>2.26.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-opentracing>3.0.0</version.io.smallrye.smallrye-opentracing>
         <version.io.smallrye.smallrye-reactive-messaging>4.1.0</version.io.smallrye.smallrye-reactive-messaging>
-        <legacy.version.io.undertow>2.2.20.Final</legacy.version.io.undertow>
+        <legacy.version.io.undertow>2.2.22.Final</legacy.version.io.undertow>
         <legacy.version.io.undertow.jastow>2.0.12.Final</legacy.version.io.undertow.jastow>
         <version.io.undertow.jastow>2.2.4.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.4</version.io.vertx.vertx>


### PR DESCRIPTION
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/WFLY-17382


        Release Notes - Undertow - Version 2.2.21.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1818'>UNDERTOW-1818</a>] -         AbstractServletInputStreamTestCase.runTestParallel fails with bytes out of order
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1988'>UNDERTOW-1988</a>] -         undertow-servlet-jakartaee9 has a Java EE 8 dependency
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2031'>UNDERTOW-2031</a>] -         protocol error with HTTP/2 and Expect: 100-continue 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2048'>UNDERTOW-2048</a>] -         CVE-2022-2764 UndertowInputStream.close() blocks waiting to read= -1
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2069'>UNDERTOW-2069</a>] -         Filter.destroy can deadlock with running filter on shutdown
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2081'>UNDERTOW-2081</a>] -         RejectedExecutionException occurs during shutdown if an open websocket session exists
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2097'>UNDERTOW-2097</a>] -         DMI_RANDOM_USED_ONLY_ONCE error reported by spotbugs
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2111'>UNDERTOW-2111</a>] -         rewrite() handler doesn&#39;t guard against missing leading slash
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2123'>UNDERTOW-2123</a>] -         AsyncContextImpl.dispatch  uses empty path sometimes
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2141'>UNDERTOW-2141</a>] -         NPE in ServletContextImpl after session timed out
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2162'>UNDERTOW-2162</a>] -         Query parameters should not be canonicalized in servlet path when get request dispatcher
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2163'>UNDERTOW-2163</a>] -         Predicate Language cannot set attribute to empty string
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2166'>UNDERTOW-2166</a>] -         When both IDLE_TIMEOUT and READ_TIMEOUT are configured the minimum of both should be used
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2167'>UNDERTOW-2167</a>] -         2.2.x branch will provide Java EE API version only
</li>
</ul>
                                                                                                                
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-1971'>UNDERTOW-1971</a>] -         Change in handling of concurrent session creation with id reuse
</li>
</ul>
                                                                                                                                                

        Release Notes - Undertow - Version 2.2.22.Final
        
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2054'>UNDERTOW-2054</a>] -         Buffer leak errors involving SslConduit on CI
</li>
</ul>
                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2198'>UNDERTOW-2198</a>] -         Add Option to force the SNIHostName 
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2123'>UNDERTOW-2123</a>] -         AsyncContextImpl.dispatch  uses empty path sometimes
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2184'>UNDERTOW-2184</a>] -         SessionListenerBridge doesn&#39;t properly implement sessionIdChanged
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2186'>UNDERTOW-2186</a>] -         Application sub directories named WEB-INF or META-INF are no longer served
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2188'>UNDERTOW-2188</a>] -         Adjust corner case of covered methods if no methods are  present 
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2189'>UNDERTOW-2189</a>] -         IOException thrown when trying to close already closed stream
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2190'>UNDERTOW-2190</a>] -         DefaultServlet serves CSS and JS blobs even if directory listing is disabled
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2202'>UNDERTOW-2202</a>] -         Cannot release the file handle in docker
</li>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2206'>UNDERTOW-2206</a>] -         IAE trying to decode a requestPath 
</li>
</ul>
                                                                                                                        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/UNDERTOW-2204'>UNDERTOW-2204</a>] -         Add CODE_OF_CONDUCT.md
</li>
</ul>
                                                                                                                                                