### PR TITLE
[27.x][WFLY-17406] Upgrade WildFly Core to 19.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,7 +601,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>19.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.http-client>1.1.15.Final</legacy.version.org.wildfly.http-client>
         <version.org.wildfly.http-client>2.0.0.Final</version.org.wildfly.http-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-17406

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/19.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/19.0.0.Final...19.0.1.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6145'>WFCORE-6145</a>] -         Unbound SocketChannels do not correctly register with SocketBindingManager
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6146'>WFCORE-6146</a>] -         Socket binding &quot;bind-address&quot; and &quot;bind-port&quot; runtime attributes throw NPE if network channel is unbound
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6168'>WFCORE-6168</a>] -         Wildfly does not start when non-ascii chars are used in configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6169'>WFCORE-6169</a>] -         Disable YAML deserialization in the YAML Configuration Extension
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6099'>WFCORE-6099</a>] -         Upgrade byteman to 4.0.20
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6110'>WFCORE-6110</a>] -         Upgrade Jandex to 3.0.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6111'>WFCORE-6111</a>] -         Upgrade Bootable JAR to 8.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6132'>WFCORE-6132</a>] -         Upgrade sshd-common from 2.8.0 to 2.9.2 to address CVE-2022-45047 
</li>
</ul>
</details>
