### PR TITLE
WFLY-17569 Allow Session returned via SessionManager.getSession(String) to be invalidated.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SimpleSessionConfig.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SimpleSessionConfig.java
@@ -39,12 +39,12 @@ public class SimpleSessionConfig implements SessionConfig {
 
     @Override
     public void setSessionId(HttpServerExchange exchange, String sessionId) {
-        throw new IllegalStateException();
+        // No-op
     }
 
     @Override
     public void clearSession(HttpServerExchange exchange, String sessionId) {
-        throw new IllegalStateException();
+        // No-op
     }
 
     @Override
@@ -54,11 +54,11 @@ public class SimpleSessionConfig implements SessionConfig {
 
     @Override
     public SessionCookieSource sessionCookieSource(HttpServerExchange exchange) {
-        throw new IllegalStateException();
+        return SessionCookieSource.NONE;
     }
 
     @Override
     public String rewriteUrl(String originalUrl, String sessionId) {
-        throw new IllegalStateException();
+        return originalUrl;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17569