### PR TITLE
WFLY-18083 Upgrade to Hibernate ORM 6.2.4.final release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,7 +497,7 @@
         <version.org.glassfish.soteria>3.0.0</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.2.3.Final</version.org.hibernate>
+        <version.org.hibernate>6.2.4.Final</version.org.hibernate>
         <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18083

Technically this could be included in `29.0.0.Alpha1` but also good to include for `29.0.0.Beta1`.  Note that the EE 10 Platform TCK tests passed with Hibernate ORM 6.2.4.final release.

Release notes: https://in.relation.to/2023/06/01/hibernate-orm-624-final/
Tag: https://github.com/hibernate/hibernate-orm/releases/tag/6.2.4
Diff: https://github.com/hibernate/hibernate-orm/compare/6.2.3...6.2.4