### PR TITLE
[WFLY-18185] Community documentation for caching realm allowing authentication with externally updated credential

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -246,7 +246,7 @@ identity for the authorization steps and aggregating the resulting attributes.
 |caching-realm |A realm definition that enables caching to another
 security realm. Caching strategy is Least Recently Used where least
 accessed entries are discarded when maximum number of entries is
-reached.
+reached. When credentials are updated externally, the user's obsolete credential will be removed when the user authenticates with the updated credential.
 
 |custom-modifiable-realm |Custom realm configured as being modifiable
 will be expected to implement the ModifiableSecurityRealm interface. By

--- a/docs/src/main/asciidoc/_elytron/migrate/Caching_Migration.adoc
+++ b/docs/src/main/asciidoc/_elytron/migrate/Caching_Migration.adoc
@@ -83,7 +83,7 @@ These can then be used in a security domain and subsequently an authentication f
 ./subsystem=elytron/http-authentication-factory=application-security-http:add(http-server-mechanism-factory=global, security-domain=application-security, mechanism-configurations=[{mechanism-name=BASIC}])
 ----
 
-In this final step it is very important that the caching-realm is referenced rather than the original realm otherwise caching will be bypassed.
+In this final step it is very important that the caching-realm is referenced rather than the original realm otherwise caching will be bypassed. When credentials are updated externally in the LDAP server, the user's obsolete credential will be removed when the user successfully authenticates with the updated credential.
 
 This results in the following definitions:
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18185

Requires: https://github.com/wildfly-security/wildfly-elytron/pull/1932
 