### PR TITLE
[WFLY-17467]: Upgrade to JBoss Metadata 15.4.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.metadata>15.3.0.Final</version.org.jboss.metadata>
+        <version.org.jboss.metadata>15.4.0</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>6.0.0.CR1</version.org.jboss.narayana>
         <legacy.version.org.jboss.narayana>5.13.1.Final</legacy.version.org.jboss.narayana>


### PR DESCRIPTION
 * Fix for JMETA-452: deny-uncovered-http-methods truncates parsing of web.xml file.

Jira: https://issues.redhat.com/browse/WFLY-17467
      https://issues.redhat.com/browse/JBMETA-452

Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>