### PR TITLE
[WFLY-17666] Deployments using JNDI over RMI must define dependency on jdk.naming.rmi JPMS module

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
@@ -23,6 +23,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
@@ -88,6 +89,7 @@ public class JMXConnectorTestCase {
         final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, CB_DEPLOYMENT_NAME);
         archive.addClass(ConnectedBean.class);
         archive.addClass(ConnectedBeanInterface.class);
+        archive.addAsManifestResource(new StringAsset("Dependencies: jdk.naming.rmi\n"), "MANIFEST.MF");
         archive.addAsManifestResource(createPermissionsXmlAsset(
             new RuntimePermission("accessClassInPackage.com.sun.jndi.url.rmi"),
             new SocketPermission("*:*", "connect,resolve")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,7 @@ public class RmiContextLookupTestCase {
     public static WebArchive getDeployment() {
         return ShrinkWrap.create(WebArchive.class, RmiContextLookupTestCase.class.getSimpleName() + ".war")
             .addClasses(RmiContextLookupTestCase.class, RmiContextLookupBean.class)
+            .addAsManifestResource(new StringAsset("Dependencies: jdk.naming.rmi\n"), "MANIFEST.MF")
             .addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessClassInPackage.com.sun.jndi.url.rmi")), "permissions.xml");
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17666
