### PR TITLE
[WFLY-17499] Upgrade Apache mime4j from 0.8.7 to 0.8.9 (resolves

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
         <version.org.apache.cxf.xjcplugins>4.0.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
-        <version.org.apache.james.apache-mime4j>0.8.7</version.org.apache.james.apache-mime4j>
+        <version.org.apache.james.apache-mime4j>0.8.9</version.org.apache.james.apache-mime4j>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
         <version.org.apache.kafka>3.2.2</version.org.apache.kafka>
         <version.org.apache.lucene>8.11.1</version.org.apache.lucene>


### PR DESCRIPTION
CVE-2022-45787)

Issue: https://issues.redhat.com/browse/WFLY-17499

Diff: https://github.com/apache/james-mime4j/compare/apache-mime4j-project-0.8.7...apache-mime4j-project-0.8.9

