### PR TITLE
[29.x][WFLY-18350] Constrain the testsuite/galleon/update testing to the minor channel associated with the branch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,9 @@
         <ee.maven.version>${project.version}</ee.maven.version>
         <product.docs.server.version>29</product.docs.server.version>
         <!-- A short variant of product.release.version used in 'startsWith' tests done by dist verification logic -->
-        <verifier.product.release.version>29.0</verifier.product.release.version>
+        <verifier.product.release.version>${product.docs.server.version}.0</verifier.product.release.version>
+        <!-- The Galleon channel for the minor version with which this branch is associated.  -->
+        <galleon.minor.channel>${product.docs.server.version}.0</galleon.minor.channel>
 
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>

--- a/testsuite/galleon/update/pom.xml
+++ b/testsuite/galleon/update/pom.xml
@@ -66,6 +66,7 @@
                                             <env key="MAVEN_LOCAL_REPO" value="${settings.localRepository}"/>
                                             <env key="WF_BASE_VERSION" value="${wildfly.test.galleon.update.base.version}"/>
                                             <env key="WILDFLY_PRODUCER" value="wildfly-ee"/>
+                                            <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="jaxrs-server"/>
                                         </exec>
                                         <exec executable="./run-test.sh" failonerror="true">
@@ -74,6 +75,7 @@
                                             <env key="MAVEN_LOCAL_REPO" value="${settings.localRepository}"/>
                                             <env key="WF_BASE_VERSION" value="${wildfly.test.galleon.update.base.version}"/>
                                             <env key="WILDFLY_PRODUCER" value="wildfly"/>
+                                            <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server"/>
                                         </exec>
                                         <exec executable="./run-test.sh" failonerror="true">
@@ -82,6 +84,7 @@
                                             <env key="MAVEN_LOCAL_REPO" value="${settings.localRepository}"/>
                                             <env key="WF_BASE_VERSION" value="${wildfly.test.galleon.update.base.version}"/>
                                             <env key="WILDFLY_PRODUCER" value="wildfly-preview"/>
+                                            <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server,microprofile-platform,-microprofile-fault-tolerance"/>
                                         </exec>
                                     </tasks>

--- a/testsuite/galleon/update/run-test.sh
+++ b/testsuite/galleon/update/run-test.sh
@@ -27,7 +27,7 @@ echo "Testing update of ${WILDFLY_PRODUCER} from ${WF_BASE_VERSION} to ${WILDFLY
 wildflyDir="${BASE_DIR}"/target/${WILDFLY_PRODUCER}
 rm -rf "${wildflyDir}"
 
-"${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh install ${WILDFLY_PRODUCER}:current/snapshot#${WF_BASE_VERSION} \
+"${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh install ${WILDFLY_PRODUCER}:${WILDFLY_CHANNEL}/snapshot#${WF_BASE_VERSION} \
 --dir="${wildflyDir}"
 "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh update --yes --dir="${wildflyDir}"
 "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh get-info --type=configs --dir="${wildflyDir}"
@@ -37,7 +37,7 @@ echo "Testing update of ${WILDFLY_PRODUCER} with Galleon layers from ${WF_BASE_V
 # Layers base update
 wildflyLayersDir="${BASE_DIR}"/target/${WILDFLY_PRODUCER}-layers
 rm -rf "${wildflyLayersDir}"
-"${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh install ${WILDFLY_PRODUCER}:current/snapshot#${WF_BASE_VERSION} \
+"${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh install ${WILDFLY_PRODUCER}:${WILDFLY_CHANNEL}/snapshot#${WF_BASE_VERSION} \
 --dir="${wildflyLayersDir}" --layers=${GALLEON_LAYERS}
 "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh update --yes --dir="${wildflyLayersDir}"
 "${BASE_DIR}"/target/galleon/galleon-${GALLEON_VERSION}/bin/galleon.sh get-info --type=configs --dir="${wildflyLayersDir}"


### PR DESCRIPTION
…nor channel associated with the branch

Issue: https://issues.redhat.com/browse/WFLY-18350
Upstream: https://github.com/wildfly/wildfly/pull/17101