### PR TITLE
WFLY-18262 Upgrade Narayana to 7.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.2.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.narayana>6.0.1.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.2.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18262

The component upgrade brings some major updates, most notable is the Re-license Narayana from LGPL to Apache-2.0 and support for JEP-444 (Virtual Threads). JEP-444 required removing the synchronized keyword from some method signatures, hence the change of the major version from 6 to 7.

Tag: https://github.com/jbosstm/narayana/releases/tag/7.0.0.Final
Diff: https://github.com/jbosstm/narayana/compare/6.0.1.Final...7.0.0.Final
Release Notes: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12406603