### PR TITLE
[WFLY-17934] Eliminating deprecated javax.xml.stream.api module usages - cleanup remaining bits

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
@@ -40,7 +40,6 @@
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
-        <module name="javax.xml.stream.api"/>
         <module name="jakarta.jms.api"/>
         <module name="org.wildfly.common"/>
     </dependencies>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
@@ -40,7 +40,6 @@
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
-        <module name="javax.xml.stream.api"/>
         <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
@@ -39,7 +39,6 @@
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.threads"/>
-        <module name="javax.xml.stream.api"/>
         <module name="jakarta.jms.api"/>
         <module name="org.wildfly.common"/>
     </dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17934