### PR TITLE
WFLY-17440 Eliminate static references to messaging-activemq subsystem ResourceDefinition instances

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -236,9 +236,7 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
             AUTO_DELETE_CREATED_QUEUES
     };
 
-    static final AddressSettingDefinition INSTANCE = new AddressSettingDefinition();
-
-    private AddressSettingDefinition() {
+    AddressSettingDefinition() {
         super(MessagingExtension.ADDRESS_SETTING_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.ADDRESS_SETTING),
                 AddressSettingAdd.INSTANCE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorServiceDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorServiceDefinition.java
@@ -48,9 +48,7 @@ public class ConnectorServiceDefinition extends PersistentResourceDefinition {
             CommonAttributes.FACTORY_CLASS,
             CommonAttributes.PARAMS };
 
-    static final ConnectorServiceDefinition INSTANCE = new ConnectorServiceDefinition();
-
-    private ConnectorServiceDefinition() {
+    ConnectorServiceDefinition() {
         super(MessagingExtension.CONNECTOR_SERVICE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(false, CommonAttributes.CONNECTOR_SERVICE),
                 new ConnectorServiceAddHandler(ATTRIBUTES),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressDefinition.java
@@ -62,8 +62,6 @@ public class CoreAddressDefinition extends SimpleResourceDefinition {
 
     public static final AttributeDefinition[] ATTRS = { QUEUE_NAMES, BINDING_NAMES, NUMBER_OF_PAGES, NUMBER_OF_BYTES_PER_PAGE };
 
-    static final CoreAddressDefinition INSTANCE = new CoreAddressDefinition();
-
     public CoreAddressDefinition() {
         super(new Parameters(PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.CORE_ADDRESS)).setRuntime());
@@ -76,8 +74,6 @@ public class CoreAddressDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registry) {
-        super.registerAttributes(registry);
-
         for (AttributeDefinition attr : ATTRS) {
             registry.registerReadOnlyAttribute(attr, AddressControlHandler.INSTANCE);
         }
@@ -85,10 +81,6 @@ public class CoreAddressDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerChildren(ManagementResourceRegistration registry) {
-        super.registerChildren(registry);
-
-        // TODO WFLY-5285 get rid of redundant .setRuntimeOnly once WFCORE-959 is integrated
-        ManagementResourceRegistration securityRole = registry.registerSubModel(SecurityRoleDefinition.RUNTIME_INSTANCE);
-        securityRole.setRuntimeOnly(true);
+        registry.registerSubModel(new SecurityRoleDefinition(true));
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertDefinition.java
@@ -79,8 +79,6 @@ public class DivertDefinition extends PersistentResourceDefinition {
 
     private final boolean registerRuntimeOnly;
 
-    static final DivertDefinition INSTANCE = new DivertDefinition(false);
-
     public DivertDefinition(boolean registerRuntimeOnly) {
         super(PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.DIVERT),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -95,9 +95,7 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
 
     public static final AttributeDefinition[] ATTRIBUTES = { TYPE, GROUPING_HANDLER_ADDRESS, TIMEOUT, GROUP_TIMEOUT, REAPER_PERIOD };
 
-    static final GroupingHandlerDefinition INSTANCE = new GroupingHandlerDefinition();
-
-    private GroupingHandlerDefinition() {
+    GroupingHandlerDefinition() {
         super(MessagingExtension.GROUPING_HANDLER_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.GROUPING_HANDLER),
                 GroupingHandlerAdd.INSTANCE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
@@ -71,9 +71,7 @@ public class HTTPAcceptorDefinition extends PersistentResourceDefinition {
             .build();
     static AttributeDefinition[] ATTRIBUTES = { HTTP_LISTENER, PARAMS, UPGRADE_LEGACY };
 
-    static final HTTPAcceptorDefinition INSTANCE = new HTTPAcceptorDefinition();
-
-    private HTTPAcceptorDefinition() {
+    HTTPAcceptorDefinition() {
         super(new SimpleResourceDefinition.Parameters(MessagingExtension.HTTP_ACCEPTOR_PATH,
                 new StandardResourceDescriptionResolver(CommonAttributes.ACCEPTOR, MessagingExtension.RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, false) {
                     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -69,6 +69,7 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_B
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -377,13 +378,8 @@ public class MessagingExtension implements Extension {
         // ActiveMQ Servers
         final ManagementResourceRegistration server = subsystem.registerSubModel(new ServerDefinition(broadcastCommandDispatcherFactoryInstaller, registerRuntimeOnly));
 
-        for (PathDefinition path : new PathDefinition[] {
-                PathDefinition.JOURNAL_INSTANCE,
-                PathDefinition.BINDINGS_INSTANCE,
-                PathDefinition.LARGE_MESSAGES_INSTANCE,
-                PathDefinition.PAGING_INSTANCE
-        }) {
-            ManagementResourceRegistration pathRegistry = server.registerSubModel(path);
+        for (PathElement path : List.of(JOURNAL_DIRECTORY_PATH, BINDINGS_DIRECTORY_PATH, LARGE_MESSAGES_DIRECTORY_PATH, PAGING_DIRECTORY_PATH)) {
+            ManagementResourceRegistration pathRegistry = server.registerSubModel(new PathDefinition(path));
             PathDefinition.registerResolveOperationHandler(context, pathRegistry);
         }
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -370,7 +370,7 @@ public class MessagingExtension implements Extension {
         subsystem.registerSubModel(RemoteTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
         subsystem.registerSubModel(new HTTPConnectorDefinition(registerRuntimeOnly));
         subsystem.registerSubModel(new ExternalConnectionFactoryDefinition(registerRuntimeOnly));
-        subsystem.registerSubModel(ExternalPooledConnectionFactoryDefinition.INSTANCE);
+        subsystem.registerSubModel(new ExternalPooledConnectionFactoryDefinition(false));
         subsystem.registerSubModel(new ExternalJMSQueueDefinition(registerRuntimeOnly));
         subsystem.registerSubModel(new ExternalJMSTopicDefinition(registerRuntimeOnly));
 
@@ -387,20 +387,20 @@ public class MessagingExtension implements Extension {
             PathDefinition.registerResolveOperationHandler(context, pathRegistry);
         }
 
-        subsystem.registerSubModel(JMSBridgeDefinition.INSTANCE);
+        subsystem.registerSubModel(new JMSBridgeDefinition());
 
         if (registerRuntimeOnly) {
             final ManagementResourceRegistration deployment = subsystemRegistration.registerDeploymentModel(new SimpleResourceDefinition(
                     new Parameters(SUBSYSTEM_PATH, getResourceDescriptionResolver("deployed")).setFeature(false).setRuntime()));
             deployment.registerSubModel(new ExternalConnectionFactoryDefinition(registerRuntimeOnly));
-            deployment.registerSubModel(ExternalPooledConnectionFactoryDefinition.DEPLOYMENT_INSTANCE);
+            deployment.registerSubModel(new ExternalPooledConnectionFactoryDefinition(true));
             deployment.registerSubModel(new ExternalJMSQueueDefinition(registerRuntimeOnly));
             deployment.registerSubModel(new ExternalJMSTopicDefinition(registerRuntimeOnly));
             final ManagementResourceRegistration deployedServer = deployment.registerSubModel(new SimpleResourceDefinition(
                     new Parameters(SERVER_PATH, getResourceDescriptionResolver(SERVER)).setFeature(false).setRuntime()));
             deployedServer.registerSubModel(new JMSQueueDefinition(true, registerRuntimeOnly));
             deployedServer.registerSubModel(new JMSTopicDefinition(true, registerRuntimeOnly));
-            deployedServer.registerSubModel(PooledConnectionFactoryDefinition.DEPLOYMENT_INSTANCE);
+            deployedServer.registerSubModel(new PooledConnectionFactoryDefinition(true));
         }
     }
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
@@ -289,22 +289,22 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
@@ -39,10 +39,7 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -205,7 +202,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -231,7 +228,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -271,7 +268,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -318,9 +315,9 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -330,7 +327,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -361,7 +358,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -424,7 +421,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -432,7 +429,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -466,7 +463,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -527,7 +524,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -568,7 +565,7 @@ public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
@@ -40,8 +40,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -240,7 +238,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -266,7 +264,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -353,9 +351,9 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -365,7 +363,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -396,7 +394,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -459,7 +457,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -467,7 +465,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -501,7 +499,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -562,7 +560,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -603,7 +601,7 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
@@ -325,22 +325,22 @@ public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_12_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_12_0.java
@@ -34,8 +34,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -238,7 +236,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                         ServerDefinition.NETWORK_CHECK_TIMEOUT,
                                         ServerDefinition.NETWORK_CHECK_URL_LIST)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -264,7 +262,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -351,9 +349,9 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -363,7 +361,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -394,7 +392,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -457,7 +455,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -465,7 +463,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -499,7 +497,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -560,7 +558,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -601,7 +599,7 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_12_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_12_0.java
@@ -323,22 +323,22 @@ public class MessagingSubsystemParser_12_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -244,7 +243,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                         ServerDefinition.CRITICAL_ANALYZER_POLICY,
                                         ServerDefinition.CRITICAL_ANALYZER_TIMEOUT)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -359,9 +358,9 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -371,7 +370,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -402,7 +401,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -465,7 +464,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -473,7 +472,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -508,7 +507,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME,
                                                         BridgeDefinition.CALL_TIMEOUT))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -569,7 +568,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -610,7 +609,7 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_0.java
@@ -332,22 +332,22 @@ public class MessagingSubsystemParser_13_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_1.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_1.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -244,7 +243,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                         ServerDefinition.CRITICAL_ANALYZER_POLICY,
                                         ServerDefinition.CRITICAL_ANALYZER_TIMEOUT)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -357,9 +356,9 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -369,7 +368,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -400,7 +399,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -463,7 +462,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -471,7 +470,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -506,7 +505,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME,
                                                         BridgeDefinition.CALL_TIMEOUT))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -567,7 +566,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -608,7 +607,7 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_1.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_13_1.java
@@ -330,22 +330,22 @@ public class MessagingSubsystemParser_13_1 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_14_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_14_0.java
@@ -29,12 +29,7 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
-import org.wildfly.extension.messaging.activemq.ha.SharedStorePrimaryDefinition;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreSecondaryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -243,7 +238,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                         ServerDefinition.CRITICAL_ANALYZER_POLICY,
                                         ServerDefinition.CRITICAL_ANALYZER_TIMEOUT)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -269,7 +264,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -296,10 +291,10 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
-                                .addChild(builder(SharedStorePrimaryDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_PRIMARY_PATH)
                                                 .addAttributes(
                                                         HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
-                                .addChild(builder(SharedStoreSecondaryDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_SECONDARY_PATH)
                                                 .addAttributes(
                                                         HAAttributes.ALLOW_FAILBACK,
                                                         HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
@@ -309,17 +304,17 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
                                                         HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL,
                                                         HAAttributes.MAX_BACKUPS,
                                                         HAAttributes.BACKUP_PORT_OFFSET)
-                                                .addChild(builder(SharedStorePrimaryDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                .addChild(builder(MessagingExtension.CONFIGURATION_PRIMARY_PATH)
                                                                 .addAttributes(
                                                                         HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
-                                                .addChild(builder(SharedStoreSecondaryDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                .addChild(builder(MessagingExtension.CONFIGURATION_SECONDARY_PATH)
                                                                 .addAttributes(
                                                                         HAAttributes.ALLOW_FAILBACK,
                                                                         HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
@@ -356,9 +351,9 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -368,7 +363,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -400,7 +395,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -463,7 +458,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -471,7 +466,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -485,7 +480,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.ATTRIBUTES
                                                         ))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -546,7 +541,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -587,7 +582,7 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_14_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_14_0.java
@@ -325,22 +325,22 @@ public class MessagingSubsystemParser_14_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -207,22 +207,22 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                                 ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                                 ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                         .addChild(
-                                                builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                                builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                         .addAttributes(
                                                                 PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                                 PathDefinition.RELATIVE_TO))
                                         .addChild(
-                                                builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                                builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                         .addAttributes(
                                                                 PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                                 PathDefinition.RELATIVE_TO))
                                         .addChild(
-                                                builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                                builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                         .addAttributes(
                                                                 PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                                 PathDefinition.RELATIVE_TO))
                                         .addChild(
-                                                builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                                builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                         .addAttributes(
                                                                 PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                                 PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -39,12 +39,8 @@ import static org.wildfly.extension.messaging.activemq.MessagingExtension.SHARED
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
 
@@ -124,7 +120,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                 CommonAttributes.INCOMING_INTERCEPTORS,
                                                 CommonAttributes.OUTGOING_INTERCEPTORS)
                                         .addChild(
-                                                builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.LIVE_ONLY_PATH)
                                                         .addAttributes(
                                                                 ScaleDownAttributes.SCALE_DOWN,
                                                                 ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -150,7 +146,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                                 ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                 ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                        .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                        .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                         .addAttributes(
                                                                 HAAttributes.REQUEST_BACKUP,
                                                                 HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -190,7 +186,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                                 ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                 ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                        .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                        .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                         .addAttributes(
                                                                 HAAttributes.REQUEST_BACKUP,
                                                                 HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -237,9 +233,9 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 CommonAttributes.DURABLE,
                                                                 CommonAttributes.FILTER))
                                         .addChild(
-                                                builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                         .addChild(
-                                                                builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                                builder(MessagingExtension.ROLE_PATH)
                                                                         .addAttributes(
                                                                                 SecurityRoleDefinition.SEND,
                                                                                 SecurityRoleDefinition.CONSUME,
@@ -249,7 +245,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                                 SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                                 SecurityRoleDefinition.MANAGE)))
                                         .addChild(
-                                                builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                         .addAttributes(
                                                                 CommonAttributes.DEAD_LETTER_ADDRESS,
                                                                 CommonAttributes.EXPIRY_ADDRESS,
@@ -356,7 +352,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                                 ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                         .addChild(
-                                                builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                         .addAttributes(
                                                                 GroupingHandlerDefinition.TYPE,
                                                                 GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -364,7 +360,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                                 GroupingHandlerDefinition.REAPER_PERIOD))
                                         .addChild(
-                                                builder(DivertDefinition.INSTANCE.getPathElement())
+                                                builder(DivertDefinition.PATH)
                                                         .addAttributes(
                                                                 DivertDefinition.ROUTING_NAME,
                                                                 DivertDefinition.ADDRESS,
@@ -396,7 +392,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 BridgeDefinition.CONNECTOR_REFS,
                                                                 BridgeDefinition.DISCOVERY_GROUP_NAME))
                                         .addChild(
-                                                builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                         .addAttributes(
                                                                 CommonAttributes.FACTORY_CLASS,
                                                                 CommonAttributes.PARAMS))
@@ -454,7 +450,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 // regular
                                                                 ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                         .addChild(
-                                                builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                         .addAttributes(
                                                                 LegacyConnectionFactoryDefinition.ENTRIES,
                                                                 LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -494,7 +490,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 LegacyConnectionFactoryDefinition.TRANSACTION_BATCH_SIZE,
                                                                 LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                         .addChild(
-                                                builder(PooledConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                                builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
                                                         .addAttributes(
                                                                 ConnectionFactoryAttributes.Common.ENTRIES,
                                                                 // common
@@ -549,7 +545,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 ConnectionFactoryAttributes.Common.INITIAL_MESSAGE_PACKET_SIZE,
                                                                 ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS)))
                         .addChild(
-                                builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                                builder(MessagingExtension.JMS_BRIDGE_PATH)
                                         .addAttributes(
                                                 JMSBridgeDefinition.MODULE,
                                                 JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
@@ -220,22 +220,22 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
@@ -39,12 +39,8 @@ import static org.wildfly.extension.messaging.activemq.MessagingExtension.SHARED
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
 
@@ -137,7 +133,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -163,7 +159,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -203,7 +199,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -250,9 +246,9 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.FILTER))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -262,7 +258,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -308,7 +304,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -371,7 +367,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -379,7 +375,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -413,7 +409,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -473,7 +469,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         // regular
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -513,7 +509,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.TRANSACTION_BATCH_SIZE,
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(
-                                        builder(PooledConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common
@@ -577,7 +573,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS,
                                                         ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_3_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_3_0.java
@@ -220,22 +220,22 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_3_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_3_0.java
@@ -39,12 +39,8 @@ import static org.wildfly.extension.messaging.activemq.MessagingExtension.SHARED
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
 
@@ -137,7 +133,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -163,7 +159,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -203,7 +199,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -250,9 +246,9 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.FILTER))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -262,7 +258,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -308,7 +304,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -373,7 +369,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -381,7 +377,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -415,7 +411,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -476,7 +472,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         // regular
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -516,7 +512,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.TRANSACTION_BATCH_SIZE,
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(
-                                        builder(PooledConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common
@@ -580,7 +576,7 @@ public class MessagingSubsystemParser_3_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS,
                                                         ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_4_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_4_0.java
@@ -344,22 +344,22 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_4_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_4_0.java
@@ -40,12 +40,8 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
 
@@ -98,7 +94,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                         CommonAttributes.PARAMS);
 
         final PersistentResourceXMLBuilder pooledConnectionFactory =
-                                        builder(PooledConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common
@@ -261,7 +257,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -287,7 +283,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -327,7 +323,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -374,9 +370,9 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.FILTER))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -386,7 +382,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -417,7 +413,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -474,7 +470,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -482,7 +478,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -516,7 +512,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -577,7 +573,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         // regular
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -618,7 +614,7 @@ public class MessagingSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(pooledConnectionFactory))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_5_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_5_0.java
@@ -346,22 +346,22 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_5_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_5_0.java
@@ -40,12 +40,8 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
 
@@ -98,7 +94,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                         CommonAttributes.PARAMS);
 
         final PersistentResourceXMLBuilder pooledConnectionFactory =
-                                        builder(PooledConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common
@@ -263,7 +259,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -289,7 +285,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -329,7 +325,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -376,9 +372,9 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.FILTER))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -388,7 +384,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -419,7 +415,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -476,7 +472,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -484,7 +480,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -518,7 +514,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -579,7 +575,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         // regular
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -620,7 +616,7 @@ public class MessagingSubsystemParser_5_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(pooledConnectionFactory))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
@@ -348,22 +348,22 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -262,7 +261,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -375,9 +374,9 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -387,7 +386,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -418,7 +417,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -475,7 +474,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -483,7 +482,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -517,7 +516,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -578,7 +577,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         // regular
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -619,7 +618,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(pooledConnectionFactory))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_7_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_7_0.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
@@ -200,7 +199,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -313,9 +312,9 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -325,7 +324,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -356,7 +355,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -413,7 +412,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -421,7 +420,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -455,7 +454,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -516,7 +515,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -557,7 +556,7 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_7_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_7_0.java
@@ -286,22 +286,22 @@ public class MessagingSubsystemParser_7_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_8_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_8_0.java
@@ -39,10 +39,7 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -199,7 +196,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -225,7 +222,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -265,7 +262,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -312,9 +309,9 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -324,7 +321,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -355,7 +352,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -412,7 +409,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -420,7 +417,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -454,7 +451,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -515,7 +512,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -556,7 +553,7 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_8_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_8_0.java
@@ -283,22 +283,22 @@ public class MessagingSubsystemParser_8_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_9_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_9_0.java
@@ -39,10 +39,7 @@ import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
-import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
-import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
-import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -205,7 +202,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                         CommonAttributes.INCOMING_INTERCEPTORS,
                                         CommonAttributes.OUTGOING_INTERCEPTORS)
                                 .addChild(
-                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LIVE_ONLY_PATH)
                                                 .addAttributes(
                                                         ScaleDownAttributes.SCALE_DOWN,
                                                         ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
@@ -231,7 +228,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.REPLICATION_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -271,7 +268,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
-                                .addChild(builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                .addChild(builder(MessagingExtension.SHARED_STORE_COLOCATED_PATH)
                                                 .addAttributes(
                                                         HAAttributes.REQUEST_BACKUP,
                                                         HAAttributes.BACKUP_REQUEST_RETRIES,
@@ -318,9 +315,9 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.FILTER,
                                                         QueueDefinition.ROUTING_TYPE))
                                 .addChild(
-                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.SECURITY_SETTING_PATH)
                                                 .addChild(
-                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                        builder(MessagingExtension.ROLE_PATH)
                                                                 .addAttributes(
                                                                         SecurityRoleDefinition.SEND,
                                                                         SecurityRoleDefinition.CONSUME,
@@ -330,7 +327,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
                                                                         SecurityRoleDefinition.MANAGE)))
                                 .addChild(
-                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.ADDRESS_SETTING_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DEAD_LETTER_ADDRESS,
                                                         CommonAttributes.EXPIRY_ADDRESS,
@@ -361,7 +358,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                 .addChild(invmConnector)
                                 .addChild(connector)
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
@@ -424,7 +421,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
                                                         ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.GROUPING_HANDLER_PATH)
                                                 .addAttributes(
                                                         GroupingHandlerDefinition.TYPE,
                                                         GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
@@ -432,7 +429,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         GroupingHandlerDefinition.GROUP_TIMEOUT,
                                                         GroupingHandlerDefinition.REAPER_PERIOD))
                                 .addChild(
-                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                        builder(DivertDefinition.PATH)
                                                 .addAttributes(
                                                         DivertDefinition.ROUTING_NAME,
                                                         DivertDefinition.ADDRESS,
@@ -466,7 +463,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         BridgeDefinition.CONNECTOR_REFS,
                                                         BridgeDefinition.DISCOVERY_GROUP_NAME))
                                 .addChild(
-                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CONNECTOR_SERVICE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
@@ -527,7 +524,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
                                 .addChild(
-                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         LegacyConnectionFactoryDefinition.ENTRIES,
                                                         LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
@@ -568,7 +565,7 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                         LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
                                 .addChild(createPooledConnectionFactory(false)))
                 .addChild(
-                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                        builder(MessagingExtension.JMS_BRIDGE_PATH)
                                 .addAttributes(
                                         JMSBridgeDefinition.MODULE,
                                         JMSBridgeDefinition.QUALITY_OF_SERVICE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_9_0.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_9_0.java
@@ -289,22 +289,22 @@ public class MessagingSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                                         ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
                                                                         ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
                                 .addChild(
-                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BINDINGS_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.JOURNAL_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                        builder(MessagingExtension.PAGING_DIRECTORY_PATH)
                                                 .addAttributes(
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
@@ -123,12 +123,7 @@ public class PathDefinition extends PersistentResourceDefinition {
         return new AttributeDefinition[] { PATHS.get(path), RELATIVE_TO };
     }
 
-    static final PathDefinition BINDINGS_INSTANCE = new PathDefinition(MessagingExtension.BINDINGS_DIRECTORY_PATH);
-    static final PathDefinition LARGE_MESSAGES_INSTANCE = new PathDefinition(MessagingExtension.LARGE_MESSAGES_DIRECTORY_PATH);
-    static final PathDefinition PAGING_INSTANCE = new PathDefinition(MessagingExtension.PAGING_DIRECTORY_PATH);
-    static final PathDefinition JOURNAL_INSTANCE = new PathDefinition(MessagingExtension.JOURNAL_DIRECTORY_PATH);
-
-    public PathDefinition(PathElement path) {
+    PathDefinition(PathElement path) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(ModelDescriptionConstants.PATH),
                 PATH_ADD,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleDefinition.java
@@ -92,10 +92,6 @@ public class SecurityRoleDefinition extends PersistentResourceDefinition {
 
     private final boolean runtimeOnly;
 
-    static final SecurityRoleDefinition RUNTIME_INSTANCE = new SecurityRoleDefinition(true);
-
-    static final SecurityRoleDefinition INSTANCE = new SecurityRoleDefinition(false);
-
     static Role transform(final OperationContext context, final String name, final ModelNode node) throws OperationFailedException {
         final boolean send = SEND.resolveModelAttribute(context, node).asBoolean();
         final boolean consume = CONSUME.resolveModelAttribute(context, node).asBoolean();
@@ -107,7 +103,7 @@ public class SecurityRoleDefinition extends PersistentResourceDefinition {
         return new Role(name, send, consume, createDurableQueue, deleteDurableQueue, createNonDurableQueue, deleteNonDurableQueue, manage);
     }
 
-    private SecurityRoleDefinition(final boolean runtimeOnly) {
+    SecurityRoleDefinition(final boolean runtimeOnly) {
         super(MessagingExtension.ROLE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.SECURITY_ROLE),
                 runtimeOnly ? null : SecurityRoleAdd.INSTANCE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecuritySettingDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecuritySettingDefinition.java
@@ -41,13 +41,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
  */
 public class SecuritySettingDefinition extends PersistentResourceDefinition {
 
-    private static final PersistentResourceDefinition[] CHILDREN = {
-            SecurityRoleDefinition.INSTANCE
-    };
-
-    static final SecuritySettingDefinition INSTANCE = new SecuritySettingDefinition();
-
-    private SecuritySettingDefinition() {
+    SecuritySettingDefinition() {
         super(SECURITY_SETTING_PATH,
                 MessagingExtension.getResourceDescriptionResolver(false, SECURITY_SETTING_PATH.getKey()),
                 SecuritySettingAdd.INSTANCE,
@@ -61,7 +55,7 @@ public class SecuritySettingDefinition extends PersistentResourceDefinition {
 
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
-        return Arrays.asList(CHILDREN);
+        return List.of(new SecurityRoleDefinition(false));
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -998,27 +998,27 @@ public class ServerDefinition extends PersistentResourceDefinition {
         List<PersistentResourceDefinition> children = new ArrayList<>();
         // Static resources
         children.addAll(Arrays.asList(// HA policy
-                LiveOnlyDefinition.INSTANCE,
-                registerRuntimeOnly ? ReplicationPrimaryDefinition.INSTANCE : ReplicationPrimaryDefinition.HC_INSTANCE,
-                registerRuntimeOnly ? ReplicationSecondaryDefinition.INSTANCE : ReplicationSecondaryDefinition.HC_INSTANCE,
-                ReplicationColocatedDefinition.INSTANCE,
-                SharedStorePrimaryDefinition.INSTANCE,
-                SharedStoreSecondaryDefinition.INSTANCE,
-                SharedStoreColocatedDefinition.INSTANCE,
+                new LiveOnlyDefinition(),
+                new ReplicationPrimaryDefinition(MessagingExtension.REPLICATION_PRIMARY_PATH, false, registerRuntimeOnly),
+                new ReplicationSecondaryDefinition(MessagingExtension.REPLICATION_SECONDARY_PATH, false, registerRuntimeOnly),
+                new ReplicationColocatedDefinition(),
+                new SharedStorePrimaryDefinition(MessagingExtension.SHARED_STORE_PRIMARY_PATH, false),
+                new SharedStoreSecondaryDefinition(MessagingExtension.SHARED_STORE_SECONDARY_PATH, false),
+                new SharedStoreColocatedDefinition(),
 
-                AddressSettingDefinition.INSTANCE,
-                SecuritySettingDefinition.INSTANCE,
+                new AddressSettingDefinition(),
+                new SecuritySettingDefinition(),
 
                 // Acceptors
-                HTTPAcceptorDefinition.INSTANCE,
+                new HTTPAcceptorDefinition(),
 
-                DivertDefinition.INSTANCE,
-                ConnectorServiceDefinition.INSTANCE,
-                GroupingHandlerDefinition.INSTANCE,
+                new DivertDefinition(false),
+                new ConnectorServiceDefinition(),
+                new GroupingHandlerDefinition(),
 
                 // Jakarta Messaging resources
-                LegacyConnectionFactoryDefinition.INSTANCE,
-                PooledConnectionFactoryDefinition.INSTANCE));
+                new LegacyConnectionFactoryDefinition(),
+                new PooledConnectionFactoryDefinition(false)));
 
         // Dynamic resources (depending on registerRuntimeOnly)
         // acceptors
@@ -1058,7 +1058,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
         // runtime queues and core-address are only registered when it is ok to register runtime resource (ie they are not registered on HC).
         if (registerRuntimeOnly) {
             resourceRegistration.registerSubModel(new QueueDefinition(registerRuntimeOnly, MessagingExtension.RUNTIME_QUEUE_PATH));
-            resourceRegistration.registerSubModel(CoreAddressDefinition.INSTANCE);
+            resourceRegistration.registerSubModel(new CoreAddressDefinition());
         }
     }
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/LiveOnlyDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/LiveOnlyDefinition.java
@@ -61,9 +61,7 @@ public class LiveOnlyDefinition extends PersistentResourceDefinition {
 
     private static final AbstractWriteAttributeHandler WRITE_ATTRIBUTE = new ActiveMQReloadRequiredHandlers.WriteAttributeHandler(ATTRIBUTES);
 
-    public static final LiveOnlyDefinition INSTANCE = new LiveOnlyDefinition();
-
-    private LiveOnlyDefinition() {
+    public LiveOnlyDefinition() {
         super(MessagingExtension.LIVE_ONLY_PATH,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 ADD,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
@@ -64,9 +64,7 @@ public class ReplicationColocatedDefinition extends PersistentResourceDefinition
             EXCLUDED_CONNECTORS
     ));
 
-    public static final ReplicationColocatedDefinition INSTANCE = new ReplicationColocatedDefinition();
-
-    private ReplicationColocatedDefinition() {
+    public ReplicationColocatedDefinition() {
         super(MessagingExtension.REPLICATION_COLOCATED_PATH,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(HA_POLICY, false, ATTRIBUTES),
@@ -105,8 +103,8 @@ public class ReplicationColocatedDefinition extends PersistentResourceDefinition
 
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
-        return Collections.unmodifiableList(Arrays.asList(
-                ReplicationPrimaryDefinition.CONFIGURATION_INSTANCE,
-                ReplicationSecondaryDefinition.CONFIGURATION_INSTANCE));
+        return List.of(
+                new ReplicationPrimaryDefinition(MessagingExtension.CONFIGURATION_PRIMARY_PATH, true, true),
+                new ReplicationSecondaryDefinition(MessagingExtension.CONFIGURATION_SECONDARY_PATH, true, true));
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationPrimaryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationPrimaryDefinition.java
@@ -55,12 +55,8 @@ public class ReplicationPrimaryDefinition extends PersistentResourceDefinition {
             INITIAL_REPLICATION_SYNC_TIMEOUT
     ));
 
-    public static final ReplicationPrimaryDefinition INSTANCE = new ReplicationPrimaryDefinition(MessagingExtension.REPLICATION_PRIMARY_PATH, false, true);
-    public static final ReplicationPrimaryDefinition HC_INSTANCE = new ReplicationPrimaryDefinition(MessagingExtension.REPLICATION_PRIMARY_PATH, false, false);
-    public static final ReplicationPrimaryDefinition CONFIGURATION_INSTANCE = new ReplicationPrimaryDefinition(MessagingExtension.CONFIGURATION_PRIMARY_PATH, true, true);
-
     private final boolean registerRuntime;
-    private ReplicationPrimaryDefinition(PathElement path, boolean allowSibling, boolean registerRuntime) {
+    public ReplicationPrimaryDefinition(PathElement path, boolean allowSibling, boolean registerRuntime) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(path.getKey(), allowSibling, ATTRIBUTES),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationSecondaryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationSecondaryDefinition.java
@@ -65,12 +65,8 @@ public class ReplicationSecondaryDefinition extends PersistentResourceDefinition
         ATTRIBUTES = Collections.unmodifiableCollection(attributes);
     }
 
-    public static final ReplicationSecondaryDefinition INSTANCE = new ReplicationSecondaryDefinition(MessagingExtension.REPLICATION_SECONDARY_PATH, false, true);
-    public static final ReplicationSecondaryDefinition HC_INSTANCE = new ReplicationSecondaryDefinition(MessagingExtension.REPLICATION_SECONDARY_PATH, false, false);
-    public static final ReplicationSecondaryDefinition CONFIGURATION_INSTANCE = new ReplicationSecondaryDefinition(MessagingExtension.CONFIGURATION_SECONDARY_PATH, true, true);
-
     private final boolean registerRuntime;
-    private ReplicationSecondaryDefinition(PathElement path, boolean allowSibling, boolean registerRuntime) {
+    public ReplicationSecondaryDefinition(PathElement path, boolean allowSibling, boolean registerRuntime) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(path.getKey(), allowSibling, ATTRIBUTES),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreColocatedDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreColocatedDefinition.java
@@ -64,9 +64,7 @@ public class SharedStoreColocatedDefinition extends PersistentResourceDefinition
             BACKUP_PORT_OFFSET
     ));
 
-    public static final SharedStoreColocatedDefinition INSTANCE = new SharedStoreColocatedDefinition();
-
-    private SharedStoreColocatedDefinition() {
+    public SharedStoreColocatedDefinition() {
         super(SHARED_STORE_COLOCATED_PATH,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(HA_POLICY, false, ATTRIBUTES),
@@ -105,9 +103,9 @@ public class SharedStoreColocatedDefinition extends PersistentResourceDefinition
 
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
-        return Collections.unmodifiableList(Arrays.asList(
-                SharedStorePrimaryDefinition.CONFIGURATION_INSTANCE,
-                SharedStoreSecondaryDefinition.CONFIGURATION_INSTANCE));
+        return List.of(
+                new SharedStorePrimaryDefinition(MessagingExtension.CONFIGURATION_PRIMARY_PATH, true),
+                new SharedStoreSecondaryDefinition(MessagingExtension.CONFIGURATION_SECONDARY_PATH, true));
     }
 
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStorePrimaryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStorePrimaryDefinition.java
@@ -48,11 +48,7 @@ public class SharedStorePrimaryDefinition extends PersistentResourceDefinition {
             FAILOVER_ON_SERVER_SHUTDOWN
     ));
 
-    public static final SharedStorePrimaryDefinition INSTANCE = new SharedStorePrimaryDefinition(MessagingExtension.SHARED_STORE_PRIMARY_PATH, false);
-    public static final SharedStorePrimaryDefinition CONFIGURATION_INSTANCE = new SharedStorePrimaryDefinition(MessagingExtension.CONFIGURATION_PRIMARY_PATH, true);
-
-
-    private SharedStorePrimaryDefinition(PathElement path, boolean allowSibling) {
+    public SharedStorePrimaryDefinition(PathElement path, boolean allowSibling) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(path.getKey(), allowSibling, ATTRIBUTES),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreSecondaryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreSecondaryDefinition.java
@@ -61,10 +61,7 @@ public class SharedStoreSecondaryDefinition extends PersistentResourceDefinition
 
     private static final AbstractWriteAttributeHandler WRITE_ATTRIBUTE = new ActiveMQReloadRequiredHandlers.WriteAttributeHandler(ATTRIBUTES);
 
-    public static final SharedStoreSecondaryDefinition INSTANCE = new SharedStoreSecondaryDefinition(MessagingExtension.SHARED_STORE_SECONDARY_PATH, false);
-    public static final SharedStoreSecondaryDefinition CONFIGURATION_INSTANCE = new SharedStoreSecondaryDefinition(MessagingExtension.CONFIGURATION_SECONDARY_PATH, true);
-
-    private SharedStoreSecondaryDefinition(PathElement path, boolean allowSibling) {
+    public SharedStoreSecondaryDefinition(PathElement path, boolean allowSibling) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(path.getKey(), allowSibling, ATTRIBUTES),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryDefinition.java
@@ -140,10 +140,6 @@ public class ExternalPooledConnectionFactoryDefinition extends PooledConnectionF
 
     public static final ConnectionFactoryAttribute[] ATTRIBUTES = define(Pooled.ATTRIBUTES, Common.ATTRIBUTES);
 
-    public static final ExternalPooledConnectionFactoryDefinition INSTANCE = new ExternalPooledConnectionFactoryDefinition(false);
-
-    public static final ExternalPooledConnectionFactoryDefinition DEPLOYMENT_INSTANCE = new ExternalPooledConnectionFactoryDefinition(true);
-
     public ExternalPooledConnectionFactoryDefinition(final boolean deployed) {
         super(new SimpleResourceDefinition.Parameters(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.POOLED_CONNECTION_FACTORY))
                 .setAddHandler(ExternalPooledConnectionFactoryAdd.INSTANCE)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
@@ -134,10 +134,6 @@ public class PooledConnectionFactoryDefinition extends PersistentResourceDefinit
     private final boolean deployed;
     private final boolean external;
 
-    public static final PooledConnectionFactoryDefinition INSTANCE = new PooledConnectionFactoryDefinition(false);
-
-    public static final PooledConnectionFactoryDefinition DEPLOYMENT_INSTANCE = new PooledConnectionFactoryDefinition(true);
-
     public PooledConnectionFactoryDefinition(final boolean deployed) {
         this(new SimpleResourceDefinition.Parameters(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.POOLED_CONNECTION_FACTORY))
                 .setAddHandler(PooledConnectionFactoryAdd.INSTANCE)

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -248,9 +248,7 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             PAUSE, RESUME
     };
 
-    public static final JMSBridgeDefinition INSTANCE = new JMSBridgeDefinition();
-
-    private JMSBridgeDefinition() {
+    public JMSBridgeDefinition() {
         super(MessagingExtension.JMS_BRIDGE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.JMS_BRIDGE),
                 JMSBridgeAdd.INSTANCE,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
@@ -473,9 +473,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
         CONNECTORS
     };
 
-    public static final LegacyConnectionFactoryDefinition INSTANCE = new LegacyConnectionFactoryDefinition();
-
-    protected LegacyConnectionFactoryDefinition() {
+    public LegacyConnectionFactoryDefinition() {
         super(new SimpleResourceDefinition.Parameters(
                 MessagingExtension.LEGACY_CONNECTION_FACTORY_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.CONNECTION_FACTORY))


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17440
