### PR TITLE
WFLY-17853 WFLY-17978 Batch job fails to restart on server resume after server suspend

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperatorService.java
@@ -536,8 +536,8 @@ public class JobOperatorService extends AbstractJobOperator implements WildFlyJo
                         }
                         try {
                             final long newId;
-                            // If the user is not null we need to restart the job with the user specified
-                            if (user == null) {
+                            // If the user is not null or $local, we need to restart the job with the user specified
+                            if (user == null || user.equals("$local")) {
                                 newId = restart(id, RESTART_PROPS);
                             } else {
                                 newId = privilegedRunAs(user, () -> restart(id, RESTART_PROPS));

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -2739,6 +2739,9 @@
                                     <excludes>
                                         <!-- Test requires agroal -->
                                         <exclude>org/jboss/as/test/integration/batch/repository/JdbcRepositoryTestCase.java</exclude>
+
+                                        <!-- Test requires remote ejb -->
+                                        <exclude>org/jboss/as/test/integration/batch/suspendejb/SuspendBatchletEjbTestCase.java</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspend/SuspendBatchletTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspend/SuspendBatchletTestCase.java
@@ -70,14 +70,14 @@ public class SuspendBatchletTestCase extends AbstractBatchTestCase {
                 ), "permissions.xml");
     }
 
-    private void suspendServer() throws IOException {
+    public static void suspendServer(ManagementClient managementClient) throws IOException {
         ModelNode op = new ModelNode();
         op.get(ModelDescriptionConstants.OP).set("suspend");
         ModelNode result = managementClient.getControllerClient().execute(op);
         Assert.assertTrue("Failed to suspend: " + result, Operations.isSuccessfulOutcome(result));
     }
 
-    private void resumeServer() throws IOException {
+    public static void resumeServer(ManagementClient managementClient) throws IOException {
         ModelNode op = new ModelNode();
         op.get(ModelDescriptionConstants.OP).set("resume");
         ModelNode result = managementClient.getControllerClient().execute(op);
@@ -131,12 +131,12 @@ public class SuspendBatchletTestCase extends AbstractBatchTestCase {
         long executionId = jobOperator.start("suspend-batchlet", jobProperties);
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        suspendServer();
+        suspendServer(managementClient);
 
         // check job is stopped
         checkJobExecution(jobOperator, jobExecution, BatchStatus.STOPPED, "KO");
 
-        resumeServer();
+        resumeServer(managementClient);
 
         // the job should be restarted with a new ID, wait for it a max of 10s
         JobInstance jobInstance = jobOperator.getJobInstance(executionId);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/LongRunningBatchletWithEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/LongRunningBatchletWithEjb.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.suspendejb;
+
+import jakarta.batch.api.BatchProperty;
+import jakarta.batch.api.Batchlet;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+@Named
+@Dependent
+public class LongRunningBatchletWithEjb implements Batchlet {
+    @Inject
+    private SuspendBatchLocal suspendBean;
+
+    private volatile boolean stopRequested;
+
+    @Inject
+    @BatchProperty(name = "max.seconds")
+    private Integer maxSeconds;
+
+    @Override
+    public String process() throws Exception {
+        final BatchStatus status = suspendBean.getStatus();
+        if (status == null || status == BatchStatus.STOPPING || status == BatchStatus.STOPPED) {
+            // this batchlet is being restarted, so just complete it
+            suspendBean.setStatus(BatchStatus.COMPLETED);
+            SuspendBatchRemote.logger.infof("Directly complete job execution with status: %s", BatchStatus.COMPLETED);
+            return BatchStatus.COMPLETED.name();
+        }
+
+        long endAt = maxSeconds * 1000 + System.currentTimeMillis();
+        do {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            if (stopRequested) {
+                suspendBean.setStatus(BatchStatus.STOPPED);
+                SuspendBatchRemote.logger.info("About to bail out after receiving stop request");
+                return BatchStatus.STOPPED.name();
+            }
+            SuspendBatchRemote.logger.infof("Waiting for stop request, or till max.seconds: %s", maxSeconds);
+        } while (System.currentTimeMillis() <= endAt);
+
+        suspendBean.setStatus(BatchStatus.FAILED);
+        return BatchStatus.FAILED.name();
+    }
+
+    @Override
+    public void stop() {
+        stopRequested = true;
+        suspendBean.setStatus(BatchStatus.STOPPING);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchLocal.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.suspendejb;
+
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.ejb.Local;
+
+@Local
+public interface SuspendBatchLocal {
+    BatchStatus getStatus();
+
+    void setStatus(BatchStatus status);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchRemote.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.suspendejb;
+
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.ejb.Remote;
+import org.jboss.logging.Logger;
+
+@Remote
+public interface SuspendBatchRemote {
+    static final Logger logger = Logger.getLogger(SuspendBatchRemote.class.getPackageName());
+
+    BatchStatus getStatus();
+
+    void startJob(String jobXmlName, int maxSeconds);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchSingleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchSingleton.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.suspendejb;
+
+import java.util.Properties;
+
+import jakarta.batch.operations.JobOperator;
+import jakarta.batch.runtime.BatchStatus;
+import jakarta.ejb.ConcurrencyManagement;
+import jakarta.ejb.ConcurrencyManagementType;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import jakarta.inject.Inject;
+
+@Singleton
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
+@TransactionManagement(TransactionManagementType.BEAN)
+public class SuspendBatchSingleton implements SuspendBatchRemote, SuspendBatchLocal {
+
+    @Inject
+    private JobOperator jobOperator;
+
+    private BatchStatus status;
+    @Override
+    public synchronized void setStatus(final BatchStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public synchronized BatchStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public void startJob(final String jobXmlName, final int maxSeconds) {
+        setStatus(BatchStatus.STARTING);
+        final Properties properties = new Properties();
+        properties.setProperty("max.seconds", String.valueOf(maxSeconds));
+        jobOperator.start(jobXmlName, properties);
+        SuspendBatchRemote.logger.infof("Starting job %s with maxSeconds %s", jobXmlName, maxSeconds);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchletEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/SuspendBatchletEjbTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.suspendejb;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.util.PropertyPermission;
+import javax.naming.InitialContext;
+
+import jakarta.batch.runtime.BatchStatus;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
+import org.jboss.as.test.integration.batch.suspend.SuspendBatchletTestCase;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that run as a remote client invoking a remote ejb, which starts a batch
+ * job execution.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SuspendBatchletEjbTestCase extends AbstractBatchTestCase {
+    private static final String ARCHIVE_NAME = "suspend-batchlet-ejb";
+    private static final String JOB_XML_NAME = "suspend-batchlet-ejb.xml";
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @ContainerResource
+    private InitialContext remoteContext;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        final WebArchive deployment = ShrinkWrap.create(WebArchive.class, ARCHIVE_NAME + ".war")
+                .addClasses(TimeoutUtil.class, LongRunningBatchletWithEjb.class,
+                        SuspendBatchLocal.class, SuspendBatchRemote.class, SuspendBatchSingleton.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
+                .setManifest(new StringAsset(
+                        Descriptors.create(ManifestDescriptor.class)
+                                .attribute("Dependencies", "org.jboss.msc,org.wildfly.security.manager")
+                                .exportAsString()))
+                .addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "permissions.xml");
+
+        addJobXml(SuspendBatchletEjbTestCase.class.getPackage(), deployment, JOB_XML_NAME);
+        return deployment;
+    }
+
+    /**
+     * A remote java client looks up and invokes a remote ejb, which starts a
+     * batch job execution. Then suspend the server, and the batch job execution
+     * should be stopped. Resume the server, and the previous batch job execution
+     * should be automatically restarted and completed.
+     *
+     * @throws Exception on any errors
+     */
+    @Test
+    public void testSuspendResumeWithEjb() throws Exception {
+        final String lookupName = "ejb:/" + ARCHIVE_NAME + "/"
+                + SuspendBatchSingleton.class.getSimpleName() + "!"
+                + SuspendBatchRemote.class.getName();
+        SuspendBatchRemote suspendRemoteBean = (SuspendBatchRemote) remoteContext.lookup(lookupName);
+        suspendRemoteBean.startJob(JOB_XML_NAME, 10);
+
+        Thread.sleep(TimeoutUtil.adjust(200));
+        SuspendBatchletTestCase.suspendServer(managementClient);
+        Thread.sleep(TimeoutUtil.adjust(500));
+        SuspendBatchletTestCase.resumeServer(managementClient);
+        Thread.sleep(TimeoutUtil.adjust(500));
+
+        suspendRemoteBean = (SuspendBatchRemote) remoteContext.lookup(lookupName);
+        final BatchStatus status = suspendRemoteBean.getStatus();
+        Assert.assertEquals(BatchStatus.COMPLETED, status);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/suspend-batchlet-ejb.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspendejb/suspend-batchlet-ejb.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<job id="suspend-batchlet-ejb"
+     xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"
+     version="2.0">
+    <step id="step1">
+        <batchlet ref="longRunningBatchletWithEjb">
+            <properties>
+                <property name="max.seconds" value="#{jobParameters['max.seconds']}"/>
+            </properties>
+        </batchlet>
+    </step>
+</job>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17853
Batch job fails to restart on server resume after server suspend

https://issues.redhat.com/browse/WFLY-17978
Add a test using remote ejb client for restarting batch job after server suspend and resume