### PR TITLE
Drop problematic transient dependency exclusions for wildfly-core modules.

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -83,12 +83,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-process-controller</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>*</artifactId>
-                    <groupId>*</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -97,12 +91,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging-activemq-injection</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>*</artifactId>
-                    <groupId>*</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -111,12 +99,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-host-controller</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -129,12 +111,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -147,12 +123,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -90,7 +90,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
     private final boolean isFullDistribution = AssumeTestGroupUtil.isFullDistribution();
     private final boolean isPreviewGalleonPack = AssumeTestGroupUtil.isWildFlyPreview();
 
-    private static final String MAJOR = "29.";
+    private static final String MAJOR = "30.";
 
     /**
      * Maintains the list of expected extensions for each host-exclude name for previous releases.
@@ -210,7 +210,8 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.wildfly.extension.microprofile.lra-participant",
                 "org.wildfly.extension.microprofile.telemetry"
         ), true),
-        CURRENT(MAJOR, WILDFLY_28_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
+        WILDFLY_29_0("WildFly29.0", WILDFLY_28_0, true),
+        CURRENT(MAJOR, WILDFLY_29_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
 
         private static List<String> getCurrentAddedExtensions() {
             // If an extension is added to this list, also check if it is supplied only by wildfly-galleon-pack. If so, add it also


### PR DESCRIPTION
This causes completely avoidable full-integration test failures in wildfly-core when new dependencies are added.