### PR TITLE
[WFLY-17904] Upgrade the RESTEasy Tracing API to 2.0.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
-        <version.org.jboss.resteasy.extensions>2.0.0.Final</version.org.jboss.resteasy.extensions>
+        <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.1.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.1.Final</version.org.jboss.resteasy.spring>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17904

This includes a fix for https://github.com/resteasy/resteasy-extensions/issues/37. This is a critical issue.