### PR TITLE
WFLY-18150 DistributableTimerService.getTimers() collection may omit timers during concurrent rescheduling process

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/InfinispanTimerManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/InfinispanTimerManager.java
@@ -186,7 +186,8 @@ public class InfinispanTimerManager<I, V> implements TimerManager<I, Transaction
 
     @Override
     public Stream<I> getActiveTimers() {
-        return this.scheduler.stream();
+        // The primary owner scheduler can miss entries, if called during a concurrent topology change event
+        return this.group.isSingleton() ? this.scheduledTimers.stream() : this.cache.keySet().stream().filter(TimerCreationMetaDataKeyFilter.INSTANCE).map(Key::getId);
     }
 
     @Override

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerSerializationContextInitializer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerSerializationContextInitializer.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 
 import org.infinispan.protostream.SerializationContext;
 import org.wildfly.clustering.marshalling.protostream.AbstractSerializationContextInitializer;
+import org.wildfly.clustering.marshalling.protostream.EnumMarshaller;
 import org.wildfly.clustering.marshalling.protostream.FunctionalMarshaller;
 
 /**
@@ -40,5 +41,6 @@ public class TimerSerializationContextInitializer extends AbstractSerializationC
         context.registerMarshaller(new IntervalTimerCreationMetaDataMarshaller());
         context.registerMarshaller(new ScheduleTimerCreationMetaDataMarshaller());
         context.registerMarshaller(new FunctionalMarshaller<>(TimerIndexKey.class, TimerIndexMarshaller.INSTANCE, TimerIndexKey::getId, TimerIndexKey::new));
+        context.registerMarshaller(new EnumMarshaller<>(TimerCreationMetaDataKeyFilter.class));
     }
 }

--- a/clustering/ejb/infinispan/src/main/resources/org.wildfly.clustering.ejb.infinispan.timer.proto
+++ b/clustering/ejb/infinispan/src/main/resources/org.wildfly.clustering.ejb.infinispan.timer.proto
@@ -59,3 +59,10 @@ message TimerIndexKey {
 	optional	string	methodName	 = 3;
 	optional	uint32	index	 = 4;
 }
+
+/**
+ * @TypeId(345)
+ */
+enum TimerCreationMetaDataKeyFilter {
+	INSTANCE	 = 0;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18150