### PR TITLE
[WFLY-17653] Upgrade OpenTelemetry to 1.23.1

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1264,7 +1264,29 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api-logs</artifactId>
+                <version>${version.io.opentelemetry.opentelemetry}-alpha</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-context</artifactId>
+                <version>${version.io.opentelemetry.opentelemetry}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-common</artifactId>
                 <version>${version.io.opentelemetry.opentelemetry}</version>
                 <exclusions>
                     <exclusion>
@@ -1297,7 +1319,7 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
+                <artifactId>opentelemetry-exporter-otlp</artifactId>
                 <version>${version.io.opentelemetry.opentelemetry}</version>
                 <exclusions>
                     <exclusion>
@@ -1342,7 +1364,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-metrics</artifactId>
-                <version>${version.io.opentelemetry.opentelemetry}-alpha</version>
+                <version>${version.io.opentelemetry.opentelemetry}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -3854,6 +3854,7 @@
 
         <!-- OpenTelemetry -->
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-api</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
+        <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-api-logs</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-context</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-sdk</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-sdk-common</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
@@ -3863,9 +3864,10 @@
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-semconv</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <!-- -->
         <!-- Jaeger -->
+        <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-common</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-jaeger</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-otlp-common</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
-        <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-otlp-trace</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
+        <dependency><groupId>io.opentelemetry</groupId><artifactId>opentelemetry-exporter-otlp</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.grpc</groupId><artifactId>grpc-okhttp</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.grpc</groupId><artifactId>grpc-core</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>
         <dependency><groupId>io.grpc</groupId><artifactId>grpc-api</artifactId><exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions></dependency>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -828,6 +828,16 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp-common</artifactId>
       <licenses>
         <license>
@@ -838,7 +848,7 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>
@@ -3300,6 +3310,17 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-opentelemetry-api</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>wildfly-opentelemetry-api-logs</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License v2.1 or later</name>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/exporter/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/exporter/main/module.xml
@@ -19,24 +19,22 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.9" name="io.opentelemetry.trace">
+<module xmlns="urn:jboss:module:1.9" name="io.opentelemetry.exporter">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
+
     <resources>
-        <artifact name="${io.opentelemetry:opentelemetry-sdk}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-sdk-logs}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-sdk-metrics}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-sdk-trace}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-sdk-common}"/>
         <artifact name="${io.opentelemetry:opentelemetry-exporter-jaeger}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-exporter-common}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp}"/>
         <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp-common}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp-trace}"/>
         <artifact name="${com.fasterxml.jackson.jr:jackson-jr-objects}"/>
     </resources>
 
     <dependencies>
         <module name="io.opentelemetry.api"/>
+        <module name="io.opentelemetry.sdk"/>
         <module name="io.opentelemetry.context"/>
         <module name="com.fasterxml.jackson.core.jackson-core"/>
         <module name="com.squareup.okhttp3"/>
@@ -46,4 +44,3 @@
         <module name="jdk.unsupported"/>
     </dependencies>
 </module>
-

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/sdk/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/sdk/main/module.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2021, Red Hat, Inc., and individual contributors
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -19,18 +19,21 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.9" name="io.opentelemetry.api">
+<module xmlns="urn:jboss:module:1.9" name="io.opentelemetry.sdk">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${io.opentelemetry:opentelemetry-api}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-api-logs}"/>
-        <artifact name="${io.opentelemetry:opentelemetry-semconv}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-sdk}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-sdk-logs}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-sdk-metrics}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-sdk-trace}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-sdk-common}"/>
     </resources>
 
     <dependencies>
+        <module name="io.opentelemetry.api"/>
         <module name="io.opentelemetry.context"/>
         <module name="java.logging"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
@@ -35,8 +35,9 @@
     <dependencies>
         <module name="org.wildfly.extension.opentelemetry-api"/>
         <module name="io.opentelemetry.api" />
+        <module name="io.opentelemetry.sdk" />
         <module name="io.opentelemetry.context" />
-        <module name="io.opentelemetry.trace" />
+        <module name="io.opentelemetry.exporter" />
 
         <module name="java.logging"/>
         <module name="javax.enterprise.api" />

--- a/observability/opentelemetry/pom.xml
+++ b/observability/opentelemetry/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <version.io.micrometer>1.9.3</version.io.micrometer>
         <legacy.version.io.netty>4.0.13.Final</legacy.version.io.netty>
         <version.io.netty>4.1.87.Final</version.io.netty>
-        <version.io.opentelemetry.opentelemetry>1.12.0</version.io.opentelemetry.opentelemetry>
+        <version.io.opentelemetry.opentelemetry>1.23.1</version.io.opentelemetry.opentelemetry>
         <version.io.opentracing>0.33.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.4.0</version.io.opentracing.concurrent>
         <version.io.opentracing.interceptors>0.1.3</version.io.opentracing.interceptors>

--- a/preview/common/src/main/resources/modules/system/layers/base/io/micrometer/main/module.xml
+++ b/preview/common/src/main/resources/modules/system/layers/base/io/micrometer/main/module.xml
@@ -30,6 +30,9 @@
     <resources>
         <artifact name="${io.micrometer:micrometer-core}"/>
         <artifact name="${io.micrometer:micrometer-registry-prometheus}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-exporter-common}"/>
+        <artifact name="${io.opentelemetry:opentelemetry-exporter-otlp-common}"/>
     </resources>
 
     <dependencies>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -103,7 +103,8 @@ public class LayersTestCase {
             // TODO test-all-layers uses microprofile-opentracing instead of opentelemetry
             "org.wildfly.extension.opentelemetry",
             "org.wildfly.extension.opentelemetry-api",
-            "io.opentelemetry.trace",
+            "io.opentelemetry.exporter",
+            "io.opentelemetry.sdk",
             // Unreferenced Infinispan modules
             "org.infinispan.cdi.common",
             "org.infinispan.cdi.embedded",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17653

Bump version
Update archives to match upstream packageing reorgs