### PR TITLE
[28.x] [WFLY-18005] Upgrade RESTEasy to 6.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <version.org.jboss.mod_cluster>2.0.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.1.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.1.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18005

Upstream #16843 