### PR TITLE
[WFLY-17701] Upgrade WildFly Core to 20.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>20.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17701

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.0.Beta7
Diff: https://github.com/wildfly/wildfly-core/compare/20.0.0.Beta6...20.0.0.Beta7

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5557'>WFCORE-5557</a>] -         Remove setAllowNull deprecated API
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6202'>WFCORE-6202</a>] -         Wildfly standalone fails on IBM i when using system Java
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6260'>WFCORE-6260</a>] -         TestModule should check the path in consistent manner
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6239'>WFCORE-6239</a>] -         Add a new wildfly-elytron-ssh-util module to wildfly-core
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6241'>WFCORE-6241</a>] -         Add `quickly` profile for fast maven builds with quick profile
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6233'>WFCORE-6233</a>] -         Upgrade JBoss MSC to 1.5.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6240'>WFCORE-6240</a>] -         Upgrade Bouncycastle OpenPGP from 1.72.1 to 1.72.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6243'>WFCORE-6243</a>] -         Upgrade WildFly Elytron to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6246'>WFCORE-6246</a>] -         Upgrade snakeyaml from 1.33 to 2.0 (resolves CVE-2022-1471)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6252'>WFCORE-6252</a>] -         Upgrade Galleon to 5.0.8.Final and galleon Plugins to 6.3.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6256'>WFCORE-6256</a>] -         Upgrade staxmapper to 1.4.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-785'>WFCORE-785</a>] -         Improve capability related error messages
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6234'>WFCORE-6234</a>] -         Eliminate deprecated DeploymentUnit methods
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6237'>WFCORE-6237</a>] -         Eliminate usage of deprecated javax.api module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6238'>WFCORE-6238</a>] -         Eliminate dead code in org.jboss.as.cli.impl.SecurityActions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6250'>WFCORE-6250</a>] -         Don&#39;t include org.jboss.vfs module to all deployments by default
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6251'>WFCORE-6251</a>] -         Eliminate usage of deprecated javax.xml.stream.api module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6254'>WFCORE-6254</a>] -         Eliminate deprecated CapabilityServiceBuilder.addCapabilityRequirement(String,Class) method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6257'>WFCORE-6257</a>] -         Refactor Schema related interfaces from wildfly-clustering-common into wildfly-controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6258'>WFCORE-6258</a>] -         Refactor Model interface from wildfly-clustering-common into wildfly-controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6259'>WFCORE-6259</a>] -         Refactor SubsystemResourceDescriptionResolver implementation from wildfly-clustering-common to wildfly-controller
</li>
</ul>
</details>
