### PR TITLE
[WFLY-18353] Update TestCustomPrincipalTransformer to no longer rely on the Elytron subsystem

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -269,11 +269,6 @@
             <artifactId>wildfly-cli</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- Required for Java 11 -->
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreI18NTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreI18NTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
@@ -99,7 +98,7 @@ public class CredentialStoreI18NTestCase extends AbstractCredentialStoreTestCase
             Assert.assertFalse(cli.sendLine("/subsystem=elytron/credential-store=CredentialStoreI18NTestCase:add-alias(alias=LOWER, secret-value=password)", true));
             ModelNode result = ModelNode.fromString(cli.readOutput());
             assertEquals("result " + result, result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).asString(),
-                    ElytronSubsystemMessages.ROOT_LOGGER.credentialAlreadyExists("LOWER", PasswordCredential.class.getName()).getMessage());
+                    String.format("WFLYELY00913: Credential alias '%s' of credential type '%s' already exists in the store", "LOWER", PasswordCredential.class.getName()));
         }
     }
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreTestCase.java
@@ -37,7 +37,6 @@ import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
@@ -148,7 +147,7 @@ public class CredentialStoreTestCase extends AbstractCredentialStoreTestCase {
                         CS_NAME_MODIFIABLE, alias, alias), true);
                 ModelNode result = ModelNode.fromString(cli.readOutput());
                 assertEquals("result " + result, result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).asString(),
-                        ElytronSubsystemMessages.ROOT_LOGGER.credentialAlreadyExists(alias, PasswordCredential.class.getName()).getMessage());
+                        String.format("WFLYELY00913: Credential alias '%s' of credential type '%s' already exists in the store", alias, PasswordCredential.class.getName()));
             } finally {
                 cli.sendLine(
                         String.format("/subsystem=elytron/credential-store=%s:remove-alias(alias=%s)", CS_NAME_MODIFIABLE, alias));

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securityapi/TestCustomPrincipalTransformer.java
@@ -16,19 +16,17 @@
 package org.wildfly.test.integration.elytron.securityapi;
 
 import java.security.Principal;
-
-import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import java.util.function.Function;
 
 /**
- * A simple {@link PrincipalTransformer} that also converts into a {@link TestCustomPrincipal custom principal}.
+ * A simple principal transformer that converts into a {@link TestCustomPrincipal custom principal}.
  *
  * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
  */
-public class TestCustomPrincipalTransformer implements PrincipalTransformer {
+public class TestCustomPrincipalTransformer implements Function<Principal, Principal> {
 
     @Override
     public Principal apply(Principal principal) {
         return new TestCustomPrincipal(principal);
     }
-
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18353

This fix is also needed to fully implement wildfly/wildfly-core#5561.
