### PR TITLE
[WFLY-17906] Remove invalid dependency io.opentelemetry:opentelemetry-sdk-extension

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -419,17 +419,6 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-sdk-extension</artifactId>
-                <version>${version.io.opentelemetry.opentelemetry}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
                 <version>${version.io.opentelemetry.opentelemetry}-alpha</version>
                 <exclusions>

--- a/galleon-pack/common/src/main/resources/license/licenses.xml
+++ b/galleon-pack/common/src/main/resources/license/licenses.xml
@@ -198,16 +198,6 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-extension</artifactId>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
             <licenses>
                 <license>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17906

Such artifact doesn't exist thus I am simply removing it. If instead there should have been different artifact, then please close this PR.

