### PR TITLE
[WFLY-18206] Typo preventing galleon state from being generated

### DIFF
--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -121,7 +121,7 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>tree</record-state>
+                            <record-state>true</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <offline>${galleon.offline}</offline>
                             <plugin-options>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18206

Fix typo
