### PR TITLE
[WFLY-17541] EESecurityAnnotationProcessor does not detect injections

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredJaspiTestBase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/ConfiguredJaspiTestBase.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 import org.wildfly.security.auth.jaspi.Flag;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.Module;
 import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
 
 /**

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityAuthMechanismMultiConstraintsTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityAuthMechanismMultiConstraintsTestCase.java
@@ -161,7 +161,7 @@ public class EESecurityAuthMechanismMultiConstraintsTestCase {
 
         @Override
         protected ConfigurableElement[] getConfigurableElements() {
-            ConfigurableElement[] elements = new ConfigurableElement[3];
+            ConfigurableElement[] elements = new ConfigurableElement[2];
             // 1 - Add empty JACC Policy
             elements[0] = Policy.builder()
                     .withName("jacc")

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledAbstractTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledAbstractTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.Module;
+
+/**
+ * Validate that the {@code ee-security} subsystem is enabled when a deployment uses the injection
+ * of {@link jakarta.security.enterprise.SecurityContext}. Allows for Jakarta Security components to
+ * be used without a full implementation. Modified from {@link EESecurityAuthMechanismMultiConstraintsTestCase}.
+ *
+ * @see <a href="https://issues.redhat.com/browse/WFLY-17541">WFLY-17541</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class EESecurityInjectionEnabledAbstractTestCase {
+    static final String MODULE_NAME = "org.wildfly.security.examples.custom-principal";
+    static final String TEST_APP_DOMAIN = "testApplicationDomain";
+
+    public void testCustomPrincipalWithInject(URL webAppURL) throws IOException, URISyntaxException {
+        testCustomPrincipalInternal(webAppURL);
+    }
+
+    /**
+     * @return the header to be used for authentication with the deployed web app
+     */
+    abstract Header[] setRequestAuthHeader();
+
+    private void testCustomPrincipalInternal(URL webAppURL) throws IOException, URISyntaxException {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            String requestURI = webAppURL.toURI() + "/inject";
+            HttpGet request = new HttpGet(requestURI);
+            request.setHeaders(setRequestAuthHeader());
+            HttpResponse response = httpClient.execute(request);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            ByteArrayOutputStream baosBody = new ByteArrayOutputStream();
+            response.getEntity().writeTo(baosBody);
+            String responseBody = baosBody.toString(StandardCharsets.UTF_8);
+
+            // Check that custom principal was retrieved
+            assertTrue(responseBody.contains("user1"));
+            assertTrue(responseBody.contains(TestCustomPrincipal.class.getCanonicalName()));
+
+            // Check that custom method was accessed and returned a valid date
+            Header loginHeader = response.getFirstHeader(TestInjectServlet.LOGIN_HEADER);
+            assertNotNull(loginHeader);
+            try {
+                LocalDateTime.parse(loginHeader.getValue(), ISO_LOCAL_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                throw new DateTimeParseException("Login timestamp returned from servlet was not a valid ISO-format LocalDateTime",
+                        e.getParsedString(), e.getErrorIndex(), e);
+            }
+
+        }
+    }
+
+    abstract static class ServerSetup extends AbstractElytronSetupTask {
+
+        static final String TEST_CUSTOM_PRINCIPAL_TRANSFORMER = "testCustomPrincipalTransformer";
+        static final String TEST_SECURITY_DOMAIN = "testSecurityDomain";
+        static final String DEFAULT_PERMISSION_MAPPER = "default-permission-mapper";
+
+        static Path modulePath;
+        static ConfigurableElement module;
+
+        static Path createJar(String namePrefix, Class<?>... classes) throws IOException {
+            Path testJar = Files.createTempFile(namePrefix, ".jar");
+            JavaArchive jar = ShrinkWrap.create(JavaArchive.class).addClasses(classes);
+            jar.as(ZipExporter.class).exportTo(testJar.toFile(), true);
+            return testJar;
+        }
+
+        @Override
+        protected void setup(ModelControllerClient modelControllerClient) throws Exception {
+            modulePath = createJar("custom-principal",
+                    TestCustomPrincipal.class, TestCustomPrincipalTransformer.class);
+
+            module = Module.builder()
+                    .withName(MODULE_NAME)
+                    .withResource(modulePath.toAbsolutePath().toString())
+                    .withDependency("jakarta.security.enterprise.api")
+                    .withDependency("org.wildfly.security.elytron")
+                    .withDependency("org.wildfly.extension.elytron")
+                    .build();
+
+            super.setup(modelControllerClient);
+        }
+
+        @Override
+        protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+            super.tearDown(modelControllerClient);
+
+            Files.deleteIfExists(modulePath);
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledElytronTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledElytronTestCase.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CustomPrincipalTransformer;
+import org.wildfly.test.security.common.elytron.FileSystemRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.SimpleHttpAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.UserWithAttributeValues;
+import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
+
+/**
+ * Validates that the {@code ee-security} subsystem is enabled when a deployment does not fully implement Jakarta Security,
+ * but still uses parts of the API. Here, a custom principal is returned to the client via
+ * {@link jakarta.security.enterprise.SecurityContext}, while authentication is performed by Elytron.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ EESecurityInjectionEnabledElytronTestCase.ServerSetup.class })
+public class EESecurityInjectionEnabledElytronTestCase extends EESecurityInjectionEnabledAbstractTestCase {
+
+    @ArquillianResource
+    private Deployer deployer;
+    private static final String WEB_APP_NAME = "WFLY-17541-Elytron";
+
+    @Deployment(name = WEB_APP_NAME, managed = false, testable = false)
+    public static WebArchive warDeployment() {
+        Class<EESecurityInjectionEnabledElytronTestCase> testClass = EESecurityInjectionEnabledElytronTestCase.class;
+        return ShrinkWrap.create(WebArchive.class, testClass.getSimpleName() + ".war")
+                .addClasses(testClass, EESecurityInjectionEnabledAbstractTestCase.class)
+                .addClasses(ServerSetup.class, EESecurityInjectionEnabledAbstractTestCase.ServerSetup.class,
+                        AbstractElytronSetupTask.class)
+                .addClasses(TestInjectElytronServlet.class, TestInjectServlet.class)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(TEST_APP_DOMAIN), "jboss-web.xml")
+                .addAsWebInfResource(testClass.getPackage(), "WFLY-17541-elytron-web.xml", "web.xml")
+                .addAsWebInfResource(testClass.getPackage(), "WFLY-17541-index.xml", "index.xml")
+                .addAsWebInfResource(testClass.getPackage(), "beans.xml", "beans.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: " + MODULE_NAME + "\n"), "MANIFEST.MF");
+    }
+
+    @Override
+    Header[] setRequestAuthHeader() {
+        // BASIC authentication - base64(username:password)
+        return new BasicHeader[] { new BasicHeader("Authorization", "Basic dXNlcjE6cGFzc3dvcmQx") };
+    }
+
+    @Test @InSequence(1)
+    public void deployApplication() {
+        deployer.deploy(WEB_APP_NAME);
+    }
+
+    @Override
+    @Test @InSequence(2)
+    public void testCustomPrincipalWithInject(@ArquillianResource URL webAppURL) throws IOException, URISyntaxException {
+        super.testCustomPrincipalWithInject(webAppURL);
+    }
+
+    @Test @InSequence(3)
+    public void undeployApplication() {
+        deployer.undeploy(WEB_APP_NAME);
+    }
+
+    static class ServerSetup extends EESecurityInjectionEnabledAbstractTestCase.ServerSetup {
+        static final String TEST_REALM = "testRealm";
+        static final String TEST_HTTP_FACTORY = "testHttpFactory";
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            ConfigurableElement[] elements =  new ConfigurableElement[7];
+            // Add module with custom principal and principal transformer
+            elements[0] = module;
+
+            // Add empty JACC policy
+            elements[1] = Policy.builder()
+                    .withName("jacc")
+                    .withJaccPolicy()
+                    .build();
+
+            // Create filesystem security realm with one identity
+            elements[2] = FileSystemRealm.builder()
+                    .withName(TEST_REALM)
+                    .withUser(UserWithAttributeValues.builder()
+                            .withName("user1")
+                            .withPassword("password1")
+                            .withValues("Login")
+                            .build())
+                    .build();
+
+            // Add custom pre-realm principal transformer to create custom principal
+            elements[3] = CustomPrincipalTransformer.builder()
+                    .withName(TEST_CUSTOM_PRINCIPAL_TRANSFORMER)
+                    .withModule(MODULE_NAME)
+                    .withClassName(TestCustomPrincipalTransformer.class.getCanonicalName())
+                    .build();
+
+            // Create security domain using security realm and principal transformer
+            elements[4] = SimpleSecurityDomain.builder()
+                    .withName(TEST_SECURITY_DOMAIN)
+                    .withRealms(SimpleSecurityDomain.SecurityDomainRealm.builder()
+                            .withRealm(TEST_REALM)
+                            .build())
+                    .withDefaultRealm(TEST_REALM)
+                    .withPermissionMapper(DEFAULT_PERMISSION_MAPPER)
+                    .build();
+
+            // Create HTTP authentication factory
+            elements[5] = SimpleHttpAuthenticationFactory.builder()
+                    .withName(TEST_HTTP_FACTORY)
+                    .withHttpServerMechanismFactory("global")
+                    .withSecurityDomain(TEST_SECURITY_DOMAIN)
+                    .addMechanismConfiguration(MechanismConfiguration.builder()
+                            .withMechanismName("BASIC")
+                            .addMechanismRealmConfiguration(MechanismRealmConfiguration.builder()
+                                    .withRealmName(TEST_REALM)
+                                    .build())
+                            .withPreRealmPrincipalTransformer(TEST_CUSTOM_PRINCIPAL_TRANSFORMER)
+                            .build())
+                    .build();
+
+            // Add HTTP authentication factory to Undertow configuration
+            elements[6] = UndertowApplicationSecurityDomain.builder()
+                    .withName(TEST_APP_DOMAIN)
+                    .httpAuthenticationFactory(TEST_HTTP_FACTORY)
+                    .withEnableJacc(true)
+                    .build();
+
+            return elements;
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledJakartaTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/EESecurityInjectionEnabledJakartaTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
+
+/**
+ * Validates that the {@code ee-security} subsystem is enabled when a deployment implements Jakarta Security (ex.
+ * implementing an {@link jakarta.security.enterprise.identitystore.IdentityStore IdentityStore}). Returns a custom
+ * principal to client via {@link jakarta.security.enterprise.SecurityContext}.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ EESecurityInjectionEnabledJakartaTestCase.ServerSetup.class })
+public class EESecurityInjectionEnabledJakartaTestCase extends EESecurityInjectionEnabledAbstractTestCase {
+
+    @ArquillianResource
+    private Deployer deployer;
+    private static final String WEB_APP_NAME = "WFLY-17541-Jakarta";
+
+    @Deployment(name = WEB_APP_NAME, managed = false, testable = false)
+    public static WebArchive warDeployment() {
+        Class<EESecurityInjectionEnabledJakartaTestCase> testClass = EESecurityInjectionEnabledJakartaTestCase.class;
+        return ShrinkWrap.create(WebArchive.class,testClass.getSimpleName() + ".war")
+                .addClasses(testClass, EESecurityInjectionEnabledAbstractTestCase.class)
+                .addClasses(ServerSetup.class, EESecurityInjectionEnabledAbstractTestCase.ServerSetup.class,
+                        AbstractElytronSetupTask.class)
+                .addClasses(TestInjectServlet.class)
+                .addClasses(TestAuthenticationMechanism.class, TestIdentityStoreCustomWrapper.class, TestIdentityStore.class)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(TEST_APP_DOMAIN), "jboss-web.xml")
+                .addAsWebInfResource(testClass.getPackage(), "WFLY-17541-jakarta-web.xml", "web.xml")
+                .addAsWebInfResource(testClass.getPackage(), "WFLY-17541-index.xml", "index.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: " + MODULE_NAME + "\n"), "MANIFEST.MF");
+    }
+
+    @Override
+    Header[] setRequestAuthHeader() {
+        return new BasicHeader[] {
+                new BasicHeader("X-USERNAME", "user1"),
+                new BasicHeader("X-PASSWORD", "password1")
+        };
+    }
+
+    @Test @InSequence(1)
+    public void deployApplication() {
+        deployer.deploy(WEB_APP_NAME);
+    }
+
+    @Test @InSequence(2)
+    public void testUnsuccessfulAuthentication(@ArquillianResource URL webAppURL) throws IOException, URISyntaxException {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            HttpGet request = new HttpGet(webAppURL.toURI() + "/inject");
+            HttpResponse response = httpClient.execute(request);
+            assertEquals(401, response.getStatusLine().getStatusCode());
+
+            // Check that the challenge message was sent
+            Header authHeader = response.getFirstHeader(TestAuthenticationMechanism.MESSAGE_HEADER);
+
+            assertNotNull(authHeader);
+            assertEquals(TestAuthenticationMechanism.MESSAGE, authHeader.getValue());
+        }
+    }
+
+    @Override
+    @Test @InSequence(3)
+    public void testCustomPrincipalWithInject(@ArquillianResource URL webAppURL) throws IOException, URISyntaxException {
+        super.testCustomPrincipalWithInject(webAppURL);
+    }
+
+    @Test @InSequence(4)
+    public void undeployApplication() {
+        deployer.undeploy(WEB_APP_NAME);
+    }
+
+    static class ServerSetup extends EESecurityInjectionEnabledAbstractTestCase.ServerSetup {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            ConfigurableElement[] elements  = new ConfigurableElement[4];
+            // Add module with custom principal and principal transformer
+            elements[0] = module;
+
+            // Add empty JACC policy
+            elements[1] = Policy.builder()
+                    .withName("jacc")
+                    .withJaccPolicy()
+                    .build();
+
+            // Create security domain with default permission mapper
+            elements[2] = SimpleSecurityDomain.builder()
+                    .withName(TEST_SECURITY_DOMAIN)
+                    .withPermissionMapper(DEFAULT_PERMISSION_MAPPER)
+                    .build();
+
+            // Add security domain to Undertow configuration
+            elements[3] = UndertowApplicationSecurityDomain.builder()
+                    .withName(TEST_APP_DOMAIN)
+                    .withSecurityDomain(TEST_SECURITY_DOMAIN)
+                    .withIntegratedJaspi(false)
+                    .build();
+
+            return elements;
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/SecurityAPITestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/SecurityAPITestCase.java
@@ -179,7 +179,7 @@ public class SecurityAPITestCase {
 
         @Override
         protected ConfigurableElement[] getConfigurableElements() {
-            ConfigurableElement[] elements = new ConfigurableElement[3];
+            ConfigurableElement[] elements = new ConfigurableElement[2];
             // 1 - Add empty JACC Policy
             elements[0] = Policy.builder()
                     .withName("jacc")

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipal.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import jakarta.security.enterprise.CallerPrincipal;
+
+/**
+ * A simple {@link jakarta.security.enterprise.CallerPrincipal} with a custom field and method.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class TestCustomPrincipal extends CallerPrincipal {
+
+    private static final long serialVersionUID = -35690086418605259L;
+    private final LocalDateTime currentLoginTime;
+    private final Principal wrappedPrincipal;
+
+    public TestCustomPrincipal(Principal principal) {
+        super(principal.getName());
+        this.wrappedPrincipal = principal;
+        this.currentLoginTime = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCurrentLoginTime() {
+        return this.currentLoginTime;
+    }
+
+    @Override
+    public String getName() {
+        return wrappedPrincipal.getName();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TestCustomPrincipal) {
+            return this.getName().equals(((TestCustomPrincipal) obj).getName());
+        } else {
+            return super.equals(obj);
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import java.security.Principal;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A simple {@link PrincipalTransformer} that also converts into a {@link TestCustomPrincipal custom principal}.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class TestCustomPrincipalTransformer implements PrincipalTransformer {
+
+    @Override
+    public Principal apply(Principal principal) {
+        return new TestCustomPrincipal(principal);
+    }
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestIdentityStoreCustomWrapper.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestIdentityStoreCustomWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+
+/**
+ * A thin wrapper for {@link TestIdentityStore} which returns a {@link TestCustomPrincipal custom princpal} in place of
+ * a {@link jakarta.security.enterprise.CallerPrincipal}.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@ApplicationScoped
+public class TestIdentityStoreCustomWrapper extends TestIdentityStore {
+    @Override
+    public CredentialValidationResult validate(Credential credential) {
+        CredentialValidationResult cvr = super.validate(credential);
+        if (cvr.getStatus() != VALID) return cvr;
+
+        return new CredentialValidationResult(
+                new TestCustomPrincipal(cvr.getCallerPrincipal()),
+                cvr.getCallerGroups()
+        );
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestInjectServlet.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestInjectServlet.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.elytron.securityapi;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+import java.util.Objects;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpMethodConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * A simple servlet to test using the custom method of {@link TestCustomPrincipal}, for the Jakarta annotation
+ * {@link Inject}.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@WebServlet(urlPatterns = "/inject")
+public class TestInjectServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1524739695027377372L;
+
+    @Inject
+    private SecurityContext securityContext = null;
+    static final String LOGIN_HEADER = "Login-Time";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        try (PrintWriter pw = resp.getWriter()) {
+            final Principal principal = Objects.requireNonNull(securityContext, "SecurityContext must be injected")
+                    .getCallerPrincipal();
+             pw.println("<html><head><title>doGet - TestCustomPrincipal</title></head>");
+            pw.println("<body><h1>Custom principal test, via SecurityContext</h1>");
+
+            if (principal instanceof TestCustomPrincipal) {
+                TestCustomPrincipal customPrincipal = (TestCustomPrincipal) principal;
+
+                pw.printf("<ul>Principal: %s</li>", customPrincipal.getName());
+                pw.printf("<li>Class: %s</li>\n", customPrincipal.getClass().getCanonicalName());
+                pw.printf("<li>Current login time: %s</li>\n", customPrincipal.getCurrentLoginTime().toString());
+                pw.println("</ul></body></html>");
+
+                resp.addHeader(LOGIN_HEADER, customPrincipal.getCurrentLoginTime().format(ISO_LOCAL_DATE_TIME));
+            } else {
+                pw.printf("<p>The principal returned was not of class TestCustomPrincipal.</p>");
+                pw.printf("<ul>Principal: %s</li>", principal.getName());
+                pw.printf("<li>Class: %s</li>\n", principal.getClass().getCanonicalName());
+                pw.println("</ul></body></html>");
+
+                resp.setStatus(500);
+            }
+
+        }
+    }
+}
+
+/** Secured Servlets using Elytron authentication require an extra annotation */
+
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Login" }) })
+class TestInjectElytronServlet extends TestInjectServlet {
+    private static final long serialVersionUID = 5806993562466870053L;
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-elytron-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-elytron-web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+            https://jakarta.ee/xml/ns/jakartaee
+            https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>testRealm</realm-name>
+    </login-config>
+
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-index.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-index.xml
@@ -1,0 +1,9 @@
+<html>
+    <head>TestCustomPrincipal</head>
+    <body>
+        <h2>Test Custom Principal - Index</h2>
+        <ul>
+            <li><a href="./inject">Access injection Servlet</a></li>
+        </ul>
+    </body>
+</html>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-jakarta-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/WFLY-17541-jakarta-web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+            https://jakarta.ee/xml/ns/jakartaee
+            https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>inject</web-resource-name>
+            <url-pattern>/inject</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>*</role-name>
+    </security-role>
+
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/beans.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+          https://jakarta.ee/xml/ns/jakartaee
+          https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all"/>

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CustomPrincipalTransformer.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CustomPrincipalTransformer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import static org.jboss.as.controller.PathElement.pathElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.ModelNodeUtil;
+
+/**
+ * A {@link ConfigurableElement} to define a custom principal transformer. Requires a {@link Module} to be
+ * added to the server.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPrincipalTransformer implements ConfigurableElement {
+
+    private final PathAddress address;
+    private final String name;
+    private final String className;
+    private final String module;
+    private final Map<String, String> configuration;
+
+    protected CustomPrincipalTransformer(String name, String className, String module, Map<String, String> configuration) {
+        this.name = name;
+        this.className = className;
+        this.module = module;
+        this.configuration = configuration;
+
+        this.address = PathAddress.pathAddress(
+                pathElement("subsystem", "elytron"),
+                pathElement("custom-principal-transformer", name));
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode addOperation = Util.createAddOperation(address);
+        ModelNodeUtil.setIfNotNull(addOperation, "class-name", className);
+        ModelNodeUtil.setIfNotNull(addOperation, "module", module);
+
+        // Add optional key-value pairs as configuration object
+        if(configuration.size() > 0) {
+            StringBuilder configurationPairs = new StringBuilder();
+            configuration.forEach((key, value) -> configurationPairs.append(',').append(key).append('=').append(value));
+            configurationPairs.replace(0, 1, "{").append('}');
+            addOperation.get("configuration").set(configurationPairs.toString());
+        }
+        Utils.applyUpdate(addOperation, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(Util.createRemoveOperation(address), client);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder to register a custom principal transformer with Elytron. */
+    public static class Builder {
+
+        private String name;
+        private String className;
+        private String module;
+        private Map<String,String> configuration = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withClassName(final String className) {
+            this.className = className;
+            return this;
+        }
+
+        public Builder withModule(String module) {
+            this.module = module;
+            return this;
+        }
+
+        public Builder addConfiguration(String key, String value) {
+            configuration.put(key, value);
+            return this;
+        }
+
+        public Builder addConfigurations(Map<String, String> configuration) {
+            this.configuration.putAll(configuration);
+            return this;
+        }
+
+        public CustomPrincipalTransformer build() {
+            return new CustomPrincipalTransformer(name, className, module, configuration);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileSystemRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileSystemRealm.java
@@ -97,6 +97,7 @@ public class FileSystemRealm extends AbstractUserAttributeValuesCapableElement i
         private Builder() {
         }
 
+        /** @implNote if a {@link Path} is set, the folder will not be automatically deleted after the test case completes. */
         public Builder withPath(Path path) {
             this.path = path;
             return this;

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/Module.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/Module.java
@@ -20,27 +20,20 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.test.integration.elytron.jaspi;
+package org.wildfly.test.security.common.elytron;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.as.test.integration.management.util.CLIWrapper;
-import org.wildfly.test.security.common.elytron.AbstractConfigurableElement;
-import org.wildfly.test.security.common.elytron.ConfigurableElement;
 
 /**
  * A {@link ConfigurableElement} to add a custom module.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class Module extends AbstractConfigurableElement {
-
-    /*
-     * Reduced visibility until we decide to make this accessible for use elsewhere which would also mean moving this class into
-     * common.
-     */
+public class Module extends AbstractConfigurableElement {
 
     private final List<String> resources;
     private final List<String> dependencies;
@@ -137,7 +130,7 @@ class Module extends AbstractConfigurableElement {
 
         @Override
         protected Builder self() {
-            return Builder.this;
+            return this;
         }
 
     }


### PR DESCRIPTION
- **Commits**
  - [WFLY-17541] EESecurityAnnotationProcessor does not detect injections
  - [WFLY-17541] Add shared test components
  - [WFLY-17541] Add test cases for ee-security enablement via injection annotation
- **Issues**
  - https://issues.redhat.com/browse/WFLY-17541
  - https://issues.redhat.com/browse/EAP7-1880

This code requires the Elytron changes made in ELY-2468 (wildfly-security/wildfly-elytron#1810), so it's being kept as a draft until those changes are pushed to a `2.x` release.