### PR TITLE
[WFLY-18047]:Remove legacy Xerces dependency from webservice modules

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
@@ -40,7 +40,6 @@
         <module name="java.xml"/>
         <module name="jakarta.xml.soap.api"/>
         <module name="jakarta.activation.api"/>
-        <module name="org.apache.xerces" services="import" />
     </dependencies>
 
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -80,7 +80,6 @@
           </exports>
         </module>
         <module name="org.apache.commons.codec"/>
-        <module name="org.apache.xerces" services="export" export="true"/>
         <module name="org.jboss.as.webservices" services="export" export="true"/>
         <module name="com.sun.xml.messaging.saaj" services="export" export="true"/>
         <module name="org.apache.ws.security" export="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -43,7 +43,6 @@
         <module name="org.jboss.ws.api"/>
         <module name="org.jboss.ws.spi"/>
         <module name="org.jboss.logging"/>
-        <module name="org.apache.xerces" services="import"/>
         <module name="org.jboss.jaxbintros"/>
     </dependencies>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -131,6 +131,8 @@ public class LayersTestBase {
             // MicroProfile
             "org.wildfly.extension.microprofile.metrics-smallrye",
             "org.wildfly.extension.microprofile.opentracing-smallrye",
+            //xerces dependency is eliminated from different subsystems and use JDK JAXP instead
+            "org.apache.xerces",
     };
     private static final String[] NOT_USED;
     // Packages that are not referenced from the module graph but needed.

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSDependenciesProcessor.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSDependenciesProcessor.java
@@ -30,7 +30,6 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
-import org.jboss.wsf.spi.deployment.Endpoint;
 
 /**
  * A DUP that sets the WS dependencies
@@ -64,12 +63,6 @@ public final class WSDependenciesProcessor implements DeploymentUnitProcessor {
         }
         for(String api : JAVAEE_APIS) {
             moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, api, false, false, true, false));
-        }
-
-        //After jboss modules 2.0, the xerces module is not added and this is required for jaxb 2.3.x(EE8) to pass the TCK
-        //But this is not needed for jaxb 3.x in WildFly Preview(EE10)
-        if (Endpoint.class.getPackage().getImplementationVersion().startsWith("3")) {
-            moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, XERCES_IMPL, true, false, true, false));
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18047