### PR TITLE
WFLY-18407 Upgrade jetty to 9.4.52.v20230823

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -187,28 +187,49 @@
                 <version>${version.org.eclipse.jetty}</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- Required by Wiremock for the MicroProfile REST Client TCK -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
                 <version>${version.org.eclipse.jetty}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Required by Wiremock for the MicroProfile REST Client TCK -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <version>${version.org.eclipse.jetty}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Required by Wiremock for the MicroProfile REST Client TCK -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
                 <version>${version.org.eclipse.jetty}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${version.org.eclipse.jetty}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${version.org.eclipse.jetty}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${version.org.eclipse.jetty}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-proxy</artifactId>
+                <version>${version.org.eclipse.jetty}</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- End requirement -->
 
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
-        <version.org.eclipse.jetty>9.2.30.v20200428</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>9.4.52.v20230823</version.org.eclipse.jetty>
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
         <version.org.javassist>3.29.1-GA</version.org.javassist>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -104,6 +104,26 @@
             <artifactId>jetty-util</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-proxy</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- End requirement -->
 
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18407

Resolves security issues:

* https://github.com/eclipse/jetty.project/security/advisories/GHSA-p26g-97m4-6q7c
* https://github.com/eclipse/jetty.project/security/advisories/GHSA-qw69-rqj8-6qw8