### PR TITLE
[WFLY-17905] Clean out unneeded xalan references

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1620,12 +1620,8 @@
                 <version>${version.org.apache.ws.xmlschema}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.apache.bcel</groupId>
-                        <artifactId>bcel</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xalan</groupId>
-                        <artifactId>xalan</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -421,6 +421,18 @@
                 <version>${version.org.wildfly.extras.creaper}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>xom</groupId>
+                <artifactId>xom</artifactId>
+                <version>${version.xom}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1080,23 +1080,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- Required for testsuite/shared which will later be moved to a test bom (WFLY-17331) -->
-            <dependency>
-                <groupId>xom</groupId>
-                <artifactId>xom</artifactId>
-                <version>${version.xom}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xerces</groupId>
-                        <artifactId>xercesImpl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
         </dependencies>
 
     </dependencyManagement>


### PR DESCRIPTION
There's still some likely crufty mentions of xalan in ee-feature-pack/common/javadoc and testsuite/tools/reporting/stylesheets/junit-frames.xsl but this covers my objective with this issue.

https://issues.redhat.com/browse/WFLY-17905