### PR TITLE
WFLY-18374 + WFLY-18375 Upgrade to Hibernate Search 6.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
         <version.org.eclipse.microprofile.telemetry>1.0</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.0</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>8.8.2</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.9.0</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.1</version.org.glassfish.jaxb>

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.2.6.Final</version.org.hibernate>
-        <version.org.hibernate.search>6.2.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>6.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.13.Final</version.org.infinispan>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -9,7 +9,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.8.2";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.9.0";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 


### PR DESCRIPTION
* [WFLY-18375](https://issues.redhat.com/browse/WFLY-18375): Upgrade to Elasticsearch client 8.9.0
* [WFLY-18374](https://issues.redhat.com/browse/WFLY-18374): Upgrade to Hibernate Search 6.2.1.Final

