### PR TITLE
WFLY-17827 Eliminate extra write operation on session creation when cache is non-transactional

### DIFF
--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/CompositeSessionFactory.java
@@ -51,10 +51,10 @@ public class CompositeSessionFactory<C, V, L> extends CompositeImmutableSessionF
     }
 
     @Override
-    public Map.Entry<CompositeSessionMetaDataEntry<L>, V> createValue(String id, Void context) {
-        CompositeSessionMetaDataEntry<L> metaDataValue = this.metaDataFactory.createValue(id, context);
+    public Map.Entry<CompositeSessionMetaDataEntry<L>, V> createValue(String id, SessionCreationMetaData creationMetaData) {
+        CompositeSessionMetaDataEntry<L> metaDataValue = this.metaDataFactory.createValue(id, creationMetaData);
         if (metaDataValue == null) return null;
-        V attributesValue = this.attributesFactory.createValue(id, context);
+        V attributesValue = this.attributesFactory.createValue(id, null);
         return new SimpleImmutableEntry<>(metaDataValue, attributesValue);
     }
 

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/ConcurrentSessionManager.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/ConcurrentSessionManager.java
@@ -113,16 +113,6 @@ public class ConcurrentSessionManager<L, B extends Batch> implements SessionMana
     }
 
     @Override
-    public Duration getDefaultMaxInactiveInterval() {
-        return this.manager.getDefaultMaxInactiveInterval();
-    }
-
-    @Override
-    public void setDefaultMaxInactiveInterval(Duration duration) {
-        this.manager.setDefaultMaxInactiveInterval(duration);
-    }
-
-    @Override
     public Batcher<B> getBatcher() {
         return this.manager.getBatcher();
     }

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionFactory.java
@@ -35,7 +35,7 @@ import org.wildfly.clustering.web.session.Session;
  * @param <LC> the local context type
  * @author Paul Ferraro
  */
-public interface SessionFactory<SC, MV, AV, LC> extends ImmutableSessionFactory<MV, AV>, Creator<String, Map.Entry<MV, AV>, Void>, Remover<String>, AutoCloseable {
+public interface SessionFactory<SC, MV, AV, LC> extends ImmutableSessionFactory<MV, AV>, Creator<String, Map.Entry<MV, AV>, SessionCreationMetaData>, Remover<String>, AutoCloseable {
     @Override
     SessionMetaDataFactory<MV> getMetaDataFactory();
     @Override

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionMetaDataFactory.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/SessionMetaDataFactory.java
@@ -28,7 +28,7 @@ import org.wildfly.clustering.ee.Remover;
 /**
  * @author Paul Ferraro
  */
-public interface SessionMetaDataFactory<V> extends ImmutableSessionMetaDataFactory<V>, Creator<String, V, Void>, Remover<String>, AutoCloseable {
+public interface SessionMetaDataFactory<V> extends ImmutableSessionMetaDataFactory<V>, Creator<String, V, SessionCreationMetaData>, Remover<String>, AutoCloseable {
     InvalidatableSessionMetaData createSessionMetaData(String id, V value);
 
     @Override

--- a/clustering/web/cache/src/test/java/org/wildfly/clustering/web/cache/session/ConcurrentSessionManagerTestCase.java
+++ b/clustering/web/cache/src/test/java/org/wildfly/clustering/web/cache/session/ConcurrentSessionManagerTestCase.java
@@ -225,30 +225,6 @@ public class ConcurrentSessionManagerTestCase {
     }
 
     @Test
-    public void getDefaultMaxInactiveInterval() {
-        SessionManager<Void, Batch> manager = mock(SessionManager.class);
-        SessionManager<Void, Batch> subject = new ConcurrentSessionManager<>(manager, SimpleManager::new);
-        Duration expected = Duration.ofMinutes(60);
-
-        when(manager.getDefaultMaxInactiveInterval()).thenReturn(expected);
-
-        Duration result = subject.getDefaultMaxInactiveInterval();
-
-        assertSame(expected, result);
-    }
-
-    @Test
-    public void setDefaultMaxInactiveInterval() {
-        SessionManager<Void, Batch> manager = mock(SessionManager.class);
-        SessionManager<Void, Batch> subject = new ConcurrentSessionManager<>(manager, SimpleManager::new);
-        Duration value = Duration.ofMinutes(60);
-
-        subject.setDefaultMaxInactiveInterval(value);
-
-        verify(manager).setDefaultMaxInactiveInterval(value);
-    }
-
-    @Test
     public void getBatcher() {
         SessionManager<Void, Batch> manager = mock(SessionManager.class);
         SessionManager<Void, Batch> subject = new ConcurrentSessionManager<>(manager, SimpleManager::new);

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionManager.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionManager.java
@@ -32,8 +32,10 @@ import org.wildfly.clustering.Registrar;
 import org.wildfly.clustering.Registration;
 import org.wildfly.clustering.ee.Batcher;
 import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
+import org.wildfly.clustering.web.cache.session.SessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.SessionFactory;
 import org.wildfly.clustering.web.cache.session.SimpleImmutableSession;
+import org.wildfly.clustering.web.cache.session.SimpleSessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.ValidSession;
 import org.wildfly.clustering.web.hotrod.logging.Logger;
 import org.wildfly.clustering.web.session.ImmutableSession;
@@ -128,10 +130,11 @@ public class HotRodSessionManager<SC, MV, AV, LC> implements SessionManager<LC, 
 
     @Override
     public Session<LC> createSession(String id) {
-        Map.Entry<MV, AV> entry = this.factory.createValue(id, null);
+        SessionCreationMetaData creationMetaData = new SimpleSessionCreationMetaData();
+        creationMetaData.setTimeout(this.defaultMaxInactiveInterval);
+        Map.Entry<MV, AV> entry = this.factory.createValue(id, creationMetaData);
         if (entry == null) return null;
         Session<LC> session = this.factory.createSession(id, entry, this.context);
-        session.getMetaData().setMaxInactiveInterval(this.defaultMaxInactiveInterval);
         return new ValidSession<>(session, this.closeTask);
     }
 

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionMetaDataFactory.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionMetaDataFactory.java
@@ -45,7 +45,6 @@ import org.wildfly.clustering.web.cache.session.SessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.SessionCreationMetaDataEntry;
 import org.wildfly.clustering.web.cache.session.SessionMetaDataFactory;
 import org.wildfly.clustering.web.cache.session.SimpleSessionAccessMetaData;
-import org.wildfly.clustering.web.cache.session.SimpleSessionCreationMetaData;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 
 /**
@@ -75,8 +74,8 @@ public class HotRodSessionMetaDataFactory<L> implements SessionMetaDataFactory<C
     }
 
     @Override
-    public CompositeSessionMetaDataEntry<L> createValue(String id, Void context) {
-        SessionCreationMetaDataEntry<L> creationMetaDataEntry = new SessionCreationMetaDataEntry<>(new SimpleSessionCreationMetaData());
+    public CompositeSessionMetaDataEntry<L> createValue(String id, SessionCreationMetaData creationMetaData) {
+        SessionCreationMetaDataEntry<L> creationMetaDataEntry = new SessionCreationMetaDataEntry<>(creationMetaData);
         SessionAccessMetaData accessMetaData = new SimpleSessionAccessMetaData();
         this.creationMetaDataMutatorFactory.createMutator(new SessionCreationMetaDataKey(id), creationMetaDataEntry).mutate();
         this.accessMetaDataMutatorFactory.createMutator(new SessionAccessMetaDataKey(id), accessMetaData).mutate();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/AbstractInfinispanSessionMetaDataFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/AbstractInfinispanSessionMetaDataFactory.java
@@ -51,7 +51,6 @@ import org.wildfly.clustering.web.cache.session.SessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.SessionCreationMetaDataEntry;
 import org.wildfly.clustering.web.cache.session.SessionMetaDataFactory;
 import org.wildfly.clustering.web.cache.session.SimpleSessionAccessMetaData;
-import org.wildfly.clustering.web.cache.session.SimpleSessionCreationMetaData;
 import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
 
 /**
@@ -96,9 +95,9 @@ public abstract class AbstractInfinispanSessionMetaDataFactory<L> implements Ses
     }
 
     @Override
-    public CompositeSessionMetaDataEntry<L> createValue(String id, Void context) {
+    public CompositeSessionMetaDataEntry<L> createValue(String id, SessionCreationMetaData creationMetaData) {
         Map<Key<String>, Object> entries = new HashMap<>(3);
-        SessionCreationMetaDataEntry<L> creationMetaDataEntry = new SessionCreationMetaDataEntry<>(new SimpleSessionCreationMetaData());
+        SessionCreationMetaDataEntry<L> creationMetaDataEntry = new SessionCreationMetaDataEntry<>(creationMetaData);
         entries.put(new SessionCreationMetaDataKey(id), creationMetaDataEntry);
         SessionAccessMetaData accessMetaData = new SimpleSessionAccessMetaData();
         entries.put(new SessionAccessMetaDataKey(id), accessMetaData);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -44,8 +44,10 @@ import org.wildfly.clustering.ee.cache.tx.TransactionBatch;
 import org.wildfly.clustering.ee.expiration.ExpirationMetaData;
 import org.wildfly.clustering.infinispan.distribution.CacheLocality;
 import org.wildfly.clustering.infinispan.distribution.Locality;
+import org.wildfly.clustering.web.cache.session.SessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.SessionFactory;
 import org.wildfly.clustering.web.cache.session.SimpleImmutableSession;
+import org.wildfly.clustering.web.cache.session.SimpleSessionCreationMetaData;
 import org.wildfly.clustering.web.cache.session.ValidSession;
 import org.wildfly.clustering.web.infinispan.logging.InfinispanWebLogger;
 import org.wildfly.clustering.web.session.ImmutableSession;
@@ -166,10 +168,11 @@ public class InfinispanSessionManager<SC, MV, AV, LC> implements SessionManager<
 
     @Override
     public Session<LC> createSession(String id) {
-        Map.Entry<MV, AV> entry = this.factory.createValue(id, null);
+        SessionCreationMetaData creationMetaData = new SimpleSessionCreationMetaData();
+        creationMetaData.setTimeout(this.defaultMaxInactiveInterval);
+        Map.Entry<MV, AV> entry = this.factory.createValue(id, creationMetaData);
         if (entry == null) return null;
         Session<LC> session = this.factory.createSession(id, entry, this.context);
-        session.getMetaData().setMaxInactiveInterval(this.defaultMaxInactiveInterval);
         return new ValidSession<>(session, this.closeTask);
     }
 

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
@@ -56,18 +56,6 @@ public interface SessionManager<L, B extends Batch> extends Restartable, ActiveS
     Session<L> createSession(String id);
 
     /**
-     * Returns the default maximum inactive interval, as a duration, for all sessions created by this session manager.
-     * @return a duration
-     */
-    Duration getDefaultMaxInactiveInterval();
-
-    /**
-     * Set the default maximum inactive interval, using the specified time duration, for all sessions created by this session manager.
-     * @param duration a time duration
-     */
-    void setDefaultMaxInactiveInterval(Duration duration);
-
-    /**
      * Exposes the batching mechanism used by this session manager.
      * @return a batcher.
      */

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
@@ -65,6 +65,9 @@ public class DistributableSessionManager implements UndertowSessionManager, Long
     private final RecordableSessionManagerStatistics statistics;
     private final StampedLock lifecycleLock = new StampedLock();
 
+    // Matches io.undertow.server.session.InMemorySessionManager
+    private volatile int defaultSessionTimeout = 30 * 60;
+
     // Guarded by this
     private OptionalLong lifecycleStamp = OptionalLong.empty();
 
@@ -150,7 +153,7 @@ public class DistributableSessionManager implements UndertowSessionManager, Long
         if (exchange.isResponseStarted()) { // Should match the condition in io.undertow.servlet.spec.HttpServletResponseImpl#isCommitted()
             // Return single-use session to be garbage collected at the end of the request
             io.undertow.server.session.Session session = new OrphanSession(this, this.manager.getIdentifierFactory().get());
-            session.setMaxInactiveInterval((int) this.manager.getDefaultMaxInactiveInterval().getSeconds());
+            session.setMaxInactiveInterval(this.defaultSessionTimeout);
             return session;
         }
 
@@ -264,7 +267,7 @@ public class DistributableSessionManager implements UndertowSessionManager, Long
 
     @Override
     public void setDefaultSessionTimeout(int timeout) {
-        this.manager.setDefaultMaxInactiveInterval(Duration.ofSeconds(timeout));
+        this.defaultSessionTimeout = timeout;
     }
 
     @Override

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
@@ -113,13 +113,6 @@ public class DistributableSessionManagerTestCase {
     }
 
     @Test
-    public void setDefaultSessionTimeout() {
-        this.adapter.setDefaultSessionTimeout(10);
-
-        verify(this.manager).setDefaultMaxInactiveInterval(Duration.ofSeconds(10L));
-    }
-
-    @Test
     public void createSessionResponseCommitted() {
         // Ugh - all this, just to get HttpServerExchange.isResponseStarted() to return true
         Configurable configurable = mock(Configurable.class);
@@ -130,6 +123,9 @@ public class DistributableSessionManagerTestCase {
         StreamConnection stream = mock(StreamConnection.class);
         String id = "foo";
         Supplier<String> identifierFactory = Functions.constantSupplier(id);
+        int expectedTimeout = 10;
+
+        this.adapter.setDefaultSessionTimeout(expectedTimeout);
 
         when(this.manager.getIdentifierFactory()).thenReturn(identifierFactory);
         when(stream.getSourceChannel()).thenReturn(sourceChannel);
@@ -150,6 +146,7 @@ public class DistributableSessionManagerTestCase {
         verify(this.manager, never()).createSession(id);
 
         Assert.assertEquals(id, session.getId());
+        Assert.assertEquals(expectedTimeout, session.getMaxInactiveInterval());
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17827
