### PR TITLE
[WFLY-17890] JacORB migration: add security migration to Elytron warning

### DIFF
--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/TransformUtils.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/TransformUtils.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.jacorb.logging.JacORBLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -83,6 +84,7 @@ public class TransformUtils {
                             value = new ModelNode(Constants.NONE);
                         } else {
                             value = new ModelNode(JacORBSubsystemConstants.ELYTRON);
+                            JacORBLogger.ROOT_LOGGER.migratedToElytronSecurityWarning();
                         }
                         break;
                     case JacORBSubsystemConstants.SECURITY_SUPPORT_SSL:

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/logging/JacORBLogger.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/logging/JacORBLogger.java
@@ -448,4 +448,9 @@ public interface JacORBLogger extends BasicLogger {
             "should be transformed manually to the new iiop-openjdk subsystem format")
     String expressionMigrationWarning(String properties);
 
+    @LogMessage(level = WARN)
+    @Message(id=137, value = "After the migration the subsystem will use Elytron implementation of org.omg.PortableInterceptor.ClientRequestInterceptor. " +
+            "Please refer to org.wildfly.iiop.openjdk.csiv2.ElytronSASClientInterceptor documentation for the implementation details.")
+    void migratedToElytronSecurityWarning();
+
 }


### PR DESCRIPTION
This is https://github.com/emmartins/wildfly/pull/1, but against the wildfly repo as the #16730 branch it targets is now merged.

https://issues.redhat.com/browse/WFLY-17890