### PR TITLE
[26.x] WF Backports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
-        <version.com.nimbus.jose-jwt>8.11</version.com.nimbus.jose-jwt>
+        <version.com.nimbus.jose-jwt>8.23</version.com.nimbus.jose-jwt>
         <version.com.squareup.okhttp3>3.14.9</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.17.5</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.2</version.com.sun.activation.jakarta.activation>

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         <version.org.apache.ws.security>2.3.3</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-6</version.org.apache.xalan>
-        <version.org.apache.xerces>2.12.0.SP03</version.org.apache.xerces>
+        <version.org.apache.xerces>2.12.0.SP05</version.org.apache.xerces>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.bitbucket.jose4j>0.7.11</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.11.12</version.org.bytebuddy>

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <version.org.apache.cxf.xjcplugins>3.3.1</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
-        <version.org.apache.james.apache-mime4j>0.8.7</version.org.apache.james.apache-mime4j>
+        <version.org.apache.james.apache-mime4j>0.8.9</version.org.apache.james.apache-mime4j>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
         <version.org.apache.kafka>3.1.0</version.org.apache.kafka>
         <version.org.apache.lucene>5.5.5</version.org.apache.lucene>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <version.com.beust>1.78</version.com.beust>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.12.7</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>2.12.7</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.12.7.1</version.com.fasterxml.jackson.databind>
         <version.com.github.ben-manes.caffeine>2.9.3</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <version.jakarta.jws.jakarta.jws-api>2.1.0</version.jakarta.jws.jakarta.jws-api>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.3.GA</version.jboss.jaxbintros>
-        <version.joda-time>2.11.0</version.joda-time>
+        <version.joda-time>2.12.1</version.joda-time>
         <version.jsoup>1.14.2</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.3.0</version.net.shibboleth.utilities.java-support>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <version.com.google.guava>31.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.j2objc>1.3</version.com.google.j2objc>
-        <version.com.google.protobuf>3.19.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>


### PR DESCRIPTION
This aggregate PR contains the following backports

|Component|Jira|Commit|Upstream PR|
|---|---|---|---|
|Jackson Databind 2.12.7.1(resolves CVE-2022-42004, CVE-2022-42003)|[WFLY-17384](https://issues.redhat.com/browse/WFLY-17384)|https://github.com/wildfly/wildfly/commit/ea8f04962e4554094eaec1a7389614ae228bc379|https://github.com/wildfly/wildfly/pull/16042|
|Google Protobuf 3.19.6 (resolves CVE-2022-3171)|[WFLY-17359](https://issues.redhat.com/browse/WFLY-17359)|https://github.com/wildfly/wildfly/commit/d47274975ce02156d31f4f30b957ed83c131c6c3|https://github.com/wildfly/wildfly/pull/16342|
|Nimbus-jose-jwt 8.23 (resolves CVE-2021-31684)|[WFLY-15904](https://issues.redhat.com/browse/WFLY-15904)|https://github.com/wildfly/wildfly/commit/465d2f4dd18a381330a446b7bc1a227cf3de9c7e|https://github.com/wildfly/wildfly/pull/15086|
|Joda-time 2.12.1|[WFLY-17504](https://issues.redhat.com/browse/WFLY-17504)|https://github.com/wildfly/wildfly/commit/cee6fdeda0c92b741ce221c4d051abb4864f0a65|https://github.com/wildfly/wildfly/pull/16459|
|Xerces 2.12.0.SP05|[WFLY-17374](https://issues.redhat.com/browse/WFLY-17374)|https://github.com/wildfly/wildfly/commit/ac7bc14feac339e4ffb35aeb0f2f2eb7ff5e26ce|https://github.com/wildfly/wildfly/pull/16355|
|Apache mime4j 0.8.9(resolves CVE-2022-45787)|[WFLY-17499](https://issues.redhat.com/browse/WFLY-17499)|https://github.com/wildfly/wildfly/commit/e9f5bf983cfa463c8614d5b8669ffda94c3c51c8|https://github.com/wildfly/wildfly/pull/16456|
