### PR TITLE
Fix for WFLY-18222, Add some metadata to Galleon layers to allow for layers discovery

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="hibernate-search">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="hibernate-search">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed"/>
+    </props>
     <dependencies>
         <!-- 'jpa-distributed' can be used instead.
              If neither is used this layer just installs modules. -->

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/batch-jberet/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/batch-jberet/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="batch-jberet">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="batch-jberet">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/classes/META-INF/batch-jobs"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.batch.api.*"/>
+    </props>
     <dependencies>
         <!-- CDI should be optional but to be conservative in the first cut at this, require it
         <layer name="cdi" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/bean-validation/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/bean-validation/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="bean-validation">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="bean-validation">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.validation"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.validation.*"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="cdi" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cdi/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cdi/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cdi">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="cdi">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/beans.xml"/>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.inject,jakarta.enterprise.context"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="bean-validation" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cloud-profile">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="cloud-profile">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="hidden"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="bean-validation" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cloud-server">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="cloud-server">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="base-layer"/>
+    </props>
     <dependencies>
         <layer name="jaxrs-server"/>
         <layer name="ee-security" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="core-tools">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="core-tools">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on" value="management,wildfly-cli"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Server command line tools: jboss-cli, add-user, elytron-tool"/>
+    </props>
     <dependencies>
         <layer name="management" optional="true"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="datasources-web-server">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="datasources-web-server">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="base-layer"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="core-server"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="datasources">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="datasources">
+    <props>
+        <prop name="org.wildfly.rule.class" value="javax.sql"/>
+    </props>
     <dependencies>
         <layer name="transactions"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-concurrency/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-concurrency/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ee-concurrency">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-concurrency">
+    <props>
+        <prop name="org.wildfly.rule.class" value="jakarta.enterprise.concurrent"/>
+    </props>
     <dependencies>
         <layer name="naming"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
@@ -18,7 +18,10 @@
   ~ limitations under the License.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ee-core-profile-server">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-core-profile-server">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="default-base-layer"/>
+    </props>
     <dependencies>
         <layer name="core-server"/>
         <layer name="cdi"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-integration/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-integration/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ee-integration">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-integration">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.annotation,jakarta.annotation.security,jakarta.annotation.sql,jakarta.xml.bind.annotation,jakarta.xml.bind.annotation.adapters"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.xml.bind.*"/>
+    </props>
     <dependencies>
         <layer name="naming"/>
         <layer name="jsonb" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-security/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-security/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ee-security">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-security">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.security.enterprise.authentication.mechanism.http,jakarta.security.enterprise.identitystore"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.security.*"/>
+    </props>
      <dependencies>
         <layer name="cdi"/>
         <layer name="elytron"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-dist-cache">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb-dist-cache">
 
     <!-- Infinispan cache configuration used for distributed SFSB caching -->
-
+    <props>
+        <prop name="org.wildfly.rule.profile-ha" value="ejb-local-cache"/>
+    </props>
     <dependencies>
         <layer name="transactions"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-http-invoker">
-
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb-http-invoker">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="ejb,http-invoker"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+    </props>
     <dependencies>
         <layer name="ejb-lite"/>
         <layer name="elytron"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-lite">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb-lite">
     <!-- Aggregates the functionality roughly associated with the EJB Lite concept.
          Note that the timer-service feature provides persistent timers which goes beyond EJB Lite requirements. -->
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.ejb"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.ejb"/>
+    </props>
     <dependencies>
         <layer name="transactions"/>
         <!-- SFSB requires a cache, so we depend on a layer for local infinispan caching.

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb/layer-spec.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb">
     <!-- Aggregates EJB functionality, excluding ejb-iiop. -->
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.ejb.MessageDriven,jakarta.ejb.Remote"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.ejb.MessageDrivenContext"/>
+    </props>
     <dependencies>
         <layer name="ejb-lite"/>
         <layer name="resource-adapters"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/elytron-oidc-client/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/elytron-oidc-client/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="elytron-oidc-client">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="elytron-oidc-client">
+    <props>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/login-config/auth-method,OIDC"/>
+    </props>
     <dependencies>
         <layer name="elytron"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="embedded-activemq">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="embedded-activemq">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:messaging-activemq"/>
+        <prop name="org.wildfly.rule.add-on" value="messaging,embedded-activemq"/>
+        <prop name="org.wildfly.rule.add-on-cardinality" value="1"/>
+        <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/*-jms.xml,/META-INF/*-jms.xml],/messaging-deployment/server/jms-destinations"/>
+    </props>
     <dependencies>
         <layer name="messaging-activemq"/>
         <layer name="cdi"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="h2-datasource">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-datasource">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="database,h2-database"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
+        <prop name="org.wildfly.rule.bring-datasource" value="java:jboss/datasources/ExampleDS"/>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/classes/META-INF/persistence.xml,/persistence/persistence-unit/jta-data-source,java:jboss/datasources/ExampleDS"/>
+    </props>
     <dependencies>
+        <layer name="datasources"/>
         <layer name="h2-driver"/>
     </dependencies>
     <feature-group name="h2-datasource"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="h2-default-datasource">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-default-datasource">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="database,h2-database:default"/>
+        <prop name="org.wildfly.rule.add-on-fix-no-default-datasource" value=""/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
+    </props>
     <dependencies>
+        <layer name="datasources"/>
         <layer name="h2-datasource"/>
     </dependencies>
     <feature-group name="h2-default-datasource"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="h2-driver">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-driver">
+    <props>
+        <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/datasource/driver,h2"/>
+        <prop name="org.wildfly.rule.xml-path-xa" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/xa-datasource/driver,h2"/>
+    </props>
     <dependencies>
+        <layer name="datasources"/>
         <layer name="base-server"/>
     </dependencies>
     <feature-group name="h2-driver"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
@@ -22,7 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="health">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="health">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="observability,health"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
+    </props>
     <dependencies>
         <layer name="management"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="iiop-openjdk">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="iiop-openjdk">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="rpc,iiop" />
+        <prop name="org.wildfly.rule.add-on-depends-on" value="none" />
+    </props>
     <dependencies>
         <layer name="base-server"/> 
         <layer name="naming"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/infinispan/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/infinispan/layer-spec.xml
@@ -21,8 +21,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="infinispan">
-
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="infinispan">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="clustering,infinispan"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Brings in infinispan caches."/>
+    </props>
     <dependencies>
         <layer name="cdi" optional="true"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/internal-standalone-full-profile/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/internal-standalone-full-profile/layer-spec.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" ?>
 <!-- WARNING. This layer is for internal use only and is not expected to be provisioned directly.
  It aggregates a set of Galleon layers that are shared between default standalone full configurations. -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="internal-standalone-full-profile">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="internal-standalone-full-profile">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="hidden"/>
+    </props>
     <dependencies>
         <layer name="internal-standalone-profile"/>
         <layer name="iiop-openjdk" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/internal-standalone-profile/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/internal-standalone-profile/layer-spec.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" ?>
 <!-- WARNING. This layer is for internal use only and is not expected to be provisioned directly.
  It aggregates a set of Galleon layers that are shared between default standalone configurations. -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="internal-standalone-profile">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="internal-standalone-profile">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="hidden"/>
+    </props>
     <dependencies>
         <layer name="jaxrs-server"/>
         <layer name="ee-security" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jaxrs-server">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jaxrs-server">
+    <props>
+        <prop name="org.wildfly.rule.kind" value="base-layer"/>
+    </props>
     <dependencies>
         <layer name="datasources-web-server"/>
         <!-- cloud-server depends on jaxrs-server, jaxrs could be excluded from cloud-server,
-             this is why jaxrs is an optional dependency -->
+        this is why jaxrs is an optional dependency -->
         <layer name="jaxrs" optional="true"/>
         <layer name="bean-validation" optional="true"/>
         <layer name="cdi" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jaxrs">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jaxrs">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.ws.rs"/>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet/servlet-class,jakarta.ws.rs.core.Application"/>
+    </props>
     <dependencies>
         <layer name="deployment-scanner" optional="true"/>
         <layer name="ee-concurrency" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jdr">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jdr">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on" value="management,jdr"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="management" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jgroups-aws/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jgroups-aws/layer-spec.xml
@@ -21,8 +21,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jgroups-aws">
-
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jgroups-aws">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:jgroups"/>
+        <prop name="org.wildfly.rule.add-on" value="clustering,jgroups-aws"/>
+    </props>
     <!--
     This layer only brings in modules required to configure the 'aws.S3_PING' discovery protocol:
     <protocol name="org.jgroups.protocols.aws.S3_PING" module="org.jgroups.aws">

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa-distributed">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jpa-distributed">
+    <props>
+        <prop name="org.wildfly.rule.profile-ha" value="jpa"/>
+    </props>
     <dependencies>
         <layer name="datasources"/>
         <layer name="bean-validation" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa/layer-spec.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jpa">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/classes/META-INF/persistence.xml"/>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.persistence"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.persistence"/>
+    </props>
     <dependencies>
         <layer name="datasources"/>
         <layer name="bean-validation" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsf/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsf/layer-spec.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jsf">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsf">
+    <props>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet/servlet-class,jakarta.faces.webapp.FacesServlet"/>
+        <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/faces-config.xml"/>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.faces.annotation"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.faces.*"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="cdi"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonb/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonb/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jsonb">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsonb">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.json.bind.annotation" />
+        <prop name="org.wildfly.rule.class" value="jakarta.json.bind.*"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonp/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonp/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jsonp">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsonp">
+    <props>
+        <prop name="org.wildfly.rule.class" value="jakarta.json"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mail/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mail/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="mail">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mail">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.mail" />
+        <prop name="org.wildfly.rule.class" value="jakarta.mail.*"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="naming"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="messaging-activemq">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="messaging-activemq">
+    <props>
+        <prop name="org.wildfly.rule.class" value="jakarta.jms"/>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.jms"/>
+        <prop name="org.wildfly.rule.expect-add-on-family" value="messaging"/>
+    </props>
     <dependencies>
         <layer name="resource-adapters"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
@@ -22,7 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="metrics">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="metrics">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="observability,metrics"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
+    </props>
     <dependencies>
         <layer name="management"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
@@ -20,8 +20,11 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="mod_cluster">
-
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mod_cluster">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="clustering,mod_cluster" />
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:undertow" />
+    </props>
     <dependencies>
         <layer name="web-server"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/naming/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/naming/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="naming">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="naming">
+    <props>
+        <prop name="org.wildfly.rule.class" value="javax.naming"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/pojo/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/pojo/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="pojo">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="pojo">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="[/META-INF/*jboss-beans.xml,/WEB-INF/*jboss-beans.xml,/WEB-INF/classes/META-INF/*jboss-beans.xml]"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remote-activemq">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="remote-activemq">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:messaging-activemq"/>
+        <prop name="org.wildfly.rule.add-on" value="messaging,remote-activemq"/>
+    </props>
     <dependencies>
         <layer name="messaging-activemq"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="resource-adapters">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="resource-adapters">
+     <props>
+        <prop name="org.wildfly.rule.expected-file" value="[/META-INF/ra.xml,/META-INF/ironjacamar.xml]"/>
+    </props>
     <dependencies>
         <layer name="transactions"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/sar/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/sar/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="sar">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="sar">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="/META-INF/jboss-service.xml"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="jmx"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/servlet/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/servlet/layer-spec.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="servlet">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="servlet">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.servlet.annotation,jakarta.websocket"/>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.servlet.*"/>
+    </props>
     <dependencies>
         <layer name="ee-integration"/>
         <layer name="naming"/>
         <layer name="undertow"/>
+        <layer name="deployment-scanner" optional="true"/>
     </dependencies>
     <feature-group name="undertow-servlet"/>
 </layer-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-ha/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-ha/layer-spec.xml
@@ -20,8 +20,10 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="singleton-ha">
-
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="singleton-ha">
+    <props>
+        <prop name="org.wildfly.rule.profile-ha" value="singleton-local"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="transactions"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-local/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-local/layer-spec.xml
@@ -20,7 +20,11 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="singleton-local">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="singleton-local">
+    <props>
+        <prop name="org.wildfly.rule.expected-file" value="[/META-INF/singleton-deployment.xml,/WEB-INF/classes/META-INF/singleton-deployment.xml]"/>
+        <prop name="org.wildfly.rule.class" value="org.wildfly.clustering.singleton.*"/>
+    </props>
 
     <dependencies>
         <layer name="base-server"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/transactions/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/transactions/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="transactions">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="transactions">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.transaction"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.transaction"/>
+    </props>
     <dependencies>
         <layer name="elytron"/>
         <layer name="ee"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="undertow-https">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="undertow-https">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on" value="security,ssl"/>
+    </props>
     <dependencies>
         <layer name="elytron"/>
         <layer name="undertow"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="undertow-load-balancer">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="undertow-load-balancer">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="web,load-balancer"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
+        <prop name="org.wildfly.rule.add-on-description" value="An undertow load balancer"/>
+    </props>
     <dependencies>
         <layer name="base-server"/>
         <layer name="io"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="web-clustering">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-clustering">
+    <props>
+        <prop name="org.wildfly.rule.profile-ha" value="web-passivation"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="transactions"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="web-console">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-console">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on" value="management,hal-web-console"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Management Web console. Make sure to add an initial user."/>
+    </props>
     <dependencies>
         <layer name="management"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-passivation/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-passivation/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="web-passivation">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-passivation">
+    <props>
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/distributable"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="transactions"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/webservices/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/webservices/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="webservices">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="webservices">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.jws,jakarta.jws.soap,jakarta.xml.ws.soap"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.jws.*,jakarta.xml.ws.*"/>
+    </props>
     <dependencies>
         <layer name="web-server"/>
         <layer name="ejb-lite" optional="true"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
@@ -18,7 +18,11 @@
   ~  * limitations under the License.
   ~  */
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="micrometer">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="micrometer">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
+        <prop name="org.wildfly.rule.add-on" value="observability,micrometer"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
     </dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
@@ -22,7 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-config">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-config">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.config.inject"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.config.*"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
     </dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-fault-tolerance/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-fault-tolerance/layer-spec.xml
@@ -22,7 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-fault-tolerance">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-fault-tolerance">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.faulttolerance"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.faulttolerance.*"/> 
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="microprofile-config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
@@ -22,7 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-health">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-health">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.health"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.health.*"/> 
+    </props>
     <dependencies>
         <layer name="management"/>
         <layer name="microprofile-config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-jwt/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-jwt/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-jwt">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-jwt">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.jwt,org.eclipse.microprofile.auth.LoginConfig"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.jwt.*"/>
+    </props>
     <dependencies>
         <layer name="ee-security"/>
         <layer name="microprofile-config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
@@ -21,7 +21,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-lra-coordinator">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-lra-coordinator">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
+        <prop name="org.wildfly.rule.add-on" value="lra,lra-coordinator"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="jaxrs"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-participant/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-participant/layer-spec.xml
@@ -21,7 +21,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-lra-participant">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-lra-participant">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.lra.annotation,org.eclipse.microprofile.lra.annotation.ws.rs"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.lra.*"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="jaxrs"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-openapi">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-openapi">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:jaxrs"/>
+        <prop name="org.wildfly.rule.add-on" value="jaxrs,openapi"/>
+    </props>
     <dependencies>
         <layer name="jaxrs"/>
         <layer name="microprofile-config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
@@ -20,7 +20,17 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-reactive-messaging-kafka">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-messaging-kafka">
+    <props>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on" value="reactive-messaging,kafka"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-web-inf-property" value="/WEB-INF/classes/META-INF/microprofile-config.properties,mp.messaging.connector.smallrye-kafka.*"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-web-inf-outgoing" value="/WEB-INF/classes/META-INF/microprofile-config.properties,mp.messaging.outgoing.*.connector,smallrye-kafka"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-web-inf-incoming" value="/WEB-INF/classes/META-INF/microprofile-config.properties,mp.messaging.incoming.*.connector,smallrye-kafka"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-meta-inf-property" value="/META-INF/microprofile-config.properties,mp.messaging.connector.smallrye-kafka.*"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-meta-inf-outgoing" value="/META-INF/microprofile-config.properties,mp.messaging.outgoing.*.connector,smallrye-kafka"/>
+        <prop name="org.wildfly.rule.properties-file-match-mp-kafka-meta-inf-incoming" value="/META-INF/microprofile-config.properties,mp.messaging.incoming.*.connector,smallrye-kafka"/>
+    </props>
     <dependencies>
         <layer name="microprofile-reactive-messaging"/>
     </dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
@@ -21,7 +21,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="reactive-messaging">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="reactive-messaging">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.reactive.messaging"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.reactive.messaging.*"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="microprofile-config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-streams-operators/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-streams-operators/layer-spec.xml
@@ -21,7 +21,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-reactive-streams-operators">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-streams-operators">
+    <props>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.reactive.streams.operators.*"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
     </dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
@@ -20,7 +20,11 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-rest-client">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-rest-client">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.rest.client.annotation,org.eclipse.microprofile.rest.client.inject"/>
+        <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.rest.client.*"/>
+    </props>
     <dependencies>
         <layer name="microprofile-config"/>
     </dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-telemetry">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-telemetry">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="io.opentelemetry.instrumentation.annotations"/>
+        <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
+        <prop name="org.wildfly.rule.add-on" value="observability,microprofile-telemetry"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="opentelemetry"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="opentelemetry">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="opentelemetry">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="io.opentelemetry.instrumentation.annotations"/>
+        <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
+        <prop name="org.wildfly.rule.add-on" value="observability,opentelemetry"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -302,13 +302,13 @@
         <version.ant.junit>1.10.12</version.ant.junit>
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.7</version.org.jacoco>
-        <version.org.jboss.galleon>5.1.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>6.4.2.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.jar.plugin>9.0.0.Final</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>10.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.3.1.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>4.1.0.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>

--- a/preview/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
+++ b/preview/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="hibernate-search">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="hibernate-search">
+    <props>
+         <prop name="org.wildfly.rule.annotations" value="org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed"/>
+    </props>
     <dependencies>
         <!-- 'jpa-distributed' can be used instead.
              If neither is used this layer just installs modules. -->


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18222

Bumping Galleon and WildFly Bootable JAR versions. Required for this new metadata parsing at provisioning time.