### PR TITLE
WFLY-17836 Global module default values in ee subsystem xsd do not match attribute definition

### DIFF
--- a/ee/src/main/resources/schema/jboss-as-ee_6_0.xsd
+++ b/ee/src/main/resources/schema/jboss-as-ee_6_0.xsd
@@ -47,10 +47,10 @@
 
     <xs:complexType name="moduleType">
         <xs:attribute name="name" type="xs:string" use="required"/>
-        <xs:attribute name="slot" type="xs:string"/>
-        <xs:attribute name="annotations" type="xs:boolean" use="optional" default="false"/>
-        <xs:attribute name="meta-inf" type="xs:boolean" use="optional" default="false"/>
-        <xs:attribute name="services" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="slot" type="xs:string" default="main"/>
+        <xs:attribute name="annotations" type="xs:boolean" default="false"/>
+        <xs:attribute name="meta-inf" type="xs:boolean" default="true"/>
+        <xs:attribute name="services" type="xs:boolean" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="directoriesType">


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17836