### PR TITLE
[WFLY-18261] Add a SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Reporting of CVEs and Security Issues
+
+## The WildFly community and our sponsor, Red Hat, take security bugs very seriously
+
+We aim to take immediate action to address serious security-related problems that involve our projects. 
+
+Note that we will only fix such issues in the most recent minor release of Wild<strong>Fly</strong>.</p>
+
+## Reporting of Security Issues
+
+When reporting a security vulnerability it is important to not accidentally broadcast to the world that the issue exists, as this makes it easier for people to exploit it. The software industry uses the term <a href="https://www.redhat.com/en/blog/security-embargoes-red-hat">embargo</a> to describe the time a security issue is known internally until it is public knowledge.
+
+Our preferred way of reporting security issues in WildFly and its related projects is listed below.
+
+### Email the mailing list</h2>
+
+The list at <a href="mailto:security.wildfly.org">security.wildfly.org</a> is the preferred mechanism for outside users to report security issues. A member of the WildFly team will open the required issues.
+    
+### Other considerations</h2>
+
+If you would like to work with us on a fix for the security vulnerability, please include your GitHub username in the above email, and we will provide you access to a temporary private fork where we can collaborate on a fix without it being disclosed publicly, **including in your own publicly visible git repository**.
+
+Do not open a public issue, send a pull request, or disclose any information about the suspected vulnerability publicly, **including in your own publicly visible git repository**. If you discover any publicly disclosed security vulnerabilities, please notify us immediately through <a href="mailto:security.wildfly.org">security.wildfy.org


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18261

This is a copy of what's on wildfly.org. I thought about doing just simple words and then a link, or simple words, a sentence saying to use the list, and then a link for more info. But this is short enough it seems best to just directly state the information vs losing people who don't want to follow further links after they already came to a logical place for info.