### PR TITLE
[WFLY-17890] forces jacorb's migrate() op to use elytron security

### DIFF
--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
@@ -77,6 +77,7 @@ public final class JacORBSubsystemConstants {
     public static final String NAMING = "naming";
     public static final String NAMING_EXPORT_CORBALOC = "export-corbaloc";
     public static final String NAMING_ROOT_CONTEXT = "root-context";
+    public static final String ELYTRON = "elytron";
     public static final String IDENTITY = "identity";
     public static final String INTEROP = "interop";
     public static final String INTEROP_SUN = "sun";

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/TransformUtils.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/TransformUtils.java
@@ -82,7 +82,7 @@ public class TransformUtils {
                         if (legacyValue.asString().equals(JacORBSubsystemConstants.OFF)) {
                             value = new ModelNode(Constants.NONE);
                         } else {
-                            value = legacyValue;
+                            value = new ModelNode(JacORBSubsystemConstants.ELYTRON);
                         }
                         break;
                     case JacORBSubsystemConstants.SECURITY_SUPPORT_SSL:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17890