### PR TITLE
WFLY-17670 Upgrade H2 to 2.1.214

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.j2objc>1.3</version.com.google.j2objc>
         <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
-        <version.com.h2database>2.1.210</version.com.h2database>
+        <version.com.h2database>2.1.214</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>
         <version.com.nimbus.jose-jwt>9.23</version.com.nimbus.jose-jwt>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-17670

Lets see if this stabilizes some of the H2 failures seen in CI runs.

