### PR TITLE
WFLY-18341 Restore incorrectly updated copyright dates in Jipijapa

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2010, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderAdaptorLoader.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderAdaptorLoader.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2023, Red Hat, Inc., and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023, Red Hat, Inc., and individual contributors
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~


### PR DESCRIPTION
This reverts incorrect changes from
096a516e745663a99fce0062ff4bb93a4ca1066f: WFLY-18197 Upgrade to Hibernate Search 6.2.0.CR1

Backport of #17091 to branch `29.x`

https://issues.redhat.com/browse/WFLY-18341

See also https://github.com/jbossas/jboss-eap8/pull/143#issuecomment-1674803759