### PR TITLE
[WFLY-17383] Excluding LDAP server tests on JDK20+ for now

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -69,11 +69,13 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.naming.subsystem.NamingExtension;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.ManagedCreateTransport;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.java.permission.JndiPermission;
@@ -87,6 +89,11 @@ import org.wildfly.naming.java.permission.JndiPermission;
 @ServerSetup({ExternalContextBindingTestCase.ObjectFactoryWithEnvironmentBindingTestCaseServerSetup.class,
         ExternalContextBindingTestCase.PrepareExternalLDAPServerSetup.class})
 public class ExternalContextBindingTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        // https://issues.redhat.com/browse/WFLY-17383
+        AssumeTestGroupUtil.assumeJDKVersionBefore(20);
+    }
 
     private static Logger LOGGER = Logger.getLogger(ExternalContextBindingTestCase.class);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -51,9 +51,11 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -66,6 +68,11 @@ import org.junit.runner.RunWith;
 @ServerSetup({ LdapUrlInSearchBaseTestCase.LDAPServerSetupTask.class })
 @RunAsClient
 public class LdapUrlInSearchBaseTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        // https://issues.redhat.com/browse/WFLY-17383
+        AssumeTestGroupUtil.assumeJDKVersionBefore(20);
+    }
 
     private static Logger LOGGER = Logger.getLogger(LdapUrlInSearchBaseTestCase.class);
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
@@ -67,9 +67,11 @@ import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServl
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -86,6 +88,11 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @ServerSetup({LdapRealmTestCase.LDAPServerSetupTask.class, LdapRealmTestCase.SetupTask.class})
 public class LdapRealmTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        // https://issues.redhat.com/browse/WFLY-17383
+        AssumeTestGroupUtil.assumeJDKVersionBefore(20);
+    }
 
     private static final String DEPLOYMENT = "ldapRealmDep";
     private static final String DEPLOYMENT_WITH_CHARSET = "ldapRealmDepCharset";


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17383
