### PR TITLE
[WFLY-17626] Fix Undertow's subsystem ServletContainerAdd.resolveWelc…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
@@ -309,7 +309,7 @@ final class ServletContainerAdd extends AbstractBoottimeAddStepHandler {
 
     private static List<String> resolveWelcomeFiles(ModelNode model) {
         if (!model.hasDefined(Constants.WELCOME_FILE)) return List.of();
-        List<Property> properties = model.get(Constants.MIME_MAPPING).asPropertyList();
+        List<Property> properties = model.get(Constants.WELCOME_FILE).asPropertyList();
         if (properties.size() == 1) {
             return List.of(properties.get(0).getName());
         }


### PR DESCRIPTION
…omeFiles, it should be using Constants.WELCOME_FILES constant to find the correct model node

Jira: https://issues.redhat.com/browse/WFLY-17626