### PR TITLE
WFLY-17434 Eliminate static references to iiop-openjdk subsystem ResourceDefinition instances

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
@@ -69,7 +69,7 @@ public class IIOPExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
-        final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(IIOPRootDefinition.INSTANCE);
+        final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(new IIOPRootDefinition());
         subsystemRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
         subsystem.registerXMLElementWriter(new IIOPSubsystemParser_3_0());
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -22,7 +22,6 @@
 
 package org.wildfly.iiop.openjdk;
 
-import static org.wildfly.iiop.openjdk.Capabilities.IIOP_CAPABILITY;
 import static org.wildfly.iiop.openjdk.Capabilities.LEGACY_SECURITY;
 
 import java.util.ArrayList;
@@ -440,9 +439,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
         ALL_ATTRIBUTES.addAll(IOR_ATTRIBUTES);
     }
 
-    public static final IIOPRootDefinition INSTANCE = new IIOPRootDefinition();
-
-    private IIOPRootDefinition() {
+    IIOPRootDefinition() {
         super(new SimpleResourceDefinition.Parameters(IIOPExtension.PATH_SUBSYSTEM, IIOPExtension.getResourceDescriptionResolver())
                 .setAddHandler(new IIOPSubsystemAdd(ALL_ATTRIBUTES))
                 .setRemoveHandler(new ReloadRequiredRemoveStepHandler() {

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -292,7 +292,7 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
     protected Properties getConfigurationProperties(OperationContext context, ModelNode model) throws OperationFailedException {
         Properties properties = new Properties();
 
-        for (AttributeDefinition attrDefinition : IIOPRootDefinition.INSTANCE.getAttributes()) {
+        for (AttributeDefinition attrDefinition : IIOPRootDefinition.ALL_ATTRIBUTES) {
             if(attrDefinition instanceof PropertiesAttributeDefinition){
                 ModelNode resolvedModelAttribute = attrDefinition.resolveModelAttribute(context, model);
                 if(resolvedModelAttribute.isDefined()) {

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_1.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_1.java
@@ -44,7 +44,7 @@ class IIOPSubsystemParser_1 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(IIOPRootDefinition.INSTANCE.getPathElement())
+        return builder(IIOPExtension.PATH_SUBSYSTEM)
                 .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .setAdditionalOperationsGenerator((address, addOperation, operations) -> {

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_2_0.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_2_0.java
@@ -46,7 +46,7 @@ public class IIOPSubsystemParser_2_0 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(IIOPRootDefinition.INSTANCE.getPathElement(), Namespace.IIOP_OPENJDK_2_0.getUriString())
+        return builder(IIOPExtension.PATH_SUBSYSTEM, Namespace.IIOP_OPENJDK_2_0.getUriString())
                 .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .setAdditionalOperationsGenerator((address, addOperation, operations) -> {

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_2_1.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_2_1.java
@@ -44,7 +44,7 @@ public class IIOPSubsystemParser_2_1 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(IIOPRootDefinition.INSTANCE.getPathElement(), Namespace.IIOP_OPENJDK_2_1.getUriString())
+        return builder(IIOPExtension.PATH_SUBSYSTEM, Namespace.IIOP_OPENJDK_2_1.getUriString())
                 .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .build();

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_3_0.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_3_0.java
@@ -44,7 +44,7 @@ public class IIOPSubsystemParser_3_0 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(IIOPRootDefinition.INSTANCE.getPathElement(), Namespace.IIOP_OPENJDK_3_0.getUriString())
+        return builder(IIOPExtension.PATH_SUBSYSTEM, Namespace.IIOP_OPENJDK_3_0.getUriString())
                 .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .build();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17434
