### PR TITLE
[WFLY-18040] Tests if deployments can share client context if static interceptors are used

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/EjbClientServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/EjbClientServlet.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.sharedcontext;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Properties;
+
+@WebServlet(urlPatterns = "/*")
+public class EjbClientServlet extends HttpServlet {
+    private static final String INITIAL_CONTEXT_FACTORY = "org.wildfly.naming.client.WildFlyInitialContextFactory";
+    private static final String MODULE_NAME = "shared-client-context-ejb";
+    private static final String PROVIDER_URL = "remote+http://localhost:8080";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final PrintWriter out = resp.getWriter();
+        InitialContext ctx = null;
+        try {
+            Properties props = new Properties();
+            props.put(Context.INITIAL_CONTEXT_FACTORY, INITIAL_CONTEXT_FACTORY);
+            props.put(Context.PROVIDER_URL, PROVIDER_URL);
+            ctx = new InitialContext(props);
+
+            TestEjbRemote myEjb = (TestEjbRemote) ctx.lookup("ejb:/" + MODULE_NAME + "/" + "TestEjb!" + TestEjbRemote.class.getName());
+            myEjb.test();
+        } catch (NamingException e) {
+            e.printStackTrace(out);
+        } finally {
+            if (ctx != null) {
+                try {
+                    ctx.close();
+                } catch (NamingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/FrontendServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/FrontendServlet.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.sharedcontext;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Servlet shares the context for the client servlets
+ */
+@WebServlet(urlPatterns = "/*")
+public class FrontendServlet extends HttpServlet {
+
+    private static final int MAX_CLIENTS = 50;
+    public static final String FRONTEND_SERVLET_OK = "OK";
+    private static final String FRONTEND_SERVLET_FAILED = "FAILED";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        final PrintWriter out = resp.getWriter();
+
+        try {
+            for (int i = 0; i < MAX_CLIENTS; i++) {
+                String contextPath = String.format("/shared-client-context-client-%02d", i);
+                ServletContext context = req.getServletContext().getContext(contextPath);
+                if (context == null || !context.getContextPath().equals(contextPath)) {
+                    break;
+                }
+                RequestDispatcher disp = context.getRequestDispatcher("/");
+                disp.include(req, resp);
+            }
+            out.print(FrontendServlet.FRONTEND_SERVLET_OK);
+        } catch (Exception e) {
+            e.printStackTrace();
+            out.print(FrontendServlet.FRONTEND_SERVLET_FAILED);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/SharedClientContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/SharedClientContextTestCase.java
@@ -1,0 +1,140 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.sharedcontext;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Daniel Cihak
+ *
+ * https://issues.redhat.com/browse/WFLY-18040
+ *
+ * Tests if deployments can share client context if static interceptors are used.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SharedClientContextTestCase extends AbstractCliTestBase {
+
+    private static final String EJB = "shared-client-context-ejb";
+    private static final String FRONTEND = "shared-client-context-frontend";
+    private static final int CLIENTS_NUMBER = 50;
+    private static List<File> clientWarFiles = new ArrayList<>();
+
+    @ArquillianResource
+    @OperateOnDeployment(FRONTEND)
+    private URL frontendUrl;
+
+    @Deployment(name = EJB)
+    public static WebArchive deployment1() {
+        final WebArchive archive = ShrinkWrap.create(WebArchive.class, EJB + ".war");
+        archive.addClasses(TestEjbRemote.class, TestEjb.class);
+        return archive;
+    }
+
+    @Deployment(name = FRONTEND)
+    public static WebArchive deployment3() {
+        final WebArchive archive = ShrinkWrap.create(WebArchive.class, FRONTEND + ".war");
+        archive.addClasses(FrontendServlet.class);
+        return archive;
+    }
+
+    /**
+     * Creates list of 50 clients trying to lookup remote bean from the other deployment
+     *
+     */
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        File clientWarFile = null;
+        for (int i = 0; i < CLIENTS_NUMBER; i++){
+            String clientWarFileName = String.format("shared-client-context-client-%02d", i);
+            clientWarFile = exportClientWar(clientWarFileName + ".war");
+            clientWarFiles.add(clientWarFile);
+        }
+
+        AbstractCliTestBase.initCLI();
+    }
+
+    private static File exportClientWar(String name) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war");
+
+        war.addClasses(EjbClientServlet.class, TestEjbRemote.class, TestSuiteEnvironment.class);
+        String tempDir = TestSuiteEnvironment.getTmpDir();
+        File warFile = new File(tempDir + File.separator + name);
+        new ZipExporterImpl(war).exportTo(warFile, true);
+        return warFile;
+    }
+
+    @Before
+    public void before() throws MalformedURLException {
+        for (int i = 0; i < clientWarFiles.size(); i++) {
+            String clientWarFileName = String.format("shared-client-context-client-%02d", i);
+            cli.sendLine("deploy --url=" + clientWarFiles.get(i).toURI().toURL().toExternalForm() + " --name=" + clientWarFileName + ".war --runtime-name=" + clientWarFileName + ".war");
+        }
+    }
+
+    @AfterClass
+    public static void closeCli() throws Exception {
+        for (int i = 0; i < clientWarFiles.size(); i++) {
+            clientWarFiles.get(i).delete();
+        }
+
+        AbstractCliTestBase.closeCLI();
+    }
+
+    @Test
+    public void testSharedClientContext() throws IOException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            String url = frontendUrl.toExternalForm() + "frontend";
+            HttpGet httpget = new HttpGet(url);
+            HttpResponse response = httpClient.execute(httpget);
+            assertEquals("FrontEndServlet could not process the shared client context or EJB lookup failed.", FrontendServlet.FRONTEND_SERVLET_OK, EntityUtils.toString(response.getEntity()));
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/TestEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/TestEjb.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.sharedcontext;
+
+import jakarta.ejb.Remote;
+import jakarta.ejb.Stateless;
+
+@Remote(TestEjbRemote.class)
+@Stateless
+public class TestEjb implements TestEjbRemote {
+
+    @Override
+    public void test() {}
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/TestEjbRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sharedcontext/TestEjbRemote.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.sharedcontext;
+
+public interface TestEjbRemote {
+    void test();
+}


### PR DESCRIPTION
Tests if deployments can share client context if static interceptors are used.

Test case for [WFLY-18040](https://issues.redhat.com/browse/WFLY-18040)