### PR TITLE
WFLY-17914 Upgrade to Hibernate 6.2.2.final release that maps Character[]/Byte[] to SQL Array by default unless DB doesn't allow

### DIFF
--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
@@ -26,7 +26,6 @@ import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.spi.PersistenceUnitInfo;
 
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.type.WrapperArrayHandling;
 import org.jboss.as.jpa.hibernate.management.HibernateManagementAdaptor;
 import org.jboss.as.jpa.hibernate.service.WildFlyCustomJtaPlatform;
 import org.jipijapa.cache.spi.Classification;
@@ -93,11 +92,6 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
 
         // Enable JPA Compliance mode
         putPropertyIfAbsent( pu, properties, AvailableSettings.JPA_COMPLIANCE, true);
-
-        // WFLY-17881 default to legacy setting for
-        // https://docs.jboss.org/hibernate/orm/6.2/migration-guide/migration-guide.html#byte-and-character-array-mapping-changes
-        putPropertyIfAbsent(pu, properties, AvailableSettings.WRAPPER_ARRAY_HANDLING, WrapperArrayHandling.LEGACY);
-
     }
 
     private void failOnIncompatibleSetting(PersistenceUnitMetadata pu, Map properties) {

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
-        <version.org.hibernate>6.2.1.Final</version.org.hibernate>
+        <version.org.hibernate>6.2.2.Final</version.org.hibernate>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.8.Final</version.org.infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17914
Revert  https://issues.redhat.com/browse/WFLY-17881

Upgrade to Hibernate 6.2.2.final release that maps Character[]/Byte[] to SQL Array by default unless database in use doesn't allow.

Revert `WFLY-17881 Fix Jakarta EE 10 TCK jpa/core test failures (related to Byte[]/Character[] mapping changes in ORM 6.2)` since that was incorrect for databases that support SQL ARRAY type.  Instead Hibernate ORM 6.2.2.Final will map Byte[]/Character[] to SQL ARRAY type if supported, otherwise legacy types are mapped (similar to mapping of byte[]/char[]).
