### PR TITLE
WFLY-17561 Added test bom dependency in microprofile

### DIFF
--- a/microprofile/lra/coordinator/pom.xml
+++ b/microprofile/lra/coordinator/pom.xml
@@ -33,7 +33,17 @@
 
   <artifactId>wildfly-microprofile-lra-coordinator</artifactId>
   <name>WildFly: MicroProfile LRA Coordinator extension</name>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-standard-test-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.jboss.narayana.rts</groupId>

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -34,6 +34,17 @@
   <artifactId>wildfly-microprofile-lra-participant</artifactId>
   <name>WildFly: MicroProfile LRA Participant extension</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-standard-test-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/microprofile/telemetry-smallrye/extension/pom.xml
+++ b/microprofile/telemetry-smallrye/extension/pom.xml
@@ -38,6 +38,18 @@
     <artifactId>wildfly-microprofile-telemetry</artifactId>
     <name>WildFly: MicroProfile Telemetry Extension</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-test-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17561
WFCORE issue integration jobs are failing https://issues.redhat.com/browse/WFCORE-6203 so need to add these dependencies in WFLY.

[Integration jobs ](https://ci.wildfly.org/buildConfiguration/WF_WildFlyCoreIntegrationExperiments?mode=builds#all-projects)are passing after adding these changes.
