### PR TITLE
[WFLY-17907] Increase test timeout

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
@@ -273,11 +273,6 @@ public class ReactiveMessagingKafkaUserApiTestCase {
             brokerProperties.put(KafkaConfig.NumPartitionsProp(), String.valueOf(getPartitions()));
         }
 
-//        @Override
-//        protected String[] getTopics() {
-//            return new String[]{"testing1", "testing2", "testing3", "testing4", "testing5", "testing6"};
-//        }
-
         @Override
         protected Map<String, Integer> getTopicsAndPartitions() {
             Map<String, Integer> map = new LinkedHashMap<>();

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/RunKafkaWithSslSetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/RunKafkaWithSslSetupTask.java
@@ -78,11 +78,15 @@ public class RunKafkaWithSslSetupTask implements ServerSetupTask {
             companion = new KafkaCompanion(EmbeddedKafkaBroker.toListenerString(internal));
             companion.topics().createAndWait("testing", 1, Duration.of(10, ChronoUnit.SECONDS));
         } catch (Exception e) {
-            if (companion != null) {
-                companion.close();
-            }
-            if (broker != null) {
-                broker.close();
+            try {
+                if (companion != null) {
+                    companion.close();
+                }
+                if (broker != null) {
+                    broker.close();
+                }
+            } finally {
+                throw e;
             }
         }
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
@@ -54,7 +54,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 public class ReactiveMessagingKafkaTestCase {
 
-    private static final long TIMEOUT = TimeoutUtil.adjust(15000);
+    private static final long TIMEOUT = TimeoutUtil.adjust(25000);
 
     @Inject
     Bean bean;


### PR DESCRIPTION
Make sure errors from the Kafka setup tasks are propagated now that logging is enabled. It will give us some pointers as to if Kafka did not start properly.

https://issues.redhat.com/browse/WFLY-17907