### PR TITLE
[WFLY-12019] HostRemove should not remove services unless allow-resource-service-restart=true is set

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
@@ -38,18 +38,22 @@ class HostRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final PathAddress address = context.getCurrentAddress();
-        final PathAddress parent = address.getParent();
-        final String name = address.getLastElement().getValue();
-        final String serverName = parent.getLastElement().getValue();
-        final ServiceName virtualHostServiceName = HostDefinition.HOST_CAPABILITY.getCapabilityServiceName(serverName, name);
-        context.removeService(virtualHostServiceName);
-        final ServiceName consoleRedirectName = UndertowService.consoleRedirectServiceName(serverName, name);
-        context.removeService(consoleRedirectName);
-        final ServiceName commonHostName = WebHost.SERVICE_NAME.append(name);
-        context.removeService(commonHostName);
-        final String defaultWebModule = HostDefinition.DEFAULT_WEB_MODULE.resolveModelAttribute(context, model).asString();
-        DefaultDeploymentMappingProvider.instance().removeMapping(defaultWebModule);
+        if (context.isResourceServiceRestartAllowed()) {
+            final PathAddress address = context.getCurrentAddress();
+            final PathAddress parent = address.getParent();
+            final String name = address.getLastElement().getValue();
+            final String serverName = parent.getLastElement().getValue();
+            final ServiceName virtualHostServiceName = HostDefinition.HOST_CAPABILITY.getCapabilityServiceName(serverName, name);
+            context.removeService(virtualHostServiceName);
+            final ServiceName consoleRedirectName = UndertowService.consoleRedirectServiceName(serverName, name);
+            context.removeService(consoleRedirectName);
+            final ServiceName commonHostName = WebHost.SERVICE_NAME.append(name);
+            context.removeService(commonHostName);
+            final String defaultWebModule = HostDefinition.DEFAULT_WEB_MODULE.resolveModelAttribute(context, model).asString();
+            DefaultDeploymentMappingProvider.instance().removeMapping(defaultWebModule);
+        } else {
+            context.reloadRequired();
+        }
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServerRemovalTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServerRemovalTestCase.java
@@ -1,0 +1,183 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *  Tests server and host removal in Undertow subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+public class UndertowServerRemovalTestCase extends AbstractUndertowSubsystemTestCase {
+
+    private static final String NODE_NAME = "node-name";
+    private static final String SERVER_ABC = "abc";
+    private static final String HOST_ABC = "abc-host";
+
+    public UndertowServerRemovalTestCase() {
+        super(UndertowSubsystemSchema.CURRENT);
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        System.setProperty("jboss.node.name", NODE_NAME);
+    }
+
+    private KernelServices load(String subsystemXml) throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(new RuntimeInitialization(this.values)).setSubsystemXml(subsystemXml);
+        KernelServices mainServices = builder.build();
+        if (!mainServices.isSuccessfulBoot()) {
+            Throwable t = mainServices.getBootError();
+            Assert.fail("Boot unsuccessful: " + (t != null ? t.toString() : "no boot error provided"));
+        }
+        return mainServices;
+    }
+
+    private PathAddress serverAddress(String server) {
+        return PathAddress.pathAddress("subsystem", "undertow").append("server", server);
+    }
+
+    private PathAddress hostAddress(String server, String host) {
+        return serverAddress(server).append("host", host);
+    }
+
+    @Test
+    public void removeDefaultServerShouldFail() throws Exception {
+        KernelServices mainServices = null;
+        try {
+            final String defaultServer = "some-server";
+            final String defaultHost = "default-virtual-host";
+            mainServices = load(getSubsystemXml());
+            final ServiceName undertowServerName = ServerDefinition.SERVER_CAPABILITY.getCapabilityServiceName(defaultServer);
+            Server server = (Server) this.values.get(undertowServerName).get();
+            assertNotNull(server);
+            Assert.assertEquals(defaultServer, server.getName());
+            final int times = 2;
+            for (int i = 0; i < times; i ++) {
+                ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, serverAddress(defaultServer));
+                ModelNode response = mainServices.executeOperation(removeOp);
+                assertEquals(ModelDescriptionConstants.FAILED, response.get(ModelDescriptionConstants.OUTCOME).asString());
+                assertNotNull(response.get(ModelDescriptionConstants.FAILURE_DESCRIPTION));
+                assertTrue(response.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).asString().contains("WFLYCTL0367"));
+            }
+            for (int i = 0; i < times; i ++) {
+                ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, hostAddress(defaultServer, defaultHost));
+                ModelNode response = mainServices.executeOperation(removeOp);
+                assertEquals(ModelDescriptionConstants.FAILED, response.get(ModelDescriptionConstants.OUTCOME).asString());
+                assertNotNull(response.get(ModelDescriptionConstants.FAILURE_DESCRIPTION));
+                assertTrue(response.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).asString().contains("WFLYCTL0367"));
+            }
+        } finally {
+            if (mainServices != null) {
+                mainServices.shutdown();
+            }
+        }
+    }
+
+    @Test
+    public void removeNonDefaultHost() throws Exception {
+        KernelServices mainServices = null;
+        try {
+            mainServices = load(getSubsystemXml("undertow-service-extra-server.xml"));
+            ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, hostAddress(SERVER_ABC, HOST_ABC));
+            ModelNode response = mainServices.executeOperation(removeOp);
+            assertEquals(ModelDescriptionConstants.SUCCESS, response.get(ModelDescriptionConstants.OUTCOME).asString());
+            assertEquals(ModelDescriptionConstants.RELOAD_REQUIRED, response.get(ModelDescriptionConstants.RESPONSE_HEADERS).get(ModelDescriptionConstants.PROCESS_STATE).asString());
+        } finally {
+            if (mainServices != null) {
+                mainServices.shutdown();
+            }
+        }
+    }
+
+    @Test
+    public void removeNonDefaultHostAllowResourceServiceRestart() throws Exception {
+        KernelServices mainServices = null;
+        try {
+            mainServices = load(getSubsystemXml("undertow-service-extra-server.xml"));
+            ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, hostAddress(SERVER_ABC, HOST_ABC));
+            removeOp.get(ModelDescriptionConstants.OPERATION_HEADERS)
+                    .get(ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART)
+                    .set(true);
+            ModelNode response = mainServices.executeOperation(removeOp);
+            assertEquals(ModelDescriptionConstants.SUCCESS, response.get(ModelDescriptionConstants.OUTCOME).asString());
+            assertFalse(response.hasDefined(ModelDescriptionConstants.RESPONSE_HEADERS));
+        } finally {
+            if (mainServices != null) {
+                mainServices.shutdown();
+            }
+        }
+    }
+
+
+    @Test
+    public void removeNonDefaultServer() throws Exception {
+        KernelServices mainServices = null;
+        try {
+            mainServices = load(getSubsystemXml("undertow-service-extra-server.xml"));
+            ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, serverAddress(SERVER_ABC));
+            ModelNode response = mainServices.executeOperation(removeOp);
+            assertEquals(ModelDescriptionConstants.SUCCESS, response.get(ModelDescriptionConstants.OUTCOME).asString());
+            assertEquals(ModelDescriptionConstants.RELOAD_REQUIRED, response.get(ModelDescriptionConstants.RESPONSE_HEADERS).get(ModelDescriptionConstants.PROCESS_STATE).asString());
+        } finally {
+            if (mainServices != null) {
+                mainServices.shutdown();
+            }
+        }
+    }
+
+    @Test
+    public void removeNonDefaultServerAllowResourceServiceRestart() throws Exception {
+        KernelServices mainServices = null;
+        try {
+            mainServices = load(getSubsystemXml("undertow-service-extra-server.xml"));
+            ModelNode removeOp = Util.createOperation(ModelDescriptionConstants.REMOVE, serverAddress(SERVER_ABC));
+            removeOp.get(ModelDescriptionConstants.OPERATION_HEADERS)
+                    .get(ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART)
+                    .set(true);
+            ModelNode response = mainServices.executeOperation(removeOp);
+            assertEquals(ModelDescriptionConstants.SUCCESS, response.get(ModelDescriptionConstants.OUTCOME).asString());
+            assertEquals(ModelDescriptionConstants.RELOAD_REQUIRED, response.get(ModelDescriptionConstants.RESPONSE_HEADERS).get(ModelDescriptionConstants.PROCESS_STATE).asString());
+        } finally {
+            if (mainServices != null) {
+                mainServices.shutdown();
+            }
+        }
+    }
+
+}

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-service-extra-server.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-service-extra-server.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:undertow:14.0" default-server="default-server" default-servlet-container="servlet-container" default-virtual-host="virtual-host" instance-id="${jboss.node.name}-undertow" statistics-enabled="true" >
+   <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
+   <server name="default-server" default-host="virtual-host" servlet-container="servlet-container">
+      <http-listener name="default" socket-binding="http" redirect-socket="ajp" enable-http2="true"/>
+      <https-listener name="https" socket-binding="https-non-default" security-realm="ApplicationRealm" enable-http2="true"/>
+      <host name="virtual-host" alias="localhost">
+         <location name="/" handler="welcome-content" />
+         <http-invoker security-realm="ApplicationRealm"/>
+      </host>
+   </server>
+   <server name="abc">
+      <host name="abc-host" alias="localhost">
+         <location name="/" handler="welcome-content" />
+      </host>
+   </server>
+   <servlet-container name="servlet-container">
+      <jsp-config/>
+      <websockets/>
+   </servlet-container>
+   <handlers>
+      <file name="welcome-content" path="${jboss.home.dir}/welcome-content" />
+   </handlers>
+</subsystem>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12019

This PR tries to replace #16894 as that has test failures, and creating a new PR based on that will be efficient.

The test failures in #16894 is interacted  tests related, means that some other tests lead to a server state not cleaned, it is not easy to locate that test, but trying to reload the server when trying to modify the server can solve the test failure issue.