### PR TITLE
WFLY-17436 Eliminate static references to JDR subsystem ResourceDefinition instances

### DIFF
--- a/jdr/src/main/java/org/jboss/as/jdr/JdrReportExtension.java
+++ b/jdr/src/main/java/org/jboss/as/jdr/JdrReportExtension.java
@@ -64,10 +64,11 @@ public class JdrReportExtension implements Extension {
 
     static final SensitiveTargetAccessConstraintDefinition JDR_SENSITIVITY_DEF = new SensitiveTargetAccessConstraintDefinition(JDR_SENSITIVITY);
 
+    @Override
     public void initialize(ExtensionContext context) {
         SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
 
-        ManagementResourceRegistration root = subsystemRegistration.registerSubsystemModel(JdrReportSubsystemDefinition.INSTANCE);
+        ManagementResourceRegistration root = subsystemRegistration.registerSubsystemModel(new JdrReportSubsystemDefinition());
         root.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
 
@@ -77,6 +78,7 @@ public class JdrReportExtension implements Extension {
         subsystemRegistration.registerXMLElementWriter(JdrReportSubsystemParser.INSTANCE);
     }
 
+    @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.CURRENT.getUriString(), () -> JdrReportSubsystemParser.INSTANCE);
     }

--- a/jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
+++ b/jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
@@ -28,9 +28,8 @@ import org.jboss.as.controller.SimpleResourceDefinition;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
-    static final JdrReportSubsystemDefinition INSTANCE = new JdrReportSubsystemDefinition();
 
-    private JdrReportSubsystemDefinition() {
+    JdrReportSubsystemDefinition() {
         super(JdrReportExtension.SUBSYSTEM_PATH, JdrReportExtension.getResourceDescriptionResolver(),
                 JdrReportSubsystemAdd.INSTANCE,
                 JdrReportSubsystemRemove.INSTANCE);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17436
