### PR TITLE
[WFLY-18176] Check the suspend-state when probing the readiness of the server

### DIFF
--- a/health/src/main/java/org/wildfly/extension/health/ServerProbesService.java
+++ b/health/src/main/java/org/wildfly/extension/health/ServerProbesService.java
@@ -75,6 +75,7 @@ public class ServerProbesService implements Service {
         modelControllerClient = modelControllerClientFactory.get().createSuperUserClient(managementExecutor.get(), true);
 
         serverProbes.add(new ServerProbes.ServerStateCheck(modelControllerClient));
+        serverProbes.add(new ServerProbes.SuspendStateCheck(modelControllerClient));
         serverProbes.add(new ServerProbes.DeploymentsStatusCheck(modelControllerClient));
         serverProbes.add(new ServerProbes.NoBootErrorsCheck(modelControllerClient));
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/health/HealthHTTPEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/health/HealthHTTPEndpointTestCase.java
@@ -35,6 +35,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,26 +52,60 @@ public class HealthHTTPEndpointTestCase {
 
     @Test
     public void testHealthEndpoint() throws Exception {
-        testHealthEndpoint("/health");
+        testHealthEndpoint("/health", 200);
     }
 
     @Test
     public void testHealthLiveEndpoint() throws Exception {
-        testHealthEndpoint("/health/live");
+        testHealthEndpoint("/health/live", 200);
     }
 
     @Test
     public void testHealthReadyEndpoint() throws Exception {
-        testHealthEndpoint("/health/ready");
+        testHealthEndpoint("/health/ready", 200);
     }
 
-    private void testHealthEndpoint(String requestPath) throws IOException {
+    /**
+     * Test that when a server is suspended, its readiness probe starts to fail (until it is resumed).
+     * Test also that suspending a server has no impact on its liveness probe.
+     * @throws Exception
+     */
+    @Test
+    public void testHealthReadyEndpointWhenServerIsSuspended() throws Exception {
+        // server is live
+        testHealthEndpoint("/health/live", 200);
+        // and ready
+        testHealthEndpoint("/health/ready", 200);
+
+        // suspend the server
+        changeSuspendState("suspend");
+
+        // server is still live
+        testHealthEndpoint("/health/live", 200);
+        // but no longer ready
+        testHealthEndpoint("/health/ready", 503);
+
+        // resume the server
+        changeSuspendState("resume");
+
+        // server is still live
+        testHealthEndpoint("/health/live", 200);
+        // and ready again
+        testHealthEndpoint("/health/ready", 200);
+    }
+
+    private void testHealthEndpoint(String requestPath, int expectedStatusCode) throws IOException {
         final String healthURL = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + requestPath;
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             CloseableHttpResponse resp = client.execute(new HttpGet(healthURL));
             String content = EntityUtils.toString(resp.getEntity());
-            assertEquals(200, resp.getStatusLine().getStatusCode());
+            assertEquals(expectedStatusCode, resp.getStatusLine().getStatusCode());
             resp.close();
         }
+    }
+
+    private void changeSuspendState(String operation) throws IOException {
+        final ModelNode op = Operations.createOperation(operation, new ModelNode().add(""));
+        managementClient.getControllerClient().execute(op);
     }
 }


### PR DESCRIPTION
A new ServerProbe checks that the server is not suspended to determine its readiness.

A server is not suspended if its `suspend-state` attribute is `RUNNING`. Any other value implies that the server is suspended (or about to) and should not be serving requests in that state.

JIRA: https://issues.redhat.com/browse/WFLY-18176