### PR TITLE
Fixes for WFLY-17808, WFLY-12816, WFLY-17820, WFLY-17821, Licenses generation fixes

### DIFF
--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -1536,17 +1536,6 @@
         <!-- module and copy artifact dependencies -->
 
         <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.3_spec</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-system-jmx</artifactId>
             <exclusions>

--- a/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
+++ b/ee-feature-pack/common/src/main/resources/license/ee-feature-pack-common-licenses.xml
@@ -4042,22 +4042,6 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.3_spec</artifactId>
-      <licenses>
-        <license>
-          <name>Eclipse Public License 2.0</name>
-          <url>http://www.eclipse.org/legal/epl-v20.html</url>
-          <distribution>repo</distribution>
-        </license>
-        <license>
-          <name>GNU General Public License v2.0 only, with Classpath exception</name>
-          <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-api</artifactId>
       <licenses>

--- a/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/transaction/api/main/module.xml
+++ b/ee-feature-pack/ee-10-api/src/main/resources/modules/system/layers/base/jakarta/transaction/api/main/module.xml
@@ -24,11 +24,6 @@
 
 <module xmlns="urn:jboss:module:1.5" name="jakarta.transaction.api">
     <resources>
-        <!--<artifact name="${org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec}">
-            <filter>
-                <exclude path="javax/transaction/xa"/>
-            </filter>
-        </artifact>-->
         <artifact name="${jakarta.transaction:jakarta.transaction-api}">
             <filter>
                 <exclude path="jakarta/transaction/xa"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -2,7 +2,7 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/full-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/full-licenses.xsl" src="docs/licenses/full-feature-pack-licenses.xml" output="docs/licenses/full-feature-pack-licenses.html" feature-pack-properties="true"/>
+    <transform stylesheet="docs/licenses/full-licenses.xsl" src="docs/licenses/full-feature-pack-licenses.xml" output="docs/licenses/full-feature-pack-licenses.html" feature-pack-properties="true" phase="FINALIZING"/>
     <delete path="docs/licenses/full-licenses.xsl"/>
     <line-endings>
       <unix>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -237,6 +237,7 @@
                         </goals>
                         <phase>process-resources</phase>
                         <configuration>
+                            <generateVersionProperty>true</generateVersionProperty>
                             <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                             <licensesConfigFiles>
                                 <licensesConfigFile>${basedir}/target/resources/license/core-feature-pack-common-licenses.xml</licensesConfigFile>
@@ -247,7 +248,7 @@
                             </licensesConfigFiles>
                             <licensesOutputFile>${license.directory}/full-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                            <excludedArtifacts>wildfly-jar-boot|wildfly-core-feature-pack-common|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-10-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
+                            <excludedArtifacts>jboss-transaction-api_1.3_spec|wildfly-standard-ee-bom|wildfly-legacy-ee-bom|wildfly-ee-feature-pack-galleon-shared|wildfly-ee-feature-pack-galleon-local|wildfly-common-ee-dependency-management|wildfly-jar-boot|wildfly-core-feature-pack-common|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-10-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -248,7 +248,7 @@
                             </licensesConfigFiles>
                             <licensesOutputFile>${license.directory}/full-feature-pack-licenses.xml</licensesOutputFile>
                             <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
-                            <excludedArtifacts>jboss-transaction-api_1.3_spec|wildfly-standard-ee-bom|wildfly-legacy-ee-bom|wildfly-ee-feature-pack-galleon-shared|wildfly-ee-feature-pack-galleon-local|wildfly-common-ee-dependency-management|wildfly-jar-boot|wildfly-core-feature-pack-common|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-10-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
+                            <excludedArtifacts>wildfly-standard-ee-bom|wildfly-legacy-ee-bom|wildfly-ee-feature-pack-galleon-shared|wildfly-ee-feature-pack-galleon-local|wildfly-common-ee-dependency-management|wildfly-jar-boot|wildfly-core-feature-pack-common|wildfly-core-feature-pack-galleon-common|wildfly-core-feature-pack-galleon-pruned|wildfly-ee-feature-pack-common|wildfly-ee-feature-pack-ee-10-api|wildfly-ee-feature-pack-galleon-common|wildfly-ee-feature-pack-pruned|wildfly-ee-feature-pack-galleon-content|wildfly-elytron\z</excludedArtifacts>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-feature-pack/galleon-shared/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/configs/standalone/model.xml
@@ -26,5 +26,7 @@
         <!-- Servlet works properly without it (in nominal) making it optional in case
             it needs to be excluded -->
         <package name="org.jboss.common-beans" optional="true"/>
+        <package name="docs.licenses" optional="true"/>
+        <package name="docs.licenses.merge" optional="true"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-content/src/main/resources/configs/standalone/model.xml
+++ b/galleon-pack/galleon-content/src/main/resources/configs/standalone/model.xml
@@ -4,5 +4,7 @@
     <packages>
         <package name="product.conf" optional="true"/>
         <package name="misc.standalone"/>
+        <package name="docs.licenses" optional="true"/>
+        <package name="docs.licenses.merge" optional="true"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -135,10 +135,12 @@
                         </goals>
                         <phase>process-resources</phase>
                         <configuration>
+                            <generateVersionProperty>true</generateVersionProperty>
                             <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                             <licensesConfigFile>${feature-pack.license.directory}/microprofile-feature-pack-licenses.xml</licensesConfigFile>
                             <licensesOutputFile>${license.directory}/microprofile-feature-pack-licenses.xml</licensesOutputFile>
-                            <excludedArtifacts>wildfly-ee-galleon-pack|wildfly-feature-pack-galleon-common|wildfly-feature-pack-galleon-content</excludedArtifacts>
+                            <excludedGroups>org.wildfly.galleon-plugins</excludedGroups>
+                            <excludedArtifacts>microprofile-reactive-messaging-api|wildfly-standard-expansion-bom|wildfly-standard-ee-bom|wildfly-mp-feature-pack-galleon-common|wildfly-legacy-expansion-bom|wildfly-legacy-ee-bom|wildfly-feature-pack-common|wildfly-common-expansion-dependency-management|wildfly-common-ee-dependency-management|wildfly-ee-galleon-pack|wildfly-feature-pack-galleon-common|wildfly-feature-pack-galleon-content</excludedArtifacts>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -26,7 +26,7 @@
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
             <packages inherit="false">
-                <!--exclude name="docs.licenses.merge"/-->
+                <exclude name="docs.licenses.merge"/>
                 <include name="docs"/>
                 <!-- appclient is not referenced from standalone nor domain configuration models.-->
                 <include name="appclient"/>

--- a/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
+++ b/microprofile/galleon-common/src/main/resources/license/microprofile-feature-pack-licenses.xml
@@ -622,7 +622,11 @@
         </license>
       </licenses>
     </dependency>
-    <dependency>
+    <!--
+    As the SmallRye jar duplicates classes (and adds some new ones) from the Eclipse RM API
+    jar, we don't provision the Eclipse jar and use just the SmallRye one
+    -->
+    <!--<dependency>
       <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
       <artifactId>microprofile-reactive-messaging-api</artifactId>
       <licenses>
@@ -632,7 +636,7 @@
           <distribution>repo</distribution>
         </license>
       </licenses>
-    </dependency>
+    </dependency>-->
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>

--- a/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/reactive-messaging/api/main/module.xml
+++ b/microprofile/galleon-common/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/reactive-messaging/api/main/module.xml
@@ -23,11 +23,6 @@
 <module xmlns="urn:jboss:module:1.9" name="org.eclipse.microprofile.reactive-messaging.api">
 
     <resources>
-        <!--
-        As the SmallRye jar duplicates classes (and adds some new ones) from the Eclipse RM API
-        jar, we disable the Eclipse jar and use just the SmallRye one
-        <artifact name="${org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api}"/>
-        -->
         <!-- Here temporarily, it should be in the io.smallrye.reactive.messaging module, or its own -->
         <artifact name="${io.smallrye.reactive:smallrye-reactive-messaging-api}"/>
     </resources>

--- a/microprofile/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/microprofile/galleon-common/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -2,7 +2,7 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/microprofile-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/microprofile-licenses.xsl" src="docs/licenses/microprofile-feature-pack-licenses.xml" output="docs/licenses/microprofile-feature-pack-licenses.html" feature-pack-properties="true"/>
+    <transform stylesheet="docs/licenses/microprofile-licenses.xsl" src="docs/licenses/microprofile-feature-pack-licenses.xml" output="docs/licenses/microprofile-feature-pack-licenses.html" feature-pack-properties="true" phase="FINALIZING"/>
     <delete path="docs/licenses/microprofile-licenses.xsl"/>
     <line-endings>
       <unix>

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>6.3.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>8.1.0.Final</version.org.wildfly.jar.plugin>
-        <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
+        <version.org.wildfly.maven.plugins>2.3.1.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>3.0.2.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -284,11 +284,11 @@
         <version.ant.junit>1.10.12</version.ant.junit>
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.7</version.org.jacoco>
-        <version.org.jboss.galleon>5.0.8.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.0.9.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.3.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.3.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>8.1.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>3.0.2.Final</version.org.wildfly.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,6 @@
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>2.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
         <legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
-        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>2.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>
         <version.org.jboss.weld.weld>5.1.0.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>5.0.SP3</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>2.0.0.Final</version.org.jboss.ws.api>
@@ -982,11 +981,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.3_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec}</version>
             </dependency>
 
             <!--

--- a/preview/galleon-content/src/main/resources/configs/standalone/model.xml
+++ b/preview/galleon-content/src/main/resources/configs/standalone/model.xml
@@ -29,6 +29,8 @@
         <package name="org.jboss.common-beans" optional="true"/>
 
         <package name="org.wildfly.deployment.transformation"/>
+        <package name="docs.licenses" optional="true"/>
+        <package name="docs.licenses.merge" optional="true"/>
 
     </packages>
 </config>


### PR DESCRIPTION
The fix for [WFLY-17808](https://issues.redhat.com/browse/WFLY-17808) depends on Galleon and License plugins upgrades.
The dynamicity introduced in [WFLY-17808](https://issues.redhat.com/browse/WFLY-17808) allows to fix [WFLY-12816](https://issues.redhat.com/browse/WFLY-12816) (Provisioning licenses files when using Galleon layers). The artifacts that are not provisioned are marked in the provisioned licenses.xml and licenses.html as "Not Installed".

Issues:
* https://issues.redhat.com/browse/WFLY-17808
* https://issues.redhat.com/browse/WFLY-12816
* https://issues.redhat.com/browse/WFLY-17820
* https://issues.redhat.com/browse/WFLY-17821

In addition, some cleanup has been done to filter-out not provisioned artifacts from the generated licenses files.


