### PR TITLE
[WFLY-17363]: Upgrade artemis-wildfly-integration from 1.0.6 to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.27.0-GA</version.org.javassist>
         <version.org.jberet>2.1.1.Final</version.org.jberet>
-        <version.org.jboss.activemq.artemis.integration>1.0.6</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>1.0.7</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.7.0.Alpha12</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <legacy.version.org.jboss.ejb-client>4.0.49.Final</legacy.version.org.jboss.ejb-client>


### PR DESCRIPTION
 * Upgrading artemis-wildfly-integration from 1.0.6 to 1.0.7 to fix the issue WFLY-17362 where some transactions are left in prepared state.

Jira: https://issues.redhat.com/browse/WFLY-17363
      https://issues.redhat.com/browse/WFLY-17362

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>