### PR TITLE
[WFLY-17933] Eliminating deprecated javax.sql.api module usages

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
@@ -31,7 +31,6 @@
 
     <dependencies>
         <module name="java.sql"/>
-        <module name="javax.sql.api"/>
         <module name="jdk.unsupported"/>
     </dependencies>
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
@@ -33,10 +33,10 @@
 
     <dependencies>
         <module name="io.agroal"/>
-        <module name="java.security.jgss"/>
         <module name="jakarta.annotation.api"/>
-        <module name="javax.sql.api"/>
         <module name="jakarta.transaction.api"/>
+        <module name="java.security.jgss"/>
+        <module name="java.sql"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -41,6 +41,7 @@ public class LayersTestCase {
             // not used
             "ibm.jdk",
             "javax.api",
+            "javax.sql.api",
             "javax.xml.stream.api",
             "sun.jdk",
             "sun.scripting",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17933
