### PR TITLE
[WFLY-17846] Upgrade WildFly Core to 20.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
         <version.org.testcontainers>1.16.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>20.0.0.Beta8</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-17846

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/20.0.0.Beta8...20.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6157'>WFCORE-6157</a>] -         Investigate what&#39;s wrong with operations cancellation
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6205'>WFCORE-6205</a>] -         Encrypted expressions in system properties do not use default resolver
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6244'>WFCORE-6244</a>] -         Elytron mapped-role-mapper does not support expressions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6270'>WFCORE-6270</a>] -         Bootable JAR, Security providers are not registered during boot
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6276'>WFCORE-6276</a>] -         RegexRoleMapperTest does not clean up resources
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6277'>WFCORE-6277</a>] -         wildflyee.api module missing dependency to module java.se
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6281'>WFCORE-6281</a>] -         RootSubsystemOperationsTestCase fails very often on Windows
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5553'>WFCORE-5553</a>] -         Prune ProxyStepHandler and GlobalOperationHandlers isWFCORE621Needed and executeWFCORE621 logic
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6203'>WFCORE-6203</a>] -         Move test dependency to testbom
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6267'>WFCORE-6267</a>] -         Remove domain.xml host-exclude entries for releases prior to WF 23
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6268'>WFCORE-6268</a>] -         Remove use of deprecated ModelTestControllerVersion enums
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6274'>WFCORE-6274</a>] -         Bump GitHub actions/stale from 7 to 8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6279'>WFCORE-6279</a>] -         Replace Deployment Processors Javax dependencies with Jakarta module identifiers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6283'>WFCORE-6283</a>] -         Make TestModule.getModulesDirectory public
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6287'>WFCORE-6287</a>] -         Remove deprecated systemProperties configuration option for surefire plugin
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6197'>WFCORE-6197</a>] -         Upgrade JBoss MSC to 1.5.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6272'>WFCORE-6272</a>] -         CVE-2022-4492 CVE-2023-1108 Upgrade Undertow to 2.3.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6273'>WFCORE-6273</a>] -         Upgrade SLF4J to 2.0.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6280'>WFCORE-6280</a>] -         Upgrade Galleon to 5.0.9.Final and galleon Plugins to 6.3.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6284'>WFCORE-6284</a>] -         Upgrade XNIO to 3.8.9.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6289'>WFCORE-6289</a>] -         Upgrade JBoss MSC to 1.5.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6245'>WFCORE-6245</a>] -         Eliminate usage of deprecated ibm.jdk module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6278'>WFCORE-6278</a>] -         Overload EnumValidator.create(...) to avoid redundant set copy
</li>
</ul>
</details>