### PR TITLE
WFLY-18138 Upgrade to Hibernate 6.2.5.Final release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,7 +497,7 @@
         <version.org.glassfish.soteria>3.0.0</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.2.4.Final</version.org.hibernate>
+        <version.org.hibernate>6.2.5.Final</version.org.hibernate>
         <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18138

Release notes: https://in.relation.to/2023/06/15/hibernate-orm-625-final (Second level cache fixes sound interesting).
Tag: https://github.com/hibernate/hibernate-orm/releases/tag/6.2.5
Diff: [hibernate/hibernate-orm@6.2.4...6.2.5](https://github.com/hibernate/hibernate-orm/compare/6.2.4...6.2.5)