### PR TITLE
[WFLY-16975] Removing TokenUtilsEncryptTest workaround after upgrade to MP JWT 2.1

### DIFF
--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -208,7 +208,6 @@
                     <systemPropertyVariables>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                     </systemPropertyVariables>
-                    <argLine>-Djdk.security.defaultKeySize=AES:128</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16975
