### PR TITLE
[WFLY-18329][WFLY-18317] Upgrade WildFly Core to 22.0.0.Beta1 and fix BouncyCastleModuleTestCase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>21.1.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>22.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
@@ -58,9 +58,7 @@ public class BouncyCastleModuleTestCase {
         archive.addPackage(BouncyCastleModuleTestCase.class.getPackage());
         archive.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml"); //needed to load CDI for arquillian
         archive.addAsManifestResource(createPermissionsXmlAsset(
-                new SecurityPermission("insertProvider"),
-                new SecurityPermission("removeProviderProperty.BC"),
-                new SecurityPermission("putProviderProperty.BC")
+                new SecurityPermission("insertProvider")
         ), "permissions.xml");
         archive.setManifest(new StringAsset(""
                 + "Manifest-Version: 1.0\n"


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18329


Includes:
https://issues.redhat.com/browse/WFLY-18317


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/22.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/21.1.0.Final...22.0.0.Beta1

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6436'>WFCORE-6436</a>] -         Create the ModelTestModelControllerService variants for the WF 29 controllers
</li>
</ul>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6423'>WFCORE-6423</a>] -         Received no final outcome response for operation &quot;reload&quot; when reloading a remote host controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6431'>WFCORE-6431</a>] -         Use InputStream.nullInputStream
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6433'>WFCORE-6433</a>] -         ServerGroupResourceDefinition registers DomainServerLifecycleHandlers in the wrong place
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6440'>WFCORE-6440</a>] -         HttpManagementAddHandler references ServerEnvironment incorrectly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6442'>WFCORE-6442</a>] -         ModuleSpecification discards dependency information
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6435'>WFCORE-6435</a>] -         Make WildFly 29 available in ModelTestControllerVersion
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6438'>WFCORE-6438</a>] -         Remove deprecated for removal VersionedURN subclasses
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6441'>WFCORE-6441</a>] -         Bump the kernel management API version to 23.0.0
</li>
</ul>
                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6371'>WFCORE-6371</a>] -         Rewrite management operations handling in order to support newly introduced o.j.m.s.ServiceTarget.addService() method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6420'>WFCORE-6420</a>] -         Upgrade Apache Commons CLI from 1.4 to 1.5.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6427'>WFCORE-6427</a>] -         Upgrade jboss-logging from 3.4.3.Final to 3.5.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6439'>WFCORE-6439</a>] -         Upgrade JBoss Modules to 2.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6444'>WFCORE-6444</a>] -         Upgrade BouncyCastle to 1.76
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6448'>WFCORE-6448</a>] -         Upgrade Eclipse Parsson from 1.1.3 to 1.1.4
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6321'>WFCORE-6321</a>] -         Expose ServerEnvironment via a capability
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6393'>WFCORE-6393</a>] -         Eliminate usages of deprecated ServiceController.getName() method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6394'>WFCORE-6394</a>] -         Eliminate usages of deprecated ServiceController.getUnavailableDependencies() method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6397'>WFCORE-6397</a>] -         CapabilityServiceTarget should overload addService()
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6398'>WFCORE-6398</a>] -         Avoid redundant array allocation for capability services that provide a value with a single ServiceName
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6399'>WFCORE-6399</a>] -         OperationContext.getServiceTarget() and OperationContext.getCapabilityServiceTarget() methods are redundant
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6400'>WFCORE-6400</a>] -         DeploymentPhaseContext.getServiceTarget() should return object capable of resolving capability requirements
</li>
</ul>
</details>