### PR TITLE
[WFLY-18115] Opentelemetry sampler-type cannot be configured correctly

### DIFF
--- a/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/WildFlyOpenTelemetryConfig.java
+++ b/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/WildFlyOpenTelemetryConfig.java
@@ -65,7 +65,19 @@ public final class WildFlyOpenTelemetryConfig implements OpenTelemetryConfig {
         addValue(config, OTEL_BSP_SCHEDULE_DELAY, batchDelay);
         addValue(config, OTEL_BSP_MAX_QUEUE_SIZE, maxQueueSize);
         addValue(config, OTEL_BSP_MAX_EXPORT_BATCH_SIZE, maxExportBatchSize);
-        addValue(config, OTEL_TRACES_SAMPLER, sampler);
+        if (sampler != null) {
+            switch (sampler) {
+                case "on":
+                    addValue(config, OTEL_TRACES_SAMPLER, "always_on");
+                    break;
+                case "off":
+                    addValue(config, OTEL_TRACES_SAMPLER, "always_off");
+                    break;
+                case "ratio":
+                    addValue(config, OTEL_TRACES_SAMPLER, "traceidratio");
+                    break;
+            }
+        }
         addValue(config, OTEL_TRACES_SAMPLER_ARG, ratio);
 
         properties = Collections.unmodifiableMap(config);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18115

Add code to translate between WF-friendly and otel-specified parameter values for sampler-type