### PR TITLE
[WFLY-18180] Upgrade netty from 4.1.92.Final to 4.1.94.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.io.agroal>2.0</version.io.agroal>
         <version.io.micrometer>1.9.3</version.io.micrometer>
-        <version.io.netty>4.1.92.Final</version.io.netty>
+        <version.io.netty>4.1.94.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.20.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentelemetry.proto>0.19.0-alpha</version.io.opentelemetry.proto>
         <version.io.perfmark>0.23.0</version.io.perfmark>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18180
Upgrade netty from 4.1.92.Final to 4.1.94.Final (resolves CVE-2023-34462)
