### PR TITLE
[WFLY-18343] Split Elytron SSL into its own subsystem and layer

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
@@ -16,19 +16,19 @@
 package org.wildfly.test.integration.elytron.securityapi;
 
 import java.security.Principal;
+import java.util.function.Function;
 
-import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.extension.elytron.common.capabilities.PrincipalTransformer;
 
 /**
  * A simple {@link PrincipalTransformer} that also converts into a {@link TestCustomPrincipal custom principal}.
  *
  * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
  */
-public class TestCustomPrincipalTransformer implements PrincipalTransformer {
+public class TestCustomPrincipalTransformer implements Function<Principal, Principal> {
 
     @Override
     public Principal apply(Principal principal) {
         return new TestCustomPrincipal(principal);
     }
-
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18343

This PR also updates the custom principal test cases for WildFly 29.
