### PR TITLE
WFLY-18227 WFLY-18228 WFLY-18229 Upgrade to Hibernate Search 6.2.0.Final, Elasticsearch client 8.8.8, Avro 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.2.6.Final</version.org.hibernate>
-        <version.org.hibernate.search>6.2.0.CR1</version.org.hibernate.search>
+        <version.org.hibernate.search>6.2.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.11.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>2.26.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
-        <version.org.apache.avro>1.11.0</version.org.apache.avro>
+        <version.org.apache.avro>1.11.2</version.org.apache.avro>
         <version.org.apache.cxf>4.0.0</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.0.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>

--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
         <version.org.eclipse.microprofile.telemetry>1.0</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.0</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>7.16.3</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.8.2</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.1</version.org.glassfish.jaxb>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -9,7 +9,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.16.3";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.8.2";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18227
https://issues.redhat.com/browse/WFLY-18228
https://issues.redhat.com/browse/WFLY-18229

Unfortunately I wasn't able to have WildFly force Hibernate Search to use its "Lucene 9 ID schema" for indexes; Hibernate Search's configuration is too dynamic to allow that reliably (see https://hibernate.atlassian.net/browse/HSEARCH-4897). We will have to handle that later.

It's still worth upgrading to 6.2 in WildFly, though. Be it just for the new [features](https://hibernate.org/search/releases/6.2/#whats-new).