### PR TITLE
Fix unmapple character for encoding UTF-8

### DIFF
--- a/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
+++ b/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/deployment/injection/AbstractJMSContextTestCase.java
@@ -42,7 +42,7 @@ import org.mockito.stubbing.Answer;
 /**
  * Test class for AbstractJMSContextTes.
  *
- * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brandão</a> (c) 2021 Red Hat inc.
+ * @author <a href="http://fnbrandao.com.br/">Fabio Nascimento Brand&atilde;o</a> (c) 2021 Red Hat inc.
  */
 public class AbstractJMSContextTestCase {
 


### PR DESCRIPTION
Trivial fix - use LATIN for single character.
