### PR TITLE
[WFLY-17908] Removing JDK 8 specific excludes from maven enforcer plugin configurations

### DIFF
--- a/ee-feature-pack/common/pom.xml
+++ b/ee-feature-pack/common/pom.xml
@@ -3834,11 +3834,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/ee-feature-pack/ee-10-api/pom.xml
+++ b/ee-feature-pack/ee-10-api/pom.xml
@@ -289,11 +289,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -414,9 +414,6 @@
                                     <rules>
                                         <banTransitiveDependencies>
                                             <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-common</exclude>

--- a/ee-feature-pack/pruned/pom.xml
+++ b/ee-feature-pack/pruned/pom.xml
@@ -116,11 +116,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/galleon-pack/common/pom.xml
+++ b/galleon-pack/common/pom.xml
@@ -164,11 +164,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -297,9 +297,6 @@
                                     <rules>
                                         <banTransitiveDependencies>
                                             <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
                                                 <exclude>${full.maven.groupId}:wildfly-mp-feature-pack-galleon-common</exclude>

--- a/microprofile/galleon-common/pom.xml
+++ b/microprofile/galleon-common/pom.xml
@@ -835,11 +835,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/preview/common-microprofile/pom.xml
+++ b/preview/common-microprofile/pom.xml
@@ -110,11 +110,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/preview/common/pom.xml
+++ b/preview/common/pom.xml
@@ -120,11 +120,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -589,9 +589,6 @@
                                     <rules>
                                         <banTransitiveDependencies>
                                             <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
                                                 <!-- Ignore the shared resource poms as those we want their
                                                      transitives. Those poms ban transitives at their level -->
                                                 <exclude>org.wildfly.core:wildfly-core-feature-pack-common</exclude>

--- a/preview/galleon-content-microprofile/pom.xml
+++ b/preview/galleon-content-microprofile/pom.xml
@@ -106,11 +106,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/preview/galleon-content/pom.xml
+++ b/preview/galleon-content/pom.xml
@@ -106,11 +106,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/testsuite/test-feature-pack-preview/pom.xml
+++ b/testsuite/test-feature-pack-preview/pom.xml
@@ -137,11 +137,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>

--- a/testsuite/test-feature-pack/pom.xml
+++ b/testsuite/test-feature-pack/pom.xml
@@ -137,11 +137,7 @@
                                 <configuration>
                                     <rules>
                                         <banTransitiveDependencies>
-                                            <excludes>
-                                                <!-- Ignore jdk jars because they are system scope -->
-                                                <exclude>com.sun:tools</exclude>
-                                                <exclude>sun.jdk:jconsole</exclude>
-                                            </excludes>
+                                            <excludes/>
                                         </banTransitiveDependencies>
                                     </rules>
                                 </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17908
