### PR TITLE
WFLY-18002 ExpirationMetaData.isExpired() should return true if expiration time is exactly now.

### DIFF
--- a/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/expiration/ExpirationMetaData.java
+++ b/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/expiration/ExpirationMetaData.java
@@ -37,7 +37,7 @@ public interface ExpirationMetaData extends Expiration {
     default boolean isExpired() {
         if (this.isImmortal()) return false;
         Instant lastAccessedTime = this.getLastAccessTime();
-        return (lastAccessedTime != null) ? lastAccessedTime.plus(this.getTimeout()).isBefore(Instant.now()) : false;
+        return (lastAccessedTime != null) ? !lastAccessedTime.plus(this.getTimeout()).isAfter(Instant.now()) : false;
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18002

Upstream PR: https://github.com/wildfly/wildfly/pull/16813