### PR TITLE
[WFLY-17605] Add in topology update wait time to stabilize before beginning test to avoid race condition.

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -43,11 +43,9 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionSupplier;
-
 
 import javax.naming.Context;
 
@@ -55,10 +53,8 @@ import javax.naming.Context;
  * A test of failover when both legacy remoting connector and HTTP Upgrade connector are enabled.
  * @author Richard Achmatowicz
  */
-
 @ServerSetup(TwoConnectorsEJBFailoverTestCase.ServerSetupTask.class)
 @RunWith(Arquillian.class)
-@Ignore("WFLY-17605")
 public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final int COUNT = 20;
@@ -134,6 +130,10 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
      * A SFSB failover test which accepts an EJBDirectory provider parameter to adjust client behaviour
      */
     public void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
+
+        // give the servers a moment to stabilize before invocation start
+        Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
         try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 


### PR DESCRIPTION
This PR does the following:
- for the test case TwoConnectorsEJBFailoverTestCase, which tests a single EJB client interacting with cluster members via the remoting protocol (on port 4447) and the remote+http protocol (on port 8080), adds in a delay to the first client interaction with the clustered deployment, to allow the cluster time to stablize when run on slow servers and prevent the client invoing on the cluster before it is ready.
-
For more details, see: https://issues.redhat.com/browse/WFLY-17605
