### PR TITLE
[WFLY-17943] Use SystemExiter.abort instead of deprecated exit variant

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
@@ -162,7 +162,7 @@ public final class Main {
                 t.printStackTrace(STDERR);
             }
         } finally {
-            SystemExiter.exit(1);
+            SystemExiter.abort(1);
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17943