### PR TITLE
WFLY-17442 Eliminate static references to naming subsystem ResourceDefinition instances

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingResourceDefinition.java
@@ -56,8 +56,6 @@ import java.util.List;
  */
 public class NamingBindingResourceDefinition extends SimpleResourceDefinition {
 
-    static final NamingBindingResourceDefinition INSTANCE = new NamingBindingResourceDefinition();
-
     static final SimpleAttributeDefinition BINDING_TYPE = new SimpleAttributeDefinitionBuilder(NamingSubsystemModel.BINDING_TYPE, ModelType.STRING, false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setValidator(EnumValidator.create(BindingType.class))
@@ -111,7 +109,7 @@ public class NamingBindingResourceDefinition extends SimpleResourceDefinition {
 
     static final OperationStepHandler VALIDATE_RESOURCE_MODEL_OPERATION_STEP_HANDLER = (context, op) -> validateResourceModel(context.readResource(PathAddress.EMPTY_ADDRESS).getModel(), true);
 
-    private NamingBindingResourceDefinition() {
+    NamingBindingResourceDefinition() {
         super(NamingSubsystemModel.BINDING_PATH,
                 NamingExtension.getResourceDescriptionResolver(NamingSubsystemModel.BINDING),
                 NamingBindingAdd.INSTANCE, NamingBindingRemove.INSTANCE);

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
@@ -87,8 +87,8 @@ public class NamingExtension implements Extension {
 
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        registration.registerSubModel(NamingBindingResourceDefinition.INSTANCE);
-        registration.registerSubModel(RemoteNamingResourceDefinition.INSTANCE);
+        registration.registerSubModel(new NamingBindingResourceDefinition());
+        registration.registerSubModel(new RemoteNamingResourceDefinition());
 
         if (context.isRuntimeOnlyRegistrationValid()) {
             registration.registerOperationHandler(NamingSubsystemRootResourceDefinition.JNDI_VIEW, JndiViewOperation.INSTANCE, false);

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingResourceDefinition.java
@@ -39,9 +39,7 @@ public class RemoteNamingResourceDefinition extends SimpleResourceDefinition {
             .addRequirements(REMOTING_ENDPOINT_CAPABILITY_NAME)
             .build();
 
-    public static final RemoteNamingResourceDefinition INSTANCE = new RemoteNamingResourceDefinition();
-
-    private RemoteNamingResourceDefinition() {
+    RemoteNamingResourceDefinition() {
         super(new Parameters(NamingSubsystemModel.REMOTE_NAMING_PATH, NamingExtension.getResourceDescriptionResolver(NamingSubsystemModel.REMOTE_NAMING))
                 .setAddHandler(RemoteNamingAdd.INSTANCE)
                 .setRemoveHandler(RemoteNamingRemove.INSTANCE)


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17442
