### PR TITLE
[WFLY-17578] Fix the Keycloak realm name used in the OIDC tests

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakConfiguration.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakConfiguration.java
@@ -80,7 +80,7 @@ public class KeycloakConfiguration {
                 .param("password", KeycloakContainer.ADMIN_PASSWORD)
                 .param("client_id", "admin-cli")
                 .when()
-                .post(authServerUrl + "/realms/primary/protocol/openid-connect/token")
+                .post(authServerUrl + "/realms/master/protocol/openid-connect/token")
                 .as(AccessTokenResponse.class).getToken();
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17578
