### PR TITLE
[WFLY-17856] The undertow-servlet module needs a dependency on the Elytron EE Jakarta Authorization module

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server-servlet/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server-servlet/main/module.xml
@@ -37,6 +37,7 @@
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-web.undertow-server"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.security.jakarta.authorization"/>
         <module name="io.undertow.core"/>
         <module name="io.undertow.servlet"/>
         <module name="javax.servlet.api"/>


### PR DESCRIPTION
It now implements an SPI from this module.

https://issues.redhat.com/browse/WFLY-17856