### PR TITLE
WFLY-18093 Upgrade smallrye-health to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
         <version.io.smallrye.smallrye-common>2.1.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.2.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.2.3</version.io.smallrye.smallrye-fault-tolerance>
-        <version.io.smallrye.smallrye-health>4.0.0</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>4.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.2.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.1.0</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>3.3.0</version.io.smallrye.smallrye-mutiny-vertx>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18093