### PR TITLE
[WFLY-17657]: Upgrade artemis-wildfly-integration to 2.0.0-Beta1.

### DIFF
--- a/boms/standard-ee/pom.xml
+++ b/boms/standard-ee/pom.xml
@@ -2190,7 +2190,7 @@
 
             <dependency>
                 <groupId>org.jboss.activemq.artemis.integration</groupId>
-                <artifactId>artemis-wildfly-jakarta-integration</artifactId>
+                <artifactId>artemis-wildfly-integration</artifactId>
                 <version>${version.org.jboss.activemq.artemis.integration}</version>
                 <exclusions>
                     <exclusion>

--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -461,7 +461,7 @@
 
         <dependency>
             <groupId>org.jboss.activemq.artemis.integration</groupId>
-            <artifactId>artemis-wildfly-jakarta-integration</artifactId>
+            <artifactId>artemis-wildfly-integration</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -30,7 +30,7 @@
 
     <resources>
         <artifact name="${org.wildfly:wildfly-messaging-activemq-subsystem}"/>
-        <artifact name="${org.jboss.activemq.artemis.integration:artemis-wildfly-jakarta-integration}"/>
+        <artifact name="${org.jboss.activemq.artemis.integration:artemis-wildfly-integration}"/>
         <resource-root path="META-INF"/>
     </resources>
 

--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -93,7 +93,7 @@
 
         <dependency>
             <groupId>org.jboss.activemq.artemis.integration</groupId>
-            <artifactId>artemis-wildfly-jakarta-integration</artifactId>
+            <artifactId>artemis-wildfly-integration</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.27.0-GA</version.org.javassist>
         <version.org.jberet>2.1.1.Final</version.org.jberet>
-        <version.org.jboss.activemq.artemis.integration>1.0.7</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>2.0.0-Beta1</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.7.0.Alpha13</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>5.0.2.Final</version.org.jboss.ejb-client>


### PR DESCRIPTION
 * Updating the GAV no longer using the jakarta as part of the artifactid.
 * Upstating the version to 2.0.0-Beta1

Jira: https://issues.redhat.com/browse/WFLY-17657