### PR TITLE
[WFLY-17959] OpenTelemetry is complaining about "java.lang.NoClassDefFoundError: sun/misc/Unsafe"

### DIFF
--- a/galleon-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/sdk/main/module.xml
+++ b/galleon-pack/common/src/main/resources/modules/system/layers/base/io/opentelemetry/sdk/main/module.xml
@@ -39,6 +39,8 @@
         <module name="io.opentelemetry.context"/>
         <module name="io.opentelemetry.exporter"/>
         <module name="io.smallrye.opentelemetry"/>
+
         <module name="java.logging"/>
+        <module name="jdk.unsupported"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17959

Add `<module name="jdk.unsupported"/>`
