### PR TITLE
WFLY-18024 CacheIdentity and IdentityContainer instances are replicating unnecessarily

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionAttributeImmutability.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionAttributeImmutability.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 
 import org.wildfly.clustering.ee.Immutability;
 import org.wildfly.clustering.ee.immutable.SimpleImmutability;
+import org.wildfly.elytron.web.undertow.server.servlet.ServletSecurityContextImpl.IdentityContainer;
+import org.wildfly.security.cache.CachedIdentity;
 
 import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 import io.undertow.servlet.util.SavedRequest;
@@ -34,7 +36,7 @@ import io.undertow.servlet.util.SavedRequest;
  * @author Paul Ferraro
  */
 public enum UndertowSessionAttributeImmutability implements Immutability {
-    CLASSES(new SimpleImmutability(Arrays.asList(AuthenticatedSession.class, SavedRequest.class))),
+    CLASSES(new SimpleImmutability(Arrays.asList(AuthenticatedSession.class, SavedRequest.class, CachedIdentity.class, IdentityContainer.class))),
     ;
     private final Immutability immutability;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18024