### PR TITLE
[WFLY-18181] Upgrade WildFly Core to 21.1.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.4</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>21.1.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-18181

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/21.1.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/21.0.0.Beta4...21.1.0.Beta1

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6096'>WFCORE-6096</a>] -         ModelTestModelControllerService does not set error when init capabilities are missing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6408'>WFCORE-6408</a>] -         Add new DEPENDENCIES_JDBC_DRIVER phase for correct JDBC driver alignment
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6409'>WFCORE-6409</a>] -         org.jboss.marshalling module should be private
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6313'>WFCORE-6313</a>] -         org.jboss.as.host.controller.resources.NativeManagementResourceDefinition uses the wrong NativeManagementRemoveHandler
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6405'>WFCORE-6405</a>] -         Make the org.wildfly.extension.elytron module private
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6412'>WFCORE-6412</a>] -         Upgrade JGit to 6.6.0.202305301015-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6413'>WFCORE-6413</a>] -         Upgrade JBoss VFS to 3.3.0.Final
</li>
</ul>
</details>
