### PR TITLE
WFLY-18399 Upgrade to Hibernate 6.2.8.Final release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
         <version.org.glassfish.soteria>3.0.0</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.2.6.Final</version.org.hibernate>
+        <version.org.hibernate>6.2.8.Final</version.org.hibernate>
         <version.org.hibernate.search>6.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>

--- a/pom.xml
+++ b/pom.xml
@@ -476,7 +476,7 @@
         <version.org.apache.ws.xmlschema>2.3.0</version.org.apache.ws.xmlschema>
         <version.org.apache.xerces>2.12.0.SP05</version.org.apache.xerces>
         <version.org.bitbucket.jose4j>0.9.3</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.12.18</version.org.bytebuddy>
+        <version.org.bytebuddy>1.14.7</version.org.bytebuddy>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.4.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18399 for the Hibernate ORM upgrade to 6.2.8
https://issues.redhat.com/browse/WFLY-18307 for the ByteBuddy upgrade to 1.14.7
