### PR TITLE
[WFLY-16418] WildCardReadsTestCase target resource no longer exists

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/WildCardReadsTestCase.java
@@ -23,7 +23,6 @@
 package org.jboss.as.test.integration.management.cli;
 
 import java.io.IOException;
-
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -48,26 +47,25 @@ import org.junit.runner.RunWith;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@org.junit.Ignore("WFLY-16418")
 @RunWith(Arquillian.class)
 @RunAsClient
 public class WildCardReadsTestCase extends AbstractCliTestBase {
 
     /*
      * This address meets a particular set of requirements needed to validate the WFLY-2527 fix:
-     * 1) the distributed-cache=dist resource does not actually exist. Therefore eviction=XXX child resources also do not
+     * 1) the cache-container=abc resource does not actually exist. Therefore local-cache=XXX child resources also do not
      *    TBH I'm not certain this aspect is all that critical, but don't blindly remove it.
-     * 2) There is no ManagementResourceRegistration for eviction=*
-     * 3) There are MRR's for eviction=XXX, eviction=YYY, etc
-     * 4) The descriptions for each of those eviction=XXX, eviction=YYY, etc are identical
+     * 2) There is no ManagementResourceRegistration for local-cache=*
+     * 3) There are MRR's for local-cache=XXX, local-cache=YYY, etc
+     * 4) The descriptions for each of those local-cache=XXX, local-cache=YYY, etc are identical
      *
      * TODO add some assertions that validate that 1-4 still hold true, in order to ensure the test continues
      * to validate the expected behavior
      */
-    private static final String OP_PATTERN = "/subsystem=infinispan/cache-container=web/distributed-cache=dist/eviction=%s:%s";
+    private static final String OP_PATTERN = "/subsystem=infinispan/cache-container=abc/local-cache=%s:%s";
     private static final String READ_OP_DESC_OP = ModelDescriptionConstants.READ_OPERATION_DESCRIPTION_OPERATION + "(name=%s)";
     private static final String READ_RES_DESC_OP = ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION + "(access-control=combined-descriptions,operations=true,recursive=true)";
-    private static final String EVICTION = "EVICTION";
+    private static final String SUBMODULE = "TEST";
 
     @BeforeClass
     public static void before() throws Exception {
@@ -85,12 +83,12 @@ public class WildCardReadsTestCase extends AbstractCliTestBase {
      */
     @Test
     public void testLenientReadOperationDescription() throws IOException {
-        cli.sendLine(String.format(OP_PATTERN, EVICTION, ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION));
+        cli.sendLine(String.format(OP_PATTERN, SUBMODULE, ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION));
         CLIOpResult opResult = cli.readAllAsOpResult();
         Assert.assertTrue(opResult.isIsOutcomeSuccess());
         for (ModelNode node : opResult.getResponseNode().get(ModelDescriptionConstants.RESULT).asList()) {
             String opPart = String.format(READ_OP_DESC_OP, node.asString());
-            cli.sendLine(String.format(OP_PATTERN, EVICTION, opPart));
+            cli.sendLine(String.format(OP_PATTERN, SUBMODULE, opPart));
             opResult = cli.readAllAsOpResult();
             Assert.assertTrue(opResult.isIsOutcomeSuccess());
             ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
@@ -106,7 +104,7 @@ public class WildCardReadsTestCase extends AbstractCliTestBase {
      */
     @Test
     public void testReadResourceDescriptionNoGenericRegistration() throws IOException {
-        cli.sendLine(String.format(OP_PATTERN, EVICTION, READ_RES_DESC_OP));
+        cli.sendLine(String.format(OP_PATTERN, SUBMODULE, READ_RES_DESC_OP));
         CLIOpResult opResult = cli.readAllAsOpResult();
         Assert.assertTrue(opResult.isIsOutcomeSuccess());
         ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);


### PR DESCRIPTION
[WFLY-16418 WildCardReadsTestCase target resource no longer exists](https://issues.redhat.com/browse/WFLY-16418)
