### PR TITLE
[WFLY-17886] IIOP: make sure that configuration of client security ty…

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -450,7 +450,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
                         super.recordCapabilitiesAndRequirements(context, operation, resource);
                         ModelNode model = resource.getModel();
                         String security = IIOPRootDefinition.SECURITY.resolveModelAttribute(context, model).asStringOrNull();
-                        if (SecurityAllowedValues.IDENTITY.toString().equals(security)) {
+                        if (SecurityAllowedValues.IDENTITY.toString().equals(security) || SecurityAllowedValues.CLIENT.toString().equals(security)) {
                             context.deregisterCapabilityRequirement(LEGACY_SECURITY, Capabilities.IIOP_CAPABILITY, Constants.ORB_INIT_SECURITY);
                         }
                     }
@@ -477,8 +477,10 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
                 boolean newIsLegacy;
                 try {
                     // For historic reasons this attribute supports expressions so resolution is required.
-                    oldIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, oldValue).asStringOrNull());
-                    newIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, newValue).asStringOrNull());
+                    oldIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, oldValue).asStringOrNull())
+                            || SecurityAllowedValues.CLIENT.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, oldValue).asStringOrNull());
+                    newIsLegacy = SecurityAllowedValues.IDENTITY.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, newValue).asStringOrNull())
+                            || SecurityAllowedValues.CLIENT.toString().equals(IIOPRootDefinition.SECURITY.resolveValue(context, newValue).asStringOrNull());
                 } catch (OperationFailedException e) {
                     throw new RuntimeException(e);
                 }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -130,7 +130,7 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
         if (IIOPExtension.SUBSYSTEM_NAME.equals(context.getCurrentAddressValue())) {
             ModelNode model = resource.getModel();
             String security = IIOPRootDefinition.SECURITY.resolveModelAttribute(context, model).asStringOrNull();
-            if (SecurityAllowedValues.IDENTITY.toString().equals(security)) {
+            if (SecurityAllowedValues.IDENTITY.toString().equals(security) || SecurityAllowedValues.CLIENT.toString().equals(security)) {
                 context.registerAdditionalCapabilityRequirement(LEGACY_SECURITY, IIOP_CAPABILITY, Constants.ORB_INIT_SECURITY);
             }
         }

--- a/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
+++ b/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
@@ -15,7 +15,7 @@ iiop-openjdk.high-water-mark=TCP connection cache parameter. Each time the numbe
 iiop-openjdk.number-to-reclaim=TCP connection cache parameter. Each time number of connections exceeds tcp-high-water-mark property then ORB tries to reclaim connections. Number of reclaimed connections is specified by this property. If it is not set then it is configured as OpenJDK ORB default.
 
 # orb initializers configuration properties.
-iiop-openjdk.security=Indicates whether the security interceptors are to be installed (client, identity, elytron) or not (none).
+iiop-openjdk.security=iiop-openjdk.security=Indicates whether the security interceptors are to be installed (elytron) or not (none). identity and client are legacy security configurations which are valid for compatibility reasons but are no longer supported.
 iiop-openjdk.authentication-context=The name of the authentication context used when the security initializer is set to 'elytron'.
 iiop-openjdk.transactions=Indicates whether the transactions interceptors are to be installed (full or spec) or not (none). The value 'full' enabled JTS while 'spec' enables a spec compliant mode (non JTS) that rejects incoming transaction contexts.
 


### PR DESCRIPTION
…pe installs requirement on legacy-security capability

https://issues.redhat.com/browse/WFLY-17886

client security configuration relies on legacy-security as well so it should behave the same way as identity security regarding capability registration.
