### PR TITLE
[WFLY-17743]: Refactor embedded-activemq and remote-activemq Galleon layers.

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -211,7 +211,7 @@ link:#gal.ee[ee] +
 link:#gal.elytron[elytron] +
 link:#gal.naming[naming] +
 link:#gal.remoting[remoting] +
-link:#gal.resource-adapters[resource-adapters] +
+link:#gal.resource-adapters[messaging-activemq] +
 link:#gal.undertow[undertow] +
 
 |[[gal.git-history]]git-history
@@ -431,7 +431,7 @@ link:#gal.base-server[base-server] +
 |Support for connections to a remote Apache Activemq Artemis Jakarta Messaging broker. +
 _Alternative:_ link:#gal.embedded-activemq[embedded-activemq]
 |
-link:#gal.resource-adapters[resource-adapters] +
+link:#gal.resource-adapters[messaging-activemq] +
 
 |[[gal.remoting]]remoting
 |Support for inbound and outbound JBoss Remoting connections, secured using Elytron.

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="embedded-activemq">
     <dependencies>
-        <layer name="resource-adapters"/>
+        <layer name="messaging-activemq"/>
         <layer name="cdi"/>
         <layer name="ee"/>
         <layer name="naming"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remote-activemq">
     <dependencies>
-        <layer name="resource-adapters"/>
+        <layer name="messaging-activemq"/>
     </dependencies>
     <feature-group name="messaging-remote-activemq"/>
     <feature-group name="messaging-remote-sockets"/>


### PR DESCRIPTION
 * embedded-activemq layer now depends on messaging-activemq layer instead of resource-adapters.
 * remote-activemq layer now depends on messaging-activemq layer instead of resource-adapters.

Jira: https://issues.redhat.com/browse/WFLY-17743