### PR TITLE
WFLY-17544 Fix use of deprecated JGroups API.

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationServiceConfigurator.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationServiceConfigurator.java
@@ -152,7 +152,7 @@ public class TransportConfigurationServiceConfigurator<T extends TP> extends Abs
             }
         }
 
-        protocol.setThreadFactory(new ClassLoaderThreadFactory(new DefaultThreadFactory("jgroups", false, true).useFibers(protocol.useVirtualThreads()), JChannelFactory.class.getClassLoader()));
+        protocol.setThreadFactory(new ClassLoaderThreadFactory(new DefaultThreadFactory("jgroups", false, true).useVirtualThreads(protocol.useVirtualThreads()), JChannelFactory.class.getClassLoader()));
         protocol.setThreadPool(this.threadPoolFactory.get().apply(protocol.getThreadFactory()));
 
         SocketBinding diagnosticsBinding = this.diagnosticsSocketBinding.get();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17544

Follows up on JGroups 5.2.12.Final upgrade.