### PR TITLE
Small changes to make the -Dquickly build work on a clean repository.…

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -47,3 +47,28 @@ jobs:
         shell: bash
       - name: Build with Maven Java 11 - ${{ matrix.os }}
         run: mvn clean install -U -B -DallTests -DskipTests
+  quick-build:
+    name: WildFly Build -Dquickly
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Clear any possible SNAPSHOT dependencies in the local maven repository
+        run: |
+          LOCAL_REPO="$HOME/.m2/repository"
+          echo "Cleaning SNAPSHOTS from $LOCAL_REPO"
+          if [ -d "$LOCAL_REPO" ]; then find "$LOCAL_REPO" -name "*SNAPSHOT*" | xargs -I {} rm -rfv "{}"; fi
+        shell: bash
+      - name: Build with Maven Java 11 - ${{ matrix.os }} -Dquickly
+        run: mvn -U -B -Dquickly

--- a/pom.xml
+++ b/pom.xml
@@ -2079,7 +2079,6 @@
                 <checkstyle.skip>true</checkstyle.skip>
                 <enforcer.skip>true</enforcer.skip>
                 <license.skip>true</license.skip>
-                <maven.test.skip>true</maven.test.skip>
             </properties>
             <build>
                 <defaultGoal>clean install</defaultGoal>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -67,7 +67,7 @@
             <id>ee8.build.profile</id>
             <activation>
                 <property>
-                    <name>!skip.ee8</name>
+                    <name>!quickly</name>
                 </property>
             </activation>
             <modules>


### PR DESCRIPTION
… Add a job to ensure it continues working.

The property `maven.test.skip` skips the `org.apache.maven.plugins:maven-jar-plugin::test-jar` goal as well as compiling tests.