### PR TITLE
[WFLY-16013]: Print more informative failure messages when working with broadcast/discovery group resources

### DIFF
--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -887,4 +887,6 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 107, value = "You must define a elytron security doman when security is enabled.")
     IllegalStateException securityEnabledWithoutDomain();
 
+    @Message(id = 108, value = "Either socket-binding or jgroups-cluster attribute is required.")
+    OperationFailedException socketBindingOrJGroupsClusterRequired();
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_BINDING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,9 +69,11 @@ public class BroadcastGroupAdd extends ShallowResourceAdd {
             if (operation.hasDefined(JGROUPS_CLUSTER.getName())) {
                 target = target.append(CommonAttributes.JGROUPS_BROADCAST_GROUP, context.getCurrentAddressValue());
                 addHandler = JGroupsBroadcastGroupAdd.LEGACY_INSTANCE;
-            } else {
+            } else if (operation.hasDefined(SOCKET_BINDING.getName())) {
                 target = target.append(CommonAttributes.SOCKET_BROADCAST_GROUP, context.getCurrentAddressValue());
                 addHandler = SocketBroadcastGroupAdd.LEGACY_INSTANCE;
+            } else {
+                throw MessagingLogger.ROOT_LOGGER.socketBindingOrJGroupsClusterRequired();
             }
             op.get(OP_ADDR).set(target.toModelNode());
             context.addStep(op, addHandler, OperationContext.Stage.MODEL, true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -19,7 +19,6 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
@@ -66,6 +65,7 @@ import org.wildfly.extension.messaging.activemq.shallow.ShallowResourceDefinitio
  * @deprecated Use JGroupsBroadcastGroupDefinition or SocketBroadcastGroupDefinition.
  */
 public class BroadcastGroupDefinition extends ShallowResourceDefinition {
+
     public static final PrimitiveListAttributeDefinition CONNECTOR_REFS = new StringListAttributeDefinition.Builder(CONNECTORS)
             .setRequired(true)
             .setElementValidator(new StringLengthValidator(1))
@@ -75,7 +75,7 @@ public class BroadcastGroupDefinition extends ShallowResourceDefinition {
             .setRestartAllServices()
             .build();
 
-     /**
+    /**
      * @see ActiveMQDefaultConfiguration#getDefaultBroadcastPeriod
      */
     public static final SimpleAttributeDefinition BROADCAST_PERIOD = create("broadcast-period", LONG)
@@ -93,8 +93,8 @@ public class BroadcastGroupDefinition extends ShallowResourceDefinition {
     public static final SimpleAttributeDefinition JGROUPS_CHANNEL = create(CommonAttributes.JGROUPS_CHANNEL)
             .build();
 
-    public static final AttributeDefinition[] ATTRIBUTES = { JGROUPS_CHANNEL_FACTORY, JGROUPS_CHANNEL, JGROUPS_CLUSTER, SOCKET_BINDING,
-            BROADCAST_PERIOD, CONNECTOR_REFS };
+    public static final AttributeDefinition[] ATTRIBUTES = {JGROUPS_CHANNEL_FACTORY, JGROUPS_CHANNEL, JGROUPS_CLUSTER, SOCKET_BINDING,
+        BROADCAST_PERIOD, CONNECTOR_REFS};
 
     public static final String GET_CONNECTOR_PAIRS_AS_JSON = "get-connector-pairs-as-json";
 
@@ -111,7 +111,6 @@ public class BroadcastGroupDefinition extends ShallowResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(ATTRIBUTES);
     }
-
 
     @Override
     public void registerOperations(ManagementResourceRegistration registry) {
@@ -130,33 +129,33 @@ public class BroadcastGroupDefinition extends ShallowResourceDefinition {
     }
 
     static void validateConnectors(OperationContext context, ModelNode operation, ModelNode connectorRefs) throws OperationFailedException {
-        final Set<String> availableConnectors =  getAvailableConnectors(context,operation);
+        final Set<String> availableConnectors = getAvailableConnectors(context, operation);
         final List<ModelNode> operationAddress = operation.get(ModelDescriptionConstants.ADDRESS).asList();
-        if(connectorRefs.isDefined()) {
-            for(ModelNode connectorRef:connectorRefs.asList()){
+        if (connectorRefs.isDefined()) {
+            for (ModelNode connectorRef : connectorRefs.asList()) {
                 final String connectorName = connectorRef.asString();
-                if(!availableConnectors.contains(connectorName)){
-                    throw MessagingLogger.ROOT_LOGGER.wrongConnectorRefInBroadCastGroup(getBroadCastGroupName(operationAddress.get(operationAddress.size()-1)), connectorName, availableConnectors);
+                if (!availableConnectors.contains(connectorName)) {
+                    throw MessagingLogger.ROOT_LOGGER.wrongConnectorRefInBroadCastGroup(getBroadCastGroupName(operationAddress.get(operationAddress.size() - 1)), connectorName, availableConnectors);
                 }
             }
         }
     }
 
     private static String getBroadCastGroupName(ModelNode node) {
-        if(node.hasDefined(CommonAttributes.BROADCAST_GROUP)) {
+        if (node.hasDefined(CommonAttributes.BROADCAST_GROUP)) {
             return node.get(CommonAttributes.BROADCAST_GROUP).asString();
         }
-        if(node.hasDefined(CommonAttributes.SOCKET_BROADCAST_GROUP)) {
+        if (node.hasDefined(CommonAttributes.SOCKET_BROADCAST_GROUP)) {
             return node.get(CommonAttributes.SOCKET_BROADCAST_GROUP).asString();
         }
-        if(node.hasDefined(CommonAttributes.JGROUPS_BROADCAST_GROUP)) {
+        if (node.hasDefined(CommonAttributes.JGROUPS_BROADCAST_GROUP)) {
             return node.get(CommonAttributes.JGROUPS_BROADCAST_GROUP).asString();
         }
         return ModelType.UNDEFINED.name();
     }
 
     // FIXME use capabilities & requirements
-    private static Set<String> getAvailableConnectors(final OperationContext context,final ModelNode operation) throws OperationFailedException{
+    private static Set<String> getAvailableConnectors(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
         PathAddress active = MessagingServices.getActiveMQServerPathAddress(address);
         Set<String> availableConnectors = new HashSet<>();
@@ -197,5 +196,10 @@ public class BroadcastGroupDefinition extends ShallowResourceDefinition {
             ignoredAttributes.add(JGROUPS_CLUSTER.getName());
         }
         return ignoredAttributes;
+    }
+
+    @Override
+    protected boolean isUsingSocketBinding(PathAddress targetAddress) {
+        return CommonAttributes.SOCKET_BROADCAST_GROUP.equals(targetAddress.getLastElement().getKey());
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.wildfly.extension.messaging.activemq.shallow.ShallowResourceAdd;
 
 /**
@@ -60,9 +61,11 @@ public class DiscoveryGroupAdd extends ShallowResourceAdd {
             if (operation.hasDefined(JGROUPS_CLUSTER.getName())) {
                 target = target.append(CommonAttributes.JGROUPS_DISCOVERY_GROUP, context.getCurrentAddressValue());
                 addHandler = JGroupsDiscoveryGroupAdd.LEGACY_INSTANCE;
-            } else {
+            } else if (operation.hasDefined(CommonAttributes.SOCKET_BINDING.getName())) {
                 target = target.append(CommonAttributes.SOCKET_DISCOVERY_GROUP, context.getCurrentAddressValue());
                 addHandler = SocketDiscoveryGroupAdd.LEGACY_INSTANCE;
+            } else {
+                throw MessagingLogger.ROOT_LOGGER.socketBindingOrJGroupsClusterRequired();
             }
             op.get(OP_ADDR).set(target.toModelNode());
             context.addStep(op, addHandler, OperationContext.Stage.MODEL, true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -129,4 +129,9 @@ public class DiscoveryGroupDefinition extends ShallowResourceDefinition {
         }
         return ignoredAttributes;
     }
+
+    @Override
+    protected boolean isUsingSocketBinding(PathAddress targetAddress) {
+        return CommonAttributes.SOCKET_DISCOVERY_GROUP.equals(targetAddress.getLastElement().getKey());
+    }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/ShallowResourceDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/ShallowResourceDefinition.java
@@ -15,12 +15,18 @@
  */
 package org.wildfly.extension.messaging.activemq.shallow;
 
-
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.messaging.activemq.CommonAttributes;
 
 /**
  *
@@ -61,4 +67,34 @@ public abstract class ShallowResourceDefinition extends PersistentResourceDefini
             }
         }
     }
+
+    /**
+     * This provides more informative message when a user tries to undefine attribute that is required by the
+     * jgroups-discovery-group or socket-discovery-group resources (while it hasn't been required on the original
+     * discovery-group resource).
+     * @param context
+     * @param targetAddress
+     * @param translatedOperation
+     * @throws org.jboss.as.controller.OperationFailedException
+     */
+    protected void validateOperation(OperationContext context, PathAddress targetAddress, ModelNode translatedOperation)
+            throws OperationFailedException {
+        String attributeName = translatedOperation.get(ModelDescriptionConstants.NAME).asString();
+        String operationName = translatedOperation.get(ModelDescriptionConstants.OP).asString();
+        boolean isUsingSocketBinding = isUsingSocketBinding(targetAddress);
+
+        // if undefining an attribute
+        if ((ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION.equals(operationName)
+                || ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION.equals(operationName))
+                && !translatedOperation.hasDefined(ModelDescriptionConstants.VALUE)) {
+            // and the attribute is socket-binding on a socket-discovery-group,
+            // or jgroups-cluster on a jgroups-discovery-group, throw an error
+            if ((isUsingSocketBinding && CommonAttributes.SOCKET_BINDING.getName().equals(attributeName))
+                    || (!isUsingSocketBinding && CommonAttributes.JGROUPS_CLUSTER.getName().equals(attributeName))) {
+                throw ControllerLogger.ROOT_LOGGER.validationFailedRequiredParameterNotPresent(attributeName, translatedOperation.toString());
+            }
+        }
+    }
+
+    protected abstract boolean isUsingSocketBinding(PathAddress targetAddress);
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/TranslatedWriteAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/shallow/TranslatedWriteAttributeHandler.java
@@ -33,19 +33,20 @@ public class TranslatedWriteAttributeHandler implements OperationStepHandler {
 
     private static final Logger LOG = Logger.getLogger(TranslatedWriteAttributeHandler.class);
 
-    private final ShallowResourceDefinition converter;
+    private final ShallowResourceDefinition shallowResource;
 
-    public TranslatedWriteAttributeHandler(ShallowResourceDefinition converter) {
-        this.converter = converter;
+    public TranslatedWriteAttributeHandler(ShallowResourceDefinition shallowResource) {
+        this.shallowResource = shallowResource;
     }
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-        PathAddress targetAddress = converter.convert(context, operation);
+        PathAddress targetAddress = shallowResource.convert(context, operation);
         ModelNode op = operation.clone();
         op.get(OP_ADDR).set(targetAddress.toModelNode());
         String attributeName = op.get(ModelDescriptionConstants.NAME).asString();
-        if (!converter.getIgnoredAttributes(context, op).contains(attributeName)) {
+        if (!shallowResource.getIgnoredAttributes(context, op).contains(attributeName)) {
+            shallowResource.validateOperation(context, targetAddress, op);
             OperationStepHandler writeAttributeHandler = context.getRootResourceRegistration()
                     .getAttributeAccess(targetAddress, attributeName).getWriteHandler();
             context.addStep(op, writeAttributeHandler, context.getCurrentStage(), true);

--- a/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/ShallowResourcesTestCase.java
+++ b/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/ShallowResourcesTestCase.java
@@ -1,0 +1,206 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.messaging.activemq;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.jgroups.spi.JGroupsDefaultRequirement;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import org.wildfly.clustering.server.service.ClusteringDefaultRequirement;
+import org.wildfly.clustering.server.service.ClusteringRequirement;
+
+/**
+ * Verifies that an attempt to undefine socket-binding attr on the socket-discovery-group resource, when performed via
+ * the original discovery-group shallow resource, fails with informative error message.
+ *
+ * The same is tested for the jgroups-cluster attr on the jgroups-discovery-group, and similarly for the *-broadcast-group resources.
+ */
+public class ShallowResourcesTestCase extends AbstractSubsystemTest {
+
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME);
+    private static final PathAddress SERVER_ADDRESS = SUBSYSTEM_ADDRESS.append(CommonAttributes.SERVER, CommonAttributes.DEFAULT);
+
+    private static PathAddress discoveryGroupAddress(String name) {
+        return SUBSYSTEM_ADDRESS.append(CommonAttributes.DISCOVERY_GROUP, name);
+    }
+
+    private static PathAddress broadcastGroupAddress(String name) {
+        return SERVER_ADDRESS.append(CommonAttributes.BROADCAST_GROUP, name);
+    }
+
+    public ShallowResourcesTestCase() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    @Test
+    public void testDiscoveryGroupRequiresSocketBindingOrJGroupsCluster() throws Exception {
+        ModelNode operationTemplate = Util.createAddOperation(discoveryGroupAddress("dg"));
+        testRequiresSocketBindingOrJGroupsCluster(operationTemplate);
+    }
+
+    @Test
+    public void testBroadcastGroupRequiresSocketBindingOrJGroupsCluster() throws Exception {
+        ModelNode operationTemplate = Util.createAddOperation(broadcastGroupAddress("bg"));
+        operationTemplate.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        testRequiresSocketBindingOrJGroupsCluster(operationTemplate);
+    }
+
+    private void testRequiresSocketBindingOrJGroupsCluster(ModelNode addOperationTemplate) throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        // try to add discovery or broadcast group with no socket-binding and no jgroups-cluster attrs -> should fail
+        // with a message saying that one of the two attributes must be set
+        ModelNode op = addOperationTemplate.clone();
+        ModelNode result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.get(FAILURE_DESCRIPTION).asString().contains("WFLYMSGAMQ0108:"));
+
+        // try to add discovery or broadcast group with jgroups-cluster set -> should succeed
+        op = addOperationTemplate.clone();
+        op.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default-cluster");
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(),
+                SUCCESS, result.get(OUTCOME).asString());
+        removeResource(kernelServices, addOperationTemplate.get(ADDRESS));
+
+        // try to add discovery or broadcast group with socket-binding set -> should succeed
+        op = addOperationTemplate.clone();
+        op.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(),
+                SUCCESS, result.get(OUTCOME).asString());
+        removeResource(kernelServices, addOperationTemplate.get(ADDRESS));
+    }
+
+    @Test
+    public void testUndefineDiscoveryGroupAttrs() throws Exception {
+        ModelNode addSocketDiscoveryGroup = Util.createAddOperation(discoveryGroupAddress("socket-group"));
+        addSocketDiscoveryGroup.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+
+        ModelNode addJGroupsDiscoveryGroup = Util.createAddOperation(discoveryGroupAddress("jgroups-group"));
+        addJGroupsDiscoveryGroup.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default");
+
+        testUndefineAttrs(addSocketDiscoveryGroup, addJGroupsDiscoveryGroup);
+    }
+
+    @Test
+    public void testUndefineBroadcastGroupAttrs() throws Exception {
+        ModelNode addSocketBroadcastGroup = Util.createAddOperation(broadcastGroupAddress("socket-group"));
+        addSocketBroadcastGroup.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        addSocketBroadcastGroup.get(CommonAttributes.SOCKET_BINDING.getName()).set("http");
+
+        ModelNode addJGroupsBroadcastGroup = Util.createAddOperation(broadcastGroupAddress("jgroups-group"));
+        addJGroupsBroadcastGroup.get(CommonAttributes.CONNECTORS).setEmptyList().add("in-vm");
+        addJGroupsBroadcastGroup.get(CommonAttributes.JGROUPS_CLUSTER.getName()).set("default");
+
+        testUndefineAttrs(addSocketBroadcastGroup, addJGroupsBroadcastGroup);
+    }
+
+    private void testUndefineAttrs(ModelNode addSocketGroupTemplate, ModelNode addJGroupsGroupTemplate) throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        // create socket-*-group to work with
+        ModelNode result = kernelServices.executeOperation(addSocketGroupTemplate);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(), SUCCESS, result.get(OUTCOME).asString());
+
+        // create jgroups-*-group to work with
+        result = kernelServices.executeOperation(addJGroupsGroupTemplate);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).asString(), SUCCESS, result.get(OUTCOME).asString());
+
+        // try to undefine socket-binding from socket-*-group
+        PathAddress socketGroupAddress = PathAddress.pathAddress(addSocketGroupTemplate.get(ADDRESS));
+        ModelNode op = Util.getUndefineAttributeOperation(socketGroupAddress, CommonAttributes.SOCKET_BINDING.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0231"));
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains(CommonAttributes.SOCKET_BINDING.getName()));
+        Assert.assertFalse("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains(CommonAttributes.JGROUPS_CLUSTER.getName()));
+
+        // try to undefine jgroups-cluster from jgroups-*-group
+        PathAddress jgroupsGroupAddress = PathAddress.pathAddress(addJGroupsGroupTemplate.get(ADDRESS));
+        op = Util.getUndefineAttributeOperation(jgroupsGroupAddress, CommonAttributes.JGROUPS_CLUSTER.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0231:"));
+        Assert.assertFalse("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains(CommonAttributes.SOCKET_BINDING.getName()));
+        Assert.assertTrue("Failure description doesn't match: " + result.get(FAILURE_DESCRIPTION).asString(),
+                result.get(FAILURE_DESCRIPTION).asString().contains(CommonAttributes.JGROUPS_CLUSTER.getName()));
+
+        // try to undefine jgroups-cluster attribute in socket-*-group, operation should succeed (it should be ignored)
+        op = Util.getUndefineAttributeOperation(socketGroupAddress, CommonAttributes.JGROUPS_CLUSTER.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+
+        // try to undefine socket-binding attribute in jgroups-*-group, operation should succeed (it should be ignored)
+        op = Util.getUndefineAttributeOperation(jgroupsGroupAddress, CommonAttributes.SOCKET_BINDING.getName());
+        result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private KernelServices createKernelServices() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(readResource("subsystem_15_0.xml"))
+                .build();
+        Assert.assertTrue("Subsystem boot failed!", kernelServices.isSuccessfulBoot());
+        return kernelServices;
+    }
+
+    private static void removeResource(KernelServices kernelServices, ModelNode address) {
+        ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(address));
+        ModelNode result = kernelServices.executeOperation(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.resolve("ee"),
+                ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName(),
+                JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(),
+                Capabilities.ELYTRON_DOMAIN_CAPABILITY,
+                Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".cs1",
+                Capabilities.DATA_SOURCE_CAPABILITY + ".fooDS",
+                "org.wildfly.messaging.activemq.connector.external.in-vm",
+                "org.wildfly.messaging.activemq.connector.external.client",
+                "org.wildfly.remoting.http-listener-registry",
+                Capabilities.HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME + ".default");
+    }
+}


### PR DESCRIPTION
The broadcast-group and discovery-group resources has been deprecated and substituted by socket-*-group and jgroups-*-group variants.
These new resources have different validation rules than the original resources, which may cause confusion for users who are not aware of these changes.

Jira: https://issues.redhat.com/browse/WFLY-16013