### PR TITLE
[WFLY-18165] Mark alias modules as deprecated or private

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
@@ -21,4 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Deprecated module alias.
+
+    This module is an alias for the module specified in the 'target-name' attribute,
+    provided for compatibility purposes.
+    Uses of this module should be updated to use the target module.
+    This alias is deprecated and will be removed in a future release.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" target-name="com.fasterxml.jackson.jakarta.jackson-jakarta-json-provider"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
@@ -21,4 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
+
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="com.sun.xml.bind" target-name="org.glassfish.jaxb"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
@@ -21,5 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
 
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="javaee.api" target-name="wildflyee.api"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
@@ -21,5 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Deprecated module alias.
 
+    This module is an alias for the module specified in the 'target-name' attribute,
+    provided for compatibility purposes.
+    Uses of this module should be updated to use the target module.
+    This alias is deprecated and will be removed in a future release.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate.envers" target-name="org.hibernate"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
@@ -21,5 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
 
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate.infinispan" target-name="org.infinispan.hibernate-cache"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
@@ -21,5 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
 
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.infinispan.cachestore.remote" target-name="org.infinispan.persistence.remote"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
@@ -21,4 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
+
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.ejb3.infinispan" target-name="org.wildfly.clustering.ejb.infinispan"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
@@ -21,4 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
+
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.clustering.web.infinispan" target-name="org.wildfly.clustering.web.infinispan"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
@@ -21,4 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
+
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.jboss.as.modcluster" target-name="org.wildfly.extension.mod_cluster"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
@@ -21,5 +21,9 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Alias for a private module.
 
+    This module is an alias for a private module and may be removed at any time.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.server" target-name="org.wildfly.clustering.singleton.server"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
@@ -21,5 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
+<!--
+    END USER MODULE USAGE: Deprecated module alias.
 
+    This module is an alias for the module specified in the 'target-name' attribute,
+    provided for compatibility purposes.
+    Uses of this module should be updated to use the target module.
+    This alias is deprecated and will be removed in a future release.
+-->
 <module-alias xmlns="urn:jboss:module:1.9" name="org.wildfly.clustering.singleton" target-name="org.wildfly.clustering.singleton.api"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18165

This incorporates the #16962 change.