### PR TITLE
WFLY-18360 Make it more clear when Persistence unit deployment fails due to bytecode enhancement failure

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -753,7 +753,7 @@ public interface JpaLogger extends BasicLogger {
 
     // id = 72, value = "Could not obtain TransactionListenerRegistry from transaction manager")
 
-    @Message(id = 73, value = "Transformation of class %s failed")
+    @Message(id = 73, value = "Bytecode rewrite (transformation) of class %s failed")
     IllegalStateException invalidClassFormat(@Cause Exception cause, String className);
 
     // @Message(id = 74, value = "Deprecated Hibernate51CompatibilityTransformer is enabled for all application deployments.")

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -754,7 +754,7 @@ public interface JpaLogger extends BasicLogger {
     // id = 72, value = "Could not obtain TransactionListenerRegistry from transaction manager")
 
     @Message(id = 73, value = "Bytecode rewrite (transformation) of class %s failed")
-    IllegalStateException invalidClassFormat(String className);
+    String invalidClassFormat(String className);
 
     // @Message(id = 74, value = "Deprecated Hibernate51CompatibilityTransformer is enabled for all application deployments.")
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -754,7 +754,7 @@ public interface JpaLogger extends BasicLogger {
     // id = 72, value = "Could not obtain TransactionListenerRegistry from transaction manager")
 
     @Message(id = 73, value = "Bytecode rewrite (transformation) of class %s failed")
-    IllegalStateException invalidClassFormat(@Cause Exception cause, String className);
+    IllegalStateException invalidClassFormat(String className);
 
     // @Message(id = 74, value = "Deprecated Hibernate51CompatibilityTransformer is enabled for all application deployments.")
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
@@ -73,8 +73,10 @@ class JPADelegatingClassFileTransformer implements ClassTransformer {
                                 // because we won't ever be called to transform already loaded classes.
                                 result = transformer.transform(classLoader, className, null, protectionDomain, transformedBuffer);
                             } catch (Exception e) {
-                                ROOT_LOGGER.error(JpaLogger.ROOT_LOGGER.invalidClassFormat(className),e);
-                                throw JpaLogger.ROOT_LOGGER.invalidClassFormat(className);
+                                String message = JpaLogger.ROOT_LOGGER.invalidClassFormat(className);
+                                // ModuleClassLoader.defineClass discards the cause of the exception we throw, so to ensure it is logged we log it here.
+                                ROOT_LOGGER.error(message,e);
+                                throw new IllegalStateException(message);
                             }
                             if (result != null) {
                                 transformedBuffer = result;

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADelegatingClassFileTransformer.java
@@ -73,7 +73,8 @@ class JPADelegatingClassFileTransformer implements ClassTransformer {
                                 // because we won't ever be called to transform already loaded classes.
                                 result = transformer.transform(classLoader, className, null, protectionDomain, transformedBuffer);
                             } catch (Exception e) {
-                                throw JpaLogger.ROOT_LOGGER.invalidClassFormat(e, className);
+                                ROOT_LOGGER.error(JpaLogger.ROOT_LOGGER.invalidClassFormat(className),e);
+                                throw JpaLogger.ROOT_LOGGER.invalidClassFormat(className);
                             }
                             if (result != null) {
                                 transformedBuffer = result;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18360 

This was initially thought to be a bug but instead it is for just improving the error message shown in the WildFly console and sent to the WildFly client (e.g. mvn clean verify wildfly:deploy) if all goes well.