### PR TITLE
[WFLY-17994] The management layer is not optional for jmx-remoting.

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -311,7 +311,7 @@ link:#gal.base-server[base-server] +
 |Support for a JMX remoting connector.
 |
 link:#gal.jmx[jmx] +
-link:#gal.management[management] (optional) +
+link:#gal.management[management] +
 
 |[[gal.jpa]]jpa
 |Support for JPA (using the latest WildFly supported Hibernate release). +


### PR DESCRIPTION
The remoting-connector needs the management endpoint for registration.

Previously we had multiple management layers to choose from but now we have just one.

Depends on https://github.com/wildfly/wildfly-core/pull/5491
