### PR TITLE
WFLY-17558 upgrade to Hibernate ORM 6.2.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,9 +473,9 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
-        <version.org.hibernate>6.1.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
+        <version.org.hibernate>6.2.0.CR2</version.org.hibernate>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.6.Final</version.org.infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17558

Signed-off-by: Scott Marlow <smarlow@redhat.com>

Depends on https://github.com/wildfly/wildfly/pull/16490 (Upgrade to Hibernate Commons Annotations 6.0.6.Final) being merged.