### PR TITLE
[WFLY-17470] Fix Mail Session cannot be injected when using CDI metho…

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -38,6 +38,7 @@ import org.jboss.msc.service.StartException;
 import jakarta.mail.Authenticator;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -169,7 +170,18 @@ class SessionProviderFactory {
 
         @Override
         public Session getSession() {
-            final Session session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
+            final Session session;
+            final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+            if (current == null) {
+                try {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(Session.class.getClassLoader());
+                    session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
+                } finally {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+                }
+            } else {
+                session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
+            }
             return session;
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MailSessionCDIInjectionTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MailSessionCDIInjectionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.mail.cdi;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.inject.Inject;
+import jakarta.mail.Session;
+
+/**
+ * Verifies Mail Session can be injected using CDI
+ */
+@RunWith(Arquillian.class)
+public class MailSessionCDIInjectionTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Inject
+    Session sessionOne;
+
+    @Inject
+    @MethodInjectQualifier
+    Session sessionTwo;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "mail-cdi-injection-test.war")
+                .addClasses(MailSessionProducer.class, MethodInjectQualifier.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void test() throws IOException, ExecutionException, TimeoutException {
+        Assert.assertNotNull(sessionOne);
+        Assert.assertNotNull(sessionTwo);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MailSessionProducer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MailSessionProducer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.mail.cdi;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.mail.Session;
+
+@ApplicationScoped
+public class MailSessionProducer {
+
+    @Produces
+    @Resource(mappedName = "java:jboss/mail/Default")
+    private Session sessionFieldProducer;
+
+    @Resource(mappedName = "java:jboss/mail/Default")
+    private Session sessionMethodProducer;
+
+    @Produces
+    @MethodInjectQualifier
+    public Session methodProducer() {
+        return sessionMethodProducer;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MethodInjectQualifier.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/cdi/MethodInjectQualifier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.mail.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD })
+public @interface MethodInjectQualifier {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionCustomProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionCustomProviderTestCase.java
@@ -22,9 +22,8 @@
 
 package org.jboss.as.test.integration.mail.providers;
 
-import jakarta.annotation.Resource;
-import jakarta.mail.Provider;
-import jakarta.mail.Session;
+import java.util.List;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -34,35 +33,54 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.mail.Provider;
+import jakarta.mail.Session;
+
 @RunWith(Arquillian.class)
 public class MailSessionCustomProviderTestCase {
 
     @Resource(lookup = "java:jboss/mail/Default")
-    private Session session;
+    private Session sessionOne;
+
+    @Inject
+    private Session sessionTwo;
+
+    @Inject
+    @MethodInjectQualifier
+    private Session sessionThree;
 
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
+                .addClasses(MailSessionProducer.class, MethodInjectQualifier.class)
                 .addAsResource(MailSessionCustomProviderTestCase.class.getPackage(),"javamail.providers", "META-INF/javamail.providers")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     public void testCustomProvidersInApplication() {
-        Assert.assertNotNull(session);
+        Assert.assertNotNull(sessionOne);
+        Assert.assertNotNull(sessionTwo);
+        Assert.assertNotNull(sessionThree);
 
-        Provider[] providers = session.getProviders();
+        List<Session> sessions = List.of(sessionOne, sessionTwo, sessionThree);
 
-        int found = 0;
-        for (Provider p : providers) {
-            if (p.toString().equals("jakarta.mail.Provider[TRANSPORT,CustomTransport,org.jboss.qa.management.mail.custom.CustomTransport,JBoss QE]")) {
-                found++;
+        for(Session session : sessions) {
+            Provider[] providers = session.getProviders();
+
+            int found = 0;
+            for (Provider p : providers) {
+                if (p.toString().equals("jakarta.mail.Provider[TRANSPORT,CustomTransport,org.jboss.qa.management.mail.custom.CustomTransport,JBoss QE]")) {
+                    found++;
+                }
+                if (p.toString().equals("jakarta.mail.Provider[STORE,CustomStore,org.jboss.qa.management.mail.custom.CustomStore,JBoss QE]")) {
+                    found++;
+                }
             }
-            if (p.toString().equals("jakarta.mail.Provider[STORE,CustomStore,org.jboss.qa.management.mail.custom.CustomStore,JBoss QE]")) {
-                found++;
-            }
+
+            Assert.assertTrue("The expected custom providers cannot be found on the default Mail Session", found == 2);
         }
-
-        Assert.assertTrue("The expected custom providers cannot be found on the default Mail Session", found == 2);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionProducer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MailSessionProducer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.mail.providers;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.mail.Session;
+
+@ApplicationScoped
+public class MailSessionProducer {
+
+    @Produces
+    @Resource(mappedName = "java:jboss/mail/Default")
+    private Session sessionFieldProducer;
+
+    @Resource(mappedName = "java:jboss/mail/Default")
+    private Session sessionMethodProducer;
+
+    @Produces
+    @MethodInjectQualifier
+    public Session methodProducer() {
+        return sessionMethodProducer;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MethodInjectQualifier.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mail/providers/MethodInjectQualifier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.mail.providers;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD })
+public @interface MethodInjectQualifier {
+}


### PR DESCRIPTION
…d producer

Jira issue: https://issues.redhat.com/browse/WFLY-17470

Weld threads explicitly set the context classloader to null, so they fail when Weld is validating the injection points since the Session providers cannot be loaded from the TCCL.