### PR TITLE
WFLY-18052 Drop problematic transitive dependency exclusions for org.wildfly.core:wildfly-controller and org.wildfly.core:wildfly-server

### DIFF
--- a/legacy/opentracing-extension/pom.xml
+++ b/legacy/opentracing-extension/pom.xml
@@ -71,22 +71,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18052

Follows up on https://github.com/wildfly/wildfly/pull/16869
This makes it impossible to run full-integration tests from wildfly-core in the event that that a new dependency is added to one of these modules.