### PR TITLE
WFLY-17958 Persistence container bytecode enhancement should be enabled by default

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -141,11 +141,6 @@ public class Configuration {
      */
     public static final String JPA_CONTAINER_CLASS_TRANSFORMER = "jboss.as.jpa.classtransformer";
 
-    private static final String HIBERNATE_USE_CLASS_ENHANCER = "hibernate.ejb.use_class_enhancer";
-    private static final String HIBERNATE_ENABLE_DIRTY_TRACKING = "hibernate.enhancer.enableDirtyTracking";
-    private static final String HIBERNATE_ENABLE_LAZY_INITIALIZATION = "hibernate.enhancer.enableLazyInitialization";
-    private static final String HIBERNATE_ENABLE_ASSOCIATION_MANAGEMENT = "hibernate.enhancer.enableAssociationManagement";
-
     /**
      * set to false to force a single phase persistence unit bootstrap to be used (default is true
      * which uses two phases to start the persistence unit).
@@ -276,32 +271,17 @@ public class Configuration {
     /**
      * Determine if class file transformer is needed for the specified persistence unit
      *
-     * if the persistence provider is Hibernate and use_class_enhancer is not true, don't need a class transformer.
-     * for other persistence providers, the transformer is assumed to be needed.
+     * for all persistence providers, the transformer is assumed to be needed unless the application indicates otherwise.
      *
      * @param pu the PU
      * @return true if class file transformer support is needed for pu
      */
     public static boolean needClassFileTransformer(PersistenceUnitMetadata pu) {
-        boolean result = true;
-        String provider = pu.getPersistenceProviderClassName();
-        if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
-            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
-        }
-        else if (isHibernateProvider(provider)) {
-            result = (Boolean.TRUE.toString().equals(pu.getProperties().getProperty(HIBERNATE_USE_CLASS_ENHANCER))
-                    || Boolean.TRUE.toString().equals(pu.getProperties().getProperty(HIBERNATE_ENABLE_DIRTY_TRACKING))
-                    || Boolean.TRUE.toString().equals(pu.getProperties().getProperty(HIBERNATE_ENABLE_LAZY_INITIALIZATION))
-                    || Boolean.TRUE.toString().equals(pu.getProperties().getProperty(HIBERNATE_ENABLE_ASSOCIATION_MANAGEMENT)));
-        }
-        return result;
-    }
 
-    private static boolean isHibernateProvider(String provider) {
-        return provider == null ||
-                PROVIDER_CLASS_HIBERNATE.equals(provider) ||
-                PROVIDER_CLASS_HIBERNATE_OGM.equals(provider) ||
-                PROVIDER_CLASS_HIBERNATE4_1.equals(provider);
+        if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
+            return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
+        }
+        return true;
     }
 
     // key = provider class name, value = adapter module name

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
@@ -90,4 +90,11 @@ public class ClassFileTransformerTestCase {
         assertTrue("was able to read database row with hibernate.ejb.use_class_enhancer enabled", emp != null);
     }
 
+    @Test
+    public void testHibernateByteCodeEnhancement() {
+        // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
+        // accordingly.
+        assertTrue("Employee class is not bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
+    }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/persistence.xml
@@ -32,6 +32,7 @@
                  to delay starting the persistence unit service until the install phase.
              -->
             <property name="wildfly.jpa.twophasebootstrap" value="false"/>
+            <property name="wildfly.jpa.applicationdatasource" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/webnontxem/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/webnontxem/persistence.xml
@@ -28,6 +28,10 @@
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
+            <!-- TODO: WFLY-17966 Allow JPA bytecode enhancement to work with applications using java:comp/DefaultDataSource
+               To recreate, set <property name="jboss.as.jpa.classtransformer" value="true"/>
+            -->
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17958

The workaround of setting `<property name="jboss.as.jpa.classtransformer" value="true"/>` is provided in the issue.  We have supported this property for many years and will likely continue to support it in the future as it has served us well with Hibernate ORM.  With other persistence providers, we have always defaulted `jboss.as.jpa.classtransformer` on.

This issue + pull request is about changing the default for `jboss.as.jpa.classtransformer` from false to true, which means applications will now need to opt out of (JPA/Persistence container managed) bytecode enhancement if they wish.