### PR TITLE
[WFLY-17563] Return back *module.xml necessary for manual steps of installing different jsf implementation

### DIFF
--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="javax.faces.api:${jsf-impl-name}-${jsf-version}">
+    <dependencies>
+        <module name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}"/>
+        <module name="javax.enterprise.api" export="true"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="javax.servlet.jsp.api" export="true"/>
+        <module name="javax.servlet.jstl.api" export="true"/>
+        <module name="javax.validation.api" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="javax.api"/>
+        <module name="javax.websocket.api"/>
+    </dependencies>
+
+    <resources>
+        <resource-root path="${jsf-api-name}-${jsf-version}.jar"/>
+    </resources>
+</module>
+

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
@@ -1,0 +1,3 @@
+module add --name=javax.faces.api --slot=mojarra-${jsf-version} --resources=${jsf-api-name}-${jsf-version}.jar --module-xml=mojarra-api-module.xml
+module add --name=com.sun.jsf-impl --slot=mojarra-${jsf-version} --resources=jsf-impl-${jsf-version}.jar --module-xml=mojarra-impl-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version} --resources=weld-jsf-${version.org.jboss.weld.weld}.jar:wildfly-jsf-injection-${project.version}.jar --resource-delimiter=: --module-xml=mojarra-injection-module.xml

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.faces.api:${jsf-impl-name}-${jsf-version}"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="javax.websocket.api" />
+        <module name="javax.validation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.ejb.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.glassfish.jakarta.el"/>
+        <module name="javax.api"/>
+        <module name="javax.servlet.jstl.api"/>
+        <module name="java.xml"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
+    </dependencies>
+
+    <resources>
+        <resource-root path="jsf-impl-${jsf-version}.jar"/>
+    </resources>
+</module>
+

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-injection-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-injection-module.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="wildfly-jsf-injection-${project.version}.jar"/>
+        <resource-root path="weld-jsf-${version.org.jboss.weld.weld}.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}"/>
+        <module name="java.naming"/>
+        <module name="java.desktop"/>
+        <module name="org.jboss.as.jsf"/>
+        <module name="org.jboss.as.web-common"/>
+        <module name="javax.servlet.api"/>
+        <module name="org.jboss.as.ee"/>
+        <module name="javax.enterprise.api"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.api"/>
+
+        <module name="javax.faces.api:${jsf-impl-name}-${jsf-version}"/>
+    </dependencies>
+</module>
+

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-undeploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-undeploy.scr
@@ -1,0 +1,3 @@
+module remove --name=javax.faces.api --slot=mojarra-${jsf-version}
+module remove --name=com.sun.jsf-impl --slot=mojarra-${jsf-version}
+module remove --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version}

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="javax.faces.api:${jsf-impl-name}-${jsf-version}">
+    <dependencies>
+        <module name="javax.enterprise.api" export="true"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="javax.servlet.jsp.api" export="true"/>
+        <module name="javax.servlet.jstl.api" export="true"/>
+        <module name="javax.validation.api" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="javax.api"/>
+
+        <!-- extra dependencies for MyFaces 1.1
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.commons.el"/> -->
+    </dependencies>
+
+    <resources>
+        <resource-root path="myfaces-api-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
@@ -1,0 +1,4 @@
+module add --name=javax.faces.api --slot=myfaces-${jsf-version} --resources=myfaces-api-${jsf-version}.jar --module-xml=myfaces-api-module.xml
+module add --name=com.sun.jsf-impl --slot=myfaces-${jsf-version} --resources=myfaces-impl-${jsf-version}.jar --module-xml=myfaces-impl-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version} --resources=weld-jsf-${version.org.jboss.weld.weld}.jar:wildfly-jsf-injection-${project.version}.jar --resource-delimiter=: --module-xml=myfaces-injection-module.xml
+module add --name=org.apache.commons.digester --slot=main --resources=commons-digester-${version.commons-digester}.jar --module-xml=myfaces-digester-module.xml

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.digester">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="commons-digester-${version.commons-digester}.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.commons.collections"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.commons.beanutils"/>
+    </dependencies>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.faces.api:${jsf-impl-name}-${jsf-version}">
+            <imports>
+                <include path="META-INF/**"/>
+            </imports>
+        </module>
+        <module name="javax.annotation.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="javax.websocket.api" />
+        <module name="javax.validation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.ejb.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.glassfish.jakarta.el"/>
+        <module name="javax.api"/>
+        <module name="javax.servlet.jstl.api"/>
+        <module name="java.xml"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
+
+        <!-- extra dependencies for MyFaces -->
+        <module name="org.apache.commons.collections"/>
+        <module name="org.apache.commons.codec"/>
+        <module name="org.apache.commons.beanutils"/>
+        <module name="org.apache.commons.digester"/>
+    </dependencies>
+
+    <resources>
+        <resource-root path="${jsf-impl-name}-impl-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-injection-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-injection-module.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.jboss.as.jsf-injection:${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="wildfly-jsf-injection-${project.version}.jar"/>
+        <resource-root path="weld-jsf-${version.org.jboss.weld.weld}.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}"/>
+        <module name="javax.api"/>
+        <module name="org.jboss.as.web-common"/>
+        <module name="javax.servlet.api"/>
+        <module name="org.jboss.as.jsf"/>
+        <module name="org.jboss.as.ee"/>
+        <module name="javax.enterprise.api"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.api"/>
+        <module name="org.wildfly.security.elytron"/>
+
+        <module name="javax.faces.api:${jsf-impl-name}-${jsf-version}"/>
+    </dependencies>
+    <provides>
+        <service name="javax.servlet.ServletContainerInitializer">
+            <with-class name="org.jboss.as.jsf.injection.MyFacesContainerInitializer"/>
+        </service>
+    </provides>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-undeploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-undeploy.scr
@@ -1,0 +1,3 @@
+module remove --name=javax.faces.api --slot=myfaces-${jsf-version}
+module remove --name=com.sun.jsf-impl --slot=myfaces-${jsf-version}
+module remove --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17563

Restore doc source files deleted under WFLY-17354

This change only restores the files. The verification/update of the functionality will be handled under another JIRA.