### PR TITLE
WFLY-18197 + WFLY-18198 Upgrade to Hibernate Search 6.2.0

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -71,6 +71,17 @@
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>jipijapa-hibernate6</artifactId>
+                <version>${ee.maven.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>jipijapa-hibernatesearch</artifactId>
                 <version>${ee.maven.version}</version>
                 <exclusions>
                     <exclusion>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -3049,6 +3049,17 @@
 
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>jipijapa-hibernatesearch</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-appclient</artifactId>
             <exclusions>
                 <exclusion>

--- a/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
@@ -2805,6 +2805,17 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>jipijapa-hibernatesearch</artifactId>
+            <licenses>
+                <license>
+                    <name>GNU Lesser General Public License v2.1 or later</name>
+                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+                    <distribution>repo</distribution>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
             <licenses>
                 <license>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
@@ -22,24 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Hibernate Search Engine: the main glue between backend (e.g. Lucene backend)
-     and mapper (e.g. Hibernate ORM mapper) -->
-<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.jipijapa-hibernatesearch">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
-        <artifact name="${org.hibernate.search:hibernate-search-util-common}"/>
-        <artifact name="${org.hibernate.search:hibernate-search-engine}"/>
+        <artifact name="${org.wildfly:jipijapa-hibernatesearch}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.logging"/>
+        <module name="jakarta.persistence.api"/>
         <module name="org.jboss.jandex"/>
-
-        <!-- Optional dependencies to import services (used for resolution of bean references in particular). -->
-        <module name="org.hibernate.search.backend.lucene" optional="true" services="import"/>
-        <module name="org.hibernate.search.backend.elasticsearch" optional="true" services="import"/>
-        <module name="org.hibernate.search.mapper.pojo" optional="true" services="import"/>
-        <module name="org.hibernate.search.mapper.orm" optional="true" services="import"/>
-        <module name="org.hibernate.search.mapper.orm.coordination.outboxpolling" optional="true" services="import"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.hibernate.search.mapper.orm"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -35,8 +35,10 @@
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="org.jboss.logging" />
+        <module name="org.jboss.jandex"/>
         <module name="org.hibernate.search.engine" export="true" />
         <module name="org.hibernate.search.mapper.pojo" export="true" />
         <module name="org.hibernate" />
+        <module name="org.hibernate.search.jipijapa-hibernatesearch" services="import" />
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2022, Red Hat, Inc., and individual contributors
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -30,6 +30,7 @@
 
     <dependencies>
         <module name="org.jboss.logging" />
+        <module name="org.jboss.jandex"/>
         <module name="java.sql" export="true" /> <!-- For java.sql.Date, etc. -->
         <module name="org.hibernate.search.engine" export="true" />
         <module name="org.hibernate.commons-annotations" export="true" />

--- a/jpa/hibernatesearch/pom.xml
+++ b/jpa/hibernatesearch/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-jpa-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>29.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jipijapa-hibernatesearch</artifactId>
+
+    <name>WildFly: Jipijapa Hibernate Search integration</name>
+
+    <properties>
+        <!-- Use the standard WildFly dependency set -->
+        <dependency.management.pom.artifactId>wildfly-standard-ee-bom</dependency.management.pom.artifactId>
+    </properties>
+
+    <dependencies>
+        <!-- Internal -->
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jipijapa-spi</artifactId>
+        </dependency>
+
+        <!-- External -->
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.common</groupId>
+            <artifactId>hibernate-commons-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/HibernateSearchIntegratorAdaptor.java
+++ b/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/HibernateSearchIntegratorAdaptor.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.hibernate.search;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import org.hibernate.search.engine.cfg.spi.ConvertUtils;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.jboss.jandex.Index;
+import org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor;
+import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
+
+/**
+ * Implements the PersistenceProviderIntegratorAdaptor for Hibernate Search
+ */
+public class HibernateSearchIntegratorAdaptor implements PersistenceProviderIntegratorAdaptor {
+
+    // Same as org.hibernate.search.engine.cfg.impl.OptionalPropertyContextImpl.MULTI_VALUE_SEPARATOR_PATTERN
+    private static final Pattern MULTI_VALUE_SEPARATOR_PATTERN = Pattern.compile( "," );
+
+    private Collection<Index> indexes;
+    private final List<WildFlyHibernateOrmSearchMappingConfigurer> configurers = new ArrayList<>();
+
+    @Override
+    public void injectIndexes(Collection<Index> indexes) {
+        this.indexes = indexes;
+    }
+
+    @Override
+    public void addIntegratorProperties(Map<String, Object> properties, PersistenceUnitMetadata pu) {
+        // See WildFlyHibernateOrmSearchMappingConfigurer
+        addMappingConfigurer(properties, pu);
+    }
+
+    private void addMappingConfigurer(Map<String, Object> properties, PersistenceUnitMetadata pu) {
+        Properties puProperties = pu.getProperties();
+
+        List<Object> mappingConfigurerRefs = new ArrayList<>();
+        Object customMappingConfigurerRefs = puProperties.get(HibernateOrmMapperSettings.MAPPING_CONFIGURER);
+        if (customMappingConfigurerRefs != null) {
+            // We need to parse user-provided config to preserve it
+            try {
+                mappingConfigurerRefs.addAll(ConvertUtils.convertMultiValue(MULTI_VALUE_SEPARATOR_PATTERN,
+                        Function.identity(), customMappingConfigurerRefs));
+            } catch (RuntimeException e) {
+                throw JpaHibernateSearchLogger.JPA_HIBERNATE_SEARCH_LOGGER.failOnPropertyParsingForIntegration(
+                        pu.getPersistenceUnitName(), HibernateOrmMapperSettings.MAPPING_CONFIGURER, e);
+            }
+        }
+        // Change the default behavior of Hibernate Search regarding Jandex indexes
+        WildFlyHibernateOrmSearchMappingConfigurer configurer = new WildFlyHibernateOrmSearchMappingConfigurer(indexes);
+        configurers.add(configurer); // for cleaning up later, see methods below
+        mappingConfigurerRefs.add(0, configurer);
+        properties.put(HibernateOrmMapperSettings.MAPPING_CONFIGURER, mappingConfigurerRefs);
+    }
+
+    @Override
+    public void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        // Don't keep any reference to indexes, as those can be quite large.
+        indexes = null;
+        for (WildFlyHibernateOrmSearchMappingConfigurer configurer : configurers) {
+            configurer.clearIndexReferences();
+        }
+        configurers.clear();
+    }
+}
+

--- a/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/JpaHibernateSearchLogger.java
+++ b/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/JpaHibernateSearchLogger.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.hibernate.search;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * JipiJapa message range is 20200-20299
+ * note: keep duplicate messages in sync between different sub-projects that use the same messages
+ */
+@MessageLogger(projectCode = "JIPISEARCH")
+public interface JpaHibernateSearchLogger extends BasicLogger {
+
+    /**
+     * A logger with the category {@code org.jipijapa}.
+     */
+    JpaHibernateSearchLogger JPA_HIBERNATE_SEARCH_LOGGER = Logger.getMessageLogger(JpaHibernateSearchLogger.class, "org.jipijapa");
+
+    @Message(id = 20290, value = "Failed to parse property '%2$s' while integrating Hibernate Search into persistence unit '%1$s")
+    IllegalStateException failOnPropertyParsingForIntegration(String puUnitName, String propertyKey, @Cause Exception cause);
+
+}

--- a/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/WildFlyHibernateOrmSearchMappingConfigurer.java
+++ b/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/WildFlyHibernateOrmSearchMappingConfigurer.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.hibernate.search;
+
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmMappingConfigurationContext;
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
+import org.jboss.jandex.Index;
+
+import java.util.Collection;
+
+final class WildFlyHibernateOrmSearchMappingConfigurer implements HibernateOrmSearchMappingConfigurer {
+    private Collection<Index> indexes;
+
+    public WildFlyHibernateOrmSearchMappingConfigurer(Collection<Index> indexes) {
+        this.indexes = indexes;
+    }
+
+    @Override
+    public void configure(HibernateOrmMappingConfigurationContext context) {
+        // Hibernate Search can't deal with WildFly's JAR URLs using vfs://,
+        // so it fails to load Jandex indexes from the JARs.
+        // Regardless, WildFly already has Jandex indexes in memory,
+        // so we'll configure Hibernate Search to just use those.
+        context.annotationMapping().discoverJandexIndexesFromAddedTypes(false)
+                 .buildMissingDiscoveredJandexIndexes(false);
+        if (indexes != null) {
+            for (Index index : indexes) {
+                // This class is garbage-collected after bootstrap,
+                // so the reference to indexes does not matter.
+                context.annotationMapping().addJandexIndex(index);
+            }
+        }
+    }
+
+    public void clearIndexReferences() {
+        indexes = null;
+    }
+}

--- a/jpa/hibernatesearch/src/main/resources/META-INF/services/org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor
+++ b/jpa/hibernatesearch/src/main/resources/META-INF/services/org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor
@@ -1,0 +1,1 @@
+org.jipijapa.hibernate.search.HibernateSearchIntegratorAdaptor

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -39,6 +39,7 @@
 
     <modules>
         <module>hibernate6</module>
+        <module>hibernatesearch</module>
         <module>subsystem</module>
         <module>spi</module>
         <module>eclipselink</module>

--- a/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderIntegratorAdaptor.java
+++ b/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderIntegratorAdaptor.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.plugin.spi;
+
+import org.jboss.jandex.Index;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Adaptor for integrators into persistence providers, e.g. Hibernate Search.
+ */
+public interface PersistenceProviderIntegratorAdaptor {
+
+    /**
+     * @param indexes The index views for the unit being deployed
+     */
+    void injectIndexes(Collection<Index> indexes);
+
+    /**
+     * Adds any integrator-specific persistence unit properties
+     *
+     * @param properties
+     * @param pu
+     */
+    void addIntegratorProperties(Map<String, Object> properties, PersistenceUnitMetadata pu);
+
+    /**
+     * Called right after persistence provider is invoked to create container entity manager factory.
+     */
+    void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu);
+
+}
+

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2023, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -189,6 +189,11 @@ public class Configuration {
      * name of the Hibernate Search module name configuration setting in persistence unit definition
      */
     public static final String HIBERNATE_SEARCH_MODULE = "wildfly.jpa.hibernate.search.module";
+
+    /**
+     * name of the Hibernate Search integrator adaptor module
+     */
+    public static final String HIBERNATE_SEARCH_INTEGRATOR_ADAPTOR_MODULE_NAME = "org.hibernate.search.jipijapa-hibernatesearch";
 
     /**
      * name of the Hibernate Search module providing the ORM mapper

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2023, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -757,4 +757,16 @@ public interface JpaLogger extends BasicLogger {
     IllegalStateException invalidClassFormat(@Cause Exception cause, String className);
 
     // @Message(id = 74, value = "Deprecated Hibernate51CompatibilityTransformer is enabled for all application deployments.")
+
+    /**
+     * Creates an exception indicating the persistence provider integrator module, represented by the
+     * {@code persistenceProviderModule} parameter, had an error loading.
+     *
+     * @param cause                     the cause of the error.
+     * @param persistenceProviderModule the name of the adapter module.
+     * @return a {@link DeploymentUnitProcessingException} for the error.
+     */
+    @Message(id = 74, value = "Persistence provider integrator module load error for %s")
+    DeploymentUnitProcessingException cannotLoadPersistenceProviderIntegratorModule(@Cause Throwable cause, String persistenceProviderModule);
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2023, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -124,6 +124,11 @@ public class HibernateSearchProcessor implements DeploymentUnitProcessor {
                         ANNOTATION_INDEXED_NAME, MODULE_MAPPER_ORM_DEFAULT);
             }
         }
+
+        // Configure sourcing of Jandex indexes in Hibernate Search,
+        // so that it can look for @ProjectionConstructor annotations
+        deploymentUnit.addToAttachmentList(JpaAttachments.INTEGRATOR_ADAPTOR_MODULE_NAMES,
+                Configuration.HIBERNATE_SEARCH_INTEGRATOR_ADAPTOR_MODULE_NAME);
 
         List<String> backendTypes = HibernateSearchDeploymentMarker.getBackendTypes(deploymentUnit);
         if (backendTypes != null) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -25,6 +25,7 @@ import org.jboss.as.jpa.beanmanager.BeanManagerAfterDeploymentValidation;
 import org.jboss.as.jpa.config.JPADeploymentSettings;
 import org.jboss.as.jpa.config.PersistenceProviderDeploymentHolder;
 import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.AttachmentList;
 import org.jboss.msc.service.ServiceName;
 
 import jakarta.transaction.TransactionSynchronizationRegistry;
@@ -50,6 +51,8 @@ public final class JpaAttachments {
     public static final AttachmentKey<PersistenceProviderDeploymentHolder> DEPLOYED_PERSISTENCE_PROVIDER = AttachmentKey.create(PersistenceProviderDeploymentHolder.class);
 
     public static final AttachmentKey<BeanManagerAfterDeploymentValidation> BEAN_MANAGER_AFTER_DEPLOYMENT_VALIDATION_ATTACHMENT_KEY = AttachmentKey.create(BeanManagerAfterDeploymentValidation.class);
+
+    public static final AttachmentKey<AttachmentList<String>> INTEGRATOR_ADAPTOR_MODULE_NAMES = AttachmentKey.createList(String.class);
 
     private JpaAttachments() {
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2023, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -89,6 +89,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUtils;
 import org.jboss.as.server.deployment.JPADeploymentMarker;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
+import org.jboss.as.server.deployment.annotation.CompositeIndex;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.weld.WeldCapability;
 import org.jboss.dmr.ModelNode;
@@ -105,6 +106,7 @@ import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
 import org.jipijapa.plugin.spi.ManagementAdaptor;
 import org.jipijapa.plugin.spi.PersistenceProviderAdaptor;
+import org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.jipijapa.plugin.spi.Platform;
 import org.jipijapa.plugin.spi.TwoPhaseBootstrapCapable;
@@ -263,11 +265,13 @@ public class PersistenceUnitServiceHandler {
                         final PersistenceProviderDeploymentHolder persistenceProviderDeploymentHolder = getPersistenceProviderDeploymentHolder(deploymentUnit);
                         final PersistenceProvider provider = lookupProvider(pu, persistenceProviderDeploymentHolder, deploymentUnit);
                         final PersistenceProviderAdaptor adaptor = getPersistenceProviderAdaptor(pu, persistenceProviderDeploymentHolder, deploymentUnit, provider, platform);
+                        final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors = getPersistenceProviderIntegratorAdaptors(deploymentUnit);
                         final boolean twoPhaseBootStrapCapable = (adaptor instanceof TwoPhaseBootstrapCapable) && Configuration.allowTwoPhaseBootstrap(pu);
 
                         if (startEarly) {
                             if (twoPhaseBootStrapCapable) {
-                                deployPersistenceUnitPhaseOne(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, adaptor);
+                                deployPersistenceUnitPhaseOne(deploymentUnit, eeModuleDescription, serviceTarget,
+                                        classLoader, pu, adaptor, integratorAdaptors);
                             }
                             else if (false == Configuration.needClassFileTransformer(pu)) {
                                 // will start later when startEarly == false
@@ -278,16 +282,18 @@ public class PersistenceUnitServiceHandler {
                                 // we need class file transformer to work, don't allow Jakarta Contexts and Dependency Injection bean manager to be access since that
                                 // could cause application classes to be loaded (workaround by setting jboss.as.jpa.classtransformer to false).  WFLY-1463
                                 final boolean allowCdiBeanManagerAccess = false;
-                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, provider, adaptor, allowCdiBeanManagerAccess);
+                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget,
+                                        classLoader, pu, provider, adaptor, integratorAdaptors, allowCdiBeanManagerAccess);
                             }
                         }
                         else { // !startEarly
                             if (twoPhaseBootStrapCapable) {
-                                deployPersistenceUnitPhaseTwo(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, provider, adaptor);
+                                deployPersistenceUnitPhaseTwo(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, provider, adaptor, integratorAdaptors);
                             } else if (false == Configuration.needClassFileTransformer(pu)) {
                                 final boolean allowCdiBeanManagerAccess = true;
                                 // PUs that have Configuration.JPA_CONTAINER_CLASS_TRANSFORMER = false will start during INSTALL phase
-                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, provider, adaptor, allowCdiBeanManagerAccess);
+                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget,
+                                        classLoader, pu, provider, adaptor, integratorAdaptors, allowCdiBeanManagerAccess);
                             }
                         }
 
@@ -311,6 +317,7 @@ public class PersistenceUnitServiceHandler {
      * @param pu
      * @param provider
      * @param adaptor
+     * @param integratorAdaptors Adapters for integrators, e.g. Hibernate Search.
      * @param allowCdiBeanManagerAccess
      * @throws DeploymentUnitProcessingException
      */
@@ -322,6 +329,7 @@ public class PersistenceUnitServiceHandler {
             final PersistenceUnitMetadata pu,
             final PersistenceProvider provider,
             final PersistenceProviderAdaptor adaptor,
+            final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors,
             final boolean allowCdiBeanManagerAccess) throws DeploymentUnitProcessingException {
         pu.setClassLoader(classLoader);
         TransactionManager transactionManager = ContextTransactionManager.getInstance();
@@ -329,7 +337,7 @@ public class PersistenceUnitServiceHandler {
         CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         try {
             ValidatorFactory validatorFactory = null;
-            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
+            final HashMap<String, Object> properties = new HashMap<>();
 
             CapabilityServiceSupport css = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
             if (!ValidationMode.NONE.equals(pu.getValidationMode())
@@ -345,6 +353,11 @@ public class PersistenceUnitServiceHandler {
             // add persistence provider specific properties
             adaptor.addProviderProperties(properties, pu);
 
+            // add persistence provider integrator specific properties
+            for (PersistenceProviderIntegratorAdaptor integratorAdaptor : integratorAdaptors) {
+                integratorAdaptor.addIntegratorProperties(properties, pu);
+            }
+
             final ServiceName puServiceName = PersistenceUnitServiceImpl.getPUServiceName(pu);
             deploymentUnit.putAttachment(JpaAttachments.PERSISTENCE_UNIT_SERVICE_KEY, puServiceName);
 
@@ -353,8 +366,10 @@ public class PersistenceUnitServiceHandler {
             deploymentUnit.addToAttachmentList(Attachments.WEB_DEPENDENCIES, puServiceName);
 
             final PersistenceUnitServiceImpl service =
-                    new PersistenceUnitServiceImpl(properties, classLoader, pu, adaptor, provider, PersistenceUnitRegistryImpl.INSTANCE,
-                            deploymentUnit.getServiceName(), validatorFactory, deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION),
+                    new PersistenceUnitServiceImpl(properties, classLoader, pu, adaptor, integratorAdaptors, provider,
+                            PersistenceUnitRegistryImpl.INSTANCE,
+                            deploymentUnit.getServiceName(), validatorFactory,
+                            deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION),
                             beanManagerAfterDeploymentValidation );
 
             ServiceBuilder<PersistenceUnitService> builder = serviceTarget.addService(puServiceName, service);
@@ -444,6 +459,7 @@ public class PersistenceUnitServiceHandler {
      * @param classLoader
      * @param pu
      * @param adaptor
+     * @param integratorAdaptors Adapters for integrators, e.g. Hibernate Search.
      * @throws DeploymentUnitProcessingException
      */
     private static void deployPersistenceUnitPhaseOne(
@@ -452,11 +468,13 @@ public class PersistenceUnitServiceHandler {
             final ServiceTarget serviceTarget,
             final ModuleClassLoader classLoader,
             final PersistenceUnitMetadata pu,
-            final PersistenceProviderAdaptor adaptor) throws DeploymentUnitProcessingException {
+            final PersistenceProviderAdaptor adaptor,
+            final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors)
+            throws DeploymentUnitProcessingException {
         CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         pu.setClassLoader(classLoader);
         try {
-            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
+            final HashMap<String, Object> properties = new HashMap<>();
 
             ProxyBeanManager proxyBeanManager = null;
             // JPA 2.1 sections 3.5.1 + 9.1 require the Jakarta Contexts and Dependency Injection bean manager to be passed to the peristence provider
@@ -477,6 +495,11 @@ public class PersistenceUnitServiceHandler {
 
             // add persistence provider specific properties
             adaptor.addProviderProperties(properties, pu);
+
+            // add persistence provider integrator specific properties
+            for (PersistenceProviderIntegratorAdaptor integratorAdaptor : integratorAdaptors) {
+                integratorAdaptor.addIntegratorProperties(properties, pu);
+            }
 
             final ServiceName puServiceName = PersistenceUnitServiceImpl.getPUServiceName(pu).append(FIRST_PHASE);
 
@@ -557,6 +580,7 @@ public class PersistenceUnitServiceHandler {
      * @param pu
      * @param provider
      * @param adaptor
+     * @param integratorAdaptors Adapters for integrators, e.g. Hibernate Search.
      * @throws DeploymentUnitProcessingException
      */
     private static void deployPersistenceUnitPhaseTwo(
@@ -566,14 +590,15 @@ public class PersistenceUnitServiceHandler {
             final ModuleClassLoader classLoader,
             final PersistenceUnitMetadata pu,
             final PersistenceProvider provider,
-            final PersistenceProviderAdaptor adaptor) throws DeploymentUnitProcessingException {
+            final PersistenceProviderAdaptor adaptor,
+            final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors) throws DeploymentUnitProcessingException {
         TransactionManager transactionManager = ContextTransactionManager.getInstance();
         TransactionSynchronizationRegistry transactionSynchronizationRegistry = deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
         CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         pu.setClassLoader(classLoader);
         try {
             ValidatorFactory validatorFactory = null;
-            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
+            final HashMap<String, Object> properties = new HashMap<>();
             if (!ValidationMode.NONE.equals(pu.getValidationMode())
                     && capabilitySupport.hasCapability("org.wildfly.bean-validation")) {
                 // Get the Jakarta Contexts and Dependency Injection enabled ValidatorFactory
@@ -586,6 +611,11 @@ public class PersistenceUnitServiceHandler {
             // add persistence provider specific properties
             adaptor.addProviderProperties(properties, pu);
 
+            // add persistence provider integrator specific properties
+            for (PersistenceProviderIntegratorAdaptor integratorAdaptor : integratorAdaptors) {
+                integratorAdaptor.addIntegratorProperties(properties, pu);
+            }
+
             final ServiceName puServiceName = PersistenceUnitServiceImpl.getPUServiceName(pu);
             deploymentUnit.putAttachment(JpaAttachments.PERSISTENCE_UNIT_SERVICE_KEY, puServiceName);
 
@@ -593,7 +623,11 @@ public class PersistenceUnitServiceHandler {
 
             deploymentUnit.addToAttachmentList(Attachments.WEB_DEPENDENCIES, puServiceName);
 
-            final PersistenceUnitServiceImpl service = new PersistenceUnitServiceImpl(properties, classLoader, pu, adaptor, provider, PersistenceUnitRegistryImpl.INSTANCE, deploymentUnit.getServiceName(), validatorFactory, deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION), beanManagerAfterDeploymentValidation);
+            final PersistenceUnitServiceImpl service = new PersistenceUnitServiceImpl(properties, classLoader, pu,
+                    adaptor, integratorAdaptors, provider, PersistenceUnitRegistryImpl.INSTANCE,
+                    deploymentUnit.getServiceName(), validatorFactory,
+                    deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION),
+                    beanManagerAfterDeploymentValidation);
             ServiceBuilder<PersistenceUnitService> builder = serviceTarget.addService(puServiceName, service);
             // the PU service has to depend on the JPAService which is responsible for setting up the necessary JPA infrastructure (like registering the cache EventListener(s))
             // @see https://issues.jboss.org/browse/WFLY-1531 for details
@@ -845,6 +879,21 @@ public class PersistenceUnitServiceHandler {
             throw JpaLogger.ROOT_LOGGER.failedToGetAdapter(pu.getPersistenceProviderClassName());
         }
         return adaptor;
+    }
+
+    private static List<PersistenceProviderIntegratorAdaptor> getPersistenceProviderIntegratorAdaptors(DeploymentUnit deploymentUnit)
+            throws DeploymentUnitProcessingException {
+        List<String> integratorAdaptorModuleNames = deploymentUnit.getAttachmentList(JpaAttachments.INTEGRATOR_ADAPTOR_MODULE_NAMES);
+        List<PersistenceProviderIntegratorAdaptor> integratorAdaptorList = new ArrayList<>();
+        CompositeIndex compositeIndex = deploymentUnit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX);
+        for (String moduleName : integratorAdaptorModuleNames) {
+            try {
+                integratorAdaptorList.addAll(PersistenceProviderAdaptorLoader.loadPersistenceProviderIntegratorModule(moduleName, compositeIndex.getIndexes()));
+            } catch (RuntimeException | ModuleLoadException e) {
+                throw JpaLogger.ROOT_LOGGER.cannotLoadPersistenceProviderIntegratorModule(e, moduleName);
+            }
+        }
+        return integratorAdaptorList;
     }
 
     private static JtaManagerImpl createManager(DeploymentUnit deploymentUnit) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2023, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -26,6 +26,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -53,6 +54,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jipijapa.plugin.spi.EntityManagerFactoryBuilder;
 import org.jipijapa.plugin.spi.PersistenceProviderAdaptor;
+import org.jipijapa.plugin.spi.PersistenceProviderIntegratorAdaptor;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.security.manager.action.GetAccessControlContextAction;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -81,6 +83,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
 
     private final Map properties;
     private final PersistenceProviderAdaptor persistenceProviderAdaptor;
+    private final List<PersistenceProviderIntegratorAdaptor> persistenceProviderIntegratorAdaptors;
     private final PersistenceProvider persistenceProvider;
     private final PersistenceUnitMetadata pu;
     private final ClassLoader classLoader;
@@ -98,6 +101,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
             final ClassLoader classLoader,
             final PersistenceUnitMetadata pu,
             final PersistenceProviderAdaptor persistenceProviderAdaptor,
+            final List<PersistenceProviderIntegratorAdaptor> persistenceProviderIntegratorAdaptors,
             final PersistenceProvider persistenceProvider,
             final PersistenceUnitRegistryImpl persistenceUnitRegistry,
             final ServiceName deploymentUnitServiceName,
@@ -106,6 +110,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
         this.properties = properties;
         this.pu = pu;
         this.persistenceProviderAdaptor = persistenceProviderAdaptor;
+        this.persistenceProviderIntegratorAdaptors = persistenceProviderIntegratorAdaptors;
         this.persistenceProvider = persistenceProvider;
         this.classLoader = classLoader;
         this.persistenceUnitRegistry = persistenceUnitRegistry;
@@ -367,6 +372,9 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
             return persistenceProvider.createContainerEntityManagerFactory(pu, properties);
         } finally {
             persistenceProviderAdaptor.afterCreateContainerEntityManagerFactory(pu);
+            for (PersistenceProviderIntegratorAdaptor adaptor : persistenceProviderIntegratorAdaptors) {
+                adaptor.afterCreateContainerEntityManagerFactory(pu);
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -498,7 +498,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.2.5.Final</version.org.hibernate>
-        <version.org.hibernate.search>6.1.8.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>6.2.0.CR1</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.11.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.9</version.org.apache.james.apache-mime4j>
         <version.org.apache.kafka>3.4.0</version.org.apache.kafka>
-        <version.org.apache.lucene>8.11.1</version.org.apache.lucene>
+        <version.org.apache.lucene>8.11.2</version.org.apache.lucene>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.1</version.org.apache.santuario>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/Author.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/Author.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Author {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @FullTextField
+    private String firstName;
+
+    @FullTextField
+    private String lastName;
+
+    @ManyToMany(mappedBy = "authors")
+    private List<Book> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/AuthorDTO.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/AuthorDTO.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AuthorDTO {
+    public final String firstName;
+    public final String lastName;
+    public final List<BookDTO> books;
+
+    public AuthorDTO(String firstName, String lastName) {
+        this(firstName, lastName, Collections.emptyList());
+    }
+
+    @ProjectionConstructor
+    public AuthorDTO(// These @FieldProjection annotations and @ObjectProjection.path wouldn't be necessary
+                     // with a record or a class compiled with -parameters
+                     @FieldProjection(path = "firstName") String firstName,
+                     @FieldProjection(path = "lastName") String lastName,
+                     @ObjectProjection(path = "books", includeDepth = 1) List<BookDTO> books) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.books = books;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/Book.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/Book.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OrderColumn;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Indexed
+public class Book {
+
+    @Id
+    private Long id;
+
+    @FullTextField
+    private String title;
+
+    @IndexedEmbedded(includeDepth = 1)
+    @ManyToMany
+    @OrderColumn
+    private List<Author> authors = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public List<Author> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(List<Author> authors) {
+        this.authors = authors;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/BookDTO.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/BookDTO.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+import java.util.List;
+
+public class BookDTO {
+    public final long id;
+    public final String title;
+    public final List<AuthorDTO> authors;
+
+    @ProjectionConstructor
+    public BookDTO(@IdProjection long id,
+                   // This @FieldProjection and @ObjectProjection.path wouldn't be necessary
+                   // with a record or a class compiled with -parameters
+                   @FieldProjection(path = "title") String title,
+                   @ObjectProjection(path = "authors", includeDepth = 1) List<AuthorDTO> authors) {
+        this.id = id;
+        this.title = title;
+        this.authors = authors;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/HibernateSearchElasticsearchProjectionConstructorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/HibernateSearchElasticsearchProjectionConstructorTestCase.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.core.api.annotation.Observer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.util.ElasticsearchServerSetupObserver;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify deployed applications can use Hibernate Search's @ProjectionConstructor with Lucene.
+ */
+@RunWith(Arquillian.class)
+@Observer(ElasticsearchServerSetupObserver.class)
+public class HibernateSearchElasticsearchProjectionConstructorTestCase {
+
+    private static final String NAME = HibernateSearchElasticsearchProjectionConstructorTestCase.class.getSimpleName();
+    private static final String WAR_ARCHIVE_NAME = NAME + ".war";
+
+    @BeforeClass
+    public static void testRequiresDocker() {
+        AssumeTestGroupUtil.assumeDockerAvailable();
+    }
+
+    @BeforeClass
+    public static void securityManagerNotSupportedInHibernateSearch() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+    }
+
+    @Deployment
+    public static WebArchive createArchive() {
+
+        // TODO maybe just use managed=false and deploy in the @BeforeClass / undeploy in an @AfterClass
+        if (!AssumeTestGroupUtil.isDockerAvailable() || AssumeTestGroupUtil.isSecurityManagerEnabled()) {
+            return AssumeTestGroupUtil.emptyWar(WAR_ARCHIVE_NAME);
+        }
+
+        return ShrinkWrap
+                .create(WebArchive.class, WAR_ARCHIVE_NAME)
+                .addClasses(HibernateSearchElasticsearchProjectionConstructorTestCase.class,
+                        SearchBean.class, Book.class, Author.class, BookDTO.class, AuthorDTO.class,
+                        AssumeTestGroupUtil.class)
+                .addAsResource(persistenceXml(), "META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    private static Asset persistenceXml() {
+        String persistenceXml = Descriptors.create(PersistenceDescriptor.class)
+                .version("2.0")
+                .createPersistenceUnit()
+                .name("jpa-search-test-pu")
+                .jtaDataSource("java:jboss/datasources/ExampleDS")
+                .clazz(Book.class.getName())
+                .clazz(Author.class.getName())
+                .getOrCreateProperties()
+                .createProperty().name("hibernate.hbm2ddl.auto").value("create-drop").up()
+                .createProperty().name("hibernate.search.schema_management.strategy").value("drop-and-create-and-drop").up()
+                .createProperty().name("hibernate.search.automatic_indexing.synchronization.strategy").value("sync").up()
+                .createProperty().name("hibernate.search.backend.type").value("elasticsearch").up()
+                .createProperty().name("hibernate.search.backend.hosts").value(ElasticsearchServerSetupObserver.getHttpHostAddress()).up()
+                .up().up()
+                .exportAsString();
+        return new StringAsset(persistenceXml);
+    }
+
+    @Inject
+    private SearchBean searchBean;
+
+    @Before
+    @After
+    public void cleanupDatabase() {
+        searchBean.deleteAll();
+    }
+
+    @Test
+    public void testProjection() {
+        BookDTO book1 = new BookDTO(1, "Hello world",
+                Arrays.asList(new AuthorDTO("John", "Smith")));
+        searchBean.storeNewBook(book1);
+        BookDTO book2 = new BookDTO(2, "Hello planet Mars",
+                Arrays.asList(new AuthorDTO("Jane", "Green"),
+                        new AuthorDTO("John", "Doe")));
+        searchBean.storeNewBook(book2);
+
+        List<BookDTO> hits = searchBean.findByKeyword("world");
+        assertEquals(1, hits.size());
+        assertSearchHit(book1, hits.get(0));
+
+        hits = searchBean.findByKeyword("mars");
+        assertEquals(1, hits.size());
+        assertSearchHit(book2, hits.get(0));
+    }
+
+    private static void assertSearchHit(BookDTO expected, BookDTO hit) {
+        assertEquals(expected.id, hit.id);
+        assertEquals(expected.title, hit.title);
+        assertEquals(expected.authors.size(), hit.authors.size());
+        for (int i = 0; i < expected.authors.size(); i++) {
+            AuthorDTO expectedAuthor = expected.authors.get(i);
+            AuthorDTO hitAuthor = hit.authors.get(i);
+            assertEquals(expectedAuthor.firstName, hitAuthor.firstName);
+            assertEquals(expectedAuthor.lastName, hitAuthor.lastName);
+            // We use includeDepth = 1 on BookDTO#authors, so book.authors.books should be empty
+            assertEquals(0, hitAuthor.books.size());
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/SearchBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/projectionconstructor/SearchBean.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.elasticsearch.projectionconstructor;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.transaction.Transactional;
+import org.hibernate.search.mapper.orm.Search;
+
+import java.util.List;
+
+@ApplicationScoped
+@Transactional
+public class SearchBean {
+
+    @PersistenceContext
+    EntityManager em;
+
+    public void storeNewBook(BookDTO bookDTO) {
+        Book book = new Book();
+        book.setId(bookDTO.id);
+        book.setTitle(bookDTO.title);
+        for (AuthorDTO authorDTO : bookDTO.authors) {
+            Author author = new Author();
+            author.setFirstName(authorDTO.firstName);
+            author.setLastName(authorDTO.lastName);
+            author.getBooks().add(book);
+            book.getAuthors().add(author);
+            em.persist(author);
+        }
+        em.persist(book);
+    }
+
+    public void deleteAll() {
+        CriteriaDelete<Book> deleteBooks = em.getCriteriaBuilder()
+                .createCriteriaDelete(Book.class);
+        deleteBooks.from(Book.class);
+        em.createQuery(deleteBooks).executeUpdate();
+
+        CriteriaDelete<Author> deleteAuthors = em.getCriteriaBuilder()
+                .createCriteriaDelete(Author.class);
+        deleteAuthors.from(Author.class);
+        em.createQuery(deleteAuthors).executeUpdate();
+
+        Search.session(em).workspace(Book.class).purge();
+    }
+
+    public List<BookDTO> findByKeyword(String keyword) {
+        return Search.session(em).search(Book.class)
+                .select(BookDTO.class)
+                .where(f -> f.match().field("title").matching(keyword))
+                .fetchAllHits();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/Author.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/Author.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Author {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @FullTextField(projectable = Projectable.YES)
+    private String firstName;
+
+    @FullTextField(projectable = Projectable.YES)
+    private String lastName;
+
+    @ManyToMany(mappedBy = "authors")
+    private List<Book> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/AuthorDTO.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/AuthorDTO.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AuthorDTO {
+    public final String firstName;
+    public final String lastName;
+    public final List<BookDTO> books;
+
+    public AuthorDTO(String firstName, String lastName) {
+        this(firstName, lastName, Collections.emptyList());
+    }
+
+    @ProjectionConstructor
+    public AuthorDTO(// These @FieldProjection annotations and @ObjectProjection.path wouldn't be necessary
+                     // with a record or a class compiled with -parameters
+                     @FieldProjection(path = "firstName") String firstName,
+                     @FieldProjection(path = "lastName") String lastName,
+                     @ObjectProjection(path = "books", includeDepth = 1) List<BookDTO> books) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.books = books;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/Book.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/Book.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OrderColumn;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Indexed
+public class Book {
+
+    @Id
+    private Long id;
+
+    @FullTextField(projectable = Projectable.YES)
+    private String title;
+
+    @IndexedEmbedded(includeDepth = 1, structure = ObjectStructure.NESTED)
+    @ManyToMany
+    @OrderColumn
+    private List<Author> authors = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public List<Author> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(List<Author> authors) {
+        this.authors = authors;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/BookDTO.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/BookDTO.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IdProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+import java.util.List;
+
+public class BookDTO {
+    public final long id;
+    public final String title;
+    public final List<AuthorDTO> authors;
+
+    @ProjectionConstructor
+    public BookDTO(@IdProjection long id,
+                   // This @FieldProjection annotations and @ObjectProjection.path wouldn't be necessary
+                   // with a record or a class compiled with -parameters
+                   @FieldProjection(path = "title") String title,
+                   @ObjectProjection(path = "authors", includeDepth = 1) List<AuthorDTO> authors) {
+        this.id = id;
+        this.title = title;
+        this.authors = authors;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/HibernateSearchLuceneProjectionConstructorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/HibernateSearchLuceneProjectionConstructorTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify deployed applications can use Hibernate Search's @ProjectionConstructor with Lucene.
+ */
+@RunWith(Arquillian.class)
+public class HibernateSearchLuceneProjectionConstructorTestCase {
+
+    private static final String NAME = HibernateSearchLuceneProjectionConstructorTestCase.class.getSimpleName();
+    private static final String JAR_ARCHIVE_NAME = NAME + ".jar";
+
+    @BeforeClass
+    public static void securityManagerNotSupportedInHibernateSearch() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+    }
+
+    @Inject
+    private SearchBean searchBean;
+
+    @Before
+    @After
+    public void cleanupDatabase() {
+        searchBean.deleteAll();
+    }
+
+    @Test
+    public void testProjection() {
+        BookDTO book1 = new BookDTO(1, "Hello world",
+                Arrays.asList(new AuthorDTO("John", "Smith")));
+        searchBean.storeNewBook(book1);
+        BookDTO book2 = new BookDTO(2, "Hello planet Mars",
+                Arrays.asList(new AuthorDTO("Jane", "Green"),
+                        new AuthorDTO("John", "Doe")));
+        searchBean.storeNewBook(book2);
+
+        List<BookDTO> hits = searchBean.findByKeyword("world");
+        assertEquals(1, hits.size());
+        assertSearchHit(book1, hits.get(0));
+
+        hits = searchBean.findByKeyword("mars");
+        assertEquals(1, hits.size());
+        assertSearchHit(book2, hits.get(0));
+    }
+
+    private static void assertSearchHit(BookDTO expected, BookDTO hit) {
+        assertEquals(expected.id, hit.id);
+        assertEquals(expected.title, hit.title);
+        assertEquals(expected.authors.size(), hit.authors.size());
+        for (int i = 0; i < expected.authors.size(); i++) {
+            AuthorDTO expectedAuthor = expected.authors.get(i);
+            AuthorDTO hitAuthor = hit.authors.get(i);
+            assertEquals(expectedAuthor.firstName, hitAuthor.firstName);
+            assertEquals(expectedAuthor.lastName, hitAuthor.lastName);
+            // We use includeDepth = 1 on BookDTO#authors, so book.authors.books should be empty
+            assertEquals(0, hitAuthor.books.size());
+        }
+    }
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        // TODO maybe just use managed=false and deploy in the @BeforeClass / undeploy in an @AfterClass
+        //   see HibernateSearchLuceneSimpleTestCase
+        if (AssumeTestGroupUtil.isSecurityManagerEnabled()) {
+            return AssumeTestGroupUtil.emptyJar(JAR_ARCHIVE_NAME);
+        }
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JAR_ARCHIVE_NAME);
+        // add Jakarta Persistence configuration
+        jar.addAsManifestResource(HibernateSearchLuceneProjectionConstructorTestCase.class.getPackage(),
+                "persistence.xml", "persistence.xml");
+        // add testing Bean and entities
+        jar.addClasses(SearchBean.class, Book.class, Author.class, BookDTO.class, AuthorDTO.class,
+                HibernateSearchLuceneProjectionConstructorTestCase.class);
+
+        return jar;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/SearchBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/SearchBean.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.hibernate.search.backend.lucene.projectionconstructor;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.transaction.Transactional;
+import org.hibernate.search.mapper.orm.Search;
+
+import java.util.List;
+
+@ApplicationScoped
+@Transactional
+public class SearchBean {
+
+    @PersistenceContext
+    EntityManager em;
+
+    public void storeNewBook(BookDTO bookDTO) {
+        Book book = new Book();
+        book.setId(bookDTO.id);
+        book.setTitle(bookDTO.title);
+        for (AuthorDTO authorDTO : bookDTO.authors) {
+            Author author = new Author();
+            author.setFirstName(authorDTO.firstName);
+            author.setLastName(authorDTO.lastName);
+            author.getBooks().add(book);
+            book.getAuthors().add(author);
+            em.persist(author);
+        }
+        em.persist(book);
+    }
+
+    public void deleteAll() {
+        CriteriaDelete<Book> deleteBooks = em.getCriteriaBuilder()
+                .createCriteriaDelete(Book.class);
+        deleteBooks.from(Book.class);
+        em.createQuery(deleteBooks).executeUpdate();
+
+        CriteriaDelete<Author> deleteAuthors = em.getCriteriaBuilder()
+                .createCriteriaDelete(Author.class);
+        deleteAuthors.from(Author.class);
+        em.createQuery(deleteAuthors).executeUpdate();
+
+        Search.session(em).workspace(Book.class).purge();
+    }
+
+    public List<BookDTO> findByKeyword(String keyword) {
+        return Search.session(em).search(Book.class)
+                .select(BookDTO.class)
+                .where(f -> f.match().field("title").matching(keyword))
+                .fetchAllHits();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/lucene/projectionconstructor/persistence.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" version="2.1">
+    <persistence-unit name="jpa-search-test-pu">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.search.schema_management.strategy" value="drop-and-create-and-drop"/>
+            <property name="hibernate.search.backend.type" value="lucene"/>
+            <property name="hibernate.search.backend.lucene_version" value="LUCENE_CURRENT"/>
+            <property name="hibernate.search.backend.directory.type" value="local-heap"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
* [WFLY-18198](https://issues.redhat.com/browse/WFLY-18198): Upgrade to Lucene 8.11.2
* [WFLY-18197](https://issues.redhat.com/browse/WFLY-18197): Upgrade to Hibernate Search 6.2.0

There is a bit more code than usual for a minor upgrade. That's to handle the passing of Jandex indexes that WildFly builds to Hibernate Search, because Hibernate Search cannot handle the `vfs://` URLs of the WildFly classloaders and would otherwise fail on startup.

That's not so bad because it means users don't need to build Jandex indexes themselves (e.g. with a Maven plugin) and can benefit from WildFly's own Jandex indexes.

See `WildFlyHibernateOrmSearchMappingConfigurer`.

Hey @scottmarlow, could you please tell me if the new `jipijapa-hibernatesearch` module complies with your expectations?