### PR TITLE
WFLY-17472 Add comment expounding the importance of defining the initial mode of the parent service within the associated ResourceServiceConfigurator.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistrar.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistrar.java
@@ -24,6 +24,8 @@ package org.jboss.as.clustering.controller;
 
 /**
  * Registers a {@link RestartParentResourceAddStepHandler}, {@link RestartParentResourceRemoveStepHandler}, and {@link RestartParentResourceWriteAttributeHandler} on behalf of a resource definition.
+ * Users of this class should ensure that the {@link ResourceServiceConfigurator} returned by the specified factory sets the appropriate initial mode of the parent service it configures.
+ * Neglecting to do this may result in use of the default initial mode (i.e. ACTIVE), which would result in the parent service starting inadvertently.
  * @author Paul Ferraro
  */
 public class RestartParentResourceRegistrar extends ResourceRegistrar {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17472
