### PR TITLE
WFLY-18278 Upgrade metainf-services from 1.8 to 1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,7 @@
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.jvnet.staxex>2.1.0</version.org.jvnet.staxex>
         <version.org.keycloak.keycloak-saml-wildfly-subsystem>18.0.2</version.org.keycloak.keycloak-saml-wildfly-subsystem>
-        <version.org.kohsuke.metainf-services>1.8</version.org.kohsuke.metainf-services>
+        <version.org.kohsuke.metainf-services>1.11</version.org.kohsuke.metainf-services>
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18278