### PR TITLE
[WFLY-16168] Remove the Apache Xerces module dependency from the REST…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -34,8 +34,6 @@
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.servlet.api"/>
         <module name="jakarta.ws.rs.api"/>
-        <!-- Some features are used in the SecureUnmarshaller that only work with Xerces. -->
-        <module name="org.apache.xerces" services="import"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
…Easy JAXB provider module, org.jboss.resteasy.resteasy-jaxb-provider.

https://issues.redhat.com/browse/WFLY-16168