### PR TITLE
[WFLY-17990] Ensure foundational layers have an application-security-domain in the undertow subsystem.

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -96,6 +96,7 @@ link:#gal.security-manager[security-manager] (optional) +
 link:#gal.core-server[core-server] +
 link:#gal.cdi[cdi] +
 link:#gal.ee-integration[ee-integration] +
+link:#gal.elytron[elytron] +
 link:#gal.jaxrs[jaxrs-core] +
 link:#gal.jsonp[jsonp] +
 link:#gal.jsonb[jsonb] +

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -57,6 +57,7 @@ You don't have to base your WildFly installation on one of these foundational la
 link:#gal.core-server[core-server] +
 link:#gal.core-tools[core-tools] (optional) +
 link:#gal.datasources[datasources] (optional) +
+link:#gal.elytron[elytron] +
 link:#gal.web-server[web-server] +
 
 |[[gal.jaxrs-server]]jaxrs-server

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -3,6 +3,7 @@
     <dependencies>
         <layer name="web-server"/>
         <layer name="core-server"/>
+        <layer name="elytron"/>  <!-- Non optional dependency needed due to use of undertow-elytron-security feature-group-->
         <layer name="core-tools" optional="true"/>
         <layer name="datasources" optional="true"/>
     </dependencies>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
@@ -23,8 +23,11 @@
         <layer name="core-server"/>
         <layer name="cdi"/>
         <layer name="ee-integration"/>
+        <layer name="elytron"/>  <!-- Non optional dependency needed due to use of undertow-elytron-security feature-group-->
         <layer name="jaxrs-core"/>
         <layer name="jsonp"/>
         <layer name="jsonb"/>
     </dependencies>
+    <!-- Ensure we have an application-security-domain mapping i.e. default security-domain -->
+    <feature-group name="undertow-elytron-security"/>
 </layer-spec>


### PR DESCRIPTION
This also means these layers need a mandatory dependency on the elytron layer.

https://issues.redhat.com/browse/WFLY-17990