### PR TITLE
[WFLY-18406] Upgrade ironjacamar to 3.0.6.Final

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/NamedDistributedWorkManager.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/NamedDistributedWorkManager.java
@@ -33,9 +33,9 @@ public class NamedDistributedWorkManager extends DistributedWorkManagerImpl {
     }
     protected WildflyWorkWrapper createWorKWrapper(SecurityIntegration securityIntegration, Work work,
                                                    ExecutionContext executionContext, WorkListener workListener, CountDownLatch startedLatch,
-                                                   CountDownLatch completedLatch) {
+                                                   CountDownLatch completedLatch, long startTimeout) {
         return new WildflyWorkWrapper(this, securityIntegration, work, executionContext, workListener,
-                startedLatch, completedLatch, System.currentTimeMillis());
+                startedLatch, completedLatch, System.currentTimeMillis(), startTimeout);
     }
     public boolean isElytronEnabled() {
         return elytronEnabled;

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/NamedWorkManager.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/NamedWorkManager.java
@@ -35,8 +35,8 @@ public class NamedWorkManager extends WorkManagerImpl {
     @Override
     protected WildflyWorkWrapper createWorkWrapper(SecurityIntegration securityIntegration, Work work,
                                             ExecutionContext executionContext, WorkListener workListener, CountDownLatch startedLatch,
-                                            CountDownLatch completedLatch) {
+                                            CountDownLatch completedLatch, long creationTime, long startTimeout) {
         return new WildflyWorkWrapper(this, securityIntegration, work, executionContext, workListener,
-                startedLatch, completedLatch, System.currentTimeMillis());
+                startedLatch, completedLatch, creationTime, startTimeout);
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/StatisticsExecutorImpl.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/StatisticsExecutorImpl.java
@@ -5,9 +5,6 @@
 
 package org.jboss.as.connector.services.workmanager;
 
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
-
 import org.jboss.as.threads.ManagedJBossThreadPoolExecutorService;
 import org.jboss.as.threads.ManagedQueueExecutorService;
 import org.jboss.as.threads.ManagedQueuelessExecutorService;
@@ -47,22 +44,6 @@ public class StatisticsExecutorImpl implements StatisticsExecutor {
     @Override
     public void execute(Runnable runnable) {
         realExecutor.execute(runnable);
-    }
-
-    @Override
-    public void executeBlocking(Runnable runnable) throws RejectedExecutionException, InterruptedException {
-        realExecutor.executeBlocking(runnable);
-    }
-
-    @Override
-    public void executeBlocking(Runnable runnable, long l, TimeUnit timeUnit) throws RejectedExecutionException,
-            InterruptedException {
-        realExecutor.executeBlocking(runnable, l, timeUnit);
-    }
-
-    @Override
-    public void executeNonBlocking(Runnable runnable) throws RejectedExecutionException {
-        realExecutor.executeNonBlocking(runnable);
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/WildflyWorkWrapper.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/WildflyWorkWrapper.java
@@ -36,8 +36,8 @@ public class WildflyWorkWrapper extends org.jboss.jca.core.workmanager.WorkWrapp
      * @throws IllegalArgumentException for null work, execution context or a negative start timeout
      */
     WildflyWorkWrapper(WorkManagerImpl workManager, SecurityIntegration si, Work work, ExecutionContext executionContext,
-            WorkListener workListener, CountDownLatch startedLatch, CountDownLatch completedLatch, long startTime) {
-        super(workManager, si, work, executionContext, workListener, startedLatch, completedLatch, startTime);
+            WorkListener workListener, CountDownLatch startedLatch, CountDownLatch completedLatch, long creationTime, long startTimeout) {
+        super(workManager, si, work, executionContext, workListener, startedLatch, completedLatch, creationTime, startTimeout);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.jboss.genericjms>3.0.0.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.6.16.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>2.0.1.Final</version.org.jboss.iiop-client>
-        <version.org.jboss.ironjacamar>3.0.4.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>3.0.6.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.3.Final</version.org.jboss.mod_cluster>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18406

Upgrade because of refactor in IronJacamar which removes usage on jboss-threads blocking API