### PR TITLE
[WFLY-17841] Adding back org.jboss.vfs as implicit deployment dependency

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Implicit_module_dependencies_for_deployments.adoc
@@ -83,7 +83,7 @@ that are always added |Dependencies that are added if a trigger
 condition is met |Trigger which leads to the implicit module dependency
 being added
 
-|Core Server |java.se |  | 
+|Core Server |java.se org.jboss.vfs|  | 
 
 |Batch Subsystem |jakarta.batch.api |  | implicit
 


### PR DESCRIPTION
Jira issue:https://issues.redhat.com/browse/WFLY-17841

