### PR TITLE
[20.x] Upgrade jboss-ejb-client to allow running on Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.33.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.52.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.6.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
Wildfly 20.x currently ships with a version of `jboss-ejb-client` which breaks the stricter encapsulation rules introduced in Java 17.

`jboss-ejb-client` has fixed this issue in later versions, so it would be good to update Wildfly 20.x to use version which works on Java 17 and later.
