### PR TITLE
[WFLY-17702] Ensure Dependency Tree Input Builder builds the boms

### DIFF
--- a/.github/workflows/dep-diff-pull_request.yml
+++ b/.github/workflows/dep-diff-pull_request.yml
@@ -9,6 +9,7 @@ on:
 env:
   # The modules to check for dependencies. If there is more than one they are comma separated
   MODULES_TO_CHECK: galleon-pack,ee-feature-pack/common,microprofile/galleon-common,servlet-feature-pack/common,elytron-oidc-client/galleon-common
+  ADDITIONAL_BUILD_MODULES: boms/common-ee,boms/common-expansion,boms/standard-ee,boms/standard-expansion,boms/standard-test
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -54,7 +55,7 @@ jobs:
         with:
           path: pr
 
-      - name: Find valid base modules
+      - name: Find valid base modules to check
         working-directory: base
         run: |
           i=0
@@ -73,7 +74,26 @@ jobs:
           echo "validBaseModules="$validBaseModules
           echo "validBaseModules=${validBaseModules}" >> $GITHUB_ENV
 
-      - name: Find valid PR modules
+      - name: Find valid base additional modules
+        working-directory: base
+        run: |
+          i=0
+          validAddlBaseModules=""
+          for module in $(echo "${ADDITIONAL_BUILD_MODULES}" | sed "s/,/ /g")
+          do
+            if [ -d ${module} ]; then
+              if [ $i -gt 0 ]; then
+                validAddlBaseModules="${validAddlBaseModules},${module}"
+              else
+                validAddlBaseModules="${module}"
+              fi
+              i=$((i + 1))
+            fi
+          done
+          echo "validAddlBaseModules="validAddlBaseModules
+          echo "validAddlBaseModules=${validAddlBaseModules}" >> $GITHUB_ENV
+
+      - name: Find valid PR modules to check
         working-directory: pr
         run: |
           i=0
@@ -92,10 +112,29 @@ jobs:
           echo "validPRModules="$validPRModules
           echo "validPRModules=${validPRModules}" >> $GITHUB_ENV
 
+      - name: Find valid pr additional modules
+        working-directory: pr
+        run: |
+          i=0
+          validAddlPRModules=""
+          for module in $(echo "${ADDITIONAL_BUILD_MODULES}" | sed "s/,/ /g")
+          do
+            if [ -d ${module} ]; then
+              if [ $i -gt 0 ]; then
+                validAddlPRModules="${validAddlPRModules},${module}"
+              else
+                validAddlPRModules="${module}"
+              fi
+              i=$((i + 1))
+            fi
+          done
+          echo "validAddlPRModules="validAddlPRModules
+          echo "validAddlPRModules=${validAddlPRModules}" >> $GITHUB_ENV
+
       - name: Build base
         working-directory: base
         run: |
-          mvn -B -ntp install -DskipTests -pl ${{ env.validBaseModules }} -am
+          mvn -B -ntp install -DskipTests -pl ${{ env.validBaseModules }},${{ env.validAddlBaseModules }} -am
 
       - name: Grab base dependencies
         id: base-versions
@@ -122,7 +161,7 @@ jobs:
         run: |
           echo "validPRModules="$validPRModules
           echo "env.validPRModules="${{ env.validPRModules }}
-          mvn -B -ntp install -DskipTests -pl ${{ env.validPRModules }} -am
+          mvn -B -ntp install -DskipTests -pl ${{ env.validPRModules }},${{ env.validAddlPRModules }} -am
 
       - name: Grab PR Dependencies
         working-directory: pr

--- a/.github/workflows/dep-diff-pull_request.yml
+++ b/.github/workflows/dep-diff-pull_request.yml
@@ -8,7 +8,7 @@ on:
     - main
 env:
   # The modules to check for dependencies. If there is more than one they are comma separated
-  MODULES_TO_CHECK: galleon-pack,ee-feature-pack/common,microprofile/galleon-common,servlet-feature-pack/common
+  MODULES_TO_CHECK: galleon-pack,ee-feature-pack/common,microprofile/galleon-common,servlet-feature-pack/common,elytron-oidc-client/galleon-common
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -54,10 +54,48 @@ jobs:
         with:
           path: pr
 
+      - name: Find valid base modules
+        working-directory: base
+        run: |
+          i=0
+          validBaseModules=""
+          for module in $(echo "${MODULES_TO_CHECK}" | sed "s/,/ /g")
+          do
+            if [ -d ${module} ]; then
+              if [ $i -gt 0 ]; then
+                validBaseModules="${validBaseModules},${module}"
+              else
+                validBaseModules="${module}"
+              fi
+              i=$((i + 1))
+            fi
+          done
+          echo "validBaseModules="$validBaseModules
+          echo "validBaseModules=${validBaseModules}" >> $GITHUB_ENV
+
+      - name: Find valid PR modules
+        working-directory: pr
+        run: |
+          i=0
+          validPRModules=""
+          for module in $(echo "${MODULES_TO_CHECK}" | sed "s/,/ /g")
+          do
+            if [ -d ${module} ]; then
+              if [ $i -gt 0 ]; then
+                validPRModules="${validPRModules},${module}"
+              else
+                validPRModules="${module}"
+              fi
+              i=$((i + 1))
+            fi
+          done
+          echo "validPRModules="$validPRModules
+          echo "validPRModules=${validPRModules}" >> $GITHUB_ENV
+
       - name: Build base
         working-directory: base
         run: |
-          mvn -B -ntp install -DskipTests -pl $MODULES_TO_CHECK -am
+          mvn -B -ntp install -DskipTests -pl ${{ env.validBaseModules }} -am
 
       - name: Grab base dependencies
         id: base-versions
@@ -65,7 +103,7 @@ jobs:
         run: |
           i=0
           baseVersionFiles=""
-          for module in $(echo "${MODULES_TO_CHECK}" | sed "s/,/ /g")
+          for module in $(echo "${{ env.validBaseModules }}" | sed "s/,/ /g")
           do
             baseVersionFile="_base-versions-$i.txt"
             mvn -B -ntp dependency:tree -pl "${module}" -DoutputFile="${ARTIFACTS}/${baseVersionFile}" || exit 1
@@ -82,7 +120,9 @@ jobs:
       - name: Build PR
         working-directory: pr
         run: |
-          mvn -B -ntp install -DskipTests -pl $MODULES_TO_CHECK -am
+          echo "validPRModules="$validPRModules
+          echo "env.validPRModules="${{ env.validPRModules }}
+          mvn -B -ntp install -DskipTests -pl ${{ env.validPRModules }} -am
 
       - name: Grab PR Dependencies
         working-directory: pr
@@ -90,7 +130,7 @@ jobs:
         run: |
           i=0
           newVersionFiles=""
-          for module in $(echo "${MODULES_TO_CHECK}" | sed "s/,/ /g")
+          for module in $(echo "${{ env.validPRModules }}" | sed "s/,/ /g")
           do
             newVersionFile="_new-versions-$i.txt"
             mvn -B -ntp dependency:tree -pl "${module}" -DoutputFile="${ARTIFACTS}/${newVersionFile}" || exit 1


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17702

Builds on #16578 by using the same approach to validate a set of "additional modules" (i.e. the boms) and include them in the build.

I have confirmed via experimental PR #16584 that this resolves the failure #16541 was seeing.

Note that I initially tried just building everything but using -Dquickly, but that doubled the job execution time and presumably the resource consumption. So I went with this more complex approach.