### PR TITLE
WFLY-17895 Upgrade to Hibernate ORM 6.2.1.Final and enable SessionFactoryTestCase testInjectPUIntoHibernateSessionFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
-        <version.org.hibernate>6.2.0.Final</version.org.hibernate>
+        <version.org.hibernate>6.2.1.Final</version.org.hibernate>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.8.Final</version.org.infinispan>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/SessionFactoryTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -125,7 +124,6 @@ public class SessionFactoryTestCase {
 
     // Test that a Persistence unit can be injected into a Hibernate Session factory
     @Test
-    @Ignore // WFLY-17830: renable when upgrading to Hibernate ORM 6.2.1.Final which should have the https://github.com/hibernate/hibernate-orm/pull/6350 change included
     public void testInjectPUIntoHibernateSessionFactory() throws Exception {
 
         SFSBHibernateSessionFactory sfsbHibernateSessionFactory =


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17895 (ORM 6.2.1.Final upgrade)
https://issues.redhat.com/browse/WFLY-17830 (enable testInjectPUIntoHibernateSessionFactory test).
