### PR TITLE
WFLY-17629 JPA/Hibernate 2nd level cache fails to invalidate updated entries when cache-container configured with ProtoStream marshaller

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/manager/DefaultCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/manager/DefaultCacheContainer.java
@@ -38,7 +38,6 @@ import org.infinispan.cache.impl.AbstractDelegatingAdvancedCache;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.internal.PrivateGlobalConfiguration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.manager.EmbeddedCacheManagerAdmin;
 import org.infinispan.manager.impl.AbstractDelegatingEmbeddedCacheManager;
@@ -49,6 +48,7 @@ import org.jboss.modules.ModuleLoader;
 import org.wildfly.clustering.infinispan.marshall.EncoderRegistry;
 import org.wildfly.clustering.infinispan.marshalling.ByteBufferMarshallerFactory;
 import org.wildfly.clustering.infinispan.marshalling.MarshalledValueTranscoder;
+import org.wildfly.clustering.infinispan.marshalling.protostream.ProtoStreamMarshaller;
 import org.wildfly.clustering.marshalling.spi.ByteBufferMarshalledKeyFactory;
 import org.wildfly.clustering.marshalling.spi.ByteBufferMarshalledValueFactory;
 import org.wildfly.clustering.marshalling.spi.ByteBufferMarshaller;
@@ -119,8 +119,8 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
         Configuration configuration = cache.getCacheConfiguration();
         CacheMode mode = configuration.clustering().cacheMode();
         boolean hasStore = configuration.persistence().usingStores();
-        // Bypass deployment-specific media types for local cache w/out a store or for hibernate 2LC
-        if ((!mode.isClustered() && !hasStore) || !this.cm.getCacheManagerConfiguration().module(PrivateGlobalConfiguration.class).isServerMode()) {
+        // Bypass deployment-specific media types for local cache w/out a store or if using a non-ProtoStream marshaller
+        if ((!mode.isClustered() && !hasStore) || !this.cm.getCacheManagerConfiguration().serialization().marshaller().mediaType().equals(ProtoStreamMarshaller.MEDIA_TYPE)) {
             return new DefaultCache<>(this, cache);
         }
         ClassLoader loader = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();

--- a/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/Tester.java
+++ b/clustering/marshalling/api/src/test/java/org/wildfly/clustering/marshalling/Tester.java
@@ -37,5 +37,17 @@ public interface Tester<T> {
         this.test(subject, Assert::assertEquals);
     }
 
+    /**
+     * Same as {@link #test(Object)}, but additionally validates equality of hash code.
+     * @param subject a test subject
+     * @throws IOException if marshalling of the test subject fails
+     */
+    default void testKey(T subject) throws IOException {
+        this.test(subject, (value1, value2) -> {
+            Assert.assertEquals(value1, value2);
+            Assert.assertEquals(value1.hashCode(), value2.hashCode());
+        });
+    }
+
     void test(T subject, BiConsumer<T, T> assertion) throws IOException;
 }

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
@@ -33,20 +33,23 @@
     </resources>
 
     <dependencies>
-        <module name="org.hibernate"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api"/>
+        <module name="jakarta.annotation.api"/>
+        <module name="jakarta.enterprise.api"/>
         <module name="jakarta.persistence.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.validation.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
         <module name="javax.xml.bind.api"/>
+
+        <module name="org.hibernate"/>
+        <module name="org.hibernate.commons-annotations"/>
+        <module name="org.infinispan" services="import"/>
+        <module name="org.infinispan.protostream"/>
+        <module name="org.infinispan.hibernate-cache" services="import"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
-        <module name="org.hibernate.commons-annotations"/>
-        <module name="org.infinispan" services="import"/>
-        <module name="org.infinispan.hibernate-cache" services="import"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/jpa/hibernate6/pom.xml
+++ b/jpa/hibernate6/pom.xml
@@ -176,5 +176,33 @@
             <artifactId>wildfly-common</artifactId>
         </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-api</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-spi</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>protoparser</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jpa/hibernate6/pom.xml
+++ b/jpa/hibernate6/pom.xml
@@ -65,6 +65,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
+        </dependency>
 
         <!-- External -->
 
@@ -122,6 +126,11 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core-jakarta</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/BasicCacheKeyImplementationMarshaller.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/BasicCacheKeyImplementationMarshaller.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.BasicCacheKeyImplementation;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link BasicCacheKeyImplementation}.
+ * @author Paul Ferraro
+ */
+public class BasicCacheKeyImplementationMarshaller implements ProtoStreamMarshaller<BasicCacheKeyImplementation> {
+
+    private static final int ID_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int HASH_CODE_INDEX = 3;
+
+    @Override
+    public Class<? extends BasicCacheKeyImplementation> getJavaClass() {
+        return BasicCacheKeyImplementation.class;
+    }
+
+    @Override
+    public BasicCacheKeyImplementation readFrom(ProtoStreamReader reader) throws IOException {
+        Serializable id = null;
+        String entity = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case ID_INDEX:
+                    id = reader.readAny(Serializable.class);
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new BasicCacheKeyImplementation(id, entity, hashCode.orElse(Objects.hashCode(id)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, BasicCacheKeyImplementation key) throws IOException {
+        Object id = key.getId();
+        if (id != null) {
+            writer.writeAny(ID_INDEX, id);
+        }
+        String entity = key.getEntityOrRoleName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(id)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/CacheKeyImplementationMarshaller.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/CacheKeyImplementationMarshaller.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.CacheKeyImplementation;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link CacheKeyImplementation}.
+ * @author Paul Ferraro
+ */
+public class CacheKeyImplementationMarshaller implements ProtoStreamMarshaller<CacheKeyImplementation> {
+
+    private static final int ID_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int TENANT_INDEX = 3;
+    private static final int HASH_CODE_INDEX = 4;
+
+    @Override
+    public Class<? extends CacheKeyImplementation> getJavaClass() {
+        return CacheKeyImplementation.class;
+    }
+
+    @Override
+    public CacheKeyImplementation readFrom(ProtoStreamReader reader) throws IOException {
+        Object id = null;
+        String entity = null;
+        String tenant = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case ID_INDEX:
+                    id = reader.readAny();
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case TENANT_INDEX:
+                    tenant = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new CacheKeyImplementation(id, entity, tenant, hashCode.orElse(Objects.hashCode(id)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, CacheKeyImplementation key) throws IOException {
+        Object id = key.getId();
+        if (id != null) {
+            writer.writeAny(ID_INDEX, id);
+        }
+        String entity = key.getEntityOrRoleName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        String tenant = key.getTenantId();
+        if (tenant != null) {
+            writer.writeString(TENANT_INDEX, tenant);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(id)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/HibernateCacheInternalSerializationContextInitializer.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/HibernateCacheInternalSerializationContextInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.marshalling.protostream.AbstractSerializationContextInitializer;
+
+/**
+ * {@link SerializationContextInitializer} for the {@link org.hibernate.cache.internal} package.
+ * @author Paul Ferraro
+ */
+@MetaInfServices(SerializationContextInitializer.class)
+public class HibernateCacheInternalSerializationContextInitializer extends AbstractSerializationContextInitializer {
+
+    public HibernateCacheInternalSerializationContextInitializer() {
+        super("org.hibernate.cache.internal.proto");
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext context) {
+        context.registerMarshaller(new BasicCacheKeyImplementationMarshaller());
+        context.registerMarshaller(new CacheKeyImplementationMarshaller());
+        context.registerMarshaller(new NaturalIdCacheKeyMarshaller());
+    }
+}

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/NaturalIdCacheKeyMarshaller.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/cache/NaturalIdCacheKeyMarshaller.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.NaturalIdCacheKey;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link NaturalIdCacheKey}.
+ * @author Paul Ferraro
+ */
+public class NaturalIdCacheKeyMarshaller implements ProtoStreamMarshaller<NaturalIdCacheKey> {
+
+    private static final int VALUES_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int TENANT_INDEX = 3;
+    private static final int HASH_CODE_INDEX = 4;
+
+    @Override
+    public Class<? extends NaturalIdCacheKey> getJavaClass() {
+        return NaturalIdCacheKey.class;
+    }
+
+    @Override
+    public NaturalIdCacheKey readFrom(ProtoStreamReader reader) throws IOException {
+        Object values = null;
+        String entity = null;
+        String tenant = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case VALUES_INDEX:
+                    values = reader.readAny();
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case TENANT_INDEX:
+                    tenant = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+            }
+        }
+        return new NaturalIdCacheKey(values, entity, tenant, hashCode.orElse(Objects.hashCode(values)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, NaturalIdCacheKey key) throws IOException {
+        Object values = key.getNaturalIdValues();
+        if (values != null) {
+            writer.writeAny(VALUES_INDEX, values);
+        }
+        String entity = key.getEntityName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        String tenant = key.getTenantId();
+        if (tenant != null) {
+            writer.writeString(TENANT_INDEX, tenant);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(values)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate6/src/main/resources/org.hibernate.cache.internal.proto
+++ b/jpa/hibernate6/src/main/resources/org.hibernate.cache.internal.proto
@@ -1,0 +1,32 @@
+package org.hibernate.cache.internal;
+
+// IDs: 350-359
+
+/**
+ * @TypeId(350)
+ */
+message BasicCacheKeyImplementation {
+	optional	bytes	id	 = 1;
+	optional	string	entity	 = 2;
+	optional	sfixed32	hashCode	 = 4;
+}
+
+/**
+ * @TypeId(351)
+ */
+message CacheKeyImplementation {
+	optional	bytes	id	 = 1;
+	optional	string	entity	 = 2;
+	optional	string	tenant	 = 3;
+	optional	sfixed32	hashCode	 = 4;
+}
+
+/**
+ * @TypeId(352)
+ */
+message NaturalIdCacheKey {
+	optional	bytes	value	 = 1;
+	optional	string	entity	 = 2;
+	optional	string	tenant	 = 3;
+	optional	sfixed32	hashCode	 = 4;
+}

--- a/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/BasicCacheKeyImplementationMarshallerTestCase.java
+++ b/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/BasicCacheKeyImplementationMarshallerTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.hibernate.cache.internal.BasicCacheKeyImplementation;
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.Tester;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamTesterFactory;
+
+/**
+ * Unit test for {@link BasicCacheKeyImplementationMarshaller}.
+ * @author Paul Ferraro
+ */
+public class BasicCacheKeyImplementationMarshallerTestCase {
+
+    @Test
+    public void test() throws IOException {
+        Tester<BasicCacheKeyImplementation> tester = ProtoStreamTesterFactory.INSTANCE.createTester();
+        UUID id = UUID.randomUUID();
+        String entity = "foo";
+        tester.testKey(new BasicCacheKeyImplementation(id, entity, id.hashCode()));
+        tester.testKey(new BasicCacheKeyImplementation(id, entity, 1));
+    }
+}

--- a/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/CacheKeyImplementationMarshallerTestCase.java
+++ b/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/CacheKeyImplementationMarshallerTestCase.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.hibernate.cache.internal.CacheKeyImplementation;
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.Tester;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamTesterFactory;
+
+/**
+ * Unit test for {@link CacheKeyImplementationMarshaller}.
+ * @author Paul Ferraro
+ */
+public class CacheKeyImplementationMarshallerTestCase {
+
+    @Test
+    public void test() throws IOException {
+        Tester<CacheKeyImplementation> tester = ProtoStreamTesterFactory.INSTANCE.createTester();
+        UUID id = UUID.randomUUID();
+        String entity = "foo";
+        String tenant = "bar";
+        tester.testKey(new CacheKeyImplementation(id, entity, tenant, id.hashCode()));
+        tester.testKey(new CacheKeyImplementation(id, entity, tenant, 1));
+    }
+}

--- a/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/NaturalIdCacheKeyMarshallerTestCase.java
+++ b/jpa/hibernate6/src/test/java/org/jboss/as/jpa/hibernate/cache/NaturalIdCacheKeyMarshallerTestCase.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.hibernate.cache;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.hibernate.cache.internal.NaturalIdCacheKey;
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.Tester;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamTesterFactory;
+
+/**
+ * Unit test for {@link NaturalIdCacheKeyMarshaller}.
+ * @author Paul Ferraro
+ */
+public class NaturalIdCacheKeyMarshallerTestCase {
+
+    @Test
+    public void test() throws IOException {
+        Tester<NaturalIdCacheKey> tester = ProtoStreamTesterFactory.INSTANCE.createTester();
+        UUID id = UUID.randomUUID();
+        String entity = "foo";
+        String tenant = "bar";
+        tester.testKey(new NaturalIdCacheKey(id, entity, tenant, id.hashCode()));
+        tester.testKey(new NaturalIdCacheKey(id, entity, tenant, 1));
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/persistence.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/persistence.xml
@@ -2,7 +2,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
     <persistence-unit name="MainPU">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
-        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <jta-data-source>java:jboss/datasources/H2</jta-data-source>
         <shared-cache-mode>ALL</shared-cache-mode>
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
@@ -11,7 +11,7 @@
             <property name="hibernate.hbm2ddl.auto" value="update"/>
             <property name="hibernate.cache.use_second_level_cache" value="true"/>
             <property name="hibernate.cache.use_query_cache" value="true"/>
-            <property name="hibernate.cache.infinispan.entity.cfg" value="entity-replicated"/>
+            <!--property name="hibernate.cache.infinispan.entity.cfg" value="entity-replicated"/-->
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17629