### PR TITLE
[WFLY-17756] Properly render adoc admonitions in the Github UI

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -4,6 +4,14 @@
 :icons: font
 :source-highlighter: coderay
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Overview
 
 The `docs` module is not in the module listing of the parent POM by default. Therefore to build you must either activate

--- a/docs/src/main/asciidoc/Admin_Guide.adoc
+++ b/docs/src/main/asciidoc/Admin_Guide.adoc
@@ -15,6 +15,12 @@ WildFly developer team;
 :include-depth: 2
 
 ifdef::env-github[:outfilesuffix: .adoc]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 
 ifndef::ebook-format[:leveloffset: 1]

--- a/docs/src/main/asciidoc/Bootable_Guide.adoc
+++ b/docs/src/main/asciidoc/Bootable_Guide.adoc
@@ -9,7 +9,14 @@ WildFly team;
 :doctype: book
 :icons: font
 :source-highlighter: coderay
+
 ifdef::env-github[:imagesdir: images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/Client_Guide.adoc
+++ b/docs/src/main/asciidoc/Client_Guide.adoc
@@ -11,6 +11,14 @@
 :wildflyVersion: 14
 :numbered:
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifdef::basebackend-html[toc::[]]
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/Developer_Guide.adoc
@@ -11,6 +11,14 @@ WildFly developer team;
 :source-highlighter: coderay
 :wildflyVersion: 14
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifndef::ebook-format[:leveloffset: 1]
 
 (C) 2017 The original authors.

--- a/docs/src/main/asciidoc/Extending_WildFly.adoc
+++ b/docs/src/main/asciidoc/Extending_WildFly.adoc
@@ -12,6 +12,14 @@ WildFly code development team;
 :wildflyVersion: 14
 :leveloffset: +1
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifndef::ebook-format[:leveloffset: 1]
 
 In this document we provide an example of how to extend the kernel

--- a/docs/src/main/asciidoc/Galleon_Guide.adoc
+++ b/docs/src/main/asciidoc/Galleon_Guide.adoc
@@ -15,7 +15,12 @@ WildFly developer team;
 :include-depth: 2
 
 ifdef::env-github[:outfilesuffix: .adoc]
-
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/Getting_Started_Developing_Applications_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Developing_Applications_Guide.adoc
@@ -11,6 +11,14 @@ WildFly team;
 :source-highlighter: coderay
 :wildflyVersion: 14
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifndef::ebook-format[:leveloffset: 1]
 
 (C) 2017 The original authors.

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -9,7 +9,14 @@ WildFly team;
 :doctype: book
 :icons: font
 :source-highlighter: coderay
+
 ifdef::env-github[:imagesdir: images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/Glossary.adoc
+++ b/docs/src/main/asciidoc/Glossary.adoc
@@ -1,6 +1,14 @@
 [[Glossary]]
 = Glossary
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[module]]
 == Module
 

--- a/docs/src/main/asciidoc/Hacking_On_WildFly.adoc
+++ b/docs/src/main/asciidoc/Hacking_On_WildFly.adoc
@@ -15,7 +15,12 @@ WildFly developer team;
 :include-depth: 2
 
 ifdef::env-github[:outfilesuffix: .adoc]
-
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/High_Availability_Guide.adoc
+++ b/docs/src/main/asciidoc/High_Availability_Guide.adoc
@@ -1,1 +1,9 @@
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 include::_high-availability/index.adoc[]

--- a/docs/src/main/asciidoc/Installation_Guide.adoc
+++ b/docs/src/main/asciidoc/Installation_Guide.adoc
@@ -11,6 +11,14 @@ WildFly team;
 :source-highlighter: coderay
 :wildflyVersion: 14
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 :leveloffset: +1
 
 ifndef::ebook-format[:leveloffset: 1]

--- a/docs/src/main/asciidoc/Migration_Guide.adoc
+++ b/docs/src/main/asciidoc/Migration_Guide.adoc
@@ -15,7 +15,12 @@ WildFly developer team;
 :include-depth: 2
 
 ifdef::env-github[:outfilesuffix: .adoc]
-
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/Quickstarts.adoc
+++ b/docs/src/main/asciidoc/Quickstarts.adoc
@@ -9,7 +9,14 @@ WildFly team;
 :doctype: book
 :icons: font
 :source-highlighter: coderay
+
 ifdef::env-github[:imagesdir: images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 (C) 2021 The original authors.
 

--- a/docs/src/main/asciidoc/Testsuite.adoc
+++ b/docs/src/main/asciidoc/Testsuite.adoc
@@ -11,6 +11,14 @@ WildFly team;
 :source-highlighter: coderay
 :wildflyVersion: 14
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 :leveloffset: +1
 
 ifndef::ebook-format[:leveloffset: 1]

--- a/docs/src/main/asciidoc/WildFly_Elytron_Security.adoc
+++ b/docs/src/main/asciidoc/WildFly_Elytron_Security.adoc
@@ -11,6 +11,14 @@
 :wildflyVersion: 14
 :numbered:
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifdef::basebackend-html[toc::[]]
 ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -9,7 +9,14 @@ WildFly team;
 :doctype: book
 :icons: font
 :source-highlighter: coderay
+
 ifdef::env-github[:imagesdir: images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
 

--- a/docs/src/main/asciidoc/_admin-guide/Application_deployment.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Application_deployment.adoc
@@ -1,6 +1,14 @@
 [[application-deployment]]
 = Application deployment
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 :toc:
 
 toc::[]

--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -1,6 +1,14 @@
 [[CLI_Recipes]]
 = CLI Recipes
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Properties
 
 [[adding-reading-and-removing-system-property-using-cli]]

--- a/docs/src/main/asciidoc/_admin-guide/Command_Line_Interface.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Command_Line_Interface.adoc
@@ -1,6 +1,14 @@
 [[Command_Line_Interface]]
 = Command Line Interface
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Command Line Interface (CLI) is a management tool for a managed
 domain or standalone server. It allows a user to connect to the domain
 controller or a standalone server and execute management operations

--- a/docs/src/main/asciidoc/_admin-guide/Core_management_concepts.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Core_management_concepts.adoc
@@ -5,6 +5,14 @@
 :toc: macro
 :leveloffset: +1
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifdef::basebackend-html[toc::[]]
 :numbered:
 

--- a/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
@@ -1,6 +1,13 @@
 [[Default_HTTP_Interface_Security]]
 = Default HTTP Interface Security
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 WildFly is distributed secured by default. The default security
 mechanism is username / password based making use of HTTP Digest for the

--- a/docs/src/main/asciidoc/_admin-guide/Default_Native_Interface_Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Default_Native_Interface_Security.adoc
@@ -1,6 +1,14 @@
 [[Default_Native_Interface_Security]]
 = Default Native Interface Security
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The native interface shares the same security configuration as the http
 interface, however we also support a local authentication mechanism
 which means that the CLI can authenticate against the local WildFly

--- a/docs/src/main/asciidoc/_admin-guide/Deployment_Overlays.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Deployment_Overlays.adoc
@@ -1,6 +1,14 @@
 [[Deployment_Overlays]]
 = Deployment Overlays
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Deployment overlays are our way of 'overlaying' content into an existing
 deployment, without physically modifying the contents of the deployment
 archive. Possible use cases include swapping out deployment descriptors,

--- a/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Domain_Setup.adoc
@@ -1,6 +1,14 @@
 [[Domain_Setup]]
 = Domain Setup
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 To run a group of servers as a managed domain you need to configure both
 the domain controller and each host that joins the domain. This sections
 focuses on the network configuration for the domain and host controller

--- a/docs/src/main/asciidoc/_admin-guide/General_configuration_concepts.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/General_configuration_concepts.adoc
@@ -1,6 +1,14 @@
 [[General_configuration_concepts]]
 = General configuration concepts
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 For both a managed domain or a standalone server, a number of common
 configuration concepts apply:
 

--- a/docs/src/main/asciidoc/_admin-guide/Interfaces_and_ports.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Interfaces_and_ports.adoc
@@ -1,6 +1,13 @@
 [[Interfaces_and_ports]]
 = Interfaces and ports
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 [[interface-declarations]]
 == Interface declarations

--- a/docs/src/main/asciidoc/_admin-guide/Management_API_reference.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_API_reference.adoc
@@ -1,6 +1,14 @@
 [[Management_API_reference]]
 = Management API reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This section is an in depth reference to the WildFly management API.
 Readers are encouraged to read the
 <<Management_Clients,Management clients>> and

--- a/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_Clients.adoc
@@ -1,6 +1,14 @@
 [[Management_Clients]]
 = Management Clients
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly offers three different approaches to configure and manage
 servers: a web interface, a command line client and a set of XML
 configuration files. Regardless of the approach you choose, the

--- a/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
@@ -1,6 +1,14 @@
 [[management-resources]]
 = Management resources
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 When WildFly parses your configuration files at boot, or when you use
 one of the AS's <<Management_Clients,Management Clients>> you are
 adding, removing or modifying _management resources_ in the AS's

--- a/docs/src/main/asciidoc/_admin-guide/Management_tasks.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_tasks.adoc
@@ -3,6 +3,14 @@
 :icons: font
 :source-highlighter: coderay
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 :leveloffset: +1
 include::management-tasks/Command_line_parameters.adoc[]
 

--- a/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
@@ -1,6 +1,13 @@
 [[Operating_modes]]
 = Operating mode
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 WildFly can be booted in two different modes. A _managed domain_ allows
 you to run and manage a multi-server topology. Alternatively, you can

--- a/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
@@ -1,6 +1,13 @@
 [[RBAC]]
 = Authorizing management actions with Role Based Access Control
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 WildFly introduces a Role Based Access Control scheme that allows
 different administrative users to have different sets of permissions to

--- a/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
@@ -7,6 +7,14 @@ Subsystem configuration reference
 :toc: macro
 :toclevels: 2
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifdef::basebackend-html[toc::[]]
 
 The following chapters will focus on the high level management use cases

--- a/docs/src/main/asciidoc/_admin-guide/Target_Audience.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Target_Audience.adoc
@@ -1,6 +1,14 @@
 [[Target_Audience]]
 = Target Audience
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This document is a guide to the setup, administration, and configuration
 of WildFly.
 

--- a/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
@@ -1,6 +1,13 @@
 [[add-user-utility]]
 = add-user utility
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 For use with the default configuration we supply a utility `add-user`
 which can be used to manage the properties files for the default realms

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
@@ -1,6 +1,15 @@
 [[Description_of_the_Management_Model]]
 = Description of the Management Model
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
+
+ifdef::env-github[:outfilesuffix: .adoc]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+ifdef::env-browser[:outfilesuffix: .adoc]
 
 A detailed description of the resources, attributes and operations that
 make up the management model provided by an individual WildFly instance

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Detyped_management_and_the_jboss-dmr_library.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Detyped_management_and_the_jboss-dmr_library.adoc
@@ -1,6 +1,14 @@
 [[Detyped_management_and_the_jboss-dmr_library]]
 = Detyped management and the jboss-dmr library
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The management model exposed by WildFly is very large and complex. There
 are dozens, probably hundreds of logical concepts involved – hosts,
 server groups, servers, subsystems, datasources, web connectors, and on

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
@@ -1,6 +1,14 @@
 [[Global_operations]]
 = Global operations
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The WildFly management API includes a number of operations that apply to
 every resource.
 

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
@@ -1,6 +1,14 @@
 [[The_HTTP_management_API]]
 = The HTTP management API
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[introduction]]
 == Introduction
 

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_native_management_API.adoc
@@ -1,6 +1,14 @@
 [[The_native_management_API]]
 = The native management API
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 A standalone WildFly process, or a managed domain Domain Controller or
 secondary Host Controller process can be configured to listen for remote
 management requests using its "native management interface":

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Audit_logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Audit_logging.adoc
@@ -1,6 +1,14 @@
 [[Audit_logging]]
 = Audit logging
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly comes with audit logging built in for management operations
 affecting the management model. By default it is turned off. The
 information is output as JSON records.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Canceling_Management_Operations.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Canceling_Management_Operations.adoc
@@ -1,6 +1,14 @@
 [[Canceling_Management_Operations]]
 = Canceling Management Operations
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly includes the ability to use the CLI to cancel management
 requests that are not proceeding normally.
 

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
@@ -1,6 +1,14 @@
 [[Command_line_parameters]]
 = Command line parameters
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 To start up a WildFly managed domain, execute the
 `$JBOSS_HOME/bin/domain.sh` script. To start up a standalone server,
 execute the `$JBOSS_HOME/bin/standalone.sh`. With no arguments, the

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
@@ -1,6 +1,14 @@
 [[Configuration_file_git_history]]
 = Git Configuration file history
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 To enhance the initial <<Configuration_file_history,configuration file history>> we have now a native Git support to manage the configuration history. This feature goes a little farther than the initial configuration file history in that it also manages content repository content and all the configuration files (such as properties). This feature only work for **standalone servers** using the default directory layout.
 
 As mentioned in <<Command_line_parameters,Command line parameters>> we support the usage of a remote Git repository to pull the configuration from or create or use a local Git repository.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
@@ -1,6 +1,14 @@
 [[Configuration_file_history]]
 = Configuration file history
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The management operations may modify the model. When this occurs the xml
 backing the model is written out again reflecting the latest changes. In
 addition a full history of the file is maintained. The history of the

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/JVM_settings.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/JVM_settings.adoc
@@ -1,6 +1,14 @@
 [[JVM_settings]]
 = JVM settings
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Configuration of the JVM settings is different for a managed domain and
 a standalone server. In a managed domain, the domain controller
 components are responsible for starting and stopping server processes and

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Starting_and_Stopping_Servers_in_a_Managed_Domain.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Starting_and_Stopping_Servers_in_a_Managed_Domain.adoc
@@ -1,6 +1,14 @@
 [[Starting_and_Stopping_Servers_in_a_Managed_Domain]]
 = Starting and Stopping Servers in a Managed Domain
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Starting a standalone server is done through the `bin/standalone.sh`
 script. However in a managed domain server instances are managed by the
 domain controller and need to be started through the management layer:

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Suspend,_Resume_and_Graceful_shutdown.adoc
@@ -1,6 +1,14 @@
 [[Suspend,_Resume_and_Graceful_shutdown]]
 = Suspend, Resume and Graceful shutdown
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[core-concepts]]
 == Core Concepts
 

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/YAML_Configuration_file.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/YAML_Configuration_file.adoc
@@ -1,6 +1,14 @@
 [[YAML_Configuration_file]]
 = (YAML) Configuration file (Experimental))
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In order to provide some way to separate customization from the configuration provisionned by Galleon we want to *experiment* with a new feature where this customization is provided by YAML files.
 Because this feature is *EXPERIMENTAL* we are disabling it by default and you can *NOT* rely on it being present or compatible in the future releases.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Core_Management.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Core_Management.adoc
@@ -1,6 +1,14 @@
 [[Core_Management]]
 = Core Management Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The core management subsystem is composed services used to manage the
 server or monitor its status. +
 The core management subsystem configuration may be used to:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/DataSource.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/DataSource.adoc
@@ -1,6 +1,14 @@
 [[DataSource]]
 = DataSource configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Datasources are configured through the _datasource_ subsystem. Declaring
 a new datasource consists of two separate steps: You would need to
 provide a JDBC driver and define a datasource that references the driver

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
@@ -1,6 +1,14 @@
 [[agroal]]
 = Agroal configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Agroal subsystem allows the definition of datasources. Declaring a new datasource consists of two separate steps: provide a JDBC driver and define a datasource that references the driver you installed.
 
 The Agroal subsystem is provided by the https://agroal.github.io/[Agroal] project. For a detailed description of the available configuration properties, please consult the project documentation.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Deployment_Scanner.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Deployment_Scanner.adoc
@@ -1,6 +1,14 @@
 [[Deployment_Scanner]]
 = Deployment Scanner configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The deployment scanner is only used in standalone mode. Its job is to
 monitor a directory for new files and to deploy those files. It can be
 found in `standalone.xml`:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE.adoc
@@ -1,6 +1,15 @@
 [[EE]]
 = EE Subsystem Configuration
 :leveloffset: +1
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The EE subsystem provides common functionality in the Jakarta EE platform,
 such as the EE Concurrency Utilities (JSR 236) and `@Resource`
 injection. The subsystem is also responsible for managing the lifecycle

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Application_Deployment_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Application_Deployment_Configuration.adoc
@@ -1,6 +1,14 @@
 [[EE_Application_Deployment_Configuration]]
 = Jakarta EE Application Deployment
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The EE subsystem configuration allows the customisation of the
 deployment behaviour for Jakarta EE Applications.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Concurrency_Utilities_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Concurrency_Utilities_Configuration.adoc
@@ -1,6 +1,14 @@
 [[EE_Concurrency_Utilities_Configuration]]
 = EE Concurrency Utilities
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 EE Concurrency Utilities (JSR 236) were introduced to
 ease the task of writing multithreaded applications. Instances
 of these utilities are managed by WildFly, and the related configuration.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Default_Bindings_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Default_Bindings_Configuration.adoc
@@ -1,6 +1,14 @@
 [[EE_Default_Bindings_Configuration]]
 = Default EE Bindings
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Jakarta EE Specification mandates the existence of a default instance
 for each of the following resources:
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
@@ -1,6 +1,14 @@
 [[Elytron_OIDC_Client]]
 = Elytron OpenID Connect Client Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The ability to secure applications using https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect] is
 provided by the _elytron-oidc-client_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Health.adoc
@@ -1,6 +1,14 @@
 [[Health]]
 = Health Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [NOTE]
 ====
 This subsystem exposes only healthiness checks for the WildFly runtime.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
@@ -1,6 +1,14 @@
 [[JMX]]
 = JMX subsystem configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The JMX subsystem registers a service with the Remoting endpoint so that
 remote access to JMX can be obtained over the exposed Remoting
 connector.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Batch]]
 = Jakarta Batch Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 The batch subsystem is used to configure an environment for running

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Enterprise_Beans_3.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Enterprise_Beans_3.adoc
@@ -1,6 +1,14 @@
 [[EJB3]]
 = EJB3 subsystem configuration guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This page lists the options that are available for configuring the EJB
 subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_RESTful_Web_Services.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_RESTful_Web_Services.adoc
@@ -1,6 +1,14 @@
 [[JAXRS]]
 == JAXRS Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The `jaxrs` subsystem represents https://projects.eclipse.org/projects/ee4j.jaxrs[Jakarta RESTful Web Services].
 https://resteasy.github.io[RESTEasy] is the implementation.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
@@ -1,6 +1,14 @@
 [[Logging]]
 = Logging Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 The overall server logging configuration is represented by the logging

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Filters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Filters.adoc
@@ -4,6 +4,14 @@
 :idprefix:
 :idseparator:       -
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Filters are used to add fine grained control over a log message. A filter can be assigned to a logger or log handler.
 See the {oracle-javadoc}/java.logging/java/util/logging/Filter.html[Filter] documentation for details on filters.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Formatters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Formatters.adoc
@@ -4,6 +4,14 @@
 :idprefix:
 :idseparator:       -
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Formatters are used to format a log message. A formatter can be assigned to a logging handler.
 
 The logging subsystem includes 4 types of handlers:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Handlers.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Handlers.adoc
@@ -2,6 +2,14 @@
 :author:            James R. Perkins
 :email:             jperkins@redhat.com
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Overview
 
 Handlers define how log messages are recorded. If a message is said to be

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_How_To.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_How_To.adoc
@@ -1,6 +1,14 @@
 [[Logging_How_To]]
 = How To
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[how-do-i-add-a-log-category]]
 == How do I add a log category?
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Loggers.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Loggers.adoc
@@ -1,6 +1,14 @@
 [[Logging_Loggers]]
 = Loggers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WIP
 
 [IMPORTANT]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Mesaging_AIO_-_NIO_for_messaging_journal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Mesaging_AIO_-_NIO_for_messaging_journal.adoc
@@ -1,6 +1,14 @@
 [[Mesaging_AIO_-_NIO_for_messaging_journal]]
 = AIO - NIO for messaging journal
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Apache ActiveMQ Artemis (like HornetQ beforehand) ships with a *high
 performance journal*. Since Apache ActiveMQ Artemis handles its own
 persistence, rather than relying on a database or other 3rd party

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -1,6 +1,14 @@
 [[Messaging]]
 = Messaging configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Jakarta Messaging server configuration is done through the _messaging-activemq_
 subsystem. In this chapter we are going outline the frequently used
 configuration options. For a more detailed explanation please consult

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Backward_and_Forward_Compatibility.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Backward_and_Forward_Compatibility.adoc
@@ -1,6 +1,14 @@
 [[Messaging_Backward_and_Forward_Compatibility]]
 = Backward & Forward Compatibility
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly supports both backwards and forwards compatibility with
 legacy versions that were using HornetQ as their messaging brokers (such
 as JBoss AS7 or WildFly 8 and 9). +

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
@@ -1,6 +1,14 @@
 [[Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server]]
 = Connect a pooled-connection-factory to a Remote Artemis Server
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The `messaging-activemq` subsystem allows to configure a
 `pooled-connection-factory` resource to let a local client deployed in
 WildFly connect to a remote Artemis server.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Discovery_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Discovery_Configuration.adoc
@@ -1,6 +1,14 @@
 [[Messaging_Discovery_Configuration]]
 = Configuring Broadcast/Discovery
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Each Artemis server can be configured to broadcast itself and/or discovery other Artemis servers within a cluster.
 Artemis supports two mechanisms for configuring broadcast/discovery:
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_JDBC_Store_for_Messaging_Journal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_JDBC_Store_for_Messaging_Journal.adoc
@@ -1,6 +1,14 @@
 [[Messaging_JDBC_Store_for_Messaging_Journal]]
 = JDBC Store for Messaging Journal
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Artemis server that are integrated to WildFly can be configured to
 use a JDBC store for its messaging journal instead of its file-based
 journal. +

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Metrics.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_Metrics_SmallRye]]
 = Metrics Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [NOTE]
 ====
 This subsystem exposes only base metrics from the WildFly Management Model and JVM MBeans.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_Config_SmallRye]]
 = MicroProfile Config Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-config[MicroProfile Config] is provided by
  the _microprofile-config-smallrye_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Fault_Tolerance_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Fault_Tolerance_SmallRye.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile-Fault-Tolerance-SmallRye]]
 = MicroProfile Fault Tolerance Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Specification
 
 WildFly's MicroProfile Fault Tolerance subsystem implements MicroProfile Fault Tolerance 4.0.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_Health_SmallRye]]
 = MicroProfile Health Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-health[MicroProfile Health] is provided by
  the _microprofile-health-smallrye_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_JWT.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_JWT.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_JWT_SmallRye]]
 = MicroProfile JWT Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-jwt-auth[MicroProfile JWT RBAC] is provided by the _microprofile-jwt-smallrye_ subsystem.
 
 The MicroProfile JWT specification describes how authentication can be performed using cryptographically signed JWT tokens and the contents of the token to be used to establish a resuting identity without relying on access to external repositories of identities such as databases or directory servers.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_Metrics_SmallRye_Subsystem_Config]]
 = MicroProfile Metrics Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile Metrics] is provided by
  the _microprofile-metrics-smallrye_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenAPI.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenAPI.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_OpenAPI_SmallRye]]
 = MicroProfile OpenAPI Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md[OpenAPI specification] defines a contract for JAX-RS applications in the same way that WSDL defined a contract for legacy web services.
 The https://download.eclipse.org/microprofile/microprofile-open-api-1.1.2/microprofile-openapi-spec.html[MicroProfile OpenAPI specification] defines a mechanism for generating an OpenAPI v3 document from a JAX-RS application as well as an API for customizing production of the document.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_OpenTracing_SmallRye]]
 = MicroProfile OpenTracing Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-opentracing[MicroProfile OpenTracing] is
 provided as a Tech Preview feature by the _microprofile-opentracing-smallrye_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Messsaging_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Messsaging_SmallRye.adoc
@@ -6,6 +6,13 @@
 :eclipse-mp-reactive-messaging-api-version: 2.0
 ----
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 Support for https://microprofile.io/project/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging] is
 provided as a Tech Preview feature by the _microprofile-reactive-messaging-smallrye_ subsystem.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Streams_Operators_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Reactive_Streams_Operators_SmallRye.adoc
@@ -1,6 +1,14 @@
 [[MicroProfile_Reactive_Streams_Operators_SmallRye]]
 = MicroProfile Reactive Streams Operators Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Support for https://microprofile.io/project/eclipse/microprofile-reactive-streams[MicroProfile Reactive Streams Operators] is
 provided as a Tech Preview feature by the _microprofile-reactive-streams-operators-smallrye_ subsystem.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Micrometer.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Micrometer.adoc
@@ -1,6 +1,14 @@
 [[Micrometer_Metrics]]
 = Micrometer Metrics Subsystem (Preview) Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [IMPORTANT]
 ====
 This subsystem is currently enabled only for WildFly Preview. It replaces the existing metrics subsystem in WildFly, and administrators should not attempt to enable both subsystems concurrently. Attempts to do so will result in a configuration that prevents the server from starting.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming.adoc
@@ -1,6 +1,14 @@
 [[Naming]]
 = Naming Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Naming subsystem provides the JNDI implementation on WildFly, and
 its configuration allows to:
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming_Global_Bindings_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming_Global_Bindings_Configuration.adoc
@@ -1,6 +1,14 @@
 [[Naming_Global_Bindings_Configuration]]
 = Global Bindings Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Naming subsystem configuration allows binding entries into the
 following global JNDI namespaces:
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming_Remote_JNDI_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Naming_Remote_JNDI_Configuration.adoc
@@ -1,6 +1,14 @@
 [[Naming_Remote_JNDI_Configuration]]
 = Remote JNDI Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Naming subsystem configuration may be used to (de)activate the
 remote JNDI interface, which allows clients to lookup entries present in
 a remote WildFly instance.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Observability_Tracing.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Observability_Tracing.adoc
@@ -1,6 +1,14 @@
 [[Observability_Tracing]]
 = OpenTelemetry Subsystem Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[required-extension-opentelemetry]]
 == Extension
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Resource_adapters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Resource_adapters.adoc
@@ -1,6 +1,14 @@
 [[Resource_adapters]]
 = Resource adapters
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Resource adapters are configured through the _resource-adapters_
 subsystem. Declaring a new resource adapter consists of two separate
 steps: You would need to deploy the .rar archive and define a resource

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Security_Authentication_Modules.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Security_Authentication_Modules.adoc
@@ -1,6 +1,14 @@
 [[Security_Authentication_Modules]]
 = Authentication Modules
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In this section we will describe each login module's options available.
 
 [[client]]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Simple_configuration_subsystems.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Simple_configuration_subsystems.adoc
@@ -1,6 +1,14 @@
 [[Simple_configuration_subsystems]]
 = Simple configuration subsystems
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The following subsystems currently have no configuration beyond its root
 element in the configuration
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Transactions.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Transactions.adoc
@@ -1,6 +1,14 @@
 [[Transactions_Subsystem]]
 = Transactions subsystem configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 *Required extension:*
 
 [source,xml,options="nowrap"]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
@@ -1,6 +1,14 @@
 [[Undertow]]
 = Undertow subsystem configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ****
 
 *Web subsystem was replaced in WildFly 8 with Undertow.*

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_AJP_listeners.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_AJP_listeners.adoc
@@ -1,6 +1,14 @@
 [[Undertow_AJP_listeners]]
 = AJP listeners
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The AJP listeners are child resources of the subsystem undertow. They
 are used with mod_jk, mod_proxy and mod_cluster of the Apache httpd
 front-end. Each listener does reference a particular socket binding:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
@@ -1,6 +1,14 @@
 [[Undertow_using_as_a_Load_Balancer]]
 = Using WildFly as a Load Balancer
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly 10 added support for using the Undertow subsystem as a load
 balancer. WildFly supports two different approaches, you can either
 define a static load balancer, and specify the back end hosts in your

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Web_services.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Web_services.adoc
@@ -1,6 +1,14 @@
 [[Web_services]]
 = Web services configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 JBossWS components are provided to the application server through the
 webservices subsystem. JBossWS components handle the processing of WS
 endpoints. The subsystem supports the configuration of published

--- a/docs/src/main/asciidoc/_client-guide/Remoting_Client_Configuration.adoc
+++ b/docs/src/main/asciidoc/_client-guide/Remoting_Client_Configuration.adoc
@@ -1,6 +1,14 @@
 [[Remoting_Client_Configuration]]
 = Remoting Client Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == <endpoint /> - Remoting Client
 
 You can use the `endpoint` element, which is in the `urn:jboss-remoting:5.0` namespace, to configure a JBoss Remoting client endpoint using the `wildfly-config.xml` file. This section describes how to configure a JBoss Remoting client using this element.

--- a/docs/src/main/asciidoc/_client-guide/Webservices_Client_Configuration.adoc
+++ b/docs/src/main/asciidoc/_client-guide/Webservices_Client_Configuration.adoc
@@ -1,5 +1,14 @@
 [[webservices-client]]
 = webservices-client
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 <webservices /> - Webservices Client
 
 The _<webservices />_ element in a `wildfly-config.xml` file can be used to specify Web Services Client configuration that will apply during link:https://docs.jboss.org/author/display/JBWS/Predefined+client+and+endpoint+configurations[assigning of configurations] when building a client. This element is from the “urn:elytron:client:1.5” namespace. Below is the example of use:

--- a/docs/src/main/asciidoc/_client-guide/XNIO_Client_Configuration.adoc
+++ b/docs/src/main/asciidoc/_client-guide/XNIO_Client_Configuration.adoc
@@ -1,6 +1,14 @@
 [[XNIO_Client_Configuration]]
 = XNIO Client Configuration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == <worker /> - XNIO Client
 
 You can use the `worker` element, which is in the `urn:xnio:3.5` namespace, to configure a default XNIO worker using the `wildfly-config.xml` file. This section describes how to do this.

--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -1,6 +1,14 @@
 [[authentication-client]]
 = <authentication-client /> - WildFly Elytron
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The _<authentication-client/>_ element can be added to the wildfly-config.xml configuration to define configuration in relation to authentication configuration for outbound connections and SSL configuration for outbound connections e.g.
 
 [source,xml,options="nowrap"]

--- a/docs/src/main/asciidoc/_client-guide/jboss-ejb-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/jboss-ejb-client.adoc
@@ -1,6 +1,14 @@
 [[jboss-ejb-client]]
 = jboss-ejb-client
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The jboss-ejb-client.xml can be used to conifure EJB client from within a deployment. The file
 should be located in jar's `META-INF` directory.
 

--- a/docs/src/main/asciidoc/_client-guide/wildfly-config-jboss-ejb-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/wildfly-config-jboss-ejb-client.adoc
@@ -1,5 +1,14 @@
 [[wildfly-config-jboss-ejb-client]]
 = jboss-ejb-client
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 <jboss-ejb-client /> - EJB Client
 
 The _<jboss-ejb-client />_ element in a wildfly-config.xml file can be used to specify EJB Client configuration. This element is from the “urn:jboss:wildfly-client-ejb:3.0” namespace, e.g.

--- a/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
@@ -1,6 +1,14 @@
 [[Application_Client_Reference]]
 = Application Client Reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 As a Jakarta EE compliant server, WildFly {wildflyVersion} contains an application
 client. An application client is essentially a cut down server instance,
 that allows you to use EE features such as injection in a client side

--- a/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
@@ -1,6 +1,13 @@
 [[Class_Loading_in_WildFly]]
 = Class Loading in WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 Since JBoss AS 7, Class loading is considerably different from previous
 versions of JBoss AS. Class loading is based on the

--- a/docs/src/main/asciidoc/_developer-guide/Deployment_Descriptors_used_In_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Deployment_Descriptors_used_In_WildFly.adoc
@@ -1,6 +1,14 @@
 [[Deployment_Descriptors_used_In_WildFly]]
 = Deployment Descriptors used In WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This page gives a list and a description of all the valid deployment
 descriptors that a WildFly deployment can use. This document is a work
 in progress.

--- a/docs/src/main/asciidoc/_developer-guide/Development_Guidelines_and_Recommended_Practices.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Development_Guidelines_and_Recommended_Practices.adoc
@@ -1,6 +1,14 @@
 [[Development_Guidelines_and_Recommended_Practices]]
 = Development Guidelines and Recommended Practices
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The purpose of this page is to document tips and techniques that will
 assist developers in creating fast, secure, and reliable applications.
 It is also a place to note what you should *avoid* doing when developing

--- a/docs/src/main/asciidoc/_developer-guide/EE_Concurrency_Utilities.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/EE_Concurrency_Utilities.adoc
@@ -1,6 +1,14 @@
 [[EE_Concurrency_Utilities]]
 = EE Concurrency Utilities
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 EE Concurrency Utilities (JSR 236) is a technology introduced with Java

--- a/docs/src/main/asciidoc/_developer-guide/Embedded_API.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Embedded_API.adoc
@@ -5,6 +5,14 @@
 :idprefix:
 :idseparator:       -
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The embedded API can be used to launch {appservername} within a currently running process.
 
 The embedded server can be reinitialized with a different JBoss Home. However the module directory, `module.path`

--- a/docs/src/main/asciidoc/_developer-guide/H2_Web_Console_Integration.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/H2_Web_Console_Integration.adoc
@@ -5,6 +5,13 @@
 :idprefix:
 :idseparator:       -
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 The H2 database library provided by WildFly's `com.h2database.h2` module includes an implementation of the Jakarta Servlet `HttpServlet` interface (`org.h2.server.web.JakartaWebServlet`) that can be used to expose the H2 project's web console tool. WildFly users could utilize this servlet in their own application by adding a dependency on the `com.h2database.h2` module to their application's deployment and then adding the servlet to the application's `web.xml`. This is certainly not recommended for production use -- no use of H2 is recommended in production applications -- but developers may find use of the H2 console useful.
 

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
@@ -6,6 +6,14 @@
 [[How_do_I_migrate_my_application_from_AS7_to_WildFly]]
 = How do I migrate my application from {PrevProductName} {PrevProductVersion}  to {ProductName} {ProductVersion}
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[about-this-document]]
 == About this Document
 

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebLogic_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebLogic_to_WildFly.adoc
@@ -1,6 +1,14 @@
 [[How_do_I_migrate_my_application_from_WebLogic_to_WildFly]]
 = How do I migrate my application from WebLogic to WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The purpose of this guide is to document the application changes that
 are needed to successfully run and deploy WebLogic applications on
 WildFly.

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebSphere_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebSphere_to_WildFly.adoc
@@ -1,6 +1,14 @@
 [[How_do_I_migrate_my_application_from_WebSphere_to_WildFly]]
 = How do I migrate my application from WebSphere to WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The purpose of this guide is to document the application changes that
 are needed to successfully run and deploy WebLogic applications on
 WildFly.

--- a/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
@@ -1,6 +1,14 @@
 [[Implicit_module_dependencies_for_deployments]]
 = Implicit module dependencies for deployments
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 As explained in the <<Class_Loading_in_WildFly,Class Loading in WildFly>> article,
 WildFly {wildflyVersion} is based on module classloading. A class within a module B
 isn't visible to a class within a module A, unless module B adds a

--- a/docs/src/main/asciidoc/_developer-guide/JNDI_Local_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JNDI_Local_Reference.adoc
@@ -1,6 +1,14 @@
 [[JNDI_Local_Reference]]
 = Local JNDI
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Jakarta EE platform specification defines the following JNDI contexts:
 
 * `java:comp` - The namespace is scoped to the current component (i.e.

--- a/docs/src/main/asciidoc/_developer-guide/JNDI_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JNDI_Reference.adoc
@@ -1,6 +1,14 @@
 [[JNDI_Reference]]
 = JNDI Reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 WildFly offers several mechanisms to retrieve components by name. Every

--- a/docs/src/main/asciidoc/_developer-guide/JNDI_Remote_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JNDI_Remote_Reference.adoc
@@ -1,6 +1,14 @@
 [[JNDI_Remote_Reference]]
 = Remote JNDI Access
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly supports two different types of remote JNDI.
 
 [[http-remoting]]

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Contexts_and_Dependency_Injection_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Contexts_and_Dependency_Injection_Reference.adoc
@@ -1,6 +1,14 @@
 [[CDI_Reference]]
 = CDI Reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly uses http://weld.cdi-spec.org/[Weld], the CDI reference
 implementation as its CDI provider. To activate CDI for a deployment
 simply add a `beans.xml` file in any archive in the deployment.

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_3_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_3_Reference_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_3_Reference_Guide]]
 = Jakarta Enterprise Beans 3 Reference Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This chapter details the extensions that are available when developing
 Enterprise Java Beans ^tm^ on WildFly {wildflyVersion}.
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_client_using_JNDI.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_client_using_JNDI.adoc
@@ -1,6 +1,14 @@
 [[EJB_invocations_from_a_remote_client_using_JNDI]]
 = EJB invocations from a remote client using JNDI
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This chapter explains how to invoke EJBs from a remote client by using
 the JNDI API to first lookup the bean proxy and then invoke on that
 proxy.

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Enterprise_Beans_invocations_from_a_remote_server_instance.adoc
@@ -1,6 +1,14 @@
 [[EJB_invocations_from_a_remote_server_instance]]
 = EJB invocations from a remote server instance
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The purpose of this chapter is to demonstrate how to lookup and invoke
 on EJBs deployed on an WildFly server instance *from another* WildFly
 server instance. This is different from invoking the EJBs

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
@@ -1,6 +1,14 @@
 [[JPA_Reference_Guide]]
 = JPA Reference Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[introduction]]
 == Introduction
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_RESTful_Web_Services_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_RESTful_Web_Services_Reference_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_RESTful_Web_Services_Reference_Guide]]
 = Jakarta RESTful Web Services Reference Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 RESTEasy is the Jakarta RESTful Web Services implementation used in {appservername}. For detailed documentation see the
 https://resteasy.dev/docs[RESTEasy {resteasyversion} documentation].
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
@@ -1,6 +1,14 @@
 [[JTA_Reference]]
 = JTA Reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly uses http://narayana.io[Narayana] as the implementation of the JTA specification.
 Narayana manages transactions in the application server.
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/ActAs_WS-Trust_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/ActAs_WS-Trust_Scenario.adoc
@@ -1,6 +1,14 @@
 [[ActAs_WS-Trust_Scenario]]
 = ActAs WS-Trust Scenario
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The ActAs feature is used in scenarios that require composite
 delegation. It is commonly used in multi-tiered systems where an
 application calls a service on behalf of a logged in user or a service

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Apache_CXF_integration.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Apache_CXF_integration.adoc
@@ -1,6 +1,14 @@
 [[Apache_CXF_integration]]
 = Apache CXF integration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[jbossws-integration-layer-with-apache-cxf]]
 == JBossWS integration layer with Apache CXF
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Authentication.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Authentication.adoc
@@ -1,6 +1,14 @@
 [[Jakarta-XML-Web-Services-Authentication]]
 = Authentication
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[Jakarta-XML-Web-Services-authentication]]
 == Authentication
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/HTTP_Proxy.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/HTTP_Proxy.adoc
@@ -1,6 +1,14 @@
 [[HTTP_Proxy]]
 = HTTP Proxy
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The HTTP Proxy related functionalities of JBoss Web Services are
 provided by the Apache CXF http transport layer.
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/OnBehalfOf_WS-Trust_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/OnBehalfOf_WS-Trust_Scenario.adoc
@@ -1,6 +1,14 @@
 [[OnBehalfOf_WS-Trust_Scenario]]
 = OnBehalfOf WS-Trust Scenario
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The OnBehalfOf feature is used in scenarios that use the proxy pattern.
 In such scenarios, the client cannot access the STS directly, instead it
 communicates through a proxy gateway. The proxy gateway authenticates

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Predefined_client_and_endpoint_configurations.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Predefined_client_and_endpoint_configurations.adoc
@@ -1,6 +1,14 @@
 [[Predefined_client_and_endpoint_configurations]]
 = Predefined client and endpoint configurations
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 JBossWS permits extra setup configuration data to be predefined and

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Published_WSDL_customization.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/Published_WSDL_customization.adoc
@@ -1,6 +1,14 @@
 [[Published_WSDL_customization]]
 = Published WSDL customization
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[endpoint-address-rewrite]]
 == Endpoint address rewrite
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SAML_Bearer_Assertion_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SAML_Bearer_Assertion_Scenario.adoc
@@ -1,6 +1,14 @@
 [[SAML_Bearer_Assertion_Scenario]]
 = SAML Bearer Assertion Scenario
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WS-Trust deals with managing software security tokens. A SAML assertion
 is a type of security token. In the SAML Bearer scenario, the service
 provider automatically trusts that the incoming SOAP request came from

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SAML_Holder-Of-Key_Assertion_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SAML_Holder-Of-Key_Assertion_Scenario.adoc
@@ -1,6 +1,14 @@
 [[SAML_Holder-Of-Key_Assertion_Scenario]]
 = SAML Holder-Of-Key Assertion Scenario
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WS-Trust deals with managing software security tokens. A SAML assertion
 is a type of security token. In the Holder-Of-Key method, the STS
 creates a SAML token containing the client's public key and signs the

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SOAP_over_Jakarta_Messaging.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/SOAP_over_Jakarta_Messaging.adoc
@@ -1,6 +1,14 @@
 [[SOAP_over_Jakarta_Messaging]]
 = SOAP over Jakarta Messaging
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 JBoss Web Services allows communication over the _Jakarta Messaging_ transport. The
 functionality comes from Apache CXF support for the
 http://www.w3.org/TR/soapjms/[SOAP over Java Message Service 1.0]

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Addressing.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Addressing.adoc
@@ -1,6 +1,14 @@
 [[WS-Addressing]]
 = WS-Addressing
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 JBoss Web Services inherits full WS-Addressing capabilities from the
 underlying Apache CXF implementation. Apache CXF provides support for
 2004-08 and http://www.w3.org/TR/ws-addr-core/[1.0] versions of

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Discovery.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Discovery.adoc
@@ -1,6 +1,14 @@
 [[WS-Discovery]]
 = WS-Discovery
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Apache CXF includes support for _Web Services Dynamic Discovery_ (
 http://docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-spec-os.html[WS-Discovery]),
 which is a protocol to enable dynamic discovery of services available on

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Policy.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Policy.adoc
@@ -1,6 +1,14 @@
 [[WS-Policy]]
 = WS-Policy
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[apache-cxf-ws-policy-support]]
 == Apache CXF WS-Policy support
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Reliable_Messaging.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Reliable_Messaging.adoc
@@ -1,6 +1,14 @@
 [[WS-Reliable_Messaging]]
 = WS-Reliable Messaging
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 JBoss Web Services inherits full WS-Reliable Messaging capabilities from
 the underlying Apache CXF implementation. At the time of writing, Apache
 CXF provides support for the

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Security.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Security.adoc
@@ -1,6 +1,13 @@
 [[WS-Security]]
 = WS-Security
+
 ifdef::env-github[:imagesdir: ../../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 [[ws-security-overview]]
 == WS-Security overview

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Trust_and_STS.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Trust_and_STS.adoc
@@ -1,6 +1,14 @@
 [[WS-Trust_and_STS]]
 = WS-Trust and STS
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[ws-trust-overview]]
 == WS-Trust overview
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Advanced_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Advanced_User_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_XML_Web_Services_Advanced_User_Guide]]
 = Jakarta XML Web Services Advanced User Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[logging]]
 == Logging
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_JBoss_Modules_and_WS_applications.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_JBoss_Modules_and_WS_applications.adoc
@@ -1,6 +1,14 @@
 [[JAX_WS_JBoss_Modules_and_WS_applications]]
 = JBoss Modules and WS applications
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The JBoss Web Services functionalities are provided by a given set of
 modules / libraries installed on WildFly, which are organized into JBoss
 Modules modules. In particular the _org.jboss.as.webservices.*_ and

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Reference_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_XML_Web_Services_Reference_guide]]
 = Webservices reference guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Web Services functionalities of WildFly are provided by the JBossWS
 project integration.
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Tools.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_Tools.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_XML_Web_Services_Tools]]
 = Jakarta XML Web Services Tools
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Jakarta XML Web Services tools provided by JBossWS can be used in a variety of ways.
 First we will look at server-side development strategies, and then
 proceed to the client.

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services_User_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_XML_Web_Services_User_Guide]]
 = Jakarta XML Web Services User Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The http://www.jcp.org/en/jsr/detail?id=224[Java API for XML-Based Web
 Services (JAX-WS / JSR-224)] defines the mapping between WSDL and Java
 as well as the classes to be used for accessing webservices and

--- a/docs/src/main/asciidoc/_developer-guide/Migrate_Order_Application_from_EAP5.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Migrate_Order_Application_from_EAP5.adoc
@@ -1,6 +1,14 @@
 [[Migrate_Order_Application_from_EAP5]]
 = Porting the Order Application from EAP 5.1 to JBoss AS 7
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Andy Miller ported an example Order application that was used for
 performance testing from EAP 5.1 to JBoss AS 7. These are the notes he
 made during the migration process.

--- a/docs/src/main/asciidoc/_developer-guide/Migrated_to_WildFly_Example_Applications.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Migrated_to_WildFly_Example_Applications.adoc
@@ -1,6 +1,14 @@
 [[Migrated_to_WildFly_Example_Applications]]
 = Example Applications - Migrated to WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[example-applications-migrated-from-previous-releases]]
 == Example Applications Migrated from Previous Releases
 

--- a/docs/src/main/asciidoc/_developer-guide/Remote_Jakarta_Enterprise_Beans_invocations_via_JNDI_-_Jakarta_Enterprise_Beans_client_API_or_wildfly-naming-client_project.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Remote_Jakarta_Enterprise_Beans_invocations_via_JNDI_-_Jakarta_Enterprise_Beans_client_API_or_wildfly-naming-client_project.adoc
@@ -1,6 +1,14 @@
 [[Remote_Jakarta_Enterprise_Beans_invocations_via_JNDI_-_Jakarta_Enterprise_Beans_client_API_or_wildfly-naming-client_project]]
 = Remote Jakarta Enterprise Beans invocations via JNDI - Jakarta Enterprise Beans client API or wildfly-naming-client project
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[purpose]]
 == Purpose
 

--- a/docs/src/main/asciidoc/_developer-guide/Scoped_Jakarta_Enterprise_Beans_client_contexts.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Scoped_Jakarta_Enterprise_Beans_client_contexts.adoc
@@ -1,6 +1,14 @@
 [[Scoped_EJB_client_contexts]]
 = Scoped EJB client contexts
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 WildFly {wildflyVersion} introduced the EJB client API for managing remote EJB

--- a/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
@@ -1,6 +1,14 @@
 [[Spring_applications_development_and_migration_guide]]
 = Spring applications development and migration guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This document details the main points that need to be considered by
 Spring developers that wish to develop new applications or to migrate
 existing applications to be run into WildFly {wildflyVersion}.

--- a/docs/src/main/asciidoc/_developer-guide/Web_(Undertow)_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Web_(Undertow)_Reference_Guide.adoc
@@ -1,6 +1,14 @@
 [[Web_Undertow_Reference_Guide]]
 = Sharing sessions between wars in an ear
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Undertow allows you to share sessions between wars in an ear, if it is
 explicitly configured to do so. Note that if you use this feature your
 applications may not be portable, as this is not a standard servlet

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Container_interceptors.adoc
@@ -1,6 +1,14 @@
 [[Container_interceptors]]
 = Container interceptors
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 JBoss AS versions prior to WildFly8 allowed a JBoss specific way to

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Client_Interceptors.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Client_Interceptors.adoc
@@ -1,5 +1,13 @@
 = Jakarta Enterprise Beans Client Interceptors
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Implementing Client Interceptors
 
 The Jakarta Enterprise Beans client supports the notion of client side interceptors. These are interceptors

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Database_Persistent_Timers.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Database_Persistent_Timers.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_Database_Persistent_Timers]]
 = Jakarta Enterprise Beans 3 Database Persistent Timers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 WildFly now supports persistent timers backed by a shared database. High-availability

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_Deployment_Runtime_Resources]]
 = Jakarta Enterprise Beans Deployment Runtime Resources
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Enterprise bean deployment exposes certain management runtime resources to help users inspect enterprise bean metadata
 and monitor invocation statistics. Bean metadata is configured in the application via deployment descriptor and
 annotations. Stateless, stateful, singleton session beans and message-driven beans support a common set of resources,

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Distributed_Timers.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Distributed_Timers.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_Distributed_Timers]]
 = Jakarta Enterprise Beans Distributed Timers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 WildFly now supports distributed timers backed by an embedded Infinispan cache.

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_IIOP_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_IIOP_Guide.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_IIOP_Guide]]
 = Jakarta Enterprise Beans IIOP Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[enabling-iiop]]
 == Enabling IIOP
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_on_Kubernetes.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_on_Kubernetes.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_on_Kubernetes]]
 = Jakarta Enterprise Beans on Kubernetes
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 If the WildFly server is deployed on Kubernetes then there are several
 points that you need to bear in mind when you use EJBs.
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_over_HTTP.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_over_HTTP.adoc
@@ -1,6 +1,14 @@
 [[Jakarta_Enterprise_Beans_over_HTTP]]
 = Jakarta Enterprise Beans over HTTP
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Beginning with WildFly 11 it is now possible to use HTTP as the
 transport (instead of remoting) for remote Jakarta Enterprise Beans and JNDI invocations.
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Message_Driven_Beans_Controlled_Delivery.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Message_Driven_Beans_Controlled_Delivery.adoc
@@ -1,6 +1,14 @@
 [[Message_Driven_Beans_Controlled_Delivery]]
 = Message Driven Beans Controlled Delivery
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 There are three mechanisms in WildFly that allow controlling if a
 specific MDB is actively receiving or not messages:
 

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Securing_Jakarta_Enterprise_Beans.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Securing_Jakarta_Enterprise_Beans.adoc
@@ -1,6 +1,14 @@
 [[Securing_Jakarta_Enterprise_Beans]]
 = Securing Jakarta Enterprise Beans
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Jakarta EE spec specifies certain annotations (like @RolesAllowed,
 @PermitAll, @DenyAll) which can be used on Jakarta Enterprise Beans implementation classes
 and/or the business method implementations of the beans. Like with all

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/jboss-ejb3.xml_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/jboss-ejb3.xml_Reference.adoc
@@ -1,6 +1,14 @@
 [[jboss-ejb3]]
 = jboss-ejb3.xml Reference
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 `jboss-ejb3.xml` is a custom deployment descriptor that can be placed in
 either ejb-jar or war archives. If it is placed in an ejb-jar then it
 must be placed in the `META-INF` folder, in a web archive it must be

--- a/docs/src/main/asciidoc/_developer-guide/wsconsume.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/wsconsume.adoc
@@ -1,6 +1,14 @@
 [[wsconsume]]
 = wsconsume
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 _wsconsume_ is a command line tool and ant task that "consumes" the
 abstract contract (WSDL file) and produces portable Jakarta XML Web Services and
 client artifacts.

--- a/docs/src/main/asciidoc/_developer-guide/wsprovide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/wsprovide.adoc
@@ -1,6 +1,14 @@
 [[wsprovide]]
 = wsprovide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 _wsprovide_ is a command line tool, Maven plugin and Ant task that
 generates portable Jakarta XML Web Services artifacts for a service endpoint
 implementation. It also has the option to "provide" the abstract

--- a/docs/src/main/asciidoc/_elytron/Audit.adoc
+++ b/docs/src/main/asciidoc/_elytron/Audit.adoc
@@ -1,6 +1,14 @@
 [[Audit]]
 = Audit
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron supports audit using security event listeners - components
 which captures security events, like successful or unsuccessful login attempts.
 

--- a/docs/src/main/asciidoc/_elytron/Bearer_Token_Authorization.adoc
+++ b/docs/src/main/asciidoc/_elytron/Bearer_Token_Authorization.adoc
@@ -1,6 +1,14 @@
 [[Bearer_Token_Authorization]]
 = Bearer Token Authorization
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Bearer Token Authorization is the process of authorizing HTTP requests based on the existence and validity of a bearer
 token representing a subject and his access context, where the token provides valuable information to determine the subject of the call as well whether or not a HTTP resource
 can be accessed.

--- a/docs/src/main/asciidoc/_elytron/Client_Authentication_with_Elytron_Client.adoc
+++ b/docs/src/main/asciidoc/_elytron/Client_Authentication_with_Elytron_Client.adoc
@@ -1,6 +1,14 @@
 [[Client_Authentication_with_Elytron_Client]]
 = Client Authentication with Elytron Client
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron uses the Elytron Client project to enable remote clients
 to authenticate using Elytron. Elytron Client has the following
 components:

--- a/docs/src/main/asciidoc/_elytron/Configuring_other_clients_using_wildfly-config.adoc
+++ b/docs/src/main/asciidoc/_elytron/Configuring_other_clients_using_wildfly-config.adoc
@@ -1,6 +1,14 @@
 [[Configuring_other_clients_using_wildfly-config]]
 = Client configuration using wildfly-config.xml
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Prior to WildFly 11, many WildFly client libraries used different configuration strategies. WildFly 11 introduces a new `wildfly-config.xml` file which unifies all client configuration in a single place. In addition to being able to configure authentication using Elytron as described in the previous section, a `wildfly-config.xml` file can also be used to:
 
 == Configure Jakarta Enterprise Beans client connections, global interceptors, and invocation timeout

--- a/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
+++ b/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
@@ -1,6 +1,14 @@
 [[CredentialStore]]
 = Credential Store
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 One new component included with WildFly Elytron for the secure storage of credentials is the Credential Store.  Previous versions of the application server made use of the Vault which was used for the secure storage of clear text strings; the credential store moves forward a step to focus on the secure storage of credentials.  As with the Vault the stored credentials could be clear text passwords however other formats are also supported.
 
 WildFly Elytron contains two default credential store implementations.  The first implementation is the `KeyStoreCredentialStore` which is an

--- a/docs/src/main/asciidoc/_elytron/Custom_Components.adoc
+++ b/docs/src/main/asciidoc/_elytron/Custom_Components.adoc
@@ -1,6 +1,14 @@
 [[Custom_Components]]
 = Custom Components
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron subsystem allows adding custom implementation of different
 components in form of WildFly modules into the WildFly instance and use them
 by the same way as built-in Elytron subsystem components.

--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[Elytron_Subsystem]]
 = Elytron Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron is a security framework used to unify security across
 the entire application server. The _elytron_ subsystem enables a single
 point of configuration for securing both applications and the management

--- a/docs/src/main/asciidoc/_elytron/Elytron_WildFly_Java_Security_Manager.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_WildFly_Java_Security_Manager.adoc
@@ -1,6 +1,14 @@
 [[Elytron_Java_Security_Manager]]
 = Elytron WildFly Java Security Manager
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Overview
 
 === General introduction

--- a/docs/src/main/asciidoc/_elytron/Elytron_and_Jakarta_Authorization.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_and_Jakarta_Authorization.adoc
@@ -1,6 +1,14 @@
 [[Elytron_and_Java_Authorization_Contract_for_Containers-JACC]]
 = Elytron and Java Authorization Contract for Containers (JACC)
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 This document will guide you on how to enable JACC using Elytron

--- a/docs/src/main/asciidoc/_elytron/Elytron_and_Java_Authentication_SPI_for_Containers-JASPI.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_and_Java_Authentication_SPI_for_Containers-JASPI.adoc
@@ -1,6 +1,14 @@
 [[Elytron_and_Java_Authentication_SPI_for_Containers-JASPI]]
 = Elytron and Java Authentication SPI for Containers (JASPI)
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 Starting from WildFly 15 an implementation of the Servlet profile from the Java Authentication SPI for Containers (JSR-196 / JASPI) is also provided by the WildFly Elytron subsystem allowing tighter integration with the security features provided by WildFly Elytron.  This JASPI implementation is available out of the box with minimal steps required to use it for deployments, this section of the documentation describes how to make use of it and the features it provides.

--- a/docs/src/main/asciidoc/_elytron/Elytron_and_Java_EE_Security.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_and_Java_EE_Security.adoc
@@ -1,6 +1,14 @@
 [[Elytron_and_Java_EE_Security]]
 = Elytron and Jakarta EE Security
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 Starting from WildFly 15 an implementation of the Servlet Profile from Java Authentication SPI for Containers (JSR-196 / JASPI) specification has been included in the application server, in addition to making JASPI available for deployments using WildFly Elytron it also makes it possible to make use of EE Security with WildFly Elytron.

--- a/docs/src/main/asciidoc/_elytron/Encrypted_Expressions.adoc
+++ b/docs/src/main/asciidoc/_elytron/Encrypted_Expressions.adoc
@@ -1,6 +1,14 @@
 [[EncryptedExpressions]]
 = Encrypted Expressions
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron provides support for handling encrypted expressions in the management model using a `SecretKey` from a `CredentialStore` to decrypt the expression at runtime.
 
 For information regarding how to create, configure, and populate credential stores including the manipulation of secret keys please refer to the <<CredentialStore, Credential Store>> chapter.

--- a/docs/src/main/asciidoc/_elytron/General_Elytron_Architecture.adoc
+++ b/docs/src/main/asciidoc/_elytron/General_Elytron_Architecture.adoc
@@ -1,6 +1,14 @@
 [[General_Elytron_Architecture]]
 = General Elytron Architecture
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The overall architecture for WildFly Elytron is building up a full
 security policy from assembling smaller components together, by default
 we include various implementations of the components - in addition to

--- a/docs/src/main/asciidoc/_elytron/Keycloak_Integration.adoc
+++ b/docs/src/main/asciidoc/_elytron/Keycloak_Integration.adoc
@@ -1,4 +1,12 @@
 [[Keycloak_Integration]]
 = Using Keycloak with WildFly Elytron
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The ability to secure applications using link:https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect] is provided by the _elytron-oidc-client_ subsystem. For details about securing applications deployed on WildFly with OpenID Connect, by using Keycloak as the OpenID provider, see the link:Admin_Guide{outfilesuffix}#Elytron_OIDC_Client[Elytron OIDC Client] documentation.

--- a/docs/src/main/asciidoc/_elytron/Migrate_Legacy_Security_to_Elytron_Security.adoc
+++ b/docs/src/main/asciidoc/_elytron/Migrate_Legacy_Security_to_Elytron_Security.adoc
@@ -1,6 +1,14 @@
 [[Migrate_Legacy_Security_to_Elytron_Security]]
 = Migrate Legacy Security to Elytron Security
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Authentication Configuration
 
 :leveloffset: +1

--- a/docs/src/main/asciidoc/_elytron/OpenSSL.adoc
+++ b/docs/src/main/asciidoc/_elytron/OpenSSL.adoc
@@ -1,6 +1,14 @@
 [[OpenSSL]]
 = OpenSSL
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[configuring-WildFly-to-use-the-OpenSSL-TLS-provider]]
 == Configuring WildFly to use the OpenSSL TLS provider
 

--- a/docs/src/main/asciidoc/_elytron/Passwords.adoc
+++ b/docs/src/main/asciidoc/_elytron/Passwords.adoc
@@ -1,6 +1,14 @@
 [[Passwords]]
 = Passwords
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 One of the core features of WildFly Elytron is the ability to work with many different formats for representing passwords, WildFly Elytron also contains APIs that can be used to convert from clear text passwords to these representations that can be stored in the underlying identity stores.
 
 This section will document how these APIs can be used to work with the different password types.

--- a/docs/src/main/asciidoc/_elytron/Subsystem_Component_Documentation.adoc
+++ b/docs/src/main/asciidoc/_elytron/Subsystem_Component_Documentation.adoc
@@ -1,6 +1,14 @@
 
 = Component Documentation
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Security Realms
 
 The primary responsibility of a security realm is the ability to load identities with associated attributes, these identities are then used within the authentication process for credential validation and subsequently wrapped to represent the `SecurityIdentity` instances using within applications for authorization.

--- a/docs/src/main/asciidoc/_elytron/Using_WildFly_Elytron_with_WildFly.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_WildFly_Elytron_with_WildFly.adoc
@@ -1,6 +1,14 @@
 [[Using_WildFly_Elytron_with_WildFly]]
 = Using Elytron within WildFly
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[using-the-out-of-the-box-elytron-components]]
 == Using the Out of the Box Elytron Components
 

--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[Using_the_Elytron_Subsystem]]
 = Using the Elytron Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[set-up-and-configure-authentication-for-applications]]
 == Set Up and Configure Authentication for Applications
 

--- a/docs/src/main/asciidoc/_elytron/Web_Single_Sign_On.adoc
+++ b/docs/src/main/asciidoc/_elytron/Web_Single_Sign_On.adoc
@@ -1,6 +1,14 @@
 [[Web_Single_Sign_On]]
 = Web Single Sign-On
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This document will guide on how to enable single sign-on across different applications deployed into different servers, where these applications belong to same security domain.
 
 == Create a Server Configuration Template

--- a/docs/src/main/asciidoc/_elytron/components/Aggregate_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Aggregate_Security_Realm.adoc
@@ -1,6 +1,14 @@
 [[aggregate-security-realm]]
 = Aggregate Security Realm
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The aggregate security realm allows for two or more security realms to be aggregated into a single security realm allowing one to be used during the authentication steps and one or more to be used to assemble the identity used for authorization decisions and aggregating any associated attributes.
 
 The `aggregate-realm` resource contains the following attributes: -

--- a/docs/src/main/asciidoc/_elytron/components/Failover_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Failover_Security_Realm.adoc
@@ -1,6 +1,14 @@
 [[failover-security-realm]]
 = Failover Security Realm
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The failover security realm allows for a realm to fail-over to another realm in case the first is unavailable.
 
 The `failover-realm` resource contains the following attributes: -

--- a/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
@@ -1,6 +1,14 @@
 [[filesystem-security-realm]]
 = Filesystem Security Realm
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The filesystem security realm is a security realm developed to support storing of identities in a filesystem with the option of associating multiple credentials and multiple attributes with each identity. Both credentials and attributes can contain multiple values.
 
 == Create and Populate Filesystem Security Realm

--- a/docs/src/main/asciidoc/_elytron/components/JAAS_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/JAAS_Security_Realm.adoc
@@ -1,6 +1,14 @@
 [[jaas-security-realm]]
 = JAAS Security Realm
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 A JAAS realm utilizes a https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/security/auth/login/LoginContext.html[LoginContext] initialized from a https://docs.oracle.com/en/java/javase/17/security/appendix-b-jaas-login-configuration-file.html[JAAS configuration file] to authenticate and authorize users with custom https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/security/auth/spi/LoginModule.html[Login Modules]. Flags and options can be specified in a https://docs.oracle.com/en/java/javase/17/security/appendix-b-jaas-login-configuration-file.html[JAAS configuration file] according to the https://docs.oracle.com/en/java/javase/17/security/appendix-b-jaas-login-configuration-file.html[Java documentation].
 
 The `jaas-realm` resource contains the following attributes: -

--- a/docs/src/main/asciidoc/_elytron/components/JDBC_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/JDBC_Security_Realm.adoc
@@ -1,6 +1,14 @@
 [[jdbc-security-realm]]
 = JDBC Security Realm
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The JDBC security realm is a security realm developed to support loading identities from a database with the option of multiple credentials and multiple attributes each with the option of containing multiple values.
 
 When defining the JDBC security realm one or more principal queries can be defined, each of these can load a credential and / or attributes for the resulting identity.  Each defined principal query is associated with it's own datasource, this means quite a complex configuration can be created loading the different aspects of an identity from multiple locations.

--- a/docs/src/main/asciidoc/_elytron/migrate/Application_Client_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Application_Client_Migration.adoc
@@ -1,6 +1,14 @@
 [[Application_Client_Migration]]
 = Application Client Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[naming-client]]
 == Naming Client
 

--- a/docs/src/main/asciidoc/_elytron/migrate/Caching_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Caching_Migration.adoc
@@ -1,6 +1,14 @@
 [[Caching_Migration]]
 = Caching Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Where a PicketBox based security domain is defined it is possible to enable caching for that security domain, this enables subsequent hits to the identity store to be avoided as an in memory cache can be used instead, this example demonstrates how caching can be used with a WildFly Elytron based configuration.
 
 The purpose of this chapter is to highlight the migration of a configuration with caching enabled, this example is based in the previous LDAP example but with caching enabled.

--- a/docs/src/main/asciidoc/_elytron/migrate/Composite_Stores_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Composite_Stores_Migration.adoc
@@ -1,6 +1,14 @@
 [[Composite_Stores_Migration]]
 = Composite Stores Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 When using either PicketBox or the legacy security realms it is possible to define a configuration where authentication is performed against one identity store whilst the information used for authorization is loaded from a different store, when using WildFly Elytron this can be achieved by using an aggregate security realm.
 
 The example here makes use of a properties file for authentication and then searches LDAP to load group / role information. Both of these are based on the previous examples within this document so the environmental information is not repeated here.

--- a/docs/src/main/asciidoc/_elytron/migrate/Database_Authentication_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Database_Authentication_Migration.adoc
@@ -1,6 +1,14 @@
 [[Database_Authentication_Migration]]
 = Database Authentication
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The section describing how to migrate from database accessible via JDBC
 datasource based authentication using PicketBox to Elytron. This section
 will illustrate some equivalent configuration using PicketBox security

--- a/docs/src/main/asciidoc/_elytron/migrate/Kerberos_Based_Authentication_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Kerberos_Based_Authentication_Migration.adoc
@@ -1,6 +1,14 @@
 [[Kerberos_Based_Authentication_Migration]]
 = Kerberos Authentication Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 When working with Kerberos configuration it is possible for the
 application server to rely on configuration from the environment or the
 key configuration can be specified using system properties, for the

--- a/docs/src/main/asciidoc/_elytron/migrate/LDAP_Based_Authentication_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/LDAP_Based_Authentication_Migration.adoc
@@ -1,6 +1,14 @@
 [[LDAP_Based_Authentication_Migration]]
 = LDAP Authentication Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The section describing how to migrate from properties based
 authentication using either PicketBox or legacy security realms to
 Elytron also contained a lot of additional information regarding

--- a/docs/src/main/asciidoc/_elytron/migrate/Properties_File_Based_Authentication_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Properties_File_Based_Authentication_Migration.adoc
@@ -1,6 +1,14 @@
 [[Properties_File_Based_Authentication_Migration]]
 = Properties Based Authentication / Authorization
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[picketbox-based-configuration]]
 == PicketBox Based Configuration
 

--- a/docs/src/main/asciidoc/_elytron/migrate/SSL_with_Client_Cert_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/SSL_with_Client_Cert_Migration.adoc
@@ -1,5 +1,14 @@
 [[SSL_with_Client_Cert_Migration]]
 = SSL with Client Cert Migration
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 As this documentation is primarily intended for users migrating to WildFly Elytron I am going to jump straight into the configuration required with WildFly Elytron.
 
 This section will cover how to create the various resources required to achieve CLIENT_CERT authentication with fallback to username / password authentication for both HTTP and SASL (i.e. Remoting) - both are being covered at the same time as predominantly they require the same core configuration, it is not until the definition of the authentication factories that the configuration becomes really specific.

--- a/docs/src/main/asciidoc/_elytron/migrate/Security_Property_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Security_Property_Migration.adoc
@@ -1,6 +1,14 @@
 [[Security_Property_Migration]]
 = Security Properties
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Lets suppose security properties "a" and "c" defined in legacy security:
 
 [source,xml,options="nowrap"]

--- a/docs/src/main/asciidoc/_elytron/migrate/Security_Vault_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Security_Vault_Migration.adoc
@@ -1,6 +1,14 @@
 [[Security_Vault_Migration]]
 = Security Vault Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Security Vault is primarily used in legacy configurations, a vault is
 used to store sensitive strings outside of the configuration files.
 WildFly server may only contain a single security vault.

--- a/docs/src/main/asciidoc/_elytron/migrate/Simple_SSL_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Simple_SSL_Migration.adoc
@@ -1,6 +1,14 @@
 [[Simple_SSL_Migration]]
 = Simple SSL Migration
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[simple-ssl-migration]]
 == Simple SSL Migration
 

--- a/docs/src/main/asciidoc/_extending-wildfly/CLI_extensibility_for_layered_products.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/CLI_extensibility_for_layered_products.adoc
@@ -1,6 +1,14 @@
 [[CLI_extensibility_for_layered_products]]
 = CLI extensibility for layered products
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In addition to supporting the ServiceLoader extension mechanism to load
 command handlers coming from outside of the CLI codebase, starting from
 the wildfly-core-1.0.0.Beta1 release the CLI running in a modular

--- a/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Domain_Mode_Subsystem_Transformers.adoc
@@ -1,6 +1,14 @@
 [[Domain_Mode_Subsystem_Transformers]]
 = Domain Mode Subsystem Transformers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 A WildFly domain may consist of a new Domain Controller (DC) controlling

--- a/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
@@ -1,6 +1,14 @@
 [[Example_subsystem]]
 = Example subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Our example subsystem will keep track of all deployments of certain
 types containing a special marker file, and expose operations to see how
 long these deployments have been deployed.

--- a/docs/src/main/asciidoc/_extending-wildfly/Key_Interfaces_and_Classes_Relevant_to_Extension_Developers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Key_Interfaces_and_Classes_Relevant_to_Extension_Developers.adoc
@@ -1,6 +1,14 @@
 [[Key_Interfaces_and_Classes_Relevant_to_Extension_Developers]]
 = Key Interfaces and Classes Relevant to Extension Developers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In the first major section of this guide, we provided an example of how
 to implement an extension to the AS. The emphasis there was learning by
 doing. In this section, we'll focus a bit more on the major WildFly

--- a/docs/src/main/asciidoc/_extending-wildfly/WildFly_JNDI_Implementation.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/WildFly_JNDI_Implementation.adoc
@@ -1,6 +1,14 @@
 [[WildFly_JNDI_Implementation]]
 = WildFly JNDI Implementation
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[introduction]]
 == Introduction
 

--- a/docs/src/main/asciidoc/_extending-wildfly/Working_with_WildFly_Capabilities.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Working_with_WildFly_Capabilities.adoc
@@ -1,6 +1,14 @@
 [[Working_with_WildFly_Capabilities]]
 = Working with WildFly Capabilities
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 An extension to WildFly will likely want to make use of services
 provided by the WildFly kernel, may want to make use of services
 provided by other subsystems, and may wish to make functionality

--- a/docs/src/main/asciidoc/_extras/Developing_Jakarta_Server_Faces_Project_Using_Maven_and_IntelliJ.adoc
+++ b/docs/src/main/asciidoc/_extras/Developing_Jakarta_Server_Faces_Project_Using_Maven_and_IntelliJ.adoc
@@ -1,6 +1,13 @@
 [[Developing_Jakarta_Server_Faces_Project_Using,_Maven_and_IntelliJ]]
 = Developing Jakarta Server Faces Project Using JBoss AS7, Maven and IntelliJ
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 JBoss AS7 is a very 'modern' application server that has very fast
 startup speed. So it's an excellent container to test your Jakarta Server Faces project.

--- a/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
+++ b/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
@@ -1,6 +1,14 @@
 [[Getting_Started_Developing_Applications_Presentation_Demo]]
 = Getting Started Developing Applications Presentation & Demo
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This document is a "script" for use with the quickstarts associated with
 the link:Getting_Started_Developing_Applications_Guide.html[Getting
 Started Developing Applications Guide]. It can be used as the basis for

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -1,6 +1,14 @@
 [[wildfly_layers]]
 === WildFly Layers
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 A Galleon layer is a name that identifies a server capability (e.g.: jaxrs, 
 ejb, microprofile-config, jpa) or an aggregation of such capabilities. A layer captures a server capability in the form of:
 

--- a/docs/src/main/asciidoc/_galleon/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_provisioning.adoc
@@ -1,6 +1,14 @@
 [[Galleon_Provisioning]]
 = Provisioning WildFly with Galleon
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 As opposed to a using traditional WildFly zip installation that installs it all (all default
 server configurations and all JBoss modules), using https://github.com/wildfly/galleon[Galleon] tooling
 you can choose to install a complete or customized WildFly server.

--- a/docs/src/main/asciidoc/_hacking/contributing.adoc
+++ b/docs/src/main/asciidoc/_hacking/contributing.adoc
@@ -1,5 +1,14 @@
 [[Contributing]]
 = Development environment
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 * Latest Maven build tool https://maven.apache.org/
 * OpenJDK 11 (eleven!) You can use any distribution in example Eclipse https://adoptium.net/
 * Eclipse https://www.eclipse.org/downloads/packages/[Eclipse Download] or any other IDE allowing correct source formatting (IntelliJ)

--- a/docs/src/main/asciidoc/_hacking/github_setup.adoc
+++ b/docs/src/main/asciidoc/_hacking/github_setup.adoc
@@ -1,6 +1,14 @@
 [[Target_Audience]]
 = Target Audience
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This document is a guide to the setup of Github, preparing and developing changes and contributing
 to WildFly.
 

--- a/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
+++ b/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
@@ -1,6 +1,14 @@
 [[WildFly_PR_Standard]]
 = WildFly Pull Request Standards and Guidelines
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 == Describe the pull request adequately
 The PR title should include a JIRA number directly from the project in question, whose corresponding JIRA issue will in turn have been linked to the pull request you are just now creating. The description should include a link to the JIRA. The description should also include a decent, human-readable summary of what is changing. Proper spelling and grammar is a plus!
 

--- a/docs/src/main/asciidoc/_high-availability/Advanced_Topics.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Advanced_Topics.adoc
@@ -1,5 +1,13 @@
 = Advanced Topics
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This section aims to describe cross-cutting topics, such as marshalling.
 
 include::advanced-topics/Marshalling.adoc[leveloffset=+1]

--- a/docs/src/main/asciidoc/_high-availability/Clustering_API.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_API.adoc
@@ -1,6 +1,14 @@
 [[Clustering_API]]
 = Clustering API
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly exposes a public API to deployments for performing common clustering operations, such as:
 
 * <<group,Cluster membership introspection>>

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -1,6 +1,13 @@
 [[Clustering_and_Domain_Setup_Walkthrough]]
 = Clustering and Domain Setup Walkthrough
+
 ifdef::env-github[:imagesdir: ../images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
 
 In this article, I'd like to show you how to setup WildFly in domain
 mode and enable clustering so we could get HA and session replication

--- a/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Distributable_Jakarta_Enterprise_Beans_Applications.adoc
@@ -1,6 +1,14 @@
 [[Distributable_Jakarta_Enterprise_Beans_Applications]]
 = Distributable Jakarta Enterprise Beans Applications
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Just as with standard web applications, session state of stateful session beans (SFSB) contained in a standard EJB application
 is not guaranteed to survive beyond the lifespan of the Jakarta Enterprise Beans container. And, as with standard web applications, there *is* a way to
 allow session state of SFSBs to survive beyond the lifespan of a single server, either through persistence or by replicating state to

--- a/docs/src/main/asciidoc/_high-availability/Distributable_Web_Applications.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Distributable_Web_Applications.adoc
@@ -1,6 +1,14 @@
 [[Distributable_Web_Applications]]
 = Distributable Web Applications
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In a standard web application, session state does not survive beyond the lifespan of the servlet container.
 A distributable web application allows session state to survive beyond the lifespan of a single server, either via persistence or by replicating state to other nodes in the cluster.
 A web application indicates its intention to be distributable via the `<distributable/>` element within the web application's deployment descriptor.

--- a/docs/src/main/asciidoc/_high-availability/HA_Singleton_Features.adoc
+++ b/docs/src/main/asciidoc/_high-availability/HA_Singleton_Features.adoc
@@ -1,6 +1,14 @@
 [[HA_Singleton_Features]]
 = HA Singleton Features
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In general, an HA or clustered singleton is a service that exists on
 multiple nodes in a cluster, but is active on just a single node at any
 given time. If the node providing the service fails or is shut down, a

--- a/docs/src/main/asciidoc/_high-availability/Infinispan.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Infinispan.adoc
@@ -1,5 +1,13 @@
 = Infinispan
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 include::infinispan/Infinispan_Subsystem.adoc[leveloffset=+1]
 
 // TODO Infinispan modules

--- a/docs/src/main/asciidoc/_high-availability/Introduction_To_High_Availability_Services.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Introduction_To_High_Availability_Services.adoc
@@ -1,6 +1,14 @@
 [[Introduction_To_High_Availability_Services]]
 = Introduction To High Availability Services
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[what-are-high-availability-services]]
 == What are High Availability services?
 

--- a/docs/src/main/asciidoc/_high-availability/JGroups.adoc
+++ b/docs/src/main/asciidoc/_high-availability/JGroups.adoc
@@ -1,5 +1,13 @@
 = JGroups
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 include::jgroups/JGroups_Subsystem.adoc[leveloffset=+1]
 
 == Member Discovery

--- a/docs/src/main/asciidoc/_high-availability/Load_Balancing.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Load_Balancing.adoc
@@ -1,5 +1,13 @@
 = Load Balancing
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 include::load-balancing/mod_cluster_Subsystem.adoc[leveloffset=+1]
 
 include::load-balancing/Ranked_Affinity.adoc[leveloffset=+1]

--- a/docs/src/main/asciidoc/_high-availability/Messaging.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Messaging.adoc
@@ -1,3 +1,11 @@
 = Messaging
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 This section is under development intending to describe high availability features and configuration pertaining to Jakarta Messaging (JMS).

--- a/docs/src/main/asciidoc/_high-availability/advanced-topics/Marshalling.adoc
+++ b/docs/src/main/asciidoc/_high-availability/advanced-topics/Marshalling.adoc
@@ -1,6 +1,14 @@
 [[marshalling]]
 = Marshalling
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 In general, the most effective way to improve the scalability of a system with persistent or distributed state is to reduce the number of bytes needed to be sent over the network or persisted to storage.
 Marshalling is the process by which Java objects in heap space are converted to a byte buffer for replication to other JVMs or for persistence to local or shared storage.
 

--- a/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_MSC_services.adoc
+++ b/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_MSC_services.adoc
@@ -1,6 +1,14 @@
 [[Singleton_MSC_services]]
 = Singleton MSC services
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The singleton service facility exposes a mechanism for installing an MSC service such that the service only starts on a single member of a cluster at a time.
 If the member providing the singleton service is shutdown or crashes, the facility automatically elects a new primary provider and starts the service on that node.
 In general, a singleton election happens in response to any change of membership, where the membership is defined as the set of cluster nodes on which the given service was installed.

--- a/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_deployments.adoc
+++ b/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_deployments.adoc
@@ -1,6 +1,14 @@
 [[Singleton_deployments]]
 = Singleton deployments
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly 10 resurrected the ability to start a given deployment on a
 single node in the cluster at any given time. If that node shuts down,
 or fails, the application will automatically start on another node on

--- a/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/ha-singleton-features/Singleton_subsystem.adoc
@@ -1,6 +1,14 @@
 [[Singleton_subsystem]]
 = Singleton subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly 10 introduced a "singleton" subsystem, which defines a set of
 policies that define how an HA singleton should behave. A singleton
 policy can be used to instrument singleton deployments or to create

--- a/docs/src/main/asciidoc/_high-availability/index.adoc
+++ b/docs/src/main/asciidoc/_high-availability/index.adoc
@@ -12,6 +12,14 @@ WildFly clustering team;
 :wildflyVersion: 27
 :leveloffset: +1
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 ifndef::ebook-format[:leveloffset: 1]
 
 (C) 2017–2022 The original authors.

--- a/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[Infinispan_Subsystem]]
 = Infinispan Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The Infinispan subsystem configures a set of Infinispan cache containers and cache configurations for use by WildFly clustering services.
 
 == Cache container

--- a/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
@@ -1,5 +1,13 @@
 === Discovery for AWS EC2
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The `org.jgroups.protocols.aws.S3_PING` is a discovery protocol for AWS EC2.
 
 For provisioning using Galleon, use the `jgroups-aws` layer.

--- a/docs/src/main/asciidoc/_high-availability/jgroups/JGroups_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/JGroups_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[JGroups_Subsystem]]
 = JGroups Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[jgroups-purpose]]
 == Purpose
 

--- a/docs/src/main/asciidoc/_high-availability/jgroups/Kubernetes.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/Kubernetes.adoc
@@ -1,5 +1,13 @@
 === Discovery for Kubernetes
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 `KUBE_PING` is a discovery protocol for JGroups cluster nodes managed by Kubernetes.
 Since Kubernetes is in charge of launching nodes, it knows the addresses of all pods it started,
 and is therefore an ideal place to ask for cluster discovery.

--- a/docs/src/main/asciidoc/_high-availability/load-balancing/Affinity_Cookie.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/Affinity_Cookie.adoc
@@ -1,6 +1,14 @@
 [[load-balancer-affinity-cookie]]
 = Support for load-balancers relying on affinity cookie
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 While the Apache family of load-balancers relies on attaching session affinity (routing) information by default to a `JSESSIONID` cookie or a `jsessionid` path parameter,
 there are other load-balancers that rely on a cookie to drive session affinity.
 

--- a/docs/src/main/asciidoc/_high-availability/load-balancing/Ranked_Affinity.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/Ranked_Affinity.adoc
@@ -1,6 +1,14 @@
 [[ranked-affinity-load-balancer]]
 = Enabling ranked affinity support in load balancer
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Enabling ranked affinity support in the <<distributable-web-subsystem,server>> must be accompanied by a compatible load balancer with ranked affinity support enabled.
 When using WildFly as a load balancer ranked routing can be enabled with the following CLI command:
 

--- a/docs/src/main/asciidoc/_high-availability/load-balancing/SSL_Configuration_using_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/SSL_Configuration_using_Elytron_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[SSL_Configuration_using_Elytron_Subsystem]]
 = SSL Configuration using Elytron Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [abstract]
 
 This section provides information how to configure mod_cluster

--- a/docs/src/main/asciidoc/_high-availability/load-balancing/mod_cluster_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/mod_cluster_Subsystem.adoc
@@ -1,6 +1,14 @@
 [[mod_cluster_Subsystem]]
 = mod_cluster Subsystem
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 The mod_cluster integration is done via the `mod_cluster` subsystem.
 
 [[mod_cluster_subsystem_configuration]]

--- a/docs/src/main/asciidoc/_migration-guide/Introduction.adoc
+++ b/docs/src/main/asciidoc/_migration-guide/Introduction.adoc
@@ -1,6 +1,14 @@
 [[Introduction]]
 = Introduction
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Since the initial development of JBoss AS7 the features added to WildFly have been continuing to
 increase, some of the older features are now being removed to make way for new features.  This
 guide contains information about the removed features and their alternatives.

--- a/docs/src/main/asciidoc/_migration-guide/Vault.adoc
+++ b/docs/src/main/asciidoc/_migration-guide/Vault.adoc
@@ -1,6 +1,14 @@
 [[Migration_PicketBox_Vault]]
 = PicketBox Vault
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WildFly Elytron has made available a new credential store which replaces the PicketBox vault.  The
 credential store can be used for credentials to be directly looked up for use by resources or it
 can be used to store a `SecretKey` which can be used by an expression resolver to decrypt

--- a/docs/src/main/asciidoc/_testsuite/How_the_server_is_built_and_configured_for_testsuite_modules.adoc
+++ b/docs/src/main/asciidoc/_testsuite/How_the_server_is_built_and_configured_for_testsuite_modules.adoc
@@ -1,6 +1,14 @@
 [[How_the_server_is_built_and_configured_for_testsuite_modules]]
 = How the WildFly is built and configured for testsuite modules.
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Refer to <<Shortened_Maven_Run_Overview,Shortened Maven Run Overview>> to see the
 mentioned build steps.
 

--- a/docs/src/main/asciidoc/_testsuite/How_to_Add_a_Test_Case.adoc
+++ b/docs/src/main/asciidoc/_testsuite/How_to_Add_a_Test_Case.adoc
@@ -1,6 +1,14 @@
 [[How_to_Add_a_Test_Case]]
 = How to Add a Test Case
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 _(Please don't (re)move - this is a landing page from a Jira link.)_
 
 *Thank you for finding time to contribute to WildFly {wildflyVersion} quality.* +

--- a/docs/src/main/asciidoc/_testsuite/Plugin_executions_matrix.adoc
+++ b/docs/src/main/asciidoc/_testsuite/Plugin_executions_matrix.adoc
@@ -1,6 +1,14 @@
 [[Plugin_executions_matrix]]
 = Plugin executions matrix
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 x - runs in this module +
 xx - runs in this and all successive modules +
 x! - runs but should not.

--- a/docs/src/main/asciidoc/_testsuite/Pre-requisites_-_test_quality_standards.adoc
+++ b/docs/src/main/asciidoc/_testsuite/Pre-requisites_-_test_quality_standards.adoc
@@ -1,6 +1,14 @@
 [[Pre-requisites_-_test_quality_standards]]
 = Before you add a test
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 Every added test, whether ported or new should follow the same
 guidelines:
 

--- a/docs/src/main/asciidoc/_testsuite/Shared_Test_Classes_and_Resources.adoc
+++ b/docs/src/main/asciidoc/_testsuite/Shared_Test_Classes_and_Resources.adoc
@@ -1,6 +1,14 @@
 [[Shared_Test_Classes_and_Resources]]
 = Shared Test Classes and Resources
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[among-testsuite-modules]]
 == Among Testsuite Modules
 

--- a/docs/src/main/asciidoc/_testsuite/Shortened_Maven_Run_Overview.adoc
+++ b/docs/src/main/asciidoc/_testsuite/Shortened_Maven_Run_Overview.adoc
@@ -1,6 +1,14 @@
 [[Shortened_Maven_Run_Overview]]
 = Shortened Maven Run Overview
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 [[how-to-get-it]]
 == How to get it
 

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
@@ -1,6 +1,14 @@
 [[WildFly_Integration_Testsuite_User_Guide]]
 = WildFly Integration Testsuite User Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 *See also:* <<WildFly_Testsuite_Test_Developer_Guide,WildFly
 Testsuite Test Developer Guide>>
 

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Harness_Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Harness_Developer_Guide.adoc
@@ -1,6 +1,14 @@
 [[WildFly_Testsuite_Harness_Developer_Guide]]
 = WildFly Testsuite Harness Developer Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 *Audience:* Whoever wants to change the testsuite harness
 
 *JIRA*: https://issues.redhat.com/browse/WFLY-576[WFLY-576]

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Overview.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Overview.adoc
@@ -1,6 +1,14 @@
 [[WildFly_Testsuite_Overview]]
 = WildFly Testsuite Overview
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 WARNING: This section has not been updated for a long time and some sections are out of date. Contributions are welcome.
 
 This document will detail the implementation of the testsuite

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
@@ -1,6 +1,14 @@
 [[WildFly_Testsuite_Test_Developer_Guide]]
 = WildFly Testsuite Test Developer Guide
 
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 *See also:* <<WildFly_Integration_Testsuite_User_Guide,WildFly
 Integration Testsuite User Guide>>
 

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,7 +1,15 @@
 [[index]]
 = WildFly Documentation
 :ext-relative: {outfilesuffix}
+
 ifdef::env-github[:imagesdir: images/]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
 :toc!:
 
 image:splash_wildflylogo_small.png[WildFly, align="center"]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17756

Unfortunately, the admonition must be in every individual document to be effective.
You can check my branch https://github.com/khermano/wildfly/tree/WFLY-17756_from_main_2, which has admonitions only in the top-level documents.
I was looking at docinfo files, but sadly, I couldn't find a workable solution yet.
For better visibility, I created multiple commits based on the directories.