### PR TITLE
[WFLY-18376] Upgrade RESTEasy to 6.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
         <version.org.jboss.mod_cluster>2.0.2.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.2.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.2.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.3.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18376
