### PR TITLE
[WFLY-17639] Upgrade WildFly Core to 20.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,7 +545,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>20.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17639

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.0.Beta6
Diff: https://github.com/wildfly/wildfly-core/compare/20.0.0.Beta5...20.0.0.Beta6

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6167'>WFCORE-6167</a>] -         Logging regression on JDK20 EA 27
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6201'>WFCORE-6201</a>] -         Element syslog-format should not be required
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6208'>WFCORE-6208</a>] -         The git configuration history may attempt to sign commits and not find a signer
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6213'>WFCORE-6213</a>] -         Grep warning in grep 3.8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6214'>WFCORE-6214</a>] -         Flaky Tests in HelpSupportTestCase due to SynopsisGenerator.java and Flaky Test in BootScriptInvokerTestCase.java
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5605'>WFCORE-5605</a>] -         The add user should not ask if the user is being added for a host controller.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5846'>WFCORE-5846</a>] -         [primary/secondary] Adapt Amazon S3 Discovery mechanism to new language usage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6207'>WFCORE-6207</a>] -         Remove the leftover maven properties from javax-&gt;jakarta maven-resource-plugin filtering
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6215'>WFCORE-6215</a>] -         Bump actions/github-script from 6.3.3 to 6.4.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6226'>WFCORE-6226</a>] -         Drop transformer registrations and tests for TransformerSubsystemTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6227'>WFCORE-6227</a>] -         Remove deprecated ProcessStateNotifier from ManagementHttpServer
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6178'>WFCORE-6178</a>] -         Upgrade JBoss MSC to 1.5.0.Beta5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6204'>WFCORE-6204</a>] -         Upgrade SLF4J to 2.0.6
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6209'>WFCORE-6209</a>] -         Upgrade galleon-plugins to 6.2.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6217'>WFCORE-6217</a>] -         Upgrade Undertow from 2.3.0.Final to 2.3.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6224'>WFCORE-6224</a>] -         Upgrade Apache HTTP Client to 4.5.14
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6225'>WFCORE-6225</a>] -         Upgrade httpcore to 4.4.16
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6228'>WFCORE-6228</a>] -         Upgrade galleon-plugins to 6.3.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6231'>WFCORE-6231</a>] -         Upgrade slf4j-jboss-logmanager to 2.0.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6199'>WFCORE-6199</a>] -         JBoss allows duplicate user and local dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6211'>WFCORE-6211</a>] -         Remove ModuleIdentifier from ServiceModuleLoader.preloadModule
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6216'>WFCORE-6216</a>] -         Add Phase constant for Micrometer
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6218'>WFCORE-6218</a>] -         Add Stream variant to PersistentResourceXMLDescription.PersistentResourceXMLBuilder
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6219'>WFCORE-6219</a>] -         Skip when empty params in ConcreteResourceRegistration.registerAdditionalRuntimePackages method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6232'>WFCORE-6232</a>] -         Eliminate ModuleSpecification deprecated methods
</li>
</ul>
</details>