### PR TITLE
[WFLY-18096] Upgrade WildFly Core to 21.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.4</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>21.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-18096

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/21.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/21.0.0.Beta1...21.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6365'>WFCORE-6365</a>] -         RestartParent OperationStepHandler implementations are incompatible with service built via CapabilityServiceTarget
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6286'>WFCORE-6286</a>] -         Document the purpose of the wildflyee.api module in its module.xml, and mark it as private
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6370'>WFCORE-6370</a>] -         Remove duplicate &#39;jakarta.xml.ws.api&#39; JBoss Modules module declaration in &#39;wildflyee.api&#39;
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6368'>WFCORE-6368</a>] -         Upgrade JBoss MSC to 1.5.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6373'>WFCORE-6373</a>] -         Upgrade WildFly Elytron EE to 3.0.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6328'>WFCORE-6328</a>] -         Add AbstractSubsystemTest subclass for use with tests parameterized via SubsystemSchema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6382'>WFCORE-6382</a>] -         Minimize retained memory if an OperationContext impl is cached beyond the lifetime of its operation
</li>
</ul>
</details>
