### PR TITLE
[WFLY-1816] Record Galleon provisioned state in WildFly distributions

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -77,7 +77,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>${galleon.offline}</offline>
                             <feature-packs>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -121,7 +121,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>${galleon.offline}</offline>
                             <plugin-options>

--- a/ee-build/pom.xml
+++ b/ee-build/pom.xml
@@ -77,7 +77,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>${galleon.offline}</offline>
                             <feature-packs>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -121,7 +121,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>tree</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>${galleon.offline}</offline>
                             <plugin-options>

--- a/preview/build/pom.xml
+++ b/preview/build/pom.xml
@@ -72,7 +72,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>true</offline>
                             <feature-packs>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -107,7 +107,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>false</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>true</offline>
                             <plugin-options>


### PR DESCRIPTION
Set `record-state` to `true` for the galleon-maven-plugin provision goal when building and creating distributions of WildFly (full, ee, and preview) so that an user can use Galleon to add other feature packs to an existing installation from any of these zips.

For consistency, the galleon provisioned state is also recorded for WildFly builds full, ee, and preview)

JIRA: https://issues.redhat.com/browse/WFLY-18186
