### PR TITLE
[28.x][WFLY-18007] Upgrade xalan to 2.7.3 (CVE-2022-34169)

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -297,6 +297,11 @@
                            <artifactId>xalan</artifactId>
                            <version>2.7.3</version>
                        </dependency>
+                       <dependency>
+                           <groupId>xalan</groupId>
+                           <artifactId>serializer</artifactId>
+                           <version>2.7.3</version>
+                       </dependency>
                    </dependencies>
                </plugin>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -295,7 +295,7 @@
                        <dependency>
                            <groupId>xalan</groupId>
                            <artifactId>xalan</artifactId>
-                           <version>2.7.1</version>
+                           <version>2.7.3</version>
                        </dependency>
                    </dependencies>
                </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18007

Upstream: https://github.com/wildfly/wildfly/pull/16831
