### PR TITLE
[WFLY-17838] Replace deprecated systemProperties configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1178,17 +1178,9 @@
                             <org.jboss.model.test.classpath.cache>${org.jboss.model.test.classpath.cache}</org.jboss.model.test.classpath.cache>
                             <org.jboss.model.test.cache.strict>true</org.jboss.model.test.cache.strict>
                             <!--<org.jboss.model.test.maven.repository.urls>${org.jboss.model.test.maven.repository.urls}</org.jboss.model.test.maven.repository.urls>-->
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <jdk.xml.enableTemplatesImplDeserialization>true</jdk.xml.enableTemplatesImplDeserialization>
                         </systemPropertyVariables>
-                        <systemProperties>
-                            <property>
-                                <name>java.util.logging.manager</name>
-                                <value>org.jboss.logmanager.LogManager</value>
-                            </property>
-                            <property>
-                                <name>jdk.xml.enableTemplatesImplDeserialization</name>
-                                <value>true</value>
-                            </property>
-                        </systemProperties>
                         <argLine>${surefire.system.args}</argLine>
                     </configuration>
                 </plugin>

--- a/testsuite/integration/microprofile-tck/config/pom.xml
+++ b/testsuite/integration/microprofile-tck/config/pom.xml
@@ -103,13 +103,11 @@
                         <config_ordinal>45</config_ordinal>
                         <customer_name>Bob</customer_name>
                     </environmentVariables>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <!-- We have put these values into mp.tck.properties above -->
                         <mp.tck.prop.dummy>dummy</mp.tck.prop.dummy>
                         <customer.hobby>Tennis</customer.hobby>
                         <config_ordinal>120</config_ordinal>
-                    </systemProperties>
-                    <systemPropertyVariables>
                         <!-- Pass the my_string_property and MY_STRING_PROPERTY as sysprop to exclude them from the
                              ConfigProviderTest#testEnvironmentConfigSource that does not deal with case-sensitive environment variables on Windows
                         -->

--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -120,10 +120,10 @@
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
                     </dependenciesToScan>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                         <test.url>http://localhost:8080</test.url>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17838

Use the up-to-date configuration via `systemPropertyVariables` (https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html)