### PR TITLE
WFLY-17958 Persistence container bytecode enhancement should be disabled by default

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -238,6 +238,7 @@ public class Configuration {
     private static final String EE_DEFAULT_DATASOURCE = "java:comp/DefaultDataSource";
     // key = provider class name, value = module name
     private static final Map<String, String> providerClassToModuleName = new HashMap<String, String>();
+    public static final String HIBERNATE = "Hibernate";
 
     static {
         // always choose the default hibernate version for the Hibernate provider class mapping
@@ -281,7 +282,14 @@ public class Configuration {
         if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
             return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
         }
+        final String provider = pu.getPersistenceProviderClassName();
+        if (provider != null && provider.contains(HIBERNATE)) {
+            return false;
+        }
         return true;
+    }
+    private static boolean isHibernateProvider(String provider) {
+        return provider == null || provider.contains("Hibernate");
     }
 
     // key = provider class name, value = adapter module name

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -238,7 +238,7 @@ public class Configuration {
     private static final String EE_DEFAULT_DATASOURCE = "java:comp/DefaultDataSource";
     // key = provider class name, value = module name
     private static final Map<String, String> providerClassToModuleName = new HashMap<String, String>();
-    public static final String HIBERNATE = "Hibernate";
+    private static final String HIBERNATE = "Hibernate";
 
     static {
         // always choose the default hibernate version for the Hibernate provider class mapping
@@ -282,14 +282,14 @@ public class Configuration {
         if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
             return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
         }
-        final String provider = pu.getPersistenceProviderClassName();
-        if (provider != null && provider.contains(HIBERNATE)) {
+        if (isHibernateProvider(pu.getPersistenceProviderClassName())) {
             return false;
         }
         return true;
     }
     private static boolean isHibernateProvider(String provider) {
-        return provider == null || provider.contains("Hibernate");
+        // If the persistence provider is not specified (null case), Hibernate ORM will be used as the persistence provider.
+        return provider == null || provider.contains(HIBERNATE);
     }
 
     // key = provider class name, value = adapter module name

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.jpa.hibernate.classfiletransformertest;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import javax.naming.InitialContext;
@@ -91,10 +92,10 @@ public class ClassFileTransformerTestCase {
     }
 
     @Test
-    public void testHibernateByteCodeEnhancement() {
+    public void testHibernateByteCodeEnhancementIsDisabledByDefault() {
         // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
         // accordingly.
-        assertTrue("Employee class is not bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
+        assertFalse("Employee class is not bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17958

This change reverts part of the https://github.com/wildfly/wildfly/pull/16782 change by reversing the default for ByteCode enhancement to be disabled by default.  

To summarize, with this change, bytecode enhancement is disabled by default now.

