### PR TITLE
[WFLY-17781] Ensure a virtual SecurityDomain is created if necessary when an EJB references a virtual security domain

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
@@ -297,8 +297,3 @@ where `DEPLOYMENT_NAME.ear` is a reference to the `virtual-security-domain` defi
 This configuration indicates that the virtual security domain associated with `DEPLOYMENT_NAME.ear`
 should be used to secure the EJB.
 
-[IMPORTANT]
-
-For now, a deployment containing a servlet secured with OpenID Connect (e.g., `DEPLOYMENT_NAME.ear`)
-MUST be deployed before a deployment that contains the `@SecurityDomain(DEPLOYMENT_NAME.ear)`
-annotation.

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcSubsystemAdd.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcSubsystemAdd.java
@@ -18,14 +18,18 @@
 
 package org.wildfly.extension.elytron.oidc;
 
+import static org.jboss.as.server.security.VirtualDomainUtil.OIDC_VIRTUAL_SECURITY_DOMAIN_CREATION_SERVICE;
+import static org.wildfly.extension.elytron.oidc.ElytronOidcSubsystemDefinition.installService;
 import static org.wildfly.extension.elytron.oidc._private.ElytronOidcLogger.ROOT_LOGGER;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceTarget;
 
 /**
  * Add handler for the Elytron OpenID Connect subsystem.
@@ -46,6 +50,8 @@ class ElytronOidcSubsystemAdd extends AbstractBoottimeAddStepHandler {
     public void performBoottime(OperationContext context, ModelNode operation, ModelNode model) {
         ROOT_LOGGER.activatingSubsystem();
         OidcConfigService.getInstance().clear();
+        ServiceTarget target = context.getServiceTarget();
+        installService(OIDC_VIRTUAL_SECURITY_DOMAIN_CREATION_SERVICE, new OidcVirtualSecurityDomainCreationService(), target);
 
         if (context.isNormalServer()) {
             context.addStep(new AbstractDeploymentChainStep() {
@@ -62,4 +68,10 @@ class ElytronOidcSubsystemAdd extends AbstractBoottimeAddStepHandler {
         }
 
     }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
+        context.removeService(OIDC_VIRTUAL_SECURITY_DOMAIN_CREATION_SERVICE);
+    }
+
 }

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/OidcVirtualSecurityDomainCreationService.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/OidcVirtualSecurityDomainCreationService.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.elytron.oidc;
+
+import org.jboss.as.server.security.VirtualSecurityDomainCreationService;
+import org.jboss.msc.service.Service;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.http.oidc.OidcSecurityRealm;
+
+/**
+ * Core {@link Service} handling virtual security domain creation.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class OidcVirtualSecurityDomainCreationService extends VirtualSecurityDomainCreationService {
+
+    private static final String VIRTUAL_REALM = "virtual";
+
+    @Override
+    public SecurityDomain.Builder createVirtualSecurityDomainBuilder() {
+        return SecurityDomain.builder()
+                .addRealm(VIRTUAL_REALM, new OidcSecurityRealm()).build()
+                .setDefaultRealmName(VIRTUAL_REALM)
+                .setPermissionMapper((permissionMappable, roles) -> LoginPermission.getInstance());
+    }
+}

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/VirtualHttpServerMechanismFactoryProcessor.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/VirtualHttpServerMechanismFactoryProcessor.java
@@ -16,7 +16,10 @@
 
 package org.wildfly.extension.elytron.oidc;
 
+import static org.jboss.as.server.security.VirtualDomainUtil.clearVirtualDomainMetaDataSecurityDomain;
 import static org.jboss.as.server.security.VirtualDomainUtil.configureVirtualDomain;
+import static org.jboss.as.server.security.VirtualDomainUtil.getVirtualDomainMetaData;
+import static org.jboss.as.server.security.VirtualDomainUtil.isVirtualDomainCreated;
 import static org.jboss.as.web.common.VirtualHttpServerMechanismFactoryMarkerUtility.isVirtualMechanismFactoryRequired;
 import static org.jboss.as.web.common.VirtualHttpServerMechanismFactoryMarkerUtility.virtualMechanismFactoryName;
 
@@ -66,24 +69,30 @@ class VirtualHttpServerMechanismFactoryProcessor implements DeploymentUnitProces
         serviceBuilder.setInitialMode(Mode.ON_DEMAND);
         serviceBuilder.install();
 
-        ServiceName virtualDomainName = VirtualDomainMarkerUtility.virtualDomainName(deploymentUnit);
-        serviceBuilder = serviceTarget.addService(virtualDomainName);
+        if (! isVirtualDomainCreated(deploymentUnit)) {
+            ServiceName virtualDomainName = VirtualDomainMarkerUtility.virtualDomainName(deploymentUnit);
+            VirtualDomainMetaData virtualDomainMetaData = getVirtualDomainMetaData(deploymentUnit);
+            serviceBuilder = serviceTarget.addService(virtualDomainName);
 
-        SecurityDomain.Builder virtualDomainBuilder = SecurityDomain.builder()
-                .addRealm(VIRTUAL_REALM, new OidcSecurityRealm()).build()
-                .setDefaultRealmName(VIRTUAL_REALM)
-                .setPermissionMapper((permissionMappable, roles) -> LoginPermission.getInstance());
-
-        VirtualDomainMetaData virtualDomainMetaData = configureVirtualDomain(phaseContext, deploymentUnit, virtualDomainBuilder);
-        SecurityDomain virtualDomain = virtualDomainBuilder.build();
-        if (virtualDomainMetaData != null) {
-            virtualDomainMetaData.setSecurityDomain(virtualDomain);
+            SecurityDomain.Builder virtualDomainBuilder = SecurityDomain.builder()
+                    .addRealm(VIRTUAL_REALM, new OidcSecurityRealm()).build()
+                    .setDefaultRealmName(VIRTUAL_REALM)
+                    .setPermissionMapper((permissionMappable, roles) -> LoginPermission.getInstance());
+            configureVirtualDomain(virtualDomainMetaData, virtualDomainBuilder);
+            SecurityDomain virtualDomain = virtualDomainBuilder.build();
+            if (virtualDomainMetaData != null) {
+                virtualDomainMetaData.setSecurityDomain(virtualDomain);
+            }
+            Consumer<SecurityDomain> securityDomainConsumer = serviceBuilder.provides(new ServiceName[]{virtualDomainName});
+            serviceBuilder.setInstance(Service.newInstance(securityDomainConsumer, virtualDomain));
+            serviceBuilder.setInitialMode(Mode.ON_DEMAND);
+            serviceBuilder.install();
         }
+    }
 
-        Consumer<SecurityDomain> securityDomainConsumer = serviceBuilder.provides(new ServiceName[]{virtualDomainName});
-        serviceBuilder.setInstance(Service.newInstance(securityDomainConsumer, virtualDomain));
-        serviceBuilder.setInitialMode(Mode.ON_DEMAND);
-        serviceBuilder.install();
+    @Override
+    public void undeploy(DeploymentUnit deploymentUnit) {
+        clearVirtualDomainMetaDataSecurityDomain(deploymentUnit);
     }
 
 }

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ComplexServletRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ComplexServletRemote.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+
+import static org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration.JBOSS_ADMIN_ROLE;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { JBOSS_ADMIN_ROLE }))
+@DeclareRoles(JBOSS_ADMIN_ROLE)
+public class ComplexServletRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private ManagementBeanRemote bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+
+        try {
+            writer.write(bean.whoAmI() + "," + String.valueOf(bean.invokeEntryDoIHaveRole("user")) + "," + String.valueOf(bean.invokeEntryDoIHaveRole("Managers")));
+        } catch (Exception e) {
+            throw new ServletException("Unexpected Failure", e);
+        }
+    }
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/EntryBeanRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/EntryBeanRemote.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ear-servlet-ejb-deployment-remote-same-domain.ear")
+public class EntryBeanRemote implements EntryRemote {
+
+    @EJB
+    private WhoAmIRemote whoAmIBean;
+
+    @Resource
+    private SessionContext context;
+
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    public boolean doIHaveRole(String roleName) {
+        return context.isCallerInRole(roleName);
+    }
+
+}
+

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/EntryRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/EntryRemote.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import jakarta.ejb.Remote;
+
+/**
+ * Interface for the bean used as the entry point to verify Enterprise Beans 3 security behaviour.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Remote
+public interface EntryRemote {
+
+    /**
+     * @return The name of the Principal obtained from a call to EJBContext.getCallerPrincipal()
+     */
+    String whoAmI();
+
+    /**
+     * @param roleName - The role to check.
+     * @return the response from EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ManagementBeanRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ManagementBeanRemote.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import static org.jboss.as.test.shared.integration.ejb.security.Util.switchIdentity;
+
+import java.util.concurrent.Callable;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * A simple EJB that can be called to obtain the current caller principal and to check the role membership for
+ * that principal.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+public class ManagementBeanRemote {
+
+    @Resource
+    private SessionContext context;
+
+    @PermitAll
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    @PermitAll
+    public boolean invokeEntryDoIHaveRole(String role) {
+        EntryRemote entry = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote-same-domain/ear-ejb-deployment-remote-same-domain-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.oidc.client.propagation.annotation.EntryRemote");
+        return entry.doIHaveRole(role);
+    }
+
+    @PermitAll
+    public String[] switchThenInvokeEntryDoIHaveRole(String username, String password, String role) {
+        EntryRemote entry = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote-same-domain/ear-ejb-deployment-remote-same-domain-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.oidc.client.propagation.annotation.EntryRemote");
+        final Callable<String[]> callable = () -> {
+            String remoteWho = entry.whoAmI();
+            boolean hasRole = entry.doIHaveRole(role);
+            return new String[] { remoteWho, String.valueOf(hasRole) };
+        };
+        try {
+            return switchIdentity(username, password, callable);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ServletOnlyRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/ServletOnlyRemote.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import static org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration.JBOSS_ADMIN_ROLE;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { JBOSS_ADMIN_ROLE }))
+@DeclareRoles(JBOSS_ADMIN_ROLE)
+public class ServletOnlyRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+
+        try {
+            EntryRemote bean = lookup(EntryRemote.class, "java:global/ear-ejb-deployment-remote-same-domain/ear-ejb-deployment-remote-same-domain-ejb/EntryBeanRemote!org.wildfly.test.integration.elytron.oidc.client.propagation.annotation.EntryRemote");
+            writer.write(bean.whoAmI() + "," + String.valueOf(bean.doIHaveRole("Managers")));
+        } catch (Exception e) {
+            throw new ServletException("Unexpected Failure", e);
+        }
+    }
+
+    public static <T> T lookup(Class<T> clazz, String jndiName) {
+        Object bean = lookup(jndiName);
+        return clazz.cast(bean);
+    }
+
+    private static Object lookup(String jndiName) {
+        Context context = null;
+        try {
+            context = new InitialContext();
+            return context.lookup(jndiName);
+        } catch (NamingException ex) {
+            throw new IllegalStateException(ex);
+        } finally {
+            try {
+                context.close();
+            } catch (NamingException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/SimpleServletRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/SimpleServletRemote.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+
+import static org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration.JBOSS_ADMIN_ROLE;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@WebServlet(urlPatterns = "/whoAmI", loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = { JBOSS_ADMIN_ROLE }))
+@DeclareRoles(JBOSS_ADMIN_ROLE)
+public class SimpleServletRemote extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private EntryRemote bean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        Writer writer = resp.getWriter();
+
+        try {
+            writer.write(bean.whoAmI() + "," + String.valueOf(bean.doIHaveRole("Managers")));
+        } catch (Exception e) {
+            throw new ServletException("Unexpected Failure", e);
+        }
+    }
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/WhoAmIBeanRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/WhoAmIBeanRemote.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+import org.wildfly.test.integration.elytron.oidc.client.propagation.base.WhoAmIBean;
+
+/**
+ * Concrete implementation to allow deployment of bean.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@Stateless
+@SecurityDomain("ear-servlet-ejb-deployment-remote-same-domain.ear")
+public class WhoAmIBeanRemote extends WhoAmIBean implements WhoAmIRemote {
+}

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/WhoAmIRemote.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/annotation/WhoAmIRemote.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.oidc.client.propagation.annotation;
+
+import java.security.Principal;
+import jakarta.ejb.Remote;
+
+/**
+ * The local interface to the simple WhoAmI bean.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Remote
+public interface WhoAmIRemote {
+
+    /**
+     * @return the caller principal obtained from the EJBContext.
+     */
+    Principal getCallerPrincipal();
+
+    /**
+     * @param roleName - The role to check.
+     * @return The result of calling EJBContext.isCallerInRole() with the supplied role name.
+     */
+    boolean doIHaveRole(String roleName);
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17781

Depends on https://github.com/wildfly/wildfly-core/pull/5452
