### PR TITLE
WFCORE-6473 Remove references to obsolete remoting resource.

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/remoting.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/remoting.xml
@@ -2,9 +2,6 @@
 <feature-group-spec name="remoting" xmlns="urn:jboss:galleon:feature-group:1.0">
     <!-- TODO Temporary fork to override use of security-realms. -->
     <feature spec="subsystem.remoting">
-        <feature spec="subsystem.remoting.configuration.endpoint">
-            <unset param="worker"/>
-        </feature>
         <feature spec="subsystem.remoting.http-connector">
             <param name="http-connector" value="http-remoting-connector"/>
             <param name="connector-ref" value="default"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/unsecured-basic-profile.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/unsecured-basic-profile.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="unsecured-basic-profile" xmlns="urn:jboss:galleon:feature-group:1.0">
 
-    <feature-group name="remoting">
-        <feature spec="subsystem.remoting">
-            <feature spec="subsystem.remoting.configuration.endpoint">
-                <unset param="worker"/>
-            </feature>
-        </feature>
-    </feature-group>
-
     <feature-group name="servlet-unsecured-basic-profile"/>
 
     <feature spec="subsystem.discovery"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFCORE-6473

See https://github.com/wildfly/wildfly-core/pull/5643 for context.