### PR TITLE
[WFLY-17960] Do not register the org.jboss.resteasy.plugins.server.se…

### DIFF
--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/service/LRACoordinatorService.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/service/LRACoordinatorService.java
@@ -25,7 +25,6 @@ package org.wildfly.extension.microprofile.lra.coordinator.service;
 import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
-import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletInfo;
 import org.jboss.msc.Service;
@@ -33,7 +32,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.wildfly.extension.microprofile.lra.coordinator._private.MicroProfileLRACoordinatorLogger;
 import org.wildfly.extension.microprofile.lra.coordinator.jaxrs.LRACoordinatorApp;
 import org.wildfly.extension.undertow.Host;
@@ -86,8 +84,6 @@ public final class LRACoordinatorService implements Service {
         // JAX-RS setup
         ServletInfo restEasyServlet = new ServletInfo("RESTEasy", HttpServletDispatcher.class).addMapping("/*");
         deploymentInfo.addServlets(restEasyServlet);
-        ListenerInfo restEasyListener = new ListenerInfo(ResteasyBootstrap.class);
-        deploymentInfo.addListener(restEasyListener);
 
         for (Map.Entry<String, String> entry : initialParameters.entrySet()) {
             deploymentInfo.addInitParameter(entry.getKey(), entry.getValue());

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/service/LRAParticipantService.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/service/LRAParticipantService.java
@@ -27,7 +27,6 @@ import static org.wildfly.extension.microprofile.lra.participant.MicroProfileLRA
 import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
-import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletInfo;
 import jakarta.servlet.ServletException;
@@ -36,7 +35,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.wildfly.extension.microprofile.lra.participant._private.MicroProfileLRAParticipantLogger;
 import org.wildfly.extension.microprofile.lra.participant.jaxrs.LRAParticipantApplication;
 import org.wildfly.extension.undertow.Host;
@@ -99,8 +97,6 @@ public final class LRAParticipantService implements Service {
         // JAX-RS setup
         ServletInfo restEasyServlet = new ServletInfo("RESTEasy", HttpServletDispatcher.class).addMapping("/*");
         deploymentInfo.addServlets(restEasyServlet);
-        ListenerInfo restEasyListener = new ListenerInfo(ResteasyBootstrap.class);
-        deploymentInfo.addListener(restEasyListener);
 
         for (Map.Entry<String, String> entry : initialParameters.entrySet()) {
             deploymentInfo.addInitParameter(entry.getKey(), entry.getValue());


### PR DESCRIPTION
…rvlet.ResteasyBootstrap listener on the servlet. The servlet already handles creating this. This ends up crating two different RESTEasy deployments.

https://issues.redhat.com/browse/WFLY-17960