### PR TITLE
Disable JPA2LCTestCase and JpaStatisticsTestCase on OpenJ9

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +54,11 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Arquillian.class)
 public class JPA2LCTestCase {
+
+    @BeforeClass
+    public static void noOpenJ9() {
+        org.junit.Assume.assumeFalse("WFLY-17913", System.getProperty("java.vm.name", "").contains("OpenJ9"));
+    }
 
     private static final String ARCHIVE_NAME = "jpa_SecondLevelCacheTestCase";
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JpaStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JpaStatisticsTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,6 +54,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class JpaStatisticsTestCase extends ContainerResourceMgmtTestBase {
+
+    @BeforeClass
+    public static void noOpenJ9() {
+        org.junit.Assume.assumeFalse("WFLY-17913", System.getProperty("java.vm.name", "").contains("OpenJ9"));
+    }
 
     private static final String ARCHIVE_NAME = "JpaStatisticsTestCase";
 


### PR DESCRIPTION
https://ci.wildfly.org/viewLog.html?buildId=365232& is a custom run of the nightly OpenJ9 job with this in place.