### PR TITLE
[WFLY-17871] added test-case for managed executor service defined via…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -2798,7 +2798,7 @@
                                 </configuration>
                             </execution>
 
-                            <!-- Tests against the install with ejb-lite -->
+                            <!-- Tests against the install with ee-concurrency -->
                             <execution>
                                 <id>ee-concurrency-layers.surefire</id>
                                 <phase>test</phase>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceAnnotationBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceAnnotationBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.LocalBean;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+
+@ManagedExecutorDefinition(
+        name = "java:module/concurrent/MyExecutor",
+        context = "java:module/concurrent/MyExecutorContext",
+        hungTaskThreshold = 120000,
+        maxAsync = 5)
+@ContextServiceDefinition(
+        name = "java:module/concurrent/MyExecutorContext",
+        propagated = { SECURITY, APPLICATION })
+@Stateless
+@LocalBean
+public class ManagedExecutorServiceAnnotationBean {
+
+    @Resource(lookup = "java:module/concurrent/MyExecutor")
+    ManagedExecutorService executorService;
+
+    public Future<?> testRunnable(Runnable runnable) throws ExecutionException, InterruptedException {
+        assert executorService != null;
+        return executorService.submit(runnable);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceAnnotationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceAnnotationTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+import jakarta.annotation.Resource;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for ManagedExecutorService defined via @ManagedExecutorDefinition
+ *
+ * @author Ivo Studensky
+ */
+@RunWith(Arquillian.class)
+public class ManagedExecutorServiceAnnotationTestCase {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, ManagedExecutorServiceAnnotationTestCase.class.getSimpleName() + ".jar")
+                .addClasses(ManagedExecutorServiceAnnotationTestCase.class, ManagedExecutorServiceAnnotationBean.class);
+    }
+
+    @Resource(lookup = "java:module/ManagedExecutorServiceAnnotationBean")
+    ManagedExecutorServiceAnnotationBean service;
+
+    private static void testMethod() {
+        // empty method
+    }
+
+    @Test
+    public void testExecutorService() throws Exception {
+        Assert.assertNotNull(service);
+        service.testRunnable(ManagedExecutorServiceAnnotationTestCase::testMethod).get();
+    }
+}


### PR DESCRIPTION
… annotation

This is a test-case for managed executor service defined via annotations. I can't see any such test in the test-suite.

Issue: https://issues.redhat.com/browse/WFLY-17871
