### PR TITLE
[WFLY-17699] reenable SpnegoMechTestCase after WildFly Core 21.0.0.Beta1 Upgrade (Elytron 2.2.0.Final included) for IBM JDK

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/SpnegoMechTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/SpnegoMechTestCase.java
@@ -87,11 +87,9 @@ import org.jboss.as.test.integration.security.common.KDCServerAnnotationProcesso
 import org.jboss.as.test.integration.security.common.Krb5LoginConfiguration;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -120,11 +118,6 @@ public class SpnegoMechTestCase extends AbstractMechTestBase {
     private static final String CHALLENGE_PREFIX = "Negotiate ";
     private static final File KRB5_CONF = new File(SpnegoMechTestCase.class.getResource(NAME + "-krb5.conf").getFile());
     private static final boolean DEBUG = false;
-
-    @BeforeClass
-    public static void beforeClass() {
-        Assume.assumeFalse("WFLY-17699 temporary skip test until IBM JDK fixes are incorporated in elytron and wfcore upgrade", TestSuiteEnvironment.isIbmJvm());
-    }
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17699

Reenable `SpnegoMechTestCase` after WildFly Core 21.0.0.Beta1 Upgrade (Elytron 2.2.0.Final included) for IBM JDK

