### PR TITLE
[WFLY-17638][WFLY-17664] RESTEasy Upgrades

### DIFF
--- a/boms/legacy-test/pom.xml
+++ b/boms/legacy-test/pom.xml
@@ -125,18 +125,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-client</artifactId>
-                <version>${legacy.version.org.jboss.resteasy}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.jboss.spec.javax.jms</groupId>
                 <artifactId>jboss-jms-api_2.0_spec</artifactId>
                 <version>${legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
         <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
-        <version.org.jboss.resteasy.microprofile>2.0.0.Final</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.microprofile>2.1.0.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.1.Final</version.org.jboss.resteasy.spring>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.2.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.microprofile>2.0.0.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.1.Final</version.org.jboss.resteasy.spring>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,6 @@
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
-        <legacy.version.org.jboss.resteasy>4.7.4.Final</legacy.version.org.jboss.resteasy>
         <version.org.jboss.resteasy>6.2.2.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.microprofile>2.0.0.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.1.Final</version.org.jboss.resteasy.spring>
@@ -1012,7 +1011,7 @@
             </dependency>
 
             <!--
-            TODO used both in testsuite/integration/legacy-ejb-client and in legacy code.
+            TODO used in legacy code.
             Once legacy code use is gone, convert to <scope>test</scope>
             -->
             <dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -50,6 +50,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
         </dependency>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -183,6 +183,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -290,7 +290,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client-api</artifactId>
+            <artifactId>resteasy-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -190,7 +190,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client-api</artifactId>
+            <artifactId>resteasy-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -98,7 +98,6 @@
                 <module>manualmode</module>
                 <module>secman</module>
                 <module>legacy</module>
-                <module>legacy-ejb-client</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>
             </modules>
@@ -230,15 +229,6 @@
             <activation><property><name>ts.legacy</name></property></activation>
             <modules>
                 <module>legacy</module>
-            </modules>
-        </profile>
-
-        <!-- -Dts.legacy.ejb.client -->
-        <profile>
-            <id>ts.integ.group.legacy.ejb.client</id>
-            <activation><property><name>ts.legacy.ejb.client</name></property></activation>
-            <modules>
-                <module>legacy-ejb-client</module>
             </modules>
         </profile>
 
@@ -480,11 +470,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/testsuite/preview/pom.xml
+++ b/testsuite/preview/pom.xml
@@ -120,7 +120,6 @@
                 <module>manualmode</module>
                 <module>secman</module>
                 <module>legacy</module>
-                <module>legacy-ejb-client</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>-->
             </modules>
@@ -167,7 +166,6 @@
                 <module>manualmode</module>
                 <module>secman</module>
                 <module>legacy</module>
-                <module>legacy-ejb-client</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>-->
             </modules>
@@ -193,7 +191,6 @@
                 <module>manualmode</module>
                 <module>secman</module>
                 <module>legacy</module>
-                <module>legacy-ejb-client</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>-->
             </modules>
@@ -329,16 +326,6 @@
             <activation><property><name>ts.legacy</name></property></activation>
             <modules>
                 <module>legacy</module>
-            </modules>
-        </profile>
-        -->
-
-        <!-- -Dts.legacy.ejb.client
-        <profile>
-            <id>ts.integ.group.legacy.ejb.client</id>
-            <activation><property><name>ts.legacy.ejb.client</name></property></activation>
-            <modules>
-                <module>legacy-ejb-client</module>
             </modules>
         </profile>
         -->

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -42,6 +42,11 @@
     <dependencies>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
This PR contains upgrades for RESTEasy and RESTEasy MicroProfile. It also removes unneeded legacy `org.jboss.resteasy:resteasy-client` dependency. There is one extra commit, that can be removed, to remove the legacy-ejb-client module from the build as it no longer exists.

---
# RESTEasy 6.2.3.Final Upgrade

Tag: https://github.com/resteasy/resteasy/releases/tag/6.2.3.Final
Diff: https://github.com/resteasy/resteasy/compare/6.2.2.Final...6.2.3.Final

https://issues.redhat.com/browse/WFLY-17638

---
# RESTEasy MicroProfile 2.1.0.Final Upgrade

Tag: https://github.com/resteasy/resteasy-microprofile/releases/tag/2.1.0.Final
Diff: https://github.com/resteasy/resteasy-microprofile/compare/2.0.0.Final...2.1.0.Final

https://issues.redhat.com/browse/WFLY-17664
