### PR TITLE
[WFLY-18026]: Configuration applied on ServerAdd shouldn't apply runtime changes on boot for the sub resources.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
@@ -19,7 +19,6 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.wildfly.extension.messaging.activemq;
 
 import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService.getActiveMQServer;
@@ -57,13 +56,18 @@ class AddressSettingAdd extends AbstractAddStepHandler {
     protected void populateModel(OperationContext context, ModelNode operation, final Resource resource) throws OperationFailedException {
         super.populateModel(context, operation, resource);
 
-        context.addStep(AddressSettingsValidator.ADD_VALIDATOR, OperationContext.Stage.MODEL);
+        context.addStep(AddressSettingsValidator.ADD_VALIDATOR, OperationContext.Stage.MODEL, true);
+    }
+
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return context.isDefaultRequiresRuntime() && !context.isBooting();
     }
 
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         final ActiveMQServer server = getActiveMQServer(context, operation);
-        if(server != null) {
+        if (server != null) {
             final AddressSettings settings = createSettings(context, model);
             server.getAddressSettingsRepository().addMatch(context.getCurrentAddressValue(), settings);
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingRemove.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+
+import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService.getActiveMQServer;
+
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -30,8 +33,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * {@code OperationStepHandler} removing an existing address setting.
@@ -44,20 +45,10 @@ class AddressSettingRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final ActiveMQServer server = getServer(context, operation);
-        if(server != null) {
+        final ActiveMQServer server = getActiveMQServer(context, operation);
+        if (server != null) {
             final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
             server.getAddressSettingsRepository().removeMatch(address.getLastElement().getValue());
         }
     }
-
-    static ActiveMQServer getServer(final OperationContext context, ModelNode operation) {
-        final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
-        final ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
-        if(controller != null) {
-            return ActiveMQServer.class.cast(controller.getValue());
-        }
-        return null;
-    }
-
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsWriteHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsWriteHandler.java
@@ -31,7 +31,6 @@ import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 
@@ -61,10 +60,9 @@ class AddressSettingsWriteHandler extends AbstractWriteAttributeHandler<AddressS
         final ActiveMQServer server = getActiveMQServer(context, operation);
         if(server != null) {
             final ModelNode model = resource.getModel();
-            final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
             final AddressSettings settings = AddressSettingAdd.createSettings(context, model);
             final HierarchicalRepository<AddressSettings> repository = server.getAddressSettingsRepository();
-            final String match = address.getLastElement().getValue();
+            final String match = context.getCurrentAddressValue();
             final AddressSettings existingSettings = repository.getMatch(match);
             repository.addMatch(match, settings);
             if(existingSettings != null) {
@@ -72,7 +70,7 @@ class AddressSettingsWriteHandler extends AbstractWriteAttributeHandler<AddressS
                     @Override
                     public void doRevertUpdateToRuntime() {
                         // Restore the old settings
-                        repository.addMatch(address.getLastElement().getValue(), existingSettings);
+                        repository.addMatch(match, existingSettings);
                     }
                 });
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
@@ -53,6 +53,11 @@ public class DivertAdd extends AbstractAddStepHandler {
     }
 
     @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return context.isDefaultRequiresRuntime() && !context.isBooting();
+    }
+
+    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
         ServiceRegistry registry = context.getServiceRegistry(true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
@@ -51,6 +51,11 @@ public class GroupingHandlerAdd extends AbstractAddStepHandler {
     }
 
     @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return context.isDefaultRequiresRuntime() && !context.isBooting();
+    }
+
+    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
         ServiceRegistry registry = context.getServiceRegistry(true);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
@@ -55,6 +55,11 @@ public class QueueAdd extends AbstractAddStepHandler {
     }
 
     @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return context.isDefaultRequiresRuntime() && !context.isBooting();
+    }
+
+    @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
         for (final AttributeDefinition attributeDefinition : QueueDefinition.ATTRIBUTES) {
             attributeDefinition.validateAndSet(operation, model);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleRemove.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+
+import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService.getActiveMQServer;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -33,8 +36,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * {@code OperationStepHandler} for removing a security role.
@@ -48,7 +49,7 @@ class SecurityRoleRemove extends AbstractRemoveStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
-        final ActiveMQServer server = getServer(context, operation);
+        final ActiveMQServer server = getActiveMQServer(context, operation);
         final String match = address.getElement(address.size() - 2).getValue();
         final String roleName = address.getLastElement().getValue();
         removeRole(server, match, roleName);
@@ -57,7 +58,7 @@ class SecurityRoleRemove extends AbstractRemoveStepHandler {
     static void removeRole(ActiveMQServer server, String match, String roleName) {
         if (server != null) {
             final Set<Role> roles = server.getSecurityRepository().getMatch(match);
-            final Set<Role> newRoles = new HashSet<Role>();
+            final Set<Role> newRoles = new HashSet<>();
             for (final Role role : roles) {
                 if (!roleName.equals(role.getName())) {
                     newRoles.add(role);
@@ -65,14 +66,5 @@ class SecurityRoleRemove extends AbstractRemoveStepHandler {
             }
             server.getSecurityRepository().addMatch(match, newRoles);
         }
-    }
-
-    static ActiveMQServer getServer(final OperationContext context, ModelNode operation) {
-        final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
-        final ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
-        if(controller != null) {
-            return ActiveMQServer.class.cast(controller.getValue());
-        }
-        return null;
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecuritySettingRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecuritySettingRemove.java
@@ -19,8 +19,9 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.wildfly.extension.messaging.activemq;
+
+import static org.wildfly.extension.messaging.activemq.ActiveMQActivationService.getActiveMQServer;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
@@ -29,8 +30,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * {@code OperationStepHandler} for removing an existing security setting.
@@ -43,20 +42,12 @@ class SecuritySettingRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final ActiveMQServer server = getServer(context, operation);
-        if(server != null) {
+        final ActiveMQServer server = getActiveMQServer(context, operation);
+        if (server != null) {
             final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
             final String match = address.getLastElement().getValue();
             server.getSecurityRepository().removeMatch(match);
         }
     }
 
-    static ActiveMQServer getServer(final OperationContext context, ModelNode operation) {
-        final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
-        final ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
-        if(controller != null) {
-            return ActiveMQServer.class.cast(controller.getValue());
-        }
-        return null;
-    }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -710,7 +710,7 @@ class ServerAdd extends AbstractAddStepHandler {
                     final String match = property.getName();
                     final ModelNode config = property.getValue();
                     final AddressSettings settings = AddressSettingAdd.createSettings(context, config);
-                    configuration.getAddressesSettings().put(match, settings);
+                    configuration.addAddressSetting(match, settings);
                 }
             }
         }


### PR DESCRIPTION
* Checking that the server isn't booting in requiresRuntime() for:
    - SecuritySetting
    - AddressSetting
    - SecurityRole
    - Grouping
    - Divert
    - Queue
* Reusing the same code to get the current broker

Jira: https://issues.redhat.com/browse/WFLY-18026