### PR TITLE
[28.x] [WFLY-18022] WildFly Core to 20.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,7 @@
         <version.org.testcontainers>1.18.0</version.org.testcontainers>
         <version.org.testng>7.4.0</version.org.testng>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>20.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>20.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-18022
https://issues.redhat.com/browse/WFLY-18022

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/20.0.2.Final
Diff: https://github.com/wildfly/wildfly-core/compare/20.0.1.Final...20.0.2.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6344'>WFCORE-6344</a>] -         Changes to json-formatter meta-data never take effect
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6346'>WFCORE-6346</a>] -         module java.base does not &quot;opens java.net&quot; to unnamed module 
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6326'>WFCORE-6326</a>] -         Add back the org.jboss.vfs module as a dependency on deployments
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6302'>WFCORE-6302</a>] -         CVE-2022-1259 Upgrade Undertow to 2.3.6.Final
</li>
</ul>
</details>