### PR TITLE
[WFLY-18243] Upgrade guava to 32.1.1-jre (resolves CVE-2023-2976)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.com.github.fge.msg-simple>1.1</version.com.github.fge.msg-simple>
         <version.com.google.api.grpc>2.0.1</version.com.google.api.grpc>
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
-        <version.com.google.guava>31.1-jre</version.com.google.guava>
+        <version.com.google.guava>32.1.1-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
         <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
         <version.com.h2database>2.1.214</version.com.h2database>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18243