### PR TITLE
[WFLY-17602] Upgrade ironjacamar to 3.0.0.Final (Jakarta EE major ver…

### DIFF
--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -2220,7 +2220,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-common-api-jakarta</artifactId>
+                <artifactId>ironjacamar-common-api</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2232,7 +2232,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+                <artifactId>ironjacamar-common-impl</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2244,7 +2244,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-common-spi-jakarta</artifactId>
+                <artifactId>ironjacamar-common-spi</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2256,7 +2256,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-core-api-jakarta</artifactId>
+                <artifactId>ironjacamar-core-api</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2268,7 +2268,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+                <artifactId>ironjacamar-core-impl</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2280,7 +2280,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+                <artifactId>ironjacamar-deployers-common</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2292,7 +2292,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+                <artifactId>ironjacamar-jdbc</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
@@ -2304,7 +2304,7 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-validator-jakarta</artifactId>
+                <artifactId>ironjacamar-validator</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>

--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -256,22 +256,22 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+    <artifactId>ironjacamar-deployers-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -108,35 +108,35 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-spi-jakarta</artifactId>
+            <artifactId>ironjacamar-common-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-common-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+            <artifactId>ironjacamar-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-validator-jakarta</artifactId>
+            <artifactId>ironjacamar-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -516,7 +516,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -527,7 +527,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-common-impl</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -538,7 +538,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-spi-jakarta</artifactId>
+            <artifactId>ironjacamar-common-spi</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -549,7 +549,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -560,7 +560,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -571,7 +571,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -582,7 +582,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+            <artifactId>ironjacamar-jdbc</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -593,7 +593,7 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-validator-jakarta</artifactId>
+            <artifactId>ironjacamar-validator</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -3535,7 +3535,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-common-api-jakarta</artifactId>
+      <artifactId>ironjacamar-common-api</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3546,7 +3546,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+      <artifactId>ironjacamar-common-impl</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3557,7 +3557,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-common-spi-jakarta</artifactId>
+      <artifactId>ironjacamar-common-spi</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3568,7 +3568,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-core-api-jakarta</artifactId>
+      <artifactId>ironjacamar-core-api</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3579,7 +3579,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+      <artifactId>ironjacamar-core-impl</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3590,7 +3590,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+      <artifactId>ironjacamar-deployers-common</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3601,7 +3601,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+      <artifactId>ironjacamar-jdbc</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>
@@ -3612,7 +3612,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-validator-jakarta</artifactId>
+      <artifactId>ironjacamar-validator</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 only</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
@@ -28,9 +28,9 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-api-jakarta}"/>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-spi-jakarta}"/>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-core-api-jakarta}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-api}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-spi}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-core-api}"/>
     </resources>
 
     <dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
@@ -29,10 +29,10 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-impl-jakarta}"/>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-core-impl-jakarta}"/>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-deployers-common-jakarta}"/>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-validator-jakarta}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-common-impl}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-core-impl}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-deployers-common}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-validator}"/>
     </resources>
 
     <dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
@@ -29,7 +29,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.ironjacamar:ironjacamar-jdbc-jakarta}"/>
+        <artifact name="${org.jboss.ironjacamar:ironjacamar-jdbc}"/>
     </resources>
 
     <dependencies>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -74,7 +74,7 @@ vi:ts=4:sw=4:expandtab
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
         </dependency>
 
         <dependency>

--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -297,27 +297,27 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-common-impl</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
         <version.org.jboss.hal.console>3.6.5.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.2.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.ironjacamar>1.5.10.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>3.0.0.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -404,27 +404,27 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-common-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+            <artifactId>ironjacamar-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -751,7 +751,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.jakarta.xml.soap</groupId>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -128,7 +128,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -160,12 +160,12 @@
              the tests fail for some reason. Changing the return type to DistributedWorkManager seems to cause issues -->
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-jdbc-jakarta</artifactId>
+            <artifactId>ironjacamar-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -324,31 +324,31 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-api-jakarta</artifactId>
+            <artifactId>ironjacamar-common-api</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-common-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-common-impl</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-api-jakarta</artifactId>
+            <artifactId>ironjacamar-core-api</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-core-impl-jakarta</artifactId>
+            <artifactId>ironjacamar-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-deployers-common-jakarta</artifactId>
+            <artifactId>ironjacamar-deployers-common</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
…sion bump)

https://issues.redhat.com/browse/WFLY-17602

The bump is not to 2.0 because there is already IronJacamar 2.0 branch with different purpose present.
