### PR TITLE
[WFLY-17647] Upgrade javassist to 3.29.1-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <version.org.infinispan>14.0.6.Final</version.org.infinispan>
         <version.org.infinispan.protostream>4.6.0.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
-        <version.org.javassist>3.27.0-GA</version.org.javassist>
+        <version.org.javassist>3.29.1-GA</version.org.javassist>
         <version.org.jberet>2.1.1.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.7</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.7.0.Alpha13</version.org.jboss.arquillian.core>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17647

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
