### PR TITLE
WFLY-17619 Upgrade SmallRye Fault Tolerance to 6.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.0.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.1.0</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.1.0</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.2.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.0.0</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>4.0.0</version.io.smallrye.smallrye-metrics>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-17619