### PR TITLE
[29.x] [WFLY-18378] Upgrade resteasy-microprofile to 2.1.3.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <version.org.jboss.openjdk-orb>9.0.2.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
-        <version.org.jboss.resteasy.microprofile>2.1.2.Final</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.microprofile>2.1.3.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.3.Final</version.org.jboss.resteasy.spring>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.1.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
         <version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18378

Upstream: #17129 
