### PR TITLE
[WFLY-18121] Upgrade WildFly Core to 21.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.4</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>21.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-18121

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/21.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/21.0.0.Beta2...21.0.0.Beta3

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6381'>WFCORE-6381</a>] -         ProcessNameReadAttributeHandler does an unnecessary recursive model read
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6386'>WFCORE-6386</a>] -         Recursive read-resource operations result in excessive peak memory use
</li>
</ul>
                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6379'>WFCORE-6379</a>] -         Upgrade Jakarta JSON Processing to 2.1.2 and Eclipse Parsson to 1.1.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6388'>WFCORE-6388</a>] -         Upgrade Undertow to 2.3.7.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6380'>WFCORE-6380</a>] -         Eliminate unnecessary validator allocations in global operation handlers
</li>
</ul>
</details>