### PR TITLE
[WFLY-18311] Eliminate Hibernate Validator dependency on legacy Xerces

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -41,6 +41,5 @@
     <module name="org.jboss.weld.core"/>
     <module name="org.jboss.weld.spi"/>
     <module name="org.joda.time"/>
-    <module name="org.apache.xerces" services="import"/>
   </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18311

Remove Xerces module dep