### PR TITLE
[WFLY-18204] Upgrade WildFly Core to 21.1.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.1.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>21.1.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
@@ -58,7 +58,9 @@ public class BouncyCastleModuleTestCase {
         archive.addPackage(BouncyCastleModuleTestCase.class.getPackage());
         archive.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml"); //needed to load CDI for arquillian
         archive.addAsManifestResource(createPermissionsXmlAsset(
-                new SecurityPermission("insertProvider")
+                new SecurityPermission("insertProvider"),
+                new SecurityPermission("removeProviderProperty.BC"),
+                new SecurityPermission("putProviderProperty.BC")
         ), "permissions.xml");
         archive.setManifest(new StringAsset(""
                 + "Manifest-Version: 1.0\n"


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-18204

Incorporates:
https://issues.redhat.com/browse/WFLY-18208

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/21.1.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/21.1.0.Beta1...21.1.0.Beta2

---

<details>
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6305'>WFCORE-6305</a>] -         Upgrade to Jandex 3.1.1 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6414'>WFCORE-6414</a>] -         Upgrade bouncycastle from 1.73 to 1.75 (resolves CVE-2023-33201)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6417'>WFCORE-6417</a>] -         Upgrade to Jandex 3.1.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6418'>WFCORE-6418</a>] -         Upgrade Elytron Web to 4.0.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6154'>WFCORE-6154</a>] -         Log reasons for implicit module dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6369'>WFCORE-6369</a>] -         Eliminate unnecessary collection copying in AbstractAddStepHandler constructors
</li>
</ul>
                                                                                                                                                            
</details>
