### PR TITLE
WFLY-17874 Drop obsolete dependency on wildfly-clustering-infinispan-client-api from wildfly-clustering-web-hotrod

### DIFF
--- a/clustering/web/hotrod/pom.xml
+++ b/clustering/web/hotrod/pom.xml
@@ -79,10 +79,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-clustering-infinispan-client-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-client-spi</artifactId>
         </dependency>
         <dependency>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/cache/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/cache/main/module.xml
@@ -35,16 +35,12 @@
     <dependencies>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>
-        <module name="org.jboss.as.clustering.common"/>
-        <module name="org.jboss.as.controller"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.msc"/>
         <module name="org.wildfly.clustering.ee.cache"/>
         <module name="org.wildfly.clustering.ee.spi"/>
         <module name="org.wildfly.clustering.marshalling.api"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
-        <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.spi"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
@@ -52,7 +52,6 @@
         <module name="org.wildfly.clustering.ee.cache" services="import"/>
         <module name="org.wildfly.clustering.ee.hotrod"/>
         <module name="org.wildfly.clustering.ee.spi"/>
-        <module name="org.wildfly.clustering.infinispan.client.api"/>
         <module name="org.wildfly.clustering.infinispan.client.service"/>
         <module name="org.wildfly.clustering.infinispan.client.spi"/>
         <module name="org.wildfly.clustering.marshalling.api"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/hotrod/main/module.xml
@@ -43,23 +43,15 @@
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>
-        <module name="org.jboss.as.clustering.common"/>
-        <module name="org.jboss.as.controller"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
-        <module name="org.jboss.msc"/>
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.ee.cache" services="import"/>
         <module name="org.wildfly.clustering.ee.hotrod"/>
         <module name="org.wildfly.clustering.ee.spi"/>
-        <module name="org.wildfly.clustering.infinispan.client.service"/>
         <module name="org.wildfly.clustering.infinispan.client.spi"/>
-        <module name="org.wildfly.clustering.marshalling.api"/>
-        <module name="org.wildfly.clustering.marshalling.jboss"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.server.api"/>
-        <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.cache" services="import"/>
         <module name="org.wildfly.clustering.web.spi"/>
         <module name="org.wildfly.common"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
@@ -43,22 +43,18 @@
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
         <module name="org.wildfly.clustering.context"/>
         <module name="org.wildfly.clustering.ee.cache" services="import"/>
         <module name="org.wildfly.clustering.ee.infinispan" services="import"/>
         <module name="org.wildfly.clustering.ee.spi"/>
         <module name="org.wildfly.clustering.infinispan.embedded.api"/>
         <module name="org.wildfly.clustering.infinispan.embedded.spi" services="import"/>
-        <module name="org.wildfly.clustering.marshalling.api"/>
-        <module name="org.wildfly.clustering.marshalling.jboss"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.server.api"/>
         <!-- Make sure galleon includes this module -->
         <module name="org.wildfly.clustering.server.infinispan" optional="true"/>
         <module name="org.wildfly.clustering.server.spi"/>
-        <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.cache" services="import"/>
         <module name="org.wildfly.clustering.web.spi"/>
         <module name="org.wildfly.common"/>


### PR DESCRIPTION
... and related module dependency cleanup.

https://issues.redhat.com/browse/WFLY-17874