### PR TITLE
WFLY-18249: add new attribute to use with datasource capability reference

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -21,6 +21,7 @@
 
     <dependencies>
         <module name="java.management"/>
+        <module name="java.sql"/>
         <module name="jakarta.resource.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="org.jboss.staxmapper"/>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
@@ -110,22 +110,17 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
     }
 
     private void useJdbcStore() throws IOException, MgmtOperationException {
-        useJdbcStore(true);
-    }
-
-    private void useJdbcStore(boolean expectedResults) throws IOException, MgmtOperationException {
         setDefaultObjectStore();
         // 1 - Create DS - required for the JDBC store
         createDataSource();
-        // 2 - Set the value for 'jdbc-store-datasource'
-        cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/"
-                + JDBC_STORE_DS_NAME + ")");
+        // 2 - Set the value for 'jdbc-store-datasource-name'
+        cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource-name, value=" + JDBC_STORE_DS_NAME + ")");
         CLIOpResult result = cli.readAllAsOpResult();
-        assertTrue("Failed to set jdbc-store-datasource.", result.isIsOutcomeSuccess());
+        assertTrue("Failed to set jdbc-store-datasource-name.", result.isIsOutcomeSuccess());
         // 3 - set 'use-jdbc-store' to true
         cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
         result = cli.readAllAsOpResult();
-        assertEquals("Failed to set use-jdbc-store to expected value", expectedResults, result.isIsOutcomeSuccess());
+        assertEquals("Failed to set use-jdbc-store to expected value", true, result.isIsOutcomeSuccess());
     }
 
     @Test
@@ -134,7 +129,7 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
             // try to set use-jdbc-store to true without defining datasource
             cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)", true);
             CLIOpResult result = cli.readAllAsOpResult();
-            assertFalse("Expected failure when jdbc-store-datasource is not set.", result.isIsOutcomeSuccess());
+            assertFalse("Expected failure when jdbc-store-datasource-name is not set.", result.isIsOutcomeSuccess());
         } finally {
             setDefaultObjectStore();
         }
@@ -145,11 +140,11 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
         try {
             // Use JDBC store
             useJdbcStore();
-            // try, and fail, to undefine jdbc-store-datasource when use-jdbc-store is set to true
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource", true);
+            // try, and fail, to undefine jdbc-store-datasource-name when use-jdbc-store is set to true
+            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource-name", true);
             CLIOpResult result = cli.readAllAsOpResult();
             if (result.isIsOutcomeSuccess())
-                fail("The jdbc-store-datasource attribute has been undefined, while JDBC store is in use.");
+                fail("The jdbc-store-datasource-name attribute has been undefined, while JDBC store is in use.");
         } finally {
             cleanJdbcSettingsAndResetToObjectStore();
         }
@@ -232,8 +227,7 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
         createDataSource();
         cli.sendLine("batch");
         cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store,value=true)");
-        cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/"
-                + JDBC_STORE_DS_NAME + ")");
+        cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource-name, value=" + JDBC_STORE_DS_NAME + ")");
         cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store,value=true)");
         cli.sendLine("run-batch");
     }
@@ -309,7 +303,7 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
             // Undefine 'use-jdbc-store' first, if defined
             undefinedAttributeIfDefined("use-jdbc-store");
             // then undefine 'jdbc-store'
-            undefinedAttributeIfDefined("jdbc-store-datasource");
+            undefinedAttributeIfDefined("jdbc-store-datasource-name");
             // finally delete Datasource if exists
             removeDatasource();
             // Reload configuration

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/Attribute.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/Attribute.java
@@ -29,6 +29,7 @@ enum Attribute {
     STATISTICS_ENABLED("statistics-enabled"),
     PATH("path"),
     DATASOURCE_JNDI_NAME("datasource-jndi-name"),
+    DATASOURCE_NAME("datasource-name"),
     TABLE_PREFIX("table-prefix"),
     DROP_TABLE("drop-table"),
     ENABLE_ASYNC_IO("enable-async-io"),

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/CommonAttributes.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/CommonAttributes.java
@@ -35,6 +35,7 @@ interface CommonAttributes {
     String JDBC_STORE = "jdbc-store";
     String USE_JDBC_STORE = "use-jdbc-store";
     String JDBC_STORE_DATASOURCE = "jdbc-store-datasource";
+    String JDBC_STORE_DATASOURCE_NAME = "jdbc-store-datasource-name";
     String JDBC_ACTION_STORE_TABLE_PREFIX = "jdbc-action-store-table-prefix";
     String JDBC_ACTION_STORE_DROP_TABLE = "jdbc-action-store-drop-table";
     String JDBC_COMMUNICATION_STORE_TABLE_PREFIX = "jdbc-communication-store-table-prefix";

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/Namespace.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/Namespace.java
@@ -28,12 +28,13 @@ enum Namespace {
     TRANSACTIONS_4_0("urn:jboss:domain:transactions:4.0"),
     TRANSACTIONS_5_0("urn:jboss:domain:transactions:5.0"),
     TRANSACTIONS_6_0("urn:jboss:domain:transactions:6.0"),
+    TRANSACTIONS_6_1("urn:jboss:domain:transactions:6.1"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = TRANSACTIONS_6_0;
+    public static final Namespace CURRENT = TRANSACTIONS_6_1;
 
     private final String name;
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionExtension.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionExtension.java
@@ -42,7 +42,7 @@ public class TransactionExtension implements Extension {
 
     private static final String RESOURCE_NAME = TransactionExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(6, 0, 0);
+    static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(6, 1, 0);
 
 
     private static final ServiceName MBEAN_SERVER_SERVICE_NAME = ServiceName.JBOSS.append("mbean", "server");
@@ -119,5 +119,6 @@ public class TransactionExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.TRANSACTIONS_4_0.getUriString(), TransactionSubsystem40Parser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.TRANSACTIONS_5_0.getUriString(), TransactionSubsystem50Parser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.TRANSACTIONS_6_0.getUriString(), TransactionSubsystem60Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.TRANSACTIONS_6_1.getUriString(), TransactionSubsystem61Parser::new);
     }
 }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem61Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem61Parser.java
@@ -4,6 +4,14 @@
  */
 package org.jboss.as.txn.subsystem;
 
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+import javax.xml.stream.XMLStreamException;
+
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+
 /**
  * The {@link org.jboss.staxmapper.XMLElementReader} that handles the version 6.1 of Transaction subsystem xml.
  */
@@ -15,5 +23,48 @@ class TransactionSubsystem61Parser extends TransactionSubsystem60Parser {
 
     TransactionSubsystem61Parser(Namespace namespace) {
         super(namespace);
+    }
+
+    @Override
+    protected void parseJdbcStoreElementAndEnrichOperation(final XMLExtendedStreamReader reader, final ModelNode logStoreOperation, ModelNode operation) throws XMLStreamException {
+        logStoreOperation.get(LogStoreConstants.LOG_STORE_TYPE.getName()).set("jdbc");
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case DATASOURCE_NAME:
+                    TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE_NAME.parseAndSetParameter(value, operation, reader);
+                    break;
+                case DATASOURCE_JNDI_NAME:
+                    TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case JDBC_ACTION_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_DROP_TABLE);
+                    break;
+                }
+                case JDBC_STATE_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_DROP_TABLE);
+                    break;
+                }
+                case JDBC_COMMUNICATION_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_DROP_TABLE);
+                    break;
+                }
+            }
+        }
+
+
     }
 }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem61Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem61Parser.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.txn.subsystem;
+
+/**
+ * The {@link org.jboss.staxmapper.XMLElementReader} that handles the version 6.1 of Transaction subsystem xml.
+ */
+class TransactionSubsystem61Parser extends TransactionSubsystem60Parser {
+
+    TransactionSubsystem61Parser() {
+        super(Namespace.TRANSACTIONS_6_1);
+    }
+
+    TransactionSubsystem61Parser(Namespace namespace) {
+        super(namespace);
+    }
+}

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemXMLPersister.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemXMLPersister.java
@@ -93,6 +93,7 @@ class TransactionSubsystemXMLPersister implements XMLElementWriter<SubsystemMars
 
         if (node.hasDefined(CommonAttributes.USE_JDBC_STORE) && node.get(CommonAttributes.USE_JDBC_STORE).asBoolean()) {
             writer.writeStartElement(Element.JDBC_STORE.getLocalName());
+            TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE_NAME.marshallAsAttribute(node, writer);
             TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE.marshallAsAttribute(node, writer);
             if (TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_TABLE_PREFIX.isMarshallable(node)
                     || TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_DROP_TABLE.isMarshallable(node)) {

--- a/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
+++ b/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
@@ -23,6 +23,8 @@ transactions.hornetq-store-enable-async-io.deprecated=Use journal-store-enable-a
 
 transactions.use-jdbc-store=Use the jdbc store for writing transaction logs. Data is saved in the database indicated by the 'jdbc-store-datasource' attribute. Set to true to enable. Note that the server will not boot if both 'use-journal-store' and 'use-jdbc-store' attributes are set to true. If both are set to false then the default filesystem based store will be used.
 transactions.jdbc-store-datasource=The JNDI name of a non-XA datasource (i.e. one whose 'jta' attribute is set to false) to be used for the JDBC store. The datasource must be defined in the datasources subsystem.
+transactions.jdbc-store-datasource.deprecated=Use jdbc-store-datasource-name
+transactions.jdbc-store-datasource-name=The name of a non-XA datasource (i.e. one whose 'jta' attribute is set to false) to be used for the JDBC store. The datasource must be defined in the datasources subsystem.
 transactions.jdbc-state-store-table-prefix=Optional prefix for the name of the database table used for writing transaction log records of the state store type.
 transactions.jdbc-state-store-drop-table=If set to true then the jdbc-state-store table will be dropped during application server startup.
 transactions.jdbc-action-store-table-prefix=Optional prefix for the name of the database table used for writing transaction log records of the action store type.

--- a/transactions/src/main/resources/schema/wildfly-txn_6_1.xsd
+++ b/transactions/src/main/resources/schema/wildfly-txn_6_1.xsd
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:transactions:6.1"
+           xmlns="urn:jboss:domain:transactions:6.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="6.1">
+
+    <!-- The transaction subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the transactions subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="core-environment" type="core-environment" maxOccurs="1"/>
+            <xs:element name="recovery-environment" type="recovery-environment" maxOccurs="1"/>
+            <xs:element name="coordinator-environment" type="coordinator-environment" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="object-store" type="object-store" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="jts" type="jts-Type" minOccurs="0" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="use-journal-store" type="use-journal-store-Type" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="jdbc-store" type="jdbc-store-Type" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="commit-markable-resources" type="cmr-resources-Type" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="client" type="client" minOccurs="0" maxOccurs="1"/>
+
+        </xs:sequence>
+
+
+    </xs:complexType>
+
+    <xs:complexType name="recovery-environment">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The recovery environment configuration.
+
+                The "socket-binding" attribute is used to reference the correct socket binding to use for the
+                recovery environment.
+                The "status-socket-binding" attribute is used to reference the correct socket binding to use for the
+                transaction status manager.
+                The "recovery-listener" attribute sets if recovery system should listen on a network socket or not.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding" type="xs:string" />
+        <xs:attribute name="status-socket-binding" type="xs:string" />
+        <xs:attribute name="recovery-listener" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="core-environment">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The core environment configuration.
+
+                The process-id element specifies the process id implemention.
+                The "node-identifier" attribute is used to set the node identifier on the core environment.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="process-id" type="process-id" />
+        </xs:all>
+        <xs:attribute name="node-identifier" type="xs:string" default="1"/>
+    </xs:complexType>
+    <xs:complexType name="process-id">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The process identifer implementation
+                The "node-identifier" attribute is used to set the node identifier on the core environment.
+                The "socket-process-id-max-ports" attribute is used to set the max ports on the core environment.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="uuid" type="uuid" />
+            <xs:element name="socket" type="socket-id" />
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="uuid">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The UUID based process identifer implementation
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+    <xs:complexType name="socket-id">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The socket based process identifer implementation
+                The "socket-binding" attribute is used to specify the port to bind to.
+                The "socket-process-id-max-ports" attribute is used to set the max ports on the core environment.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding" type="xs:string" use="required"/>
+        <xs:attribute name="socket-process-id-max-ports" type="xs:int" default="10" />
+    </xs:complexType>
+
+    <xs:attribute name="socket-process-id-max-ports" type="xs:int" default="10" />
+
+    <xs:complexType name="coordinator-environment">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The coordinator environment configuration.
+                statistics-enabled - if recording of transaction statistics is enabled, false otherwise.
+                enable-tsm-status - if the transaction status manager (TSM) service, needed for out of process recovery, should be provided or not.
+                default-timeout - the default transaction lifetime, in seconds.
+                maximum-timeout - the maximum transaction lifetime, in seconds.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false"/>
+        <xs:attribute name="enable-statistics" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Deprecated. Use statistics-enabled. ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-tsm-status" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-timeout" type="xs:int" default="300" />
+        <xs:attribute name="maximum-timeout" type="xs:int" default="31536000" />
+    </xs:complexType>
+
+    <xs:complexType name="object-store">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The object store configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem path denoting where the transaction
+                manager object store should store data.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" default="tx-object-store"/>
+        <xs:attribute name="relative-to" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="jts-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The flag to enable JTS.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="use-journal-store-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The flag to enable the journal transaction log store.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enable-async-io" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Enable AsyncIO for the journal transaction log store.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-store-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                        The presence of this tag enable the jdbc transaction log store.
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="action" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                             Configure jdbc store for default action store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="communication" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Configure jdbc store for communication store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="state" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                           Configure jdbc store for state store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="datasource-jndi-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Configure datasource jndi used to connect for jdbc store
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-store-settings-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Settings for jdbc store
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="table-prefix" type="xs:string" use="optional" />
+        <xs:attribute name="drop-table" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="cmr-resources-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    A list of non XA aware datasources that can reliably participate in an XA transaction.
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="commit-markable-resource" type="cmr-resource-Type" minOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="cmr-resource-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Settings for a single commit markable resource.
+					Each datasource must be defined in the datasources subsystem configuration and
+					each one must be marked with the connectable="true" attribute.
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="xid-location" type="cmr-table-Type" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="jndi-name" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="cmr-table-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Storage settings for a single commit markable resource. For datasource resources
+					this will specifiy the table name where the xid of the commit-markable-resource
+					is stored
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:token" use="optional" default="xids">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+					A name for the storage location
+					]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="immediate-cleanup" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+					Indicates whether the entry should be removed as soon as the transaction has
+					completed
+					]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="batch-size" type="xs:integer" use="optional" default="100">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+					If deletion of entries are deferred to the recovery module (ie immediate-cleanup
+					is set to false) then the batch size specifies how many xids to remove per DML
+					statement. Tuning the batch size is resource manager specific.
+					]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="client">
+        <xs:attribute name="stale-transaction-time" type="xs:int" default="600">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The time after which completed transactions that contain remote enlistments are removed from the memory.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/transactions/src/main/resources/schema/wildfly-txn_6_1.xsd
+++ b/transactions/src/main/resources/schema/wildfly-txn_6_1.xsd
@@ -226,7 +226,17 @@
                 </xs:annotation>
             </xs:element>
         </xs:all>
-        <xs:attribute name="datasource-jndi-name" type="xs:string" use="required">
+        <!-- these attributes are mutually exclusive but there is no way to declare it -->
+        <xs:attribute name="datasource-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Configure datasource used to connect for jdbc store
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="datasource-jndi-name" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[

--- a/transactions/src/test/java/org/jboss/as/txn/subsystem/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/subsystem/TransactionSubsystemTestCase.java
@@ -34,7 +34,7 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-txn_6_0.xsd";
+        return "schema/wildfly-txn_6_1.xsd";
     }
 
     @Override

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem/full-expressions.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem/full-expressions.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:transactions:6.0">
+<subsystem xmlns="urn:jboss:domain:transactions:6.1">
     <core-environment node-identifier="${test.node.identifier:1}">
         <process-id>
             <socket socket-binding="${test.socket-binding:txn-socket-id}" socket-process-id-max-ports="${test.socket.process.id-max.ports:10}"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem/full.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem/full.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:transactions:6.0">
+<subsystem xmlns="urn:jboss:domain:transactions:6.1">
     <core-environment node-identifier="1">
         <process-id>
             <socket socket-binding="txn-socket-id" socket-process-id-max-ports="10"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem/jdbc-store-expressions.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem/jdbc-store-expressions.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:transactions:2.0">
+<subsystem xmlns="urn:jboss:domain:transactions:6.1">
     <core-environment>
         <process-id>
             <uuid/>
@@ -11,7 +11,7 @@
     </core-environment>
     <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
     <object-store relative-to="jboss.server.data.dir"/>
-    <jdbc-store datasource-jndi-name="${test.exp:java:jboss/ExampleDS}">
+    <jdbc-store datasource-name="ExampleDS">
         <action table-prefix="${test.exp:action}" drop-table="${test.exp:true}"/>
         <communication table-prefix="${test.exp:communication}" drop-table="${test.exp:false}"/>
         <state table-prefix="${test.exp:state}" drop-table="${test.exp:true}"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem/jdbc-store.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem/jdbc-store.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:transactions:2.0">
+<subsystem xmlns="urn:jboss:domain:transactions:6.1">
     <core-environment>
         <process-id>
             <uuid/>
@@ -11,7 +11,7 @@
     </core-environment>
     <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
     <object-store relative-to="jboss.server.data.dir"/>
-    <jdbc-store datasource-jndi-name="java:jboss/ExampleDS">
+    <jdbc-store datasource-name="ExampleDS">
         <action table-prefix="action" drop-table="true"/>
         <communication table-prefix="communication" drop-table="false"/>
         <state table-prefix="state" drop-table="true"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem/subsystem.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem/subsystem.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:transactions:6.0">
+<subsystem xmlns="urn:jboss:domain:transactions:6.1">
     <core-environment>
         <process-id>
             <uuid/>


### PR DESCRIPTION
Issue: [WFLY-18249](https://issues.redhat.com/browse/WFLY-18249)

Btw. I noticed the capabilities in this subsystem are not documented in the wildfly-capabilities repo (looks like there's a PR hanging - wildfly/wildfly-capabilities#32)