### PR TITLE
WFLY-18389 <max-active-sessions/> causes sessions to expire prematurely using the HotRod-based HttpSession manager

### DIFF
--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionAttributesFactoryConfiguration.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionAttributesFactoryConfiguration.java
@@ -22,7 +22,6 @@
 
 package org.wildfly.clustering.web.hotrod.session;
 
-import org.wildfly.clustering.ee.cache.CacheProperties;
 import org.wildfly.clustering.ee.hotrod.HotRodConfiguration;
 import org.wildfly.clustering.web.cache.session.SessionAttributesFactoryConfiguration;
 
@@ -35,9 +34,4 @@ import org.wildfly.clustering.web.cache.session.SessionAttributesFactoryConfigur
  * @param <SV> attributes serialized form type
  */
 public interface HotRodSessionAttributesFactoryConfiguration<S, C, L, V, SV> extends SessionAttributesFactoryConfiguration<S, C, L, V, SV>, HotRodConfiguration {
-
-    @Override
-    default CacheProperties getCacheProperties() {
-        return HotRodConfiguration.super.getCacheProperties();
-    }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -24,14 +24,15 @@ package org.jboss.as.test.clustering.cluster.web.expiration;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -57,6 +58,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public abstract class SessionExpirationTestCase extends AbstractClusteringTestCase {
 
+    private static final Duration EXPIRATION_DURATION = Duration.ofSeconds(2);
+
     public static WebArchive getBaseDeployment(String moduleName) {
         WebArchive war = ShrinkWrap.create(WebArchive.class, moduleName + ".war");
         war.addClasses(SessionOperationServlet.class, RecordingWebListener.class);
@@ -75,14 +78,13 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
     public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
                      @ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
                              throws IOException, URISyntaxException, InterruptedException {
-
-        HttpResponse response;
         String sessionId;
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // This should trigger session creation event, but not added attribute event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a")))) {
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                sessionId = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -90,16 +92,14 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-                Assert.assertEquals(response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue(), response.getFirstHeader(SessionOperationServlet.CREATED_SESSIONS).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.CREATED_SESSIONS).getValue());
             }
 
             // This should trigger attribute added event and bound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "1")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "1")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -109,8 +109,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.ADDED_ATTRIBUTES).getValue());
                 Assert.assertEquals("1", response.getFirstHeader(SessionOperationServlet.BOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -118,9 +116,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // No events should have been triggered on remote node
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertEquals("1", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
@@ -130,14 +129,13 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             // Make sure remove attribute event is not fired since attribute does not exist
-            response = client.execute(new HttpGet(SessionOperationServlet.createRemoveURI(baseURL2, "b")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createRemoveURI(baseURL2, "b")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
@@ -146,8 +144,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -155,9 +151,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger attribute replaced event, as well as valueBound/valueUnbound binding events
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "2")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "2")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -168,8 +165,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.REPLACED_ATTRIBUTES).getValue());
                 Assert.assertEquals("2", response.getFirstHeader(SessionOperationServlet.BOUND_ATTRIBUTES).getValue());
                 Assert.assertEquals("1", response.getFirstHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -177,9 +172,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // No events should have been triggered on remote node
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertEquals("2", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
@@ -189,8 +185,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -198,9 +192,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger attribute removed event and valueUnbound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -210,8 +205,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.REMOVED_ATTRIBUTES).getValue());
                 Assert.assertEquals("2", response.getFirstHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -219,9 +212,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // No events should have been triggered on remote node
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
@@ -230,8 +224,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -239,9 +231,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger attribute added event and valueBound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "3", "4")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "3", "4")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -251,8 +244,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.ADDED_ATTRIBUTES).getValue());
                 Assert.assertEquals("3", response.getFirstHeader(SessionOperationServlet.BOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -260,9 +251,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // No events should have been triggered on remote node
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertEquals("4", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
@@ -272,8 +264,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -281,9 +271,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger attribute removed event and valueUnbound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createRemoveURI(baseURL1, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createRemoveURI(baseURL1, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -293,8 +284,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.REMOVED_ATTRIBUTES).getValue());
                 Assert.assertEquals("4", response.getFirstHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -302,9 +291,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // No events should have been triggered on remote node
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
@@ -313,15 +303,13 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             // This should trigger attribute added event and valueBound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL2, "a", "5")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL2, "a", "5")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -331,8 +319,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.ADDED_ATTRIBUTES).getValue());
                 Assert.assertEquals("5", response.getFirstHeader(SessionOperationServlet.BOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -340,10 +326,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger session destroyed event, attribute removed event, and valueUnbound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createInvalidateURI(baseURL1)));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createInvalidateURI(baseURL1)))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -354,8 +340,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertEquals(response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue(), response.getFirstHeader(SessionOperationServlet.DESTROYED_SESSIONS).getValue());
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.REMOVED_ATTRIBUTES).getValue());
                 Assert.assertEquals("5", response.getFirstHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -363,10 +347,10 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // This should trigger attribute added event and valueBound binding event
-            response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL2, "a", "6")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL2, "a", "6")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                sessionId = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -377,17 +361,15 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertEquals(response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue(), response.getFirstHeader(SessionOperationServlet.CREATED_SESSIONS).getValue());
                 Assert.assertEquals("a", response.getFirstHeader(SessionOperationServlet.ADDED_ATTRIBUTES).getValue());
                 Assert.assertEquals("6", response.getFirstHeader(SessionOperationServlet.BOUND_ATTRIBUTES).getValue());
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             // This should not trigger any events
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetAndSetURI(baseURL2, "a", "7")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetAndSetURI(baseURL2, "a", "7")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertEquals("6", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
-                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -395,17 +377,15 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             // This should not trigger any events
-            response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertEquals("7", response.getFirstHeader(SessionOperationServlet.RESULT).getValue());
-                Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -413,8 +393,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.REMOVED_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
-            } finally {
-                HttpClientUtils.closeQuietly(response);
             }
 
             if (!this.transactional) {
@@ -422,11 +400,11 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
             }
 
             // Trigger session timeout in 1 second
-            response = client.execute(new HttpGet(SessionOperationServlet.createTimeoutURI(baseURL1, 1)));
-            try {
+            try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createTimeoutURI(baseURL1, 1)))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.CREATED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.DESTROYED_SESSIONS));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.ADDED_ATTRIBUTES));
@@ -435,14 +413,23 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.BOUND_ATTRIBUTES));
                 Assert.assertFalse(response.containsHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES));
                 sessionId = response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue();
-            } finally {
-                HttpClientUtils.closeQuietly(response);
+            }
+
+            Instant start = Instant.now();
+            // Verify that the session does not expire until it is sufficiently idle
+            while (Instant.now().isBefore(start.plus(EXPIRATION_DURATION))) {
+                try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL1, "a")))) {
+                    Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                    Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
+                    Assert.assertEquals(sessionId, response.getFirstHeader(SessionOperationServlet.SESSION_ID).getValue());
+                }
+                Thread.sleep(100);
             }
         }
 
         // Trigger timeout of sessionId - accounts for session timeout (1s) and infinispan reaper thread interval (1s)
         // so that test conditions are typically met within the first attempt
-        Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+        Thread.sleep(EXPIRATION_DURATION.toMillis());
 
         // Use a new session for awaiting expiration notification of the previous session scheduled to expire
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
@@ -457,8 +444,7 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                 // Timeout should trigger session destroyed event, attribute removed event, and valueUnbound binding event
                 for (URL baseURL : Arrays.asList(baseURL1, baseURL2)) {
                     if (!destroyed) {
-                        response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a", sessionId)));
-                        try {
+                        try (CloseableHttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL, "a", sessionId)))) {
                             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                             Assert.assertFalse(response.containsHeader(SessionOperationServlet.RESULT));
                             Assert.assertTrue(response.containsHeader(SessionOperationServlet.SESSION_ID));
@@ -480,8 +466,6 @@ public abstract class SessionExpirationTestCase extends AbstractClusteringTestCa
                                 Assert.assertEquals("7", response.getFirstHeader(SessionOperationServlet.UNBOUND_ATTRIBUTES).getValue());
                                 log.infof("Session destroyed within %d attempts.", attempt);
                             }
-                        } finally {
-                            HttpClientUtils.closeQuietly(response);
                         }
                     }
                 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseHotRodSessionExpirationTestCase.java
@@ -49,6 +49,9 @@ public class CoarseHotRodSessionExpirationTestCase extends AbstractHotRodSession
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_coarse_transactional.xml", "jboss-all.xml");
+        return getBaseDeployment(MODULE_NAME)
+                .addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_coarse_transactional.xml", "jboss-all.xml")
+                .addAsWebInfResource(CoarseHotRodSessionExpirationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
+                ;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineHotRodSessionExpirationTestCase.java
@@ -49,6 +49,9 @@ public class FineHotRodSessionExpirationTestCase extends AbstractHotRodSessionEx
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_fine_transactional.xml", "jboss-all.xml");
+        return getBaseDeployment(MODULE_NAME)
+                .addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-all_fine_transactional.xml", "jboss-all.xml")
+                .addAsWebInfResource(FineHotRodSessionExpirationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
+                ;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18389