### PR TITLE
[WFLY-17593] Upgrade Jastow to 2.2.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>2.26.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-opentracing>3.0.0</version.io.smallrye.smallrye-opentracing>
         <version.io.smallrye.smallrye-reactive-messaging>4.1.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.undertow.jastow>2.2.5.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.2.6.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.3.4</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>${version.io.vertx.vertx}</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.1</version.jakarta.activation.jakarta.activation-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17593