### PR TITLE
Fix for WFLY-17630, Upgrade galleon-plugins to 6.3.0.Final

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -50,10 +50,6 @@
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>
     </plugins>
 
-    <resources>
-        <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
-    </resources>
-
     <system-paths>
         <system-path path="modules/system/layers/base/"/>
     </system-paths>

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.2.3.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.3.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>8.1.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>3.0.2.Final</version.org.wildfly.plugin>

--- a/preview/feature-pack/wildfly-feature-pack-build.xml
+++ b/preview/feature-pack/wildfly-feature-pack-build.xml
@@ -46,10 +46,6 @@
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>
     </plugins>
 
-    <resources>
-        <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
-    </resources>
-
     <generate-feature-specs>
         <extensions>
             <standalone>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17630
Upgrade galleon-plugins and remove the copy of wildfly-config-gen artifact inside the feature-pack. It is now resolved from maven.
