### PR TITLE
[WFLY-18201] Require Remote HTTP Invoker to participate in EE interoperability handshake.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/RemoteHttpInvokerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/RemoteHttpInvokerService.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.undertow;
 
+import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.CookieImpl;
 import io.undertow.server.session.SecureRandomSessionIdGenerator;
 import org.jboss.msc.service.Service;
@@ -29,31 +30,50 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import io.undertow.server.handlers.PathHandler;
+import org.wildfly.httpclient.common.HttpServiceConfig;
 
 /**
- * Service that exposes the Wildfly
+ * Service that exposes the Wildfly Remote HTTP invoker base PathHandler.
  *
  * @author Stuart Douglas
+ * @author Richard Achmatowicz
  */
 public class RemoteHttpInvokerService implements Service<PathHandler> {
 
-    private static final String AFFINITY_PATH = "/common/v1/affinity";
+    private static final String COMMON_PATH = "/common";
+    private static final String AFFINITY_PATH = "/affinity";
 
     private final PathHandler pathHandler = new PathHandler();
 
     @Override
     public void start(StartContext context) throws StartException {
         pathHandler.clearPaths();
-        SecureRandomSessionIdGenerator generator = new SecureRandomSessionIdGenerator();
 
-        pathHandler.addPrefixPath(AFFINITY_PATH, exchange -> {
+        // add in a handler for servicing affinity requests from Wildfly HTTP client
+        pathHandler.addPrefixPath(COMMON_PATH, getAffinityServiceHandler());
+    }
+
+    /**
+     * An HttpHandler for handling affinity requests from a Wildfly HTTP client application.
+     *
+     * This handler is wrapped by HttpServiceConfig.wrap() to allow it to participate in the ee interoperability
+     * protocol, used by HTTP client applications to permit interoperability between jakarta and javax clients
+     * and servers.
+     *
+     * @return the HttpHandler
+     */
+    private HttpHandler getAffinityServiceHandler() {
+        PathHandler wrappedHandler = new PathHandler();
+        SecureRandomSessionIdGenerator generator = new SecureRandomSessionIdGenerator();
+        wrappedHandler.addPrefixPath(AFFINITY_PATH, exchange -> {
             String resolved = exchange.getResolvedPath();
-            int index = resolved.lastIndexOf(AFFINITY_PATH);
+            int index = resolved.lastIndexOf(COMMON_PATH);
             if(index > 0) {
                 resolved = resolved.substring(0, index);
             }
             exchange.getResponseCookies().put("JSESSIONID", new CookieImpl("JSESSIONID", generator.createSessionId()).setPath(resolved));
         });
+        return HttpServiceConfig.getInstance().wrap(wrappedHandler);
     }
 
     @Override


### PR DESCRIPTION
This PR does the following:
* fixes an issue with the EE Interoperability handshake used with EJB/HTTP, Naming/HTTP and Transactions/HTTP and the Undertow HTTP Invoker service.

For more details, see: https://issues.redhat.com/browse/WFLY-18201