### PR TITLE
[WFLY-17891] Updating DeploymentModulesListTestCase to not require that WildFly installs a static module with a slot

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/moduleslisting/DeploymentModulesListTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/moduleslisting/DeploymentModulesListTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.Operations;
@@ -50,6 +51,7 @@ import org.junit.runner.RunWith;
  * @author <a href="mailto:szhantem@redhat.com">Sultan Zhantemirov</a> (c) 2019 Red Hat, inc.
  */
 @RunWith(Arquillian.class)
+@ServerSetup(UserModuleSetupTask.class)
 @RunAsClient
 public class DeploymentModulesListTestCase {
 
@@ -58,8 +60,7 @@ public class DeploymentModulesListTestCase {
     private static final String EXAMPLE_MODULE_TO_EXCLUDE = "org.slf4j.impl";
     private static final String INNER_WAR_ARCHIVE_NAME = "list-modules.war";
     private static final String EAR_DEPLOYMENT_NAME = "list-modules-ear-test.ear";
-    private static final String USER_MODULE = "org.hibernate";
-    private static final String CUSTOM_SLOT = "main"; // TODO WFLY-17891 install a TestModule with a non-main slot
+    public static final String TEST_MODULE = "org.testModule";
 
     @ContainerResource
     private static ManagementClient managementClient;
@@ -121,8 +122,7 @@ public class DeploymentModulesListTestCase {
             // check module presence
             assertTrue(checkModulesListPresence(operationResult, "deployment." + EAR_DEPLOYMENT_NAME));
             // check user defined module with custom slot
-            // TODO WFLY-17891 install a TestModule with a non-main slot
-            assertTrue(checkModulesListPresence(operationResult, USER_MODULE /*+ ":" + CUSTOM_SLOT*/));
+            assertTrue(checkModulesListPresence(operationResult, TEST_MODULE));
             // check module absence
             assertFalse(checkModulesListPresence(operationResult, EXAMPLE_MODULE_TO_EXCLUDE));
             // check system and user dependencies presence
@@ -214,7 +214,7 @@ public class DeploymentModulesListTestCase {
                 "           <module name=\"" + EXAMPLE_MODULE_TO_EXCLUDE + "\"/>\n" +
                 "       </exclusions>\n" +
                 "       <dependencies>\n" +
-                "           <module name=\"" + USER_MODULE + "\" slot=\"" + CUSTOM_SLOT + "\"/>\n" +
+                "           <module name=\"" + TEST_MODULE + "\"/>\n" +
                 "       </dependencies>\n" +
                 "   </sub-deployment>\n" +
                 "</jboss-deployment-structure>\n";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/moduleslisting/UserModuleSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/moduleslisting/UserModuleSetupTask.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.deployment.moduleslisting;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.module.util.TestModule;
+
+public class UserModuleSetupTask implements ServerSetupTask {
+    private volatile TestModule testModule;
+
+    @Override
+    public void setup(ManagementClient arg0, String arg1) throws Exception {
+        testModule = new TestModule(DeploymentModulesListTestCase.TEST_MODULE);
+        testModule.create();
+    }
+
+    @Override
+    public void tearDown(ManagementClient arg0, String arg1) throws Exception {
+        if (testModule != null) {
+            testModule.remove();
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17891
