### PR TITLE
WFLY-18064 Upgrade SmallRye Fault Tolerance to 6.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.1.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.2.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.2.2</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.2.3</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.2.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.1.0</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-18064

No real changes in this release.