### PR TITLE
[WFLY-18263] Upgrade WildFly Core to 21.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,7 +545,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.1.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>21.1.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:
https://issues.redhat.com/browse/WFLY-18263

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/21.1.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/21.1.0.Beta2...21.1.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6290'>WFCORE-6290</a>] -         Failure to handle errors loading process-uuid file
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6421'>WFCORE-6421</a>] -         InterfaceManagementUnitTestCase fails on RHEL9
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6424'>WFCORE-6424</a>] -         Generic command argument value issue with List containing Object
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6425'>WFCORE-6425</a>] -         Domain testsuite uses invalid remoting configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6428'>WFCORE-6428</a>] -         Error occurred in starting fork when running with jacoco profile
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6285'>WFCORE-6285</a>] -         Document how to move off deprecated modules in their module.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6430'>WFCORE-6430</a>] -         Update the SECURITY.md document
</li>
</ul>
                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6422'>WFCORE-6422</a>] -         Upgrade xalan to 2.7.3 (CVE-2022-34169) - Test Only Dependency
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6426'>WFCORE-6426</a>] -         Upgrade to Remoting JMX 3.1.0.Final and update License to the Apache License
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6429'>WFCORE-6429</a>] -         Upgrade Eclipse Parsson from 1.1.2 to 1.1.3
</li>
</ul>
</details>