### PR TITLE
[WFLY-18348] PermissionUtils should delegate to the WildFly Core variant where possible

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -501,18 +501,6 @@
                 <version>${version.org.wildfly.extras.creaper}</version>
                 <scope>test</scope>
             </dependency>
-
-            <dependency>
-                <groupId>xom</groupId>
-                <artifactId>xom</artifactId>
-                <version>${version.xom}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
         </dependencies>
 
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,6 @@
         <version.org.wildfly.arquillian>5.0.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.extras.creaper>1.6.2</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>
-        <version.xom>1.3.8</version.xom>
 
         <!--
             *Non-plugin* PRODUCTION CODE dependency versions. Please keep alphabetical.

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -244,11 +244,6 @@
             <artifactId>wildfly-elytron-ssl</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/JVMServerPropertiesTestCase.java
@@ -35,7 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestSupport.safeClose;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.domain.management.cli;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.net.SocketPermission;

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -774,10 +774,6 @@
             <artifactId>wildfly-http-transaction-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-        </dependency>
-        <dependency>
             <groupId>wsdl4j</groupId>
             <artifactId>wsdl4j</artifactId>
         </dependency>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.batch.chunk;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.net.URL;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.batch.common;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.batch.deployment;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.io.IOException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.bc;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/BeanValidationEE8TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/BeanValidationEE8TestCase.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A test validating the Jakarta Bean Validation 2.0 support.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureDepedenciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureDepedenciesTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 @RunWith(Arquillian.class)
 public class EarJbossStructureDepedenciesTestCase {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarChildFirstClassLoadingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarChildFirstClassLoadingTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.war;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.ejb.Stateless;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarInEarChildFirstClassLoadingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarInEarChildFirstClassLoadingTestCase.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jboss.as.test.integration.common.WebInfLibClass;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 @RunWith(Arquillian.class)
 public class WarInEarChildFirstClassLoadingTestCase {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/JCETestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/JCETestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.integration.deployment.jcedeployment;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/EarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/EarJBossDeploymentStructureTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.integration.deployment.structure.ear;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import jakarta.ejb.EJB;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.integration.deployment.structure.jar;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import jakarta.ejb.EJB;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ee.concurrent;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.permission.ElytronPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Test for EE's default ManagedExecutorService

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ee.concurrent;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ee.concurrent;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 import java.util.concurrent.Callable;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/EEConcurrentManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/EEConcurrentManagementTestCase.java
@@ -26,7 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/HungTasksTerminationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/HungTasksTerminationTestCase.java
@@ -58,7 +58,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Test case for managed executor's hung tasks termination feature.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceMetricsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedExecutorServiceMetricsTestCase.java
@@ -61,7 +61,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Test case for managed executor runtime stats

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/websocket/WebSocketInjectionSupportTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/websocket/WebSocketInjectionSupportTestCase.java
@@ -45,7 +45,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author Matus Abaffy

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/lifecycle/servlet/LifecycleInterceptionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/lifecycle/servlet/LifecycleInterceptionTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author Matus Abaffy

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/remotelookup/LookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/remotelookup/LookupTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ee.remotelookup;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.SocketPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/EEConcurrencySuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/EEConcurrencySuspendTestCase.java
@@ -26,7 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND_STATE;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/serverside/ServerInterceptorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/serverside/ServerInterceptorsTestCase.java
@@ -27,7 +27,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OP_ADDR;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertTrue;
 import java.io.FilePermission;
 import java.util.Collections;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/serverside/protocol/RemoteProtocolChangeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/serverside/protocol/RemoteProtocolChangeTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.interceptor.serverside.protocol;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Collections;
 import java.util.Hashtable;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessageDrivenBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessageDrivenBeanTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.mdb;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
@@ -47,7 +47,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.io.IOException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationconfig/unit/MDBActivationConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/activationconfig/unit/MDBActivationConfigTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.integration.ejb.mdb.activationconfig.unit;
 
 import static org.jboss.as.test.integration.ejb.mdb.activationconfig.JMSHelper.assertSendAndReceiveTextMessage;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 import java.util.UUID;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBCdiIntegrationTestCase.java
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that the CDI request scope is active in MDB invocations.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.integration.ejb.mdb.cdi;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.util.Hashtable;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.integration.ejb.mdb.cmt.notsupported;
 
 import static org.jboss.as.test.shared.TimeoutUtil.adjust;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/SendMessagesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/SendMessagesTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.integration.ejb.mdb.containerstart;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jboss.as.test.integration.common.jms.JMSOperationsProvider.getInstance;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
@@ -48,7 +48,7 @@ import java.util.PropertyPermission;
 
 import static org.jboss.as.test.integration.ejb.mdb.dynamic.impl.TtyCodes.TTY_Bright;
 import static org.jboss.as.test.integration.ejb.mdb.dynamic.impl.TtyCodes.TTY_Reset;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
@@ -43,7 +43,7 @@ import jakarta.jms.Queue;
 import javax.naming.InitialContext;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.jms.QueueRequestor;
 import jakarta.jms.QueueSession;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
@@ -45,7 +45,7 @@ import jakarta.jms.Queue;
 import javax.naming.InitialContext;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.jms.QueueRequestor;
 import jakarta.jms.QueueSession;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
@@ -48,7 +48,7 @@ import javax.naming.InitialContext;
 import java.io.FilePermission;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import jakarta.jms.QueueRequestor;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
@@ -43,7 +43,7 @@ import jakarta.jms.Queue;
 import javax.naming.InitialContext;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests EJB2.1 MDB deployments.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that the {@link jakarta.ejb.MessageDrivenBean#setMessageDrivenContext(jakarta.ejb.MessageDrivenContext)}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
@@ -46,7 +46,7 @@ import jakarta.jms.TextMessage;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that if a message listener interface is implemented by the base class of a message driven bean, then

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/objectmessage/unit/ObjectMessageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/objectmessage/unit/ObjectMessageTestCase.java
@@ -52,7 +52,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that a MDB can get hold of the underlying Object from a {@link ObjectMessage} without any classloading issues.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameTestCase.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 @RunWith(Arquillian.class)
 @ServerSetup({ConfiguredResourceAdapterNameTestCase.JmsQueueSetup.class})

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterNameTestCase.java
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * User: jpai

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/vaultedproperties/MDBWithVaultedPropertiesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/vaultedproperties/MDBWithVaultedPropertiesTestCase.java
@@ -27,7 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.wildfly.test.security.common.SecureExpressionUtil.getDeploymentPropertiesAsset;
 import static org.wildfly.test.security.common.SecureExpressionUtil.setupCredentialStore;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.as.test.integration.ejb.pool.lifecycle;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/override/PoolOverrideTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/override/PoolOverrideTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.pool.override;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/RemoteAsyncInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/RemoteAsyncInvocationTestCase.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Simple remote ejb tests

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.remote.client.api.interceptor;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.HashMap;
 import java.util.Hashtable;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.remote.security;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -23,7 +23,7 @@ package org.jboss.as.test.integration.ejb.security;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MDBRoleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MDBRoleTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.security;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MixedSecurityAnnotationAuthorizationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MixedSecurityAnnotationAuthorizationTestCase.java
@@ -29,7 +29,7 @@ import jakarta.ejb.EJBAccessException;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -64,7 +64,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.security.auth.permission.ChangeRoleMapperPermission;
 import org.wildfly.security.permission.ElytronPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Migration of test from EJB3 testsuite [JBQA-5451] Testing calling with runasprincipal annotation (ejbthree1945)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.security.callerprincipal;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/RunAsMDBUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/RunAsMDBUnitTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.security.runas.mdb;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.security.singleton;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.servlet;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.URL;
 import java.util.concurrent.TimeUnit;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/MDBWhichDependsOnTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/MDBWhichDependsOnTestCase.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * WFLY-2732 - test if MDB can access @DependsOn ejbs in @PostConstruct and @PreDestroy annotated methods.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/reentrant/SingletonReentrantTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/reentrant/SingletonReentrantTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.singleton.reentrant;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationFailedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationFailedTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestBase2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestBase2.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.stateful.timeout;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.threadpool;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import javax.naming.InitialContext;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/security/runas/TimeoutMethodWithRunAsAnnotationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/security/runas/TimeoutMethodWithRunAsAnnotationTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.timerservice.security.runas;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import javax.naming.InitialContext;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/suspend/TimerServiceSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/suspend/TimerServiceSuspendTestCase.java
@@ -42,7 +42,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests suspend/resume for non-calendar based timers

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessTimeoutTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.transaction.bmt.timeout;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.transaction.cmt.fail;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
@@ -32,7 +32,7 @@ import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig
 import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException.NONE;
 import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException.ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION;
 import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException.ROLLBACK_CAUSED_BY_XA_EXCEPTION;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.rmi.RemoteException;
 import java.security.AllPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenTimeoutTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 import jakarta.inject.Inject;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
@@ -39,7 +39,7 @@ import org.jboss.as.test.integration.jaxb.bindings.Items;
 import org.jboss.as.test.integration.jaxb.bindings.ObjectFactory;
 import org.jboss.as.test.integration.jaxb.bindings.PurchaseOrderType;
 import org.jboss.as.test.integration.jaxb.bindings.USAddress;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
 import static org.wildfly.common.Assert.checkNotNullParamWithNullPointerException;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
@@ -25,7 +25,7 @@
 package org.jboss.as.test.integration.jca.capacitypolicies;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.ReflectPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/classloading/custommodule/DatasourceCustomModulesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/classloading/custommodule/DatasourceCustomModulesTestCase.java
@@ -31,7 +31,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.REMOVE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
@@ -25,7 +25,7 @@ package org.jboss.as.test.integration.jca.datasource;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.sql.Connection;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceSetTxQueryTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceSetTxQueryTimeoutTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.as.test.integration.jca.datasource;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.sql.Connection;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/flushing/FlushOperationsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/flushing/FlushOperationsTestCase.java
@@ -62,7 +62,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.REMOVE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Test for flush operations on data source pools:

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMaxPoolAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMaxPoolAttributeTestCase.java
@@ -27,7 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.annotation.Resource;
 import javax.sql.DataSource;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMinPoolAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMinPoolAttributeTestCase.java
@@ -27,7 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.annotation.Resource;
 import javax.sql.DataSource;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
@@ -27,7 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -24,7 +24,7 @@
 package org.jboss.as.test.integration.jca.poolattributes;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronEnabledTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/workmanager/WildFlyActivationRaWithWMElytronSecurityDomainWorkManagerElytronEnabledTestCase.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.security.Principal;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
@@ -46,7 +46,7 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.jca.rar.MultipleResourceAdapter3;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/el/FacesExpressionFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/el/FacesExpressionFactoryTestCase.java
@@ -20,7 +20,7 @@
 
 package org.jboss.as.test.integration.jsf.el;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.jsf.version;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.io.IOException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/expression/ExpressionSubstitutionInContainerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/expression/ExpressionSubstitutionInContainerTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.management.api.expression;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.util.PropertyPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/InjectedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/InjectedJMSContextTestCase.java
@@ -25,7 +25,7 @@ package org.jboss.as.test.integration.messaging.jms.context;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.jboss.as.test.shared.TimeoutUtil.adjust;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.PropertyPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/ScopedInjectedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/ScopedInjectedJMSContextTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.integration.messaging.jms.context;
 
 import static jakarta.jms.DeliveryMode.NON_PERSISTENT;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/VaultedInjectedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/VaultedInjectedJMSContextTestCase.java
@@ -28,7 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.test.shared.TimeoutUtil.adjust;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.wildfly.test.security.common.SecureExpressionUtil.getDeploymentPropertiesAsset;
 import static org.wildfly.test.security.common.SecureExpressionUtil.setupCredentialStore;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notclosinginjectedcontext/NotClosingInjectedContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notclosinginjectedcontext/NotClosingInjectedContextTestCase.java
@@ -66,7 +66,7 @@ import static org.jboss.as.test.shared.TimeoutUtil.adjust;
 import java.io.File;
 import java.io.FilePermission;
 import java.net.SocketPermission;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.remoting3.security.RemotingPermission;
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.messaging.jms.context.transactionscoped;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import jakarta.annotation.Resource;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/DependentMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/DependentMessagingDeploymentTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.messaging.jms.deployment;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.integration.messaging.jms.external;
 import static org.jboss.as.controller.client.helpers.ClientConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JndiLookupMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JndiLookupMessagingDeploymentTestCase.java
@@ -16,7 +16,7 @@
 
 package org.jboss.as.test.integration.messaging.jms.naming;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/ScheduledThreadPoolMetricsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/ScheduledThreadPoolMetricsTestCase.java
@@ -48,7 +48,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/ThreadPoolMetricsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/ThreadPoolMetricsTestCase.java
@@ -47,7 +47,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -37,7 +37,7 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.CLASS;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.ENVIRONMENT;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.EXTERNAL_CONTEXT;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.MODULE;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.security.Security;
 import javax.naming.Context;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/RebindTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/RebindTestCase.java
@@ -40,7 +40,7 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.REBIND;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.SIMPLE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.VALUE;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.net.URL;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/URLBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/URLBindingTestCase.java
@@ -35,7 +35,7 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING_TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.SIMPLE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.VALUE;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.net.URL;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
@@ -41,7 +41,7 @@ import java.net.SocketPermission;
 import java.rmi.registry.LocateRegistry;
 import java.util.Properties;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that JMX Connector work properly from container.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/injection/LinkRefResourceInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/injection/LinkRefResourceInjectionTestCase.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.java.permission.JndiPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A test which enforces that

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.naming.ldap;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.net.SocketPermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/local/simple/DeploymentWithBindTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/local/simple/DeploymentWithBindTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.integration.naming.local.simple;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertNotNull;
 
 import javax.naming.InitialContext;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.naming.remote.ejb;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import org.jboss.as.test.integration.security.common.Utils;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import org.jboss.remoting3.security.RemotingPermission;
 import static org.junit.Assert.assertEquals;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -1,7 +1,7 @@
 package org.jboss.as.test.integration.naming.remote.multiple;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.FilePermission;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingHTTPTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingHTTPTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.naming.remote.simple;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URI;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -41,7 +41,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 
 import javax.naming.InitialContext;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  *

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/SharedBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/SharedBindingTestCase.java
@@ -38,7 +38,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.concurrent.TimeUnit;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A test case which verifies proper release of shared binds, i.e., automated unbind only after every deployment that shares the bind is undeployed.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.integration.sar;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.IoUtils;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that the MBean instance lifecycle has the correct TCCL set. The TCCL is expected to be the classloader of the deployment through which the MBean was deployed.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/order/ServiceMBeanSupportOrderingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/order/ServiceMBeanSupportOrderingTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.sar.order;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.java.permission.JndiPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Test MBeans which implement {@link ServiceMBean} and extend {@link ServiceMBeanSupport}.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.integration.security.jacc.context;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java
@@ -58,7 +58,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests for EAP7-981 / WFLY-10009

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/TransactionStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/TransactionStatisticsTestCase.java
@@ -55,7 +55,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_GROUP_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 @RunWith(Arquillian.class)
 @ServerSetup({TransactionStatisticsTestCase.TransactionEnabledSetup.class})

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.integration.transaction.inflow;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
 import java.util.Hashtable;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
@@ -49,7 +49,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.ServerReload;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
@@ -20,7 +20,7 @@ package org.jboss.as.test.integration.web.servlet.preservepath;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/suspend/WebSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/suspend/WebSuspendTestCase.java
@@ -49,7 +49,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests for suspend/resume functionality in the web subsystem

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
@@ -41,7 +41,7 @@ import javax.naming.NamingException;
 import java.util.PropertyPermission;
 import java.util.concurrent.TimeUnit;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests possible deployment scenarios for CDI ApplicationScoped events, and usage of other EE technologies in such event handlers.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/xerces/unit/XercesUsageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/xerces/unit/XercesUsageTestCase.java
@@ -38,7 +38,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.xerces.JSFManagedBean;
 import org.jboss.as.test.integration.xerces.XercesUsageServlet;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.test.integration.weld.beanarchives;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/builtinBeans/InjectPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/builtinBeans/InjectPrincipalTestCase.java
@@ -15,7 +15,7 @@
  */
 package org.wildfly.test.integration.weld.builtinBeans;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -438,11 +438,6 @@
             <artifactId>wildfly-http-transaction-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.clustering;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.forwarding;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
 
 import java.net.SocketPermission;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
@@ -40,7 +40,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SecureStatelessIncre
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
@@ -34,7 +34,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.HeartbeatBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.ejb.client.ClusterNodeSelector;
 import org.jboss.ejb.client.EJBClientConnection;
 import org.jboss.ejb.client.EJBClientContext;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
@@ -38,7 +38,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.InfinispanExceptionT
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/PassivationDisabledRemoteStatefulEjbFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/PassivationDisabledRemoteStatefulEjbFailoverTestCase.java
@@ -14,7 +14,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -42,7 +42,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SlowStatefulIncremen
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
@@ -32,7 +32,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
@@ -37,7 +37,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.HeartbeatBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
@@ -41,7 +41,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorB
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.ServerReload;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatelessTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatelessTestCase.java
@@ -48,7 +48,7 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingletonRemote;
 import org.jboss.as.test.integration.transactions.RemoteLookups;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -38,7 +38,7 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.CLIServerSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
@@ -37,7 +37,7 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.NamingEJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.ejb.client.ClusterNodeSelector;
 import org.jboss.ejb.client.EJBClientConnection;
 import org.jboss.ejb.client.EJBClientContext;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/SuspendResumeRemoteEJB2TestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/SuspendResumeRemoteEJB2TestCase.java
@@ -39,7 +39,7 @@ import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.SlowHeartbeatBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.clustering.cluster.ejb2.stateful.failover;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.clustering.cluster.ejb2.stateful.failover.dd;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.clustering.cluster.ejb2.stateless;
 
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/GroupListenerTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/GroupListenerTestCase.java
@@ -34,7 +34,7 @@ import org.jboss.as.test.clustering.cluster.group.bean.ClusterTopologyRetrieverB
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/infinispan/AbstractCacheTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/infinispan/AbstractCacheTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.clustering.cluster.infinispan;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.lang.reflect.ReflectPermission;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -12,7 +12,7 @@ import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriev
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.clustering.cluster.registry;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.*;
 
 import java.util.Collection;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
@@ -41,7 +41,7 @@ import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.singleton.service.ValueServiceActivator;
 import org.jboss.as.test.clustering.cluster.singleton.service.ValueServiceServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
@@ -31,7 +31,7 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.clustering.single.provider;
 
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.*;
 
 import java.util.Collection;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.clustering.single.registry;
 
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.*;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.*;
 
 import java.util.Collection;

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -133,11 +133,6 @@
             <artifactId>wildfly-naming-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/OidcIdentityPropagationTestCase.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/propagation/OidcIdentityPropagationTestCase.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.operations.common.Util.createAddOperation;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assume.assumeTrue;
 import static org.wildfly.test.integration.elytron.oidc.client.KeycloakConfiguration.getRealmRepresentation;
 import static org.wildfly.test.integration.elytron.oidc.client.OidcBaseTest.KEYCLOAK_CONTAINER;

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -140,11 +140,6 @@
             <artifactId>jboss-ejb-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- This is not ideal, however the BatchPermission is used which does indicate this might be an issue -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/AbstractCredentialStoreTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/AbstractCredentialStoreTestCase.java
@@ -53,7 +53,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
@@ -47,7 +47,7 @@ import org.jboss.as.test.shared.CdiUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
@@ -23,7 +23,7 @@ package org.wildfly.test.integration.elytron.ejb;
 
 import static org.wildfly.test.integration.elytron.util.HttpUtil.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/DefaultElytronEjbSecurityDomainTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/DefaultElytronEjbSecurityDomainTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.elytron.ejb;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/IdentityPropagationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/IdentityPropagationTestCase.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.operations.common.Util.createAddOperation;
 import static org.jboss.as.controller.operations.common.Util.getUndefineAttributeOperation;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.test.integration.elytron.util.HttpUtil.get;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
@@ -22,7 +22,7 @@
 package org.wildfly.test.integration.elytron.realm;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.wildfly.test.integration.elytron.realm.AggregateRealmUtil.assertAttribute;
 import static org.wildfly.test.integration.elytron.realm.AggregateRealmUtil.assertAuthenticationFailed;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmWithTransformerTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmWithTransformerTestCase.java
@@ -55,7 +55,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.hamcrest.CoreMatchers.is;
 
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.elytron.realm.AggregateRealmUtil.assertAttribute;
 import static org.wildfly.test.integration.elytron.realm.AggregateRealmUtil.assertAuthenticationFailed;
 import static org.wildfly.test.integration.elytron.realm.AggregateRealmUtil.assertAuthenticationSuccess;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JdbcRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JdbcRealmTestCase.java
@@ -17,7 +17,7 @@
 package org.wildfly.test.integration.elytron.realm;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URL;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/web/WebAuthenticationTestCaseBase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/web/WebAuthenticationTestCaseBase.java
@@ -23,7 +23,7 @@
 package org.wildfly.test.integration.elytron.web;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.wildfly.test.integration.elytron.util.HttpUtil.get;
 

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -96,11 +96,6 @@
             <artifactId>wildfly-transaction-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/BasicIIOPInvocationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/BasicIIOPInvocationTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.PropertiesValueResolver;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/security/IIOPSecurityInvocationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/security/IIOPSecurityInvocationTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.PropertiesValueResolver;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/TransactionIIOPInvocationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/TransactionIIOPInvocationTestCase.java
@@ -40,7 +40,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.PropertiesValueResolver;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/IIOPTimeoutTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/IIOPTimeoutTestCase.java
@@ -50,7 +50,7 @@ import java.rmi.RemoteException;
 import java.rmi.ServerException;
 import java.util.PropertyPermission;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests on transaction timeout behavior with SLSB beans

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -321,11 +321,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-client-all</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/transaction/preparehalt/TransactionPropagationFailureTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/transaction/preparehalt/TransactionPropagationFailureTestCase.java
@@ -62,7 +62,7 @@ import java.util.Arrays;
 import java.util.PropertyPermission;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Testing transaction recovery on cases where WildFly calls remote Jakarta Enterprise Beans on the other WildFly instance.

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ActivemqServerAddonsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ActivemqServerAddonsTestCase.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.as.test.manualmode.messaging;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/NongracefulStartTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/server/nongraceful/NongracefulStartTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.manualmode.server.nongraceful;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
 import java.util.PropertyPermission;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/builtinBeans/LegacyCompliantPrincipalPropagationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/builtinBeans/LegacyCompliantPrincipalPropagationTestCase.java
@@ -40,7 +40,7 @@ import org.wildfly.security.auth.permission.ChangeRoleMapperPermission;
 import org.wildfly.security.permission.ElytronPermission;
 
 import static org.jboss.as.controller.client.helpers.Operations.createWriteAttributeOperation;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 
 /**

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/extension/BeforeShutdownJNDILookupTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/extension/BeforeShutdownJNDILookupTestCase.java
@@ -6,7 +6,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
@@ -24,7 +24,7 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/ServerChainSecurityContextPropagationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/ServerChainSecurityContextPropagationTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.test.manual.elytron.seccontext;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -47,6 +47,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance</artifactId>
             <scope>test</scope>
@@ -74,11 +79,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.extension.microprofile.faulttolerance.tck;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -315,12 +315,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- TODO confirm if this is needed -->
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
@@ -53,7 +53,7 @@ import java.util.PropertyPermission;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.kafka.serializer;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.kafka.ssl;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.kafka.tx;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/config/ConnectorConfigTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/config/ConnectorConfigTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.config;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.checkList;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/config/ConnectorProfileConfigTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/config/ConnectorProfileConfigTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.config;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 
 import java.util.List;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/ProcessorSignatureTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/ProcessorSignatureTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.signatures;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.checkList;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/PublisherSignatureTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/PublisherSignatureTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.signatures;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.checkList;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/SubscriberSignatureTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/SubscriberSignatureTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.signatures;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.checkList;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/TransformerSignatureTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/ported/signatures/TransformerSignatureTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.ported.signatures;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.await;
 import static org.wildfly.test.integration.microprofile.reactive.messaging.ported.utils.ReactiveMessagingTestUtils.checkList;
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.rest.channels;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/sanity/ReactiveMessagingSanityTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/sanity/ReactiveMessagingSanityTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.sanity;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.PropertyPermission;
 import java.util.concurrent.TimeUnit;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/tx/ReactiveMessagingTransactionTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/tx/ReactiveMessagingTransactionTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.tx;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Collections;
 import java.util.PropertyPermission;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/streams/operators/ReactiveStreamsOperatorsInjectedReactiveEngineProviderSanityTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/streams/operators/ReactiveStreamsOperatorsInjectedReactiveEngineProviderSanityTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.streams.operators;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.util.List;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/streams/operators/ReactiveStreamsOperatorsNoReactiveEngineProviderSanityTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/streams/operators/ReactiveStreamsOperatorsNoReactiveEngineProviderSanityTestCase.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive.streams.operators;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
 import java.util.List;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -19,7 +19,7 @@
 
 package org.wildfly.test.integration.observability.opentelemetry;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import jakarta.inject.Inject;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -93,11 +93,6 @@
             <artifactId>wildfly-transaction-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
@@ -28,7 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.getRemoteContext;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.net.SocketPermission;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/RemoteCallClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/RemoteCallClientInterceptorTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.multinode.clientinterceptor;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/multiple/MultipleClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/multiple/MultipleClientInterceptorTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.multinode.clientinterceptor.multiple;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
 import java.security.SecurityPermission;
 import java.util.Arrays;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/protocol/RemoteProtocolChangeClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/protocol/RemoteProtocolChangeClientInterceptorTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.multinode.clientinterceptor.protocol;
 
 import static org.jboss.as.test.shared.TestSuiteEnvironment.getSystemProperty;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/secured/SecuredBeanClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/secured/SecuredBeanClientInterceptorTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.multinode.clientinterceptor.secured;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.FilePermission;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpDescriptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpDescriptorTestCase.java
@@ -41,7 +41,7 @@ import javax.naming.InitialContext;
 import java.net.SocketPermission;
 import java.util.Arrays;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 
 /**

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
@@ -57,7 +57,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 
 /**

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.multinode.ejb.http;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
 import java.util.Arrays;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -28,7 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.getRemoteContext;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
@@ -32,7 +32,7 @@ import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServic
 import static org.jboss.as.test.multinode.ejb.timer.database.RefreshIF.Info.CLIENT1;
 import static org.jboss.as.test.multinode.ejb.timer.database.RefreshIF.Info.RETURN_HANDLE;
 import static org.jboss.as.test.multinode.ejb.timer.database.RefreshIF.Info.SERVER1;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
@@ -28,7 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.multinode.remotecall;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.security.SecurityPermission;
 import java.util.Arrays;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
@@ -40,7 +40,7 @@ import java.io.FilePermission;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A test case for testing the feature introduced in https://issues.jboss.org/browse/EJBCLIENT-34 which

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A simple Jakarta Enterprise Beans Remoting transaction context propagation in JTS style from one AS7 server to another.

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/async/TransactionPropagationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/async/TransactionPropagationTestCase.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.util.Arrays;
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/nooutbound/TransactionContextRemoteCallTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/nooutbound/TransactionContextRemoteCallTestCase.java
@@ -23,7 +23,7 @@
 package org.jboss.as.test.multinode.transaction.nooutbound;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
 import java.util.Arrays;

--- a/testsuite/integration/rts/pom.xml
+++ b/testsuite/integration/rts/pom.xml
@@ -122,11 +122,6 @@
             <artifactId>wildfly-core-testsuite-shared</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/CoordinatorTestCase.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/CoordinatorTestCase.java
@@ -31,7 +31,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.jbossts.star.util.TxMediaType;
 import org.jboss.jbossts.star.util.TxStatusMediaType;
 import org.jboss.jbossts.star.util.TxSupport;

--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/ParticipantTestCase.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/ParticipantTestCase.java
@@ -33,7 +33,7 @@ import jakarta.xml.bind.JAXBException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.jbossts.star.util.TxStatus;
 import org.jboss.jbossts.star.util.TxSupport;
 import org.jboss.narayana.rest.integration.api.Aborted;

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -93,11 +93,6 @@
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
@@ -38,7 +38,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.security.common.Utils;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.testsuite.integration.secman.servlets.JSMCheckServlet;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.asset.Asset;

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PropertyPermissionExpressionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PropertyPermissionExpressionsTestCase.java
@@ -43,7 +43,7 @@ import org.jboss.as.subsystem.test.SubsystemOperations;
 import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.testsuite.integration.secman.servlets.JSMCheckServlet;
 import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
 import org.jboss.dmr.ModelNode;

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MaximumPermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MaximumPermissionsTestCase.java
@@ -40,7 +40,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -416,12 +416,6 @@
             <artifactId>wsdl4j</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
@@ -24,7 +24,7 @@ package org.jboss.as.test.smoke.jms;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -167,12 +167,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- TODO confirm if this is needed -->
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.integration.ee.concurrent;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.URL;
 

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/ForwardedHandlerTestCase.java
@@ -3,7 +3,7 @@ package org.jboss.as.test.integration.web.handlers;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java
@@ -7,7 +7,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROTOCOL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.net.SocketPermission;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/UndertowHandlersConfigTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/UndertowHandlersConfigTestCase.java
@@ -12,7 +12,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -23,6 +22,7 @@ import org.junit.runner.RunWith;
 import java.io.FilePermission;
 import java.net.URL;
 
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -41,7 +41,7 @@ public class UndertowHandlersConfigTestCase {
                 .addAsWebInfResource(UndertowHandlersConfigTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
                 .addAsWebResource(new StringAsset("A file"), "file.txt")
                 .addAsWebInfResource(new StringAsset("regex['/rewrite.*'] -> rewrite['/file.txt']"), "undertow-handlers.conf")
-                .addAsWebResource(PermissionUtils.createPermissionsXmlAsset(new FilePermission("<<ALL FILES>>", "read,write")), "META-INF/permissions.xml");
+                .addAsWebResource(createPermissionsXmlAsset(new FilePermission("<<ALL FILES>>", "read,write")), "META-INF/permissions.xml");
 
     }
 

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/WebSecurityProgrammaticLoginTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/WebSecurityProgrammaticLoginTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.web.security.servlet3;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/websocket/WebSocketSecurityTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/websocket/WebSocketSecurityTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.web.security.websocket;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.SocketPermission;
 import java.net.URI;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
@@ -22,7 +22,7 @@
 package org.jboss.as.test.integration.web.servlet.lifecycle;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URL;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.as.test.integration.web.websocket;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.net.SocketPermission;

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -360,11 +360,6 @@
             <artifactId>wsdl4j</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:rsvoboda@redhat.com">Rostislav Svoboda</a>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpointTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpointTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:rsvoboda@redhat.com">Rostislav Svoboda</a>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
@@ -48,7 +48,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests for WS ServiceRef from servlet to verify access for <service-ref> in nested war

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
@@ -46,7 +46,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:rsvoboda@redhat.com">Rostislav Svoboda</a>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java
@@ -45,7 +45,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Serviceref through ejb3 deployment descriptor.

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -211,11 +211,6 @@
             <artifactId>wsdl4j</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- TODO confirm if this is needed -->
         <dependency>

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/AbstractTestCase.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/AbstractTestCase.java
@@ -41,7 +41,7 @@ import java.net.SocketPermission;
 import java.net.URL;
 import java.util.List;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.as.test.xts.suspend.Helpers.getExecutorService;
 import static org.jboss.as.test.xts.suspend.Helpers.getRemoteService;
 

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/util/DeploymentHelper.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/util/DeploymentHelper.java
@@ -26,7 +26,7 @@ import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
 
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/util/TestsuiteModuleTestCase.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/util/TestsuiteModuleTestCase.java
@@ -17,7 +17,7 @@
  */
 
 package org.wildfly.test.preview.util;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/testsuite/preview/pom.xml
+++ b/testsuite/preview/pom.xml
@@ -85,11 +85,6 @@
             <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -255,11 +255,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
@@ -22,65 +22,18 @@
 
 package org.jboss.as.test.shared.integration.ejb.security;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FilePermission;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.Permission;
 import java.util.Arrays;
 import java.util.Iterator;
-
-import nu.xom.Attribute;
-import nu.xom.Document;
-import nu.xom.Element;
-import nu.xom.Serializer;
-import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class PermissionUtils {
-
-    public static Asset createPermissionsXmlAsset(Permission... permissions) {
-        final Element permissionsElement = new Element("permissions");
-        permissionsElement.setNamespaceURI("http://xmlns.jcp.org/xml/ns/javaee");
-        permissionsElement.addAttribute(new Attribute("version", "7"));
-        for (Permission permission : permissions) {
-            final Element permissionElement = new Element("permission");
-
-            final Element classNameElement = new Element("class-name");
-            final Element nameElement = new Element("name");
-            classNameElement.appendChild(permission.getClass().getName());
-            nameElement.appendChild(permission.getName());
-            permissionElement.appendChild(classNameElement);
-            permissionElement.appendChild(nameElement);
-
-            final String actions = permission.getActions();
-            if (actions != null && ! actions.isEmpty()) {
-                final Element actionsElement = new Element("actions");
-                actionsElement.appendChild(actions);
-                permissionElement.appendChild(actionsElement);
-            }
-            permissionsElement.appendChild(permissionElement);
-        }
-        Document document = new Document(permissionsElement);
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            final NiceSerializer serializer = new NiceSerializer(stream);
-            serializer.setIndent(4);
-            serializer.setLineSeparator("\n");
-            serializer.write(document);
-            serializer.flush();
-            return new StringAsset(stream.toString("UTF-8"));
-        } catch (IOException e) {
-            throw new IllegalStateException("Generating permissions.xml failed", e);
-        }
-    }
 
     /**
      * Creates a new {@link FilePermission} with the base path of the system property {@code jboss.inst}.
@@ -151,17 +104,5 @@ public final class PermissionUtils {
             }
         }
         return new FilePermission(path.toString(), action);
-    }
-
-    static class NiceSerializer extends Serializer {
-
-        public NiceSerializer(OutputStream out) throws UnsupportedEncodingException {
-            super(out, "UTF-8");
-        }
-
-        protected void writeXMLDeclaration() throws IOException {
-            super.writeXMLDeclaration();
-            super.breakLine();
-        }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18348
