### PR TITLE
[WFLY-18202] Correct docs image link handling

### DIFF
--- a/docs/src/main/asciidoc/Bootable_Guide.adoc
+++ b/docs/src/main/asciidoc/Bootable_Guide.adoc
@@ -11,7 +11,6 @@ WildFly team;
 :source-highlighter: coderay
 
 ifdef::env-github[]
-:imagesdir: images/
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -11,7 +11,6 @@ WildFly team;
 :source-highlighter: coderay
 
 ifdef::env-github[]
-:imagesdir: images/
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -444,7 +443,7 @@ As with previous WildFly releases, you can point your browser to
 *_http://localhost:8080_* (if using the default configured http port)
 which brings you to the Welcome Screen:
 
-image:wildfly.png[images/wildfly.png]
+image:images/wildfly.png[wildfly.png]
 
 From here you can access links to the WildFly community documentation
 set, stay up-to-date on the latest project information, have a

--- a/docs/src/main/asciidoc/Quickstarts.adoc
+++ b/docs/src/main/asciidoc/Quickstarts.adoc
@@ -11,7 +11,6 @@ WildFly team;
 :source-highlighter: coderay
 
 ifdef::env-github[]
-:imagesdir: images/
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -11,7 +11,6 @@ WildFly team;
 :source-highlighter: coderay
 
 ifdef::env-github[]
-:imagesdir: images/
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:

--- a/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
@@ -2,7 +2,7 @@
 = Default HTTP Interface Security
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -24,7 +24,7 @@ default user in the distribution.
 If you attempt to connect to the admin console before you have added a
 user to the server you will be presented with the following screen.
 
-image:no-users.png[images/no-users.png]
+image:images/no-users.png[alt=no-users.png]
 ////
 
 The user are stored in a properties file called mgmt-users.properties
@@ -43,7 +43,7 @@ the same password.
 To manipulate the files and add users we provide a utility add-user.sh
 and add-user.bat to add the users and generate the hashes, to add a user
 you should execute the script and follow the guided process.
-image:add-user.png[images/add-user.png] +
+image:images/add-user.png[alt=add-user.png] +
 The full details of the add-user utility are described later but for the
 purpose of accessing the management interface you need to enter the
 following values: -

--- a/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
@@ -2,7 +2,7 @@
 = Operating mode
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -58,7 +58,7 @@ Controller. See <<Domain_Setup,Domain Setup>> for details.
 
 The following is an example managed domain topology:
 
-image:DC-HC-Server.png[images/DC-HC-Server.png]
+image::images/DC-HC-Server.png[alt=DC-HC-Server.png]
 
 [[host]]
 === Host

--- a/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
@@ -2,7 +2,7 @@
 = Authorizing management actions with Role Based Access Control
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -261,7 +261,7 @@ admin console.
 Navigate to the "Administration" tab and the "Users" subtab. From there
 individual user mappings can be added, removed, or edited.
 
-image:usermapping.png[images/usermapping.png,width=450]
+image:images/usermapping.png[alt=usermapping.png,width=450]
 
 The CLI can also be used to map individuals users to roles.
 
@@ -328,7 +328,7 @@ console.
 Navigate to the "Administration" tab and the "Groups" subtab. From there
 group mappings can be added, removed, or edited.
 
-image:groupmapping.png[images/groupmapping.png,width=450]
+image:images/groupmapping.png[alt=groupmapping.png,width=450]
 
 The CLI can also be used to map groups to roles. The only difference to
 individual user mapping is the value of the `type` attribute should be
@@ -365,7 +365,7 @@ In the web based admin console, navigate to the "Administration" tab,
 "Roles" subtab, highlight the relevant role, click the "Edit" button and
 click on the "Include All" checkbox:
 
-image:includeall.png[images/includeall.png,width=450]
+image:images/includeall.png[alt=includeall.png,width=450]
 
 The same change can be made using the CLI:
 
@@ -392,7 +392,7 @@ where the `include-all` attribute is set to true for a role.
 In the admin console, excludes are done in the same screens as includes.
 In the add dialog, simply change the "Type" pulldown to "Exclude".
 
-image:excludemapping.png[images/excludemapping.png,width=450]
+image:images/excludemapping.png[alt=excludemapping.png,width=450]
 
 In the CLI, excludes are identical to includes, except the resource
 address has `exclude` instead of `include` as the key for the last
@@ -559,14 +559,14 @@ Both server-group and host scoped roles can be added, removed or edited
 via the admin console. Select "Scoped Roles" from the "Administration"
 tab, "Roles" subtab:
 
-image:scopedroles.png[images/scopedroles.png,width=450]
+image:images/scopedroles.png[alt=scopedroles.png,width=450]
 
 When adding a new scoped role, use the dialogue's "Type" pull down to
 choose between a host scoped role and a server-group scoped role. Then
 place the names of the relevant hosts or server groups in the "Scope"
 text are.
 
-image:addscopedrole.png[images/addscopedrole.png,width=450]
+image:images/addscopedrole.png[alt=addscopedrole.png,width=450]
 
 [[configuring-constraints]]
 == Configuring constraints
@@ -1142,7 +1142,7 @@ Users can learn in which roles they are operating. In the admin console,
 click on your name in the top right corner; the roles you are in will be
 shown.
 
-image:callersroles.png[images/callersroles.png,width=450]
+image:images/callersroles.png[alt=callersroles.png,width=450]
 
 CLI users should use the `whoami` operation with the `verbose` attribute
 set:
@@ -1222,11 +1222,11 @@ Admin console users can change the role in which they operate by
 clicking on their name in the top right corner and clicking on the "Run
 as..." link.
 
-image:callersroles.png[images/callersroles.png,width=450]
+image:images/callersroles.png[alt=callersroles.png,width=450]
 
 Then select the role in which you wish to operate:
 
-image:runasrole.png[images/runasrole.png,width=450]
+image:images/runasrole.png[alt=runasrole.png,width=450]
 
 The console will need to be restarted in order for the change to take
 effect.

--- a/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
@@ -2,7 +2,7 @@
 = add-user utility
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -58,7 +58,7 @@ unless you have switched to a different realm.
 [[interactive-mode]]
 ==== Interactive Mode
 
-image:add-mgmt-user-interactive.png[images/add-mgmt-user-interactive.png]
+image:images/add-mgmt-user-interactive.png[alt=add-mgmt-user-interactive.png]
 
 Here we have added a new Management User called `adminUser`, as you can
 see some of the questions offer default responses so you can just press
@@ -74,7 +74,7 @@ management chapter.
 To add a user in non-interactive mode the command
 `./add-user.sh {username} {password`} can be used.
 
-image:add-mgmt-user-non-interactive.png[images/add-mgmt-user-non-interactive.png]
+image:images/add-mgmt-user-non-interactive.png[alt=add-mgmt-user-non-interactive.png]
 
 [WARNING]
 
@@ -94,7 +94,7 @@ user.
 [[interactive-mode-1]]
 ==== Interactive Mode
 
-image:add-app-user-interactive.png[images/add-app-user-interactive.png]
+image:images/add-app-user-interactive.png[alt=add-app-user-interactive.png]
 
 Here a new user called `appUser` has been added, in this case a comma
 separated list of roles has also been specified.
@@ -109,7 +109,7 @@ a connection from one server to another.
 To add an application user non-interactively use the command
 `./add-user.sh -a {username} {password`}.
 
-image:add-app-user-non-interactive.png[images/add-app-user-non-interactive.png]
+image:images/add-app-user-non-interactive.png[alt=add-app-user-non-interactive.png]
 
 [NOTE]
 
@@ -130,7 +130,7 @@ your intention.
 [[interactive-mode-2]]
 ==== Interactive Mode
 
-image:update-mgmt-user-interactive.png[images/update-mgmt-user-interactive.png]
+image:images/update-mgmt-user-interactive.png[alt=update-mgmt-user-interactive.png]
 
 [[non-interactive-mode-2]]
 ==== Non-Interactive Mode
@@ -143,7 +143,7 @@ with no confirmation prompt.
 
 ==== Interactive Mode
 
-image:update-app-user-interactive.png[images/update-app-user-interactive.png]
+image:images/update-app-user-interactive.png[alt=update-app-user-interactive.png]
 
 [NOTE]
 

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Security.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_XML_Web_Services/WS-Security.adoc
@@ -2,7 +2,7 @@
 = WS-Security
 
 ifdef::env-github[]
-:imagesdir: ../../images/
+:imagesdir: ../../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -31,7 +31,7 @@ configure WS-Security. With public key cryptography, a user has a pair
 of public and private keys. These are generated using a large prime
 number and a key function.
 
-image:Public_key_making.png[images/Public_key_making.png]
+image:images/Public_key_making.png[alt=Public_key_making.png]
 
 The keys are related mathematically, but cannot be derived from one
 another. With these keys we can encrypt messages. For example, if Bob
@@ -40,7 +40,7 @@ public key. Alice can then decrypt this message using her private key.
 Only Alice can decrypt this message as she is the only one with the
 private key.
 
-image:Public_key_encryption-mod.svg.png[images/Public_key_encryption-mod.svg.png]
+image:images/Public_key_encryption-mod.svg.png[alt=Public_key_encryption-mod.svg.png]
 
 Messages can also be signed. This allows you to ensure the authenticity
 of the message. If Alice wants to send a message to Bob, and Bob wants
@@ -48,7 +48,7 @@ to be sure that it is from Alice, Alice can sign the message using her
 private key. Bob can then verify that the message is from Alice by using
 her public key.
 
-image:250px-Public_key_making.svg.png[images/250px-Public_key_making.svg.png]
+image:images/250px-Public_key_making.svg.png[alt=250px-Public_key_making.svg.png]
 
 [[jboss-ws-security-support]]
 == JBoss WS-Security support

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
@@ -2,6 +2,7 @@
 = Jakarta Enterprise Beans Deployment Runtime Resources
 
 ifdef::env-github[]
+:imagesdir: ../../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -101,7 +102,7 @@ The following is a sample output for a stateless session bean named `ManagedStat
 
 To view it in WildFly Administration Console, go to the `Management Model` section of the target deployment. For example,
 
-image:ejb/stateless-management-resource.png[images/ejb/stateless-management-resource.png]
+image:images/ejb/stateless-management-resource.png[alt=ejb/stateless-management-resource.png]
 
 [[Stateful_Session_Bean_Runtime_Resources]]
 == Stateful Session Bean Runtime Resources
@@ -182,7 +183,7 @@ The following is a sample output for a stateful session bean named `ManagedState
 
 To view it in WildFly Administration Console, go to the `Management Model` section of the target deployment. For example,
 
-image:ejb/stateful-management-resource.png[images/ejb/stateful-management-resource.png]
+image:images/ejb/stateful-management-resource.png[alt=ejb/stateful-management-resource.png]
 
 [[Singleton_Bean_Runtime_Resources]]
 == Singleton Bean Runtime Resources
@@ -257,7 +258,7 @@ The following is a sample output for a singleton bean named `ManagedSingletonBea
 
 To view it in WildFly Administration Console, go to the `Management Model` section of the target deployment. For example,
 
-image:ejb/singleton-management-resource.png[images/ejb/singleton-management-resource.png]
+image:images/ejb/singleton-management-resource.png[alt=ejb/singleton-management-resource.png]
 
 [[Message_Driven_Bean_Runtime_Resources]]
 == Message-driven Bean Runtime Resources
@@ -328,4 +329,4 @@ The following is a sample output for a message-driven bean named `ManagedMDB` in
 
 To view it in WildFly Administration Console, go to the `Management Model` section of the target deployment. For example,
 
-image:ejb/mdb-management-resource.png[images/ejb/mdb-management-resource.png]
+image:images/ejb/mdb-management-resource.png[alt=ejb/mdb-management-resource.png]

--- a/docs/src/main/asciidoc/_extras/Developing_Jakarta_Faces_Project_Using_Maven_and_IntelliJ.adoc
+++ b/docs/src/main/asciidoc/_extras/Developing_Jakarta_Faces_Project_Using_Maven_and_IntelliJ.adoc
@@ -2,7 +2,7 @@
 = Developing Jakarta Faces Project Using JBoss AS7, Maven and IntelliJ
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -83,7 +83,7 @@ mvn archetype:create -DarchetypeGroupId=org.apache.maven.archetypes \
 
 If everything goes fine maven will generate the project for us:
 
-image:jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg[images/jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg]
+image:images/jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg[alt=jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg]
 
 The contents of the project is shown as above.
 
@@ -223,12 +223,12 @@ mvn -q jboss-as:deploy
 Maven will use some time to download necessary components for a while,
 so please wait patiently. After a while, we can see the result:
 
-image:jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg[images/jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg]
+image:images/jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg[alt=jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg]
 
 And if you check the console output of AS7, you can see the project is
 deployed:
 
-image:jsf/2._java.jpg[images/jsf/2._java.jpg]
+image:images/jsf/2._java.jpg[alt=jsf/2._java.jpg]
 
 Now we have learnt how to create a Jakarta Faces project and deploy it to AS7
 without any help from graphical tools. Next let's see how to use
@@ -240,29 +240,29 @@ IntelliJ IDEA to go on developing/debugging our project.
 Now it's time to import the project into IntelliJ. Now let's open
 IntelliJ, and choose 'New Project...':
 
-image:jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg[images/jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg]
+image:images/jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg[alt=jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg]
 
 The we choose 'Import project from external model':
 
-image:jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg[images/jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg]
+image:images/jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg[alt=jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg]
 
 Next step is choosing 'Maven':
 
-image:jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg[images/jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg]
+image:images/jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg[alt=jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg]
 
 Then IntelliJ will ask you the position of the project you want to
 import. In 'Root directory' input your project's directory and leave
 other options as default:
 
-image:jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg[images/jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg]
+image:images/jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg[alt=jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg]
 
 For next step, just click 'Next':
 
-image:jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg[images/jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg]
+image:images/jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg[alt=jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg]
 
 Finally click 'Finish':
 
-image:jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg[images/jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg]
+image:images/jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg[alt=jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg]
 
 Hooray! We've imported the project into IntelliJ now icon:smile-o[role="yellow"]
 
@@ -272,20 +272,20 @@ Hooray! We've imported the project into IntelliJ now icon:smile-o[role="yellow"]
 Let's see how to use IntelliJ and AS7 to debug the project. First we
 need to add 'Jakarta Faces' facet into project. Open project setting:
 
-image:jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg[images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg]
+image:images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg[alt=jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg]
 
 Click on 'Facets' section on left; Select 'Web' facet that we already
 have, and click the '+' on top, choose 'Jakarta Faces':
 
-image:jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg[images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg]
+image:images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg[alt=jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg]
 
 Select 'Web' as parent facet:
 
-image:jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg[images/jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg]
+image:images/jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg[alt=jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg]
 
 Click 'Ok':
 
-image:jsf/9988c572bad281146f405e9287f645a3da201885.jpg[images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg]
+image:images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg[alt=jsf/9988c572bad281146f405e9287f645a3da201885.jpg]
 
 Now we have enabled IntelliJ's Jakarta Faces support for project.
 
@@ -295,28 +295,28 @@ Now we have enabled IntelliJ's Jakarta Faces support for project.
 Let's add JBoss AS7 into IntelliJ and use it to debug our project. First
 please choose 'Edit Configuration' in menu tab:
 
-image:jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg[images/jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg]
+image:images/jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg[alt=jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg]
 
 Click '+' and choose 'JBoss Server' -> 'Local':
 
-image:jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg[images/jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg]
+image:images/jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg[alt=jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg]
 
 Click 'configure':
 
-image:jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg[images/jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg]
+image:images/jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg[alt=jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg]
 
 and choose your JBoss AS7:
 
-image:jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg[images/jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg]
+image:images/jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg[alt=jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg]
 
 Now we need to add our project into deployment. Click the 'Deployment'
 tab:
 
-image:jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg[images/jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg]
+image:images/jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg[alt=jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg]
 
 Choose 'Artifact', and add our project:
 
-image:jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg[images/jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg]
+image:images/jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg[alt=jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg]
 
 Leave everything as default and click 'Ok', now we've added JBoss AS7
 into IntelliJ
@@ -359,7 +359,7 @@ bin/standalone.sh --debug --server-config=standalone.xml
 
 Now we start AS7 in IntelliJ:
 
-image:jsf/52369d67f9117c924213de24dd6642b48e47a436.png[images/jsf/52369d67f9117c924213de24dd6642b48e47a436.png]
+image:images/jsf/52369d67f9117c924213de24dd6642b48e47a436.png[alt=jsf/52369d67f9117c924213de24dd6642b48e47a436.png]
 
 Please note we should undeploy the existing 'jsfdemo' project in AS7 as
 we've added by maven jboss deploy plugin before. Or AS7 will tell us
@@ -369,46 +369,46 @@ deploy the project anymore.
 If the project start correctly we can see from the IntelliJ console
 window, and please check the debug option is enabled:
 
-image:jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png[images/jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png]
+image:images/jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png[alt=jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png]
 
 Now we will setup the debug configuration, click 'debug' option on menu:
 
-image:jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg[images/jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg]
+image:images/jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg[alt=jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg]
 
 Choose 'Edit Configurations':
 
-image:jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg[images/jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg]
+image:images/jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg[alt=jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg]
 
 Then we click 'Add' and choose Remote:
 
-image:jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg[images/jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg]
+image:images/jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg[alt=jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg]
 
 Set the 'port' to the one you used in AS7 config file 'standalone.conf':
 
-image:jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png[images/jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png]
+image:images/jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png[alt=jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png]
 
 Leave other configurations as default and click 'Ok'. Now we need to set
 breakpoints in project, let's choose TimeBean.java and set a breakpoint
 on 'getNow()' method by clicking the left side of that line of code:
 
-image:jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg[images/jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg]
+image:images/jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg[alt=jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg]
 
 Now we can use the profile to do debug:
 
-image:jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png[images/jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png]
+image:images/jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png[alt=jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png]
 
 If everything goes fine we can see the console output:
 
-image:jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg[images/jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg]
+image:images/jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg[alt=jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg]
 
 Now we go to web browser and see our project's main page, try to click
 on 'Get current time':
 
-image:jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png[images/jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png]
+image:images/jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png[alt=jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png]
 
 Then IntelliJ will popup and the code is pausing on break point:
 
-image:jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg[images/jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg]
+image:images/jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg[alt=jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg]
 
 And we could inspect our project now.
 

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -2,7 +2,7 @@
 = Clustering and Domain Setup Walkthrough
 
 ifdef::env-github[]
-:imagesdir: ../images/
+:imagesdir: ../
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -47,7 +47,7 @@ will run as a domain controller, the secondary host will under the domain manage
 mod_cluster module. The WildFly on primary and secondary hosts will form a
 cluster and discovered by httpd.
 
-image:clustering/Clustering.jpg[images/clustering/Clustering.jpg]
+image:images/clustering/Clustering.jpg[alt=clustering/Clustering.jpg]
 
 * We will deploy a demo project into the domain, and verify that the project
 is deployed into both primary and secondary Host Controllers by the domain controller.
@@ -68,7 +68,7 @@ the HA is working and sessions are replicated.
 it. We should see the Domain Controller is registered back into cluster, also we
 should see the secondary Host Controller sees the primary Host Controller as a domain controller again and connect to it.
 
-image:clustering/test_scenario.jpg[images/clustering/test_scenario.jpg]
+image:images/clustering/test_scenario.jpg[alt=clustering/test_scenario.jpg]
 
 Please don't worry if you cannot digest so many details currently. Let's
 move on and you will get the points step by step.
@@ -403,7 +403,7 @@ After server-three on both primary and secondary hosts are started, we will add 
 cluster-demo.war for deployment. Click on the 'Manage Deployments' link
 at the bottom of left menu list.
 
-image:clustering/JBoss_Management.png[images/clustering/JBoss_Management.png] +
+image:images/clustering/JBoss_Management.png[alt=clustering/JBoss_Management.png] +
 (We should ensure the server-three should be started on both primary and
 secondary hosts)
 
@@ -417,7 +417,7 @@ button and add the war to 'other-server-group' and then click 'save'.
 Wait a few seconds, management console will tell you that the project is
 deployed into 'other-server-group'.：
 
-image:clustering/JBoss_Management_2.png[images/clustering/JBoss_Management_2.png]
+image:images/clustering/JBoss_Management_2.png[alt=clustering/JBoss_Management_2.png]
 
 Please note we have two hosts participate in this server group, so the
 project should be deployed in both primary and secondary hosts now - that's the
@@ -431,14 +431,14 @@ and secondary hosts, and they should all work now:
 http://10.211.55.7:8330/cluster-demo/
 ----
 
-image:clustering/http---10.211.55.7-8330-cluster-demo-.png[images/clustering/http---10.211.55.7-8330-cluster-demo-.png]
+image:images/clustering/http---10.211.55.7-8330-cluster-demo-.png[alt=clustering/http---10.211.55.7-8330-cluster-demo-.png]
 
 [source,options="nowrap"]
 ----
 http://10.211.55.2:8330/cluster-demo/
 ----
 
-image:clustering/http---10.211.55.2-8330-cluster-demo-.png[images/clustering/http---10.211.55.2-8330-cluster-demo-.png]
+image:images/clustering/http---10.211.55.2-8330-cluster-demo-.png[alt=clustering/http---10.211.55.2-8330-cluster-demo-.png]
 
 Now that we have finished the project deployment and see the usages of
 domain controller, we will then head up for using these two hosts to
@@ -651,7 +651,7 @@ Now we access the cluster:
 http://10.211.55.7/cluster-demo/put.jsp
 ----
 
-image:clustering/http---10.211.55.7-cluster-demo-put.jsp.png[images/clustering/http---10.211.55.7-cluster-demo-put.jsp.png]
+image:images/clustering/http---10.211.55.7-cluster-demo-put.jsp.png[alt=clustering/http---10.211.55.7-cluster-demo-put.jsp.png]
 
 We should see the request is distributed to one of the hosts (primary or
 secondary) from the WildFly log. For me the request is sent to primary host:
@@ -677,7 +677,7 @@ Then wait for a few seconds and access cluster:
 http://10.211.55.7/cluster-demo/get.jsp
 ----
 
-image:clustering/http---10.211.55.7-cluster-demo-get.jsp.png[images/clustering/http---10.211.55.7-cluster-demo-get.jsp.png]
+image:images/clustering/http---10.211.55.7-cluster-demo-get.jsp.png[alt=clustering/http---10.211.55.7-cluster-demo-get.jsp.png]
 
 Now the request should be served by the secondary host and we should see the log from
 the secondary Host Controller:

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -3,7 +3,6 @@
 :ext-relative: {outfilesuffix}
 
 ifdef::env-github[]
-:imagesdir: images/
 :tip-caption: :bulb:
 :note-caption: :information_source:
 :important-caption: :heavy_exclamation_mark:
@@ -13,7 +12,7 @@ endif::[]
 
 :toc!:
 
-image:splash_wildflylogo_small.png[WildFly, align="center"]
+image:images/splash_wildflylogo_small.png[WildFly, align="center"]
 
 Welcome to the WildFly documentation. The documentation for WildFly is
 split into multiple categories:


### PR DESCRIPTION
The document-relative path to the image goes outside the brackets.

The env-github imagesdir setting should not include 'images' as that should be part of the image macro itself.

https://issues.redhat.com/browse/WFLY-18202