### PR TITLE
WFLY-18215 license correction for jipijapa-hibernate6 + wildfly-jpa

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
@@ -2797,6 +2797,11 @@
             <artifactId>jipijapa-hibernate6</artifactId>
             <licenses>
                 <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                    <distribution>repo</distribution>
+                </license>
+                <license>
                     <name>GNU Lesser General Public License v2.1 or later</name>
                     <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
                     <distribution>repo</distribution>
@@ -3544,6 +3549,11 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jpa</artifactId>
             <licenses>
+               <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                    <distribution>repo</distribution>
+                </license>
                 <license>
                     <name>GNU Lesser General Public License v2.1 or later</name>
                     <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>


### PR DESCRIPTION
[WFLY-18215](https://issues.redhat.com/browse/WFLY-18215)

Update to ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml