### PR TITLE
WFLY-17780 Add @ClientViewScoped into bean defining annotations

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BeanDefiningAnnotationProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/BeanDefiningAnnotationProcessor.java
@@ -34,6 +34,7 @@ public class BeanDefiningAnnotationProcessor implements DeploymentUnitProcessor 
 
     private static final DotName VIEW_SCOPED_NAME = DotName.createSimple("jakarta.faces.view.ViewScoped");
     private static final DotName FLOW_SCOPED_NAME = DotName.createSimple("jakarta.faces.flow.FlowScoped");
+    private static final DotName CLIENT_WINDOW_SCOPED = DotName.createSimple("jakarta.faces.lifecycle.ClientWindowScoped");
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
@@ -52,6 +53,7 @@ public class BeanDefiningAnnotationProcessor implements DeploymentUnitProcessor 
         addAnnotation(deploymentUnit, new AnnotationType(TransactionScoped.class));
         addAnnotation(deploymentUnit, new AnnotationType(VIEW_SCOPED_NAME, true));
         addAnnotation(deploymentUnit, new AnnotationType(FLOW_SCOPED_NAME, true));
+        addAnnotation(deploymentUnit, new AnnotationType(CLIENT_WINDOW_SCOPED, true));
 
         for (AnnotationType annotationType : CdiAnnotations.BEAN_DEFINING_META_ANNOTATIONS) {
             addAnnotations(deploymentUnit, getAnnotationsAnnotatedWith(index, annotationType.getName()));


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-17780

CC @jasondlee @bstansberry 

This doesn't address the fact that these should likely be provided to Weld via some other means instead of hard-coding them but it makes the sample work.
Although I am fairly surprised there isn't any TCK test with `@ClientWindowScoped` that would be failing?