### PR TITLE
[WFLY-18316] Implement canonical links for WildFly documentation

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -40,18 +40,20 @@ version, but should likely be checked.
 Building the documentation can be done with the following command:
 
 .Generate Only
-```
+[source,shell]
+----
 mvn clean package
-```
+----
 
 .Generate and Copy
-```
-mvn clean package -Pcopy-site
-```
+[source,shell]
+----
+mvn clean package -Pcopy-site -DpreviousVersion=<prevVer>
+----
 
 The `asciidoctor-maven-plugin` will execute and generate html5 files. The files are generated in the
-`target/generated-docs` directory. You can optionally activate the `copy-site` profile to copy the generated site. See
-<<copy-site-profile,copy site option 2>> for more details
+`target/generated-docs` directory. You can optionally activate the `copy-site` profile to copy the generated site. See the
+<<copy-site,Copy Site section>> for more details.
 
 
 == Adding the documentation to docs.wildfly.org
@@ -61,31 +63,61 @@ The `asciidoctor-maven-plugin` will execute and generate html5 files. The files 
 The first thing required here is a clone of the https://github.com/wildfly/wildfly.github.io repository. Once cloned
 it's likely best to checkout a new branch for to update the documentation.
 
-=== Copy Site
+=== Copy Site [[copy-site]]
 
-Copying the site can be done one of two ways:
+The `wildfly.github.io/latest/` path is the canonical link for documentation on the most recent version of WildFly, with pages in the versioned directory redirecting to this link (ex. if the latest version is `28`, the link https://docs.wildfly.org/28/index.html will redirect to https://docs.wildfly.org/latest/index.html). When updating documentation, the versioned directory (containing redirects) should be deleted, and the `latest/` folder should be renamed to that version; then a new `latest/` folder is created for the next release, with versioned redirects for the updated documentation. The Mermaid diagram below demonstrates how an upgrade works (or https://mermaid.live/edit#pako:eNp1UsFuwjAM_RXLu2wSBdFNArWC03bbLttx2SE0LkRKkypJ2VDVf59DmRCI-RLH9vOzX9Jj5RRhgbVx39VO-giv76WwwBa6zdbLdgcbqp0n-BR48u6NjBQi7MkH7SzoAPniQeDXCZnM5QsG5IsZhyGbgielPVUxQHQwzdZg5pwfG83OULLqml7WkXxiH51b5MsrcpsvE_nyf_L8FnkyM4csA4Gh8rqNjLSyoSPu7vGp5H3SAV3QdsuFrae9dl3I_qZxbeRDIOfWPMZZg0tpOP0Dqu8Fxh0vME7n_CFto8hQJCVwGK41Oem_Wq3WoywlTrAh30it-BH7VJVaUkMCC3YV1bIzUaCwA5fKLrqPg62wiL6jCXatYg2etWSlm8vgi9I8EBa1NIGDdLy-jZ_l-GeGXwcUsxs[view in the live editor]):
 
-1. You can manually copy the `target/generated-site` from the `docs` directory of WildFly over to the
-   `wildfly.github.io` repository. This should be copied into a version directory. For example `16` for WildFly 16.
+[source,mermaid]
+----
+flowchart LR;
+    subgraph before ["before (latest version is 27)"];
+        o27["27/"] -. redirects to .-> l1["latest/"];
+    end;
+    subgraph after ["after (latest version is 28)"];
+        n28["28/"] -. redirects to .-> l2["latest/"];
+        l1 -- "script renames to #34;27/#34; using --previous-version option" --> n27["27/"];
+        o27 --x d{{"this directory is deleted"}}
+    end;
+    before ===> after;
+----
 
-2. [[copy-site-profile]]You can run the build with `mvn clean package -Pcopy-site` which by default attempts to copy the site to
-   `../../wildfly.github.io/${product.docs.server.version}`. This can be overridden with the `wildfly.github.io.dir`
-   property.
+You can deploy a new version of the WildFly documentation by running `mvn clean package -Pcopy-site -DpreviousVersion=<prevVer>`, where `<prevVer>` refers to the previous version of the documentation (ex. 27). The Python script called requires BeautifulSoup (install with `pip install beautifulsoup4`)
 
-=== Add Copied Content
-
-Once copied you'll need to add the directory to the git repository; `git add ./16` for example.
+This attempts to copy the site to `../../wildfly.github.io/latest-new`, and then renames folders and creates redirects as needed. This path be overridden with the `wildfly.github.io.dir` property.
 
 === Edit and Build Index
 
 Next in the `wildfly.github.io` repository you'll need to edit the `index.adoc` and add the newly created directory. We
-try to keep the listings in release order with the new release on top.
+try to keep the listings in release order with the new release on top. Only the versioned URLs
+should be used.
 
 Once you edit the `index.adoc` you'll need to regenerate the `index.html` file. This can be done with the `asciidoctor`
 command.
 
-```
-asciidoctor index.adoc
-```
+You should also update the `sitemap.xml` with the latest versions.
 
-After all that is complete you can commit your changes and submit a PR.
+[source]
+----
+asciidoctor index.adoc
+----
+
+After all that is complete, you can commit your changes and submit a PR. Since many files will be moved and renamed, splitting into multiple commits makes this simpler to follow. The below script can be run after all changes are made, instead of making changes between commits:
+
+[source,shell]
+----
+# Run from the root documentation directory, where '27' was the previous version.
+
+git rm -r --cached "27/*.html"
+git commit -m "Remove redirection pages for WildFly 27"
+
+git add "27/"
+git rm -r --cached "latest/"
+git commit -m "Move docs to versioned directory for WildFly 27"
+
+git add latest/ "28/"
+git rm -r --cached "28/*.html"
+git commit -m "Generate canonical links for WildFly 28"
+
+git add "28/" "sitemap.xml"
+git commit -m "Generate redirection pages for WildFly 28"
+----

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -47,9 +47,10 @@
         <management-model.filename>${server.name}.dmr</management-model.filename>
 
         <wildfly.github.io.dir>
-            ..${file.separator}..${file.separator}wildfly.github.io${file.separator}${product.docs.server.version}
+            ..${file.separator}..${file.separator}wildfly.github.io${file.separator}latest-new
         </wildfly.github.io.dir>
         <jboss.home>${project.build.directory}/wildfly</jboss.home>
+        <previousVersion/>
     </properties>
 
     <build>
@@ -190,6 +191,37 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <!-- DO NOT REORDER - script must be run after directory is copied -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>python-update-latest</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>python3</executable>
+                            <arguments>
+                                <argument>src/main/scripts/update-latest-and-redirects.py</argument>
+                                <argument>--source</argument>
+                                <argument>${wildfly.github.io.dir}</argument> <!-- Directory with new documentation -->
+                                <argument>--source-version</argument>
+                                <argument>${parent.version}</argument> <!-- Version number of the new documentation -->
+                                <argument>--previous</argument>
+                                <argument>latest</argument>
+                                <argument>--previous-version</argument>
+                                <argument>${previousVersion}</argument> <!-- Version number of the previous documentation -->
+                                <argument>--product</argument>
+                                <argument>${full.dist.product.release.name}</argument> <!-- Product name -->
+                                <argument>--update-sitemap</argument>
+                            </arguments>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/docs/src/main/scripts/update-latest-and-redirects.py
+++ b/docs/src/main/scripts/update-latest-and-redirects.py
@@ -1,0 +1,442 @@
+# Copyright 2023 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import os
+import shutil
+import sys
+from argparse import ArgumentParser, Namespace
+from datetime import datetime, timezone
+from typing import Tuple
+from pathlib import Path, PurePath
+from xml.etree import ElementTree
+from xml.etree.ElementTree import SubElement
+
+from bs4 import BeautifulSoup, Tag
+
+REDIRECT_TEMPLATE: Tuple[str, str, str, str, str] = (
+    """<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"UTF-8\">
+    <meta http-equiv=\"refresh\" content=\"0; url=""",
+    """\">
+    <link rel=\"canonical\" href=\"""",
+    """\" />
+  </head>
+  <body>
+    <p>Redirecting to the latest version. If the page doesn't open, click the following link: <a href=\"""",
+    """\">""",
+    """</a></p>
+  </body>
+</html>""",
+)
+
+REMOVED_REDIRECT_TEMPLATE: Tuple[str, str, str, str, str, str] = (
+    """<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"UTF-8\">
+    <meta http-equiv=\"refresh\" content=\"3; url=""",
+    """\">
+    <link rel=\"canonical\" href=\"""",
+    """\" />
+  </head>
+  <body>
+    <p>This page does not exist in the latest version (""",
+    """). You will be redirected to the last available version in 3 seconds.</p>
+    <p>If the page doesn't open, click the following link: <a href=\"""",
+    """\">""",
+    """</a></p>
+  </body>
+</html>""",
+)
+
+REL_PATH_PATTERN = re.compile(r"(/)?([^/]+)")
+
+SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+
+def rename_directories(
+    base_docs_path: Path,
+    latest_docs_path: PurePath,
+    args: Namespace,
+) -> None:
+    """Adjust names of the latest directories.
+
+    :param base_docs_path: base directory for documentation
+    :param latest_docs_path: directory for latest docs. If the directory already exists, it is renamed to the previous
+        version (if provided as an argument) or deleted
+    :param args: paths and versions for current and previous documentation
+    """
+    if Path(latest_docs_path).exists():
+        # Rename to previous directory version if provided
+        if args.previous_version:
+            prev_relative_path = base_docs_path.joinpath(args.previous_version)
+
+            shutil.rmtree(prev_relative_path) if prev_relative_path.exists() else None
+            os.rename(latest_docs_path, prev_relative_path)
+        else:
+            shutil.rmtree(latest_docs_path)
+
+    os.rename(args.source, latest_docs_path)
+    if (versioned_path := base_docs_path.joinpath(args.source_version)).exists():
+        shutil.rmtree(versioned_path)
+
+
+def rel_path_replace(matched: re.Match) -> str:
+    """Replaces path elements with ".." for relative URLs
+
+    :param matched: the match element
+    :return: a replacement for ascending levels in a relative path
+    """
+    replacement: str = ""
+    for m in matched.groups():
+        if m is not None:
+            replacement += ".." if os.sep not in m else os.sep
+
+    return replacement
+
+
+def generate_redirect_url(
+    base_docs_path: Path,
+    canon_file: PurePath,
+    canon_dir_path: PurePath,
+    redirect_dirname: str,
+) -> Tuple[PurePath, str]:
+    """Returns relative URLs for two files with identical paths, except for one level
+
+    :param base_docs_path: base directory for documentation. Both files have an identical path to this point
+    :param canon_file: full path of the canonical file
+    :param canon_dir_path: full path of the directory immediately below :py:data:`base_docs_path`
+        containing :py:data:`canon_file`
+    :param redirect_dirname: name of the directory immediately below :py:data:`base_docs_path`
+        containing the redirect file
+    """
+    redirect_file = base_docs_path.joinpath(redirect_dirname).joinpath(
+        canon_file.relative_to(canon_dir_path)
+    )
+
+    # Generated a relative path via the base directory (ex. "../../..")
+    redirect_url = PurePath(
+        re.sub(
+            REL_PATH_PATTERN,
+            rel_path_replace,
+            str(redirect_file.relative_to(base_docs_path)),
+        )
+    )
+    redirect_url = redirect_url.joinpath(canon_file.relative_to(base_docs_path))
+
+    return redirect_file, str(redirect_url).replace(os.sep, "/")
+
+
+def create_redirect(
+    base_docs_path: Path,
+    latest_docs_path: PurePath,
+    latest_file: PurePath,
+    version: str,
+    use_abs_path: bool,
+) -> None:
+    """Create a versioned redirect for a new documentation page.
+
+    :param base_docs_path: base directory for documentation
+    :param latest_docs_path: directory for latest docs
+    :param latest_file: the file a redirect is being created for
+    :param version: name of the latest version
+    :param use_abs_path: sets redirects to use relative or absolute paths
+    """
+    versioned_file, relative_redirect = generate_redirect_url(
+        base_docs_path, latest_file, latest_docs_path, version
+    )
+    if use_abs_path:
+        relative_redirect = "/" + str(latest_file.relative_to(base_docs_path)).replace(
+            os.sep, "/"
+        )
+
+    os.makedirs(versioned_file.parent, exist_ok=True)
+    with open(versioned_file, "w") as redirect_file:
+        redirect_file.write(relative_redirect.join(REDIRECT_TEMPLATE))
+
+
+def redirect_removed_file(
+    base_docs_path: Path,
+    previous_docs_file: PurePath,
+    current_version: str,
+    previous_version: str,
+    use_abs_path: bool,
+    product_name: str | None,
+) -> None:
+    """Create a redirect for a page found in the previous version, but not the current.
+
+    This method also propagates static redirects found in the previous version.
+
+    :param base_docs_path: base directory for documentation
+    :param previous_docs_file: path of a file present in the previous version
+    :param current_version: name of the latest version
+    :param previous_version: name of the previous version
+    :param use_abs_path: sets redirects to use relative or absolute paths
+    :param product_name: name of the product, if provided
+    """
+    redirect_file, redirect_url = generate_redirect_url(
+        base_docs_path,
+        previous_docs_file,
+        base_docs_path.joinpath(previous_version),
+        "latest",
+    )
+    if use_abs_path:
+        redirect_url = "/" + str(
+            previous_docs_file.relative_to(base_docs_path)
+        ).replace(os.sep, "/")
+
+    # For versioned page of current docs
+    versioned_redirect_file = generate_redirect_url(
+        base_docs_path,
+        previous_docs_file,
+        base_docs_path.joinpath(previous_version),
+        current_version,
+    )[0]
+
+    if not Path(redirect_file).exists():
+        redirect_file_contents: str
+
+        # Extract existing static redirect in the "canonical" page, and use as redirect instead
+        with open(previous_docs_file, "r") as prev_file_io:
+            prev_file = BeautifulSoup(prev_file_io.read(), "html.parser")
+            if static_redirect := prev_file.find(
+                "meta", attrs={"http-equiv": "refresh"}
+            ):
+                canon_link = prev_file.find("link", rel="canonical")
+
+                if canon_link and canon_link["href"] in static_redirect["content"]:
+                    redirect_url = canon_link["href"]
+
+        if product_name:
+            redirect_file_contents = (
+                redirect_url.join(REMOVED_REDIRECT_TEMPLATE[0:3])
+                + f"{product_name} {current_version}"
+                + redirect_url.join(REMOVED_REDIRECT_TEMPLATE[3:6])
+            )
+        else:
+            redirect_file_contents = (
+                redirect_url.join(REMOVED_REDIRECT_TEMPLATE[0:3])
+                + str(current_version)
+                + redirect_url.join(REMOVED_REDIRECT_TEMPLATE[3:6])
+            )
+
+        os.makedirs(redirect_file.parent, exist_ok=True)
+        with open(redirect_file, "w") as red_file_io:
+            red_file_io.write(redirect_file_contents)
+
+        os.makedirs(versioned_redirect_file.parent, exist_ok=True)
+        with open(versioned_redirect_file, "w") as ver_red_file_io:
+            ver_red_file_io.write(redirect_file_contents)
+
+
+def redirect_walker(
+    base_docs_path: Path, latest_docs_path: PurePath, version: str, use_abs_path: bool
+) -> None:
+    """Walk the files contained within the "latest/" directory and create redirects for the versioned path.
+
+    Redirects are only created for HTML pages, since they do not consistently work with images, stylesheets, etc.
+
+    :param base_docs_path: base directory for documentation
+    :param latest_docs_path: directory with new documentation
+    :param version: name of the latest version
+    :param use_abs_path: sets redirects to use relative or absolute paths
+    """
+
+    for parent, dirs, files in os.walk(latest_docs_path):
+        for f in files:
+            if f.endswith(".html"):
+                create_redirect(
+                    base_docs_path,
+                    latest_docs_path,
+                    PurePath(parent, f),
+                    version,
+                    use_abs_path,
+                )
+
+
+def redirect_previous_versions(
+    base_docs_path: Path,
+    previous_docs_path: PurePath,
+    current_version: str,
+    previous_version: str,
+    use_abs_path: bool,
+    product_name: str | None,
+) -> None:
+    """Create redirects from the previous version of the documentation, if pages have been removed.
+
+    :param base_docs_path: base directory for documentation
+    :param previous_docs_path: directory with documentation for previous version
+    :param current_version: name of the current version
+    :param previous_version: name of the previous version
+    :param use_abs_path: sets redirects to use relative or absolute paths
+    :param product_name: name of the product, if provided
+    """
+    for parent, dirs, files in os.walk(previous_docs_path):
+        for f in files:
+            if f.endswith("html"):
+                redirect_removed_file(
+                    base_docs_path,
+                    PurePath(parent, f),
+                    current_version,
+                    previous_version,
+                    use_abs_path,
+                    product_name,
+                )
+
+
+def update_sitemap(base_docs_path: Path) -> None:
+    """Update a file sitemap.xml, located in the same folder as :py:data:`base_docs_path`.
+
+    Sets `lastmod` on all URLs to today's date.
+
+    :param base_docs_path: base directory, containing sitemap.xml
+    """
+    ElementTree.register_namespace("", SITEMAP_NS)
+    revdate = str(datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    sitemap_path = base_docs_path.joinpath("sitemap.xml")
+    tree = ElementTree.parse(sitemap_path)
+
+    for link in tree.getroot().findall(f"{{{SITEMAP_NS}}}url"):
+        for lastmod in link.findall(f"{{{SITEMAP_NS}}}lastmod"):
+            link.remove(lastmod)
+
+        lastmod = SubElement(link, f"{{{SITEMAP_NS}}}lastmod")
+        lastmod.text = revdate
+
+    ElementTree.indent(tree)
+    tree.write(
+        sitemap_path,
+        xml_declaration=True,
+        encoding="utf-8",
+    )
+
+    with open(sitemap_path, "r") as sitemap:
+        decl = sitemap.readline()
+        remainder = sitemap.readlines()
+
+    decl = decl.replace("'", '"')
+    decl_end = decl.rfind("?")
+    decl = decl[:decl_end] + ' standalone="yes" ' + decl[decl_end:]
+    remainder.insert(0, decl)
+
+    with open(sitemap_path, "w") as sitemap:
+        sitemap.writelines(remainder)
+
+
+def setup_argparse() -> ArgumentParser:
+    """Loads args into the argument parser.
+
+    :return: The argument parser
+    """
+    parser = ArgumentParser(
+        prog="update-latest-and-redirects",
+        description="Use `latest` as a canonical path for current documentation. (ex. wildfly.org/latest/)."
+        + " All paths are relative to the parent directory of -s, --source.",
+    )
+    parser.add_argument(
+        "-s",
+        "--source",
+        metavar="directory",
+        help="Required. Directory containing the latest documentation. This directory will be renamed to `latest`. "
+        + "Any existing directory named `latest` will be removed, unless renamed (see -p, --previous).",
+        type=lambda p: Path(p).resolve(),
+        required=True,
+    )
+    parser.add_argument(
+        "-sv",
+        "--source-version",
+        metavar="version",
+        help="Required. Version of the latest documentation (ex. 28). To be used for versioned redirects. "
+        + " Any existing directory with this name will be deleted.",
+        required=True,
+    )
+    parser.add_argument(
+        "-p",
+        "--previous",
+        metavar="directory",
+        help="Folder with canonical links to the previous version of the documentation. If previously configured, "
+        "this argument should be `latest`. If used, the argument -pv, --previous-version is also required.",
+    )
+    parser.add_argument(
+        "-pv",
+        "--previous-version",
+        metavar="version",
+        help="Version of the previous documentation (ex. 27). To be used for redirecting to pages not present in "
+        + "the latest version. Any existing directory with this name will be deleted. If used, the argument "
+        + "-p, --previous is also required.",
+    )
+    parser.add_argument(
+        "--no-absolute-path",
+        help="Do not treat the parent directory of -s, --source as a top level path element when generating redirects. "
+        + "Ex. a source directory at latest-new/ will create a redirect of the form `../latest/index.html` "
+        + "instead of `/latest/index.html`. This may break some redirects.",
+        dest="absolute_path",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--product",
+        metavar="name",
+        help="Name of the product (ex. WildFly), used on redirect pages.",
+    )
+    parser.add_argument(
+        "--update-sitemap",
+        help="Update a file sitemap.xml, located in the same folder as -s, --source.  Sets `lastmod` on all URLs "
+        + "to today's date.",
+        action="store_true",
+    )
+
+    return parser
+
+
+def main():
+    args = setup_argparse().parse_args()
+
+    if (args.previous and not args.previous_version) or (
+        args.previous_version and not args.previous
+    ):
+        print(
+            "Both -p, --previous and -pv, --previous-version are required if either argument is provided",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not args.source.exists():
+        print(f"{args.source} is not a valid directory", file=sys.stderr)
+        sys.exit(1)
+
+    base_docs_path = Path(args.source.parent)
+    latest_docs_path = base_docs_path.joinpath("latest")
+
+    rename_directories(base_docs_path, latest_docs_path, args)
+    redirect_walker(
+        base_docs_path, latest_docs_path, args.source_version, args.absolute_path
+    )
+
+    if args.previous:
+        previous_docs_path = base_docs_path.joinpath(args.previous_version)
+        redirect_previous_versions(
+            base_docs_path,
+            previous_docs_path,
+            args.source_version,
+            args.previous_version,
+            args.absolute_path,
+            args.product,
+        )
+
+    if args.update_sitemap:
+        update_sitemap(base_docs_path)
+
+
+main()


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18316

To implement support for a link of the form `docs.wildlfy.com/latest/`, I've updated the Maven build with a Python script. This script will handle the necessary renaming and reorganization of files when upgrading to a new release. More details on how the script works are included in [the docs README](https://github.com/cam-rod/wildfly/blob/latest-redirect/docs/README.adoc).