### PR TITLE
WFLY-17455 Upgrade netty from 4.1.84.Final to 4.1.86.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
         <version.io.grpc>1.38.1</version.io.grpc>
         <version.io.jaegertracing>1.6.0</version.io.jaegertracing>
         <version.io.micrometer>1.9.3</version.io.micrometer>
-        <version.io.netty>4.1.84.Final</version.io.netty>
+        <version.io.netty>4.1.86.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.12.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentracing>0.33.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.4.0</version.io.opentracing.concurrent>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17455

Resolving CVE-2022-41881.