### PR TITLE
[WFLY-17591]:Upgrade jbossws-cxf to 6.2.0.Final

### DIFF
--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -2802,7 +2802,6 @@
                 <groupId>org.jboss.ws.cxf</groupId>
                 <artifactId>jbossws-cxf-resources</artifactId>
                 <version>${version.org.jboss.ws.cxf}</version>
-                <classifier>wildfly2700</classifier>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -1911,7 +1911,6 @@
         <dependency>
             <groupId>org.jboss.ws.cxf</groupId>
             <artifactId>jbossws-cxf-resources</artifactId>
-            <classifier>wildfly2700</classifier>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -34,7 +34,7 @@
 
     <resources>
         <artifact name="${org.wildfly:wildfly-webservices-server-integration}"/>
-        <artifact name="${org.jboss.ws.cxf:jbossws-cxf-resources::wildfly2700}"/>
+        <artifact name="${org.jboss.ws.cxf:jbossws-cxf-resources}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <version.org.jboss.ws.api>2.0.0.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>4.0.0.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.4.0.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>6.1.0.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>6.2.0.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>2.0.0.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>4.1.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17591