### PR TITLE
[WFLY-15358] Refactor PolicyContextTestCase so it tests access to HttpServletRequest in Servlet and EJB containers.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestBean.java
@@ -31,6 +31,11 @@ import jakarta.servlet.http.HttpServletRequest;
 public class PolicyContextTestBean {
 
     public HttpServletRequest getHttpServletRequestFromPolicyContext() throws PolicyContextException {
+        return getHttpServletRequest();
+    }
+
+    // public as accessed from a different module.
+    public static HttpServletRequest getHttpServletRequest() throws PolicyContextException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) PolicyContext
                 .getContext("jakarta.servlet.http.HttpServletRequest");
         return httpServletRequest;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestServlet.java
@@ -23,16 +23,21 @@
 package org.jboss.as.test.integration.security.jacc.context;
 
 import java.io.IOException;
+
+import org.jboss.logging.Logger;
+import org.wildfly.common.function.ExceptionSupplier;
+
 import jakarta.ejb.EJB;
-import jakarta.security.jacc.PolicyContextException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@WebServlet(urlPatterns = {PolicyContextTestServlet.SERVLET_PATH})
+@WebServlet(urlPatterns = { PolicyContextTestServlet.SERVLET_PATH })
 public class PolicyContextTestServlet extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(PolicyContextTestServlet.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -43,11 +48,35 @@ public class PolicyContextTestServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // This test is just using a static method on the bean implementation so it running in the servlet container.
+        boolean availableForServlet = isAvailable(PolicyContextTestBean::getHttpServletRequest);
+        // This test makes a call to the EJB so is running in the EJB container.
+        boolean availableForEjb = isAvailable(() -> policyContextTestBean.getHttpServletRequestFromPolicyContext());
+
+        if (!availableForServlet || !availableForEjb) {
+            throw new ServletException(String.format(
+                    "HttpServletRequest not available in all containers availableForServlet=%b, availableForEjb=%b.",
+                    availableForServlet, availableForEjb));
+        }
+
+        String responseString = "HttpServletRequest successfully obtained from both containers.";
+        LOGGER.debug(responseString);
+        response.getWriter().write(responseString);
+    }
+
+    private boolean isAvailable(ExceptionSupplier<HttpServletRequest, Exception> testSupplier) {
         try {
-            HttpServletRequest servletRequest = this.policyContextTestBean.getHttpServletRequestFromPolicyContext();
-            if (servletRequest != null) { response.getWriter().write("EJB successfully retrieved HttpServletRequest reference from PolicyContext"); }
-        } catch (PolicyContextException e) {
-            throw new ServletException("Error retrieving request: " + e.getMessage(), e);
+            HttpServletRequest request = testSupplier.get();
+
+            if (request == null) {
+                LOGGER.debug("Instance from test Supplier<T> was null.");
+                return false;
+            }
+
+            return true;
+        } catch (Exception e) {
+            LOGGER.warn("Unable to get instance from test Supplier<T>", e);
+            return false;
         }
     }
 }


### PR DESCRIPTION
Enable the Elytron JACC Policy so the PolicyContext is registered at boot.

https://issues.redhat.com/browse/WFLY-15358