### PR TITLE
[WFLY-17839] Update mutiny vertx client to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.io.smallrye.smallrye-health>4.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.2.0</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.1.0</version.io.smallrye.smallrye-mutiny>
-        <version.io.smallrye.smallrye-mutiny-vertx>2.26.0</version.io.smallrye.smallrye-mutiny-vertx>
+        <version.io.smallrye.smallrye-mutiny-vertx>3.0.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.0.0</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.3.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-opentracing>3.0.0</version.io.smallrye.smallrye-opentracing>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17839

This should have come in with https://github.com/wildfly/wildfly/pull/16521 but was missed. Although the tests work without the upgrade, this is the version used by SmallRye Reactive Messaging 4.3.0. Also, https://github.com/wildfly/wildfly/pull/16281 fails without upgrade when rebased on main.