### PR TITLE
[WFLY-18332] Update LayersTestBase and LayersTestCase(s)

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -77,7 +77,7 @@ public class JPADefinition extends SimpleResourceDefinition {
     public void registerAdditionalRuntimePackages(final ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerAdditionalRuntimePackages(
                 // Only if annotation is in use.
-                RuntimePackageDependency.optional("org.hibernate.search.orm"),
+                RuntimePackageDependency.optional("org.hibernate.search.mapper.orm"),
                 RuntimePackageDependency.required("org.hibernate"),
                 // An alias to org.hibernate module.
                 RuntimePackageDependency.optional("org.hibernate.envers"));

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -649,6 +649,7 @@
                                                 <layer>ejb-lite</layer>
                                                 <layer>ejb-local-cache</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>embedded-activemq</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>
@@ -756,6 +757,7 @@
                                                 <layer>ejb-http-invoker</layer>
                                                 <layer>ejb-lite</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>
@@ -857,6 +859,7 @@
                                                 <layer>ejb-lite</layer>
                                                 <layer>ejb-local-cache</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>embedded-activemq</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -764,6 +764,7 @@
                                                 <layer>h2-default-datasource</layer>
                                                 <layer>h2-driver</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
@@ -874,7 +875,9 @@
                                                 <layer>h2-driver</layer>
                                                 <layer>health</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
@@ -976,6 +979,7 @@
                                                 <layer>h2-driver</layer>
                                                 <layer>health</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -673,6 +673,7 @@
                                                 <layer>mail</layer>
                                                 <layer>management</layer>
                                                 <layer>messaging-activemq</layer>
+                                                <layer>micrometer</layer>
                                                 <layer>mod_cluster</layer>
                                                 <layer>naming</layer>
                                                 <layer>observability</layer>
@@ -778,6 +779,7 @@
                                                 <layer>mail</layer>
                                                 <layer>management</layer>
                                                 <layer>messaging-activemq</layer>
+                                                <layer>micrometer</layer>
                                                 <layer>mod_cluster</layer>
                                                 <layer>naming</layer>
                                                 <layer>observability</layer>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -694,7 +694,7 @@
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
                                                 <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
+                                                    Galleon layers defined only in the wildfly feature-pack
                                                  -->
                                                 <layer>microprofile-config</layer>
                                                 <layer>microprofile-fault-tolerance</layer>
@@ -801,13 +801,18 @@
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
                                                 <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
+                                                    Galleon layers defined only in the wildfly feature-pack
                                                  -->
                                                 <layer>microprofile-config</layer>
                                                 <layer>microprofile-fault-tolerance</layer>
                                                 <layer>microprofile-health</layer>
+                                                <layer>microprofile-lra-coordinator</layer>
+                                                <layer>microprofile-lra-participant</layer>
                                                 <layer>microprofile-jwt</layer>
                                                 <layer>microprofile-openapi</layer>
+                                                <layer>microprofile-reactive-streams-operators</layer>
+                                                <layer>microprofile-reactive-messaging</layer>
+                                                <layer>microprofile-reactive-messaging-kafka</layer>
                                                 <layer>microprofile-telemetry</layer>
                                                 <layer>microprofile-platform</layer>
                                             </layers>
@@ -903,9 +908,10 @@
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
                                                 <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
+                                                    Galleon layers defined only in the wildfly feature-pack
                                                  -->
                                                 <layer>microprofile-config</layer>
+                                                <layer>microprofile-fault-tolerance</layer>
                                                 <layer>microprofile-health</layer>
                                                 <layer>microprofile-jwt</layer>
                                                 <layer>microprofile-lra-coordinator</layer>
@@ -916,6 +922,7 @@
                                                 <layer>microprofile-reactive-messaging-kafka</layer>
                                                 <layer>microprofile-rest-client</layer>
                                                 <layer>microprofile-telemetry</layer>
+                                                <layer>microprofile-platform</layer>
                                             </layers>
                                         </config>
                                     </configurations>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -769,6 +769,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>
@@ -881,6 +882,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>
@@ -984,6 +986,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>

--- a/testsuite/layers-expansion/src/test/java/org/jboss/as/test/layers/expansion/LayersTestCase.java
+++ b/testsuite/layers-expansion/src/test/java/org/jboss/as/test/layers/expansion/LayersTestCase.java
@@ -4,9 +4,6 @@
  */
 package org.jboss.as.test.layers.expansion;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.jboss.as.test.shared.LayersTestBase;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
@@ -15,18 +12,11 @@ public class LayersTestCase extends LayersTestBase {
 
     protected Set<String> getExpectedUnreferenced() {
         String[] extra = AssumeTestGroupUtil.isWildFlyPreview() ? NOT_REFERENCED_WILDFLY_PREVIEW : NOT_REFERENCED_WILDFLY;
-        return new HashSet<>(List.of(concatArrays(NOT_REFERENCED_COMMON, NOT_REFERENCED_EXPANSION, extra)));
+        return concatArrays(NO_LAYER_OR_REFERENCE_COMMON, NOT_REFERENCED_COMMON, NOT_REFERENCED_EXPANSION, extra);
     }
 
     protected  Set<String> getExpectedUnusedInAllLayers() {
         String[] extra = AssumeTestGroupUtil.isWildFlyPreview() ? NO_LAYER_WILDFLY_PREVIEW : NO_LAYER_WILDFLY;
-        return new HashSet<>(List.of(concatArrays(NO_LAYER_COMMON, NO_LAYER_EXPANSION, extra)));
-    }
-
-    private static String[] concatArrays(String[] common, String[] expansion, String[] pack) {
-        String[] result = Arrays.copyOf(common, common.length + expansion.length + pack.length);
-        System.arraycopy(expansion, 0, result, common.length, expansion.length);
-        System.arraycopy(pack, 0, result, common.length + expansion.length, pack.length);
-        return result;
+        return concatArrays(NO_LAYER_OR_REFERENCE_COMMON, NO_LAYER_COMMON, NO_LAYER_EXPANSION, extra);
     }
 }

--- a/testsuite/layers-expansion/src/test/java/org/jboss/as/test/layers/expansion/LayersTestCase.java
+++ b/testsuite/layers-expansion/src/test/java/org/jboss/as/test/layers/expansion/LayersTestCase.java
@@ -4,9 +4,29 @@
  */
 package org.jboss.as.test.layers.expansion;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.jboss.as.test.shared.LayersTestBase;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 
 public class LayersTestCase extends LayersTestBase {
-    // Currently we get all functionality from the superclass; this class is just so surefire has something to run
-    // in this testsuite module
+
+    protected Set<String> getExpectedUnreferenced() {
+        String[] extra = AssumeTestGroupUtil.isWildFlyPreview() ? NOT_REFERENCED_WILDFLY_PREVIEW : NOT_REFERENCED_WILDFLY;
+        return new HashSet<>(List.of(concatArrays(NOT_REFERENCED_COMMON, NOT_REFERENCED_EXPANSION, extra)));
+    }
+
+    protected  Set<String> getExpectedUnusedInAllLayers() {
+        String[] extra = AssumeTestGroupUtil.isWildFlyPreview() ? NO_LAYER_WILDFLY_PREVIEW : NO_LAYER_WILDFLY;
+        return new HashSet<>(List.of(concatArrays(NO_LAYER_COMMON, NO_LAYER_EXPANSION, extra)));
+    }
+
+    private static String[] concatArrays(String[] common, String[] expansion, String[] pack) {
+        String[] result = Arrays.copyOf(common, common.length + expansion.length + pack.length);
+        System.arraycopy(expansion, 0, result, common.length, expansion.length);
+        System.arraycopy(pack, 0, result, common.length + expansion.length, pack.length);
+        return result;
+    }
 }

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2241,6 +2241,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>
@@ -2365,6 +2366,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>
@@ -2452,6 +2454,7 @@
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
+                                                <layer>jgroups-aws</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2236,6 +2236,7 @@
                                                 <layer>h2-default-datasource</layer>
                                                 <layer>h2-driver</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
@@ -2359,6 +2360,7 @@
                                                 <layer>h2-driver</layer>
                                                 <layer>health</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
@@ -2445,6 +2447,7 @@
                                                 <layer>h2-driver</layer>
                                                 <layer>health</layer>
                                                 <layer>iiop-openjdk</layer>
+                                                <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -70,9 +70,12 @@
         <jbossas.project.dir>${jbossas.ts.dir}/../..</jbossas.project.dir>
 
         <!-- GAVs to use for feature packs. Profiles can reset to trigger provisioning
-             using alternative feature packs. -->
+             using alternative feature packs.
+             By default we test the wildfly-ee feature pack as all the layers we test
+             in this module are from that feature pack.
+        -->
         <ee.feature.pack.groupId>${testsuite.ee.galleon.pack.groupId}</ee.feature.pack.groupId>
-        <ee.feature.pack.artifactId>${testsuite.ee.galleon.pack.artifactId}</ee.feature.pack.artifactId>
+        <ee.feature.pack.artifactId>wildfly-ee-galleon-pack</ee.feature.pack.artifactId>
         <ee.feature.pack.version>${testsuite.ee.galleon.pack.version}</ee.feature.pack.version>
 
         <!-- Where to look for artifacts when provisioning and running. -->
@@ -790,7 +793,7 @@
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
-                                <phase>${provisioning.phase}</phase>
+                                <phase>${provisioning.phase.preview.excluded}</phase>
                                 <configuration>
                                     <install-dir>${layers.install.dir}/test-standalone-reference</install-dir>
                                     <feature-packs>
@@ -1838,34 +1841,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>opentelemetry-provisioning</id>
-                                <goals>
-                                    <goal>provision</goal>
-                                </goals>
-                                <phase>${provisioning.phase}</phase>
-                                <configuration>
-                                    <install-dir>${layers.install.dir}/opentelemetry</install-dir>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>${ee.feature.pack.groupId}</groupId>
-                                            <artifactId>${ee.feature.pack.artifactId}</artifactId>
-                                            <version>${ee.feature.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>opentelemetry</layer>
-                                            </layers>
-                                        </config>
-                                    </configurations>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>pojo-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -2190,7 +2165,6 @@
                                                 <layer>mod_cluster</layer>
                                                 <layer>naming</layer>
                                                 <layer>observability</layer>
-                                                <layer>opentelemetry</layer>
                                                 <layer>pojo</layer>
                                                 <layer>remoting</layer>
                                                 <layer>request-controller</layer>
@@ -2206,22 +2180,6 @@
                                                 <layer>web-console</layer>
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
-                                                <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
-                                                 -->
-                                                <layer>microprofile-config</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-health</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-lra-coordinator</layer>
-                                                <layer>microprofile-lra-participant</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>microprofile-reactive-streams-operators</layer>
-                                                <layer>microprofile-reactive-messaging</layer>
-                                                <layer>microprofile-reactive-messaging-kafka</layer>
-                                                <layer>microprofile-rest-client</layer>
-                                                <layer>microprofile-telemetry</layer>
-                                                <layer>microprofile-platform</layer>
                                             </layers>
                                         </config>
                                     </configurations>
@@ -2294,7 +2252,6 @@
                                                 <layer>mod_cluster</layer>
                                                 <layer>naming</layer>
                                                 <layer>observability</layer>
-                                                <layer>opentelemetry</layer>
                                                 <layer>pojo</layer>
                                                 <layer>remote-activemq</layer>
                                                 <layer>remoting</layer>
@@ -2311,16 +2268,6 @@
                                                 <layer>web-console</layer>
                                                 <layer>web-server</layer>
                                                 <layer>webservices</layer>
-                                                <!--
-                                                    Galleon layers defined only in the wildfly-galleon-pack
-                                                 -->
-                                                <layer>microprofile-config</layer>
-                                                <layer>microprofile-fault-tolerance</layer>
-                                                <layer>microprofile-health</layer>
-                                                <layer>microprofile-jwt</layer>
-                                                <layer>microprofile-openapi</layer>
-                                                <layer>microprofile-telemetry</layer>
-                                                <layer>microprofile-platform</layer>
                                             </layers>
                                             <excluded-layers>
                                                 <layer>jpa</layer>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2139,6 +2139,7 @@
                                                 <layer>ejb-lite</layer>
                                                 <layer>ejb-local-cache</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>embedded-activemq</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>
@@ -2229,6 +2230,7 @@
                                                 <layer>ejb-http-invoker</layer>
                                                 <layer>ejb-lite</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>
@@ -2349,6 +2351,7 @@
                                                 <layer>ejb-lite</layer>
                                                 <layer>ejb-local-cache</layer>
                                                 <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
                                                 <layer>embedded-activemq</layer>
                                                 <layer>hibernate-search</layer>
                                                 <layer>h2-datasource</layer>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
@@ -5,6 +5,11 @@
 package org.jboss.as.test.layers.base;
 
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.jboss.as.test.layers.LayersTest;
 import org.jboss.as.test.shared.LayersTestBase;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
@@ -31,5 +36,19 @@ public class LayersTestCase extends LayersTestBase {
         // checks the execution of the layers, do it directly
         AssumeTestGroupUtil.assumeWildFlyPreview();
         LayersTest.testExecution(root);
+    }
+
+    protected Set<String> getExpectedUnreferenced() {
+        return new HashSet<>(List.of(concatArrays(NOT_REFERENCED_COMMON, NOT_REFERENCED_WILDFLY_EE)));
+    }
+
+    protected  Set<String> getExpectedUnusedInAllLayers() {
+        return new HashSet<>(List.of(concatArrays(NO_LAYER_COMMON, NO_LAYER_WILDFLY_EE)));
+    }
+
+    private static String[] concatArrays(String[] common, String[] pack) {
+        String[] result = Arrays.copyOf(common, common.length + pack.length);
+        System.arraycopy(pack, 0, result, common.length, pack.length);
+        return result;
     }
 }

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
@@ -5,8 +5,10 @@
 package org.jboss.as.test.layers.base;
 
 
+import org.jboss.as.test.layers.LayersTest;
 import org.jboss.as.test.shared.LayersTestBase;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.Test;
 
 public class LayersTestCase extends LayersTestBase {
 
@@ -21,5 +23,13 @@ public class LayersTestCase extends LayersTestBase {
         AssumeTestGroupUtil.assumeNotWildFlyPreview();
 
         super.test();
+    }
+
+    @Test
+    public void testLayers() throws Exception {
+        // Since we don't run 'test()' with WFP, which among other things
+        // checks the execution of the layers, do it directly
+        AssumeTestGroupUtil.assumeWildFlyPreview();
+        LayersTest.testExecution(root);
     }
 }

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/base/LayersTestCase.java
@@ -4,10 +4,6 @@
  */
 package org.jboss.as.test.layers.base;
 
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.test.layers.LayersTest;
@@ -39,16 +35,10 @@ public class LayersTestCase extends LayersTestBase {
     }
 
     protected Set<String> getExpectedUnreferenced() {
-        return new HashSet<>(List.of(concatArrays(NOT_REFERENCED_COMMON, NOT_REFERENCED_WILDFLY_EE)));
+        return concatArrays(NO_LAYER_OR_REFERENCE_COMMON, NOT_REFERENCED_COMMON, NO_LAYER_OR_REFERENCE_WILDFLY_EE, NOT_REFERENCED_WILDFLY_EE);
     }
 
     protected  Set<String> getExpectedUnusedInAllLayers() {
-        return new HashSet<>(List.of(concatArrays(NO_LAYER_COMMON, NO_LAYER_WILDFLY_EE)));
-    }
-
-    private static String[] concatArrays(String[] common, String[] pack) {
-        String[] result = Arrays.copyOf(common, common.length + pack.length);
-        System.arraycopy(pack, 0, result, common.length, pack.length);
-        return result;
+        return concatArrays(NO_LAYER_OR_REFERENCE_COMMON, NO_LAYER_COMMON, NO_LAYER_OR_REFERENCE_WILDFLY_EE, NO_LAYER_WILDFLY_EE);
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -205,6 +205,10 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
             "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
             "io.vertx.client",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.metrics-smallrye",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.opentracing-smallrye",
             // Injected by jaxrs subsystem
             "org.jboss.resteasy.microprofile.config",
             "org.jboss.resteasy.resteasy-client-microprofile",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -157,7 +157,9 @@ public abstract class LayersTestBase {
             "org.jboss.mod_cluster.core",
             "org.jboss.mod_cluster.load.spi",
             "org.wildfly.extension.mod_cluster",
-            "org.wildfly.mod_cluster.undertow"
+            "org.wildfly.mod_cluster.undertow",
+            // Brought by galleon ServerRootResourceDefinition
+            "wildflyee.api"
     };
 
 
@@ -166,8 +168,6 @@ public abstract class LayersTestBase {
      * only when testing provisioning directly from the wildfly-ee feature pack.
      */
     public static final String[] NOT_REFERENCED_WILDFLY_EE = {
-            // Brought by galleon ServerRootResourceDefinition
-            "wildflyee.api"
     };
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -95,20 +95,6 @@ public abstract class LayersTestBase {
             "org.wildfly.reactive.dep.jts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
-            // TODO test-all-layers uses microprofile-opentracing instead of opentelemetry
-            "org.wildfly.extension.opentelemetry",
-            "org.wildfly.extension.opentelemetry-api",
-            "io.opentelemetry.exporter",
-            "io.opentelemetry.sdk",
-            "io.opentelemetry.proto",
-            "io.opentelemetry.otlp",
-            // Micrometer is not included in standard configs
-            "io.micrometer",
-            "org.wildfly.extension.micrometer",
-            "org.wildfly.micrometer.deployment",
-            "com.squareup.okhttp3",
-            "org.jetbrains.kotlin.kotlin-stdlib",
-            "com.google.protobuf",
             // Unreferenced Infinispan modules
             "org.infinispan.cdi.common",
             "org.infinispan.cdi.embedded",
@@ -275,6 +261,12 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
             "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
             "io.vertx.client",
+            // Extension not included in the default config
+            "org.wildfly.extension.micrometer",
+            "org.wildfly.micrometer.deployment",
+            "io.micrometer",
+            "com.google.protobuf",
+            "io.opentelemetry.proto",
             // Injected by jaxrs subsystem
             "org.jboss.resteasy.microprofile.config"
     };

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -120,9 +120,6 @@ public abstract class LayersTestBase {
             // JGroups external protocols - AWS
             "org.jgroups.aws",
             "software.amazon.awssdk.s3",
-            // MicroProfile
-            "org.wildfly.extension.microprofile.metrics-smallrye",
-            "org.wildfly.extension.microprofile.opentracing-smallrye",
             //xerces dependency is eliminated from different subsystems and use JDK JAXP instead
             "org.apache.xerces",
     };
@@ -147,17 +144,17 @@ public abstract class LayersTestBase {
      * when testing provisioning from the wildfly or wildfly-preview feature packs.
      * Use this array for items common between the two feature packs.
      */
-    public static final String[] NO_LAYER_EXPANSION = {};
+    public static final String[] NO_LAYER_EXPANSION = {
+            // Legacy subsystems for which we will not provide layers
+            "org.wildfly.extension.microprofile.metrics-smallrye",
+            "org.wildfly.extension.microprofile.opentracing-smallrye",
+    };
 
     /**
      * Included in the return value of {@link #getExpectedUnusedInAllLayers()}
      * only when testing provisioning from the wildfly feature pack.
      */
-    public static final String[] NO_LAYER_WILDFLY = {
-            // Legacy subsystems for which we will not provide layers
-            "org.wildfly.extension.microprofile.metrics-smallrye",
-            "org.wildfly.extension.microprofile.opentracing-smallrye",
-    };
+    public static final String[] NO_LAYER_WILDFLY = {};
 
     /**
      * Included in the return value of {@link #getExpectedUnusedInAllLayers()}
@@ -172,7 +169,7 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.fault-tolerance-smallrye",
             "org.wildfly.microprofile.fault-tolerance-smallrye.deployment",
             // Used by Hibernate Search but only in preview TODO this doesn't seem right; NOT_REFERENCED should suffice
-            "org.hibernate.search.mapper.orm.coordination.outboxpolling"
+            "org.hibernate.search.mapper.orm.coordination.outboxpolling",
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -115,9 +115,6 @@ public abstract class LayersTestBase {
     public static final String[] NO_LAYER_WILDFLY_EE = {
             // Messaging broker not included in the messaging-activemq layer
             "org.jboss.xnio.netty.netty-xnio-transport",
-            // No patching modules in layers
-            "org.jboss.as.patching",
-            "org.jboss.as.patching.cli",
             // In wildfly-ee only referenced by the
             // unused-in-all-layers org.jboss.resteasy.resteasy-rxjava2
             "io.reactivex.rxjava2.rxjava"

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -249,12 +249,6 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
             "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
             "io.vertx.client",
-            // Extension not included in the default config
-            "org.wildfly.extension.micrometer",
-            "org.wildfly.micrometer.deployment",
-            "io.micrometer",
-            "com.google.protobuf",
-            "io.opentelemetry.proto",
             // Injected by jaxrs subsystem
             "org.jboss.resteasy.microprofile.config",
             "org.jboss.resteasy.resteasy-client-microprofile",
@@ -264,7 +258,14 @@ public abstract class LayersTestBase {
      * Included in the return value of {@link #getExpectedUnreferenced()}
      * only when testing provisioning from the wildfly-preview feature pack.
      */
-    public static final String[] NOT_REFERENCED_WILDFLY = {};
+    public static final String[] NOT_REFERENCED_WILDFLY = {
+            // Extension not included in the default config
+            "org.wildfly.extension.micrometer",
+            "org.wildfly.micrometer.deployment",
+            "io.micrometer",
+            "com.google.protobuf",
+            "io.opentelemetry.proto",
+    };
 
     /**
      * Included in the return value of {@link #getExpectedUnreferenced()}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -201,15 +201,6 @@ public abstract class LayersTestBase {
     public static final String[] NOT_REFERENCED_WILDFLY_EE = {
             // injected by ee
             "jakarta.json.bind.api",
-            // injected by jpa
-            "org.hibernate.search.mapper.orm",
-            "org.hibernate.search.backend.elasticsearch",
-            "org.hibernate.search.backend.lucene",
-            // Used by the hibernate search that's injected by jpa
-            "org.elasticsearch.client.rest-client",
-            "com.google.code.gson",
-            "com.carrotsearch.hppc",
-            "org.apache.lucene",
             // Brought by galleon ServerRootResourceDefinition
             "wildflyee.api"
     };

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -158,8 +158,6 @@ public abstract class LayersTestBase {
      * only when testing provisioning directly from the wildfly-ee feature pack.
      */
     public static final String[] NOT_REFERENCED_WILDFLY_EE = {
-            // injected by ee
-            "jakarta.json.bind.api",
             // Brought by galleon ServerRootResourceDefinition
             "wildflyee.api"
     };

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -196,6 +196,9 @@ public abstract class LayersTestBase {
      * Packages that are always expected to be included in the return value of {@link #getExpectedUnreferenced()}.
      */
     public static final String[] NOT_REFERENCED_COMMON = {
+            // injected by logging
+            "org.apache.logging.log4j.api",
+            "org.jboss.logmanager.log4j2",
             // injected by ee
             "org.eclipse.yasson",
             // injected by ee
@@ -275,10 +278,6 @@ public abstract class LayersTestBase {
             // TODO
             "io.netty.netty-resolver-dns",
             "io.reactivex.rxjava2.rxjava",
-            // injected by logging
-            "org.apache.logging.log4j.api",
-            // injected by logging
-            "org.jboss.logmanager.log4j2",
             // injected by ee
             "jakarta.json.bind.api",
             // injected by jpa

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -58,7 +58,7 @@ public abstract class LayersTestBase {
             "org.keycloak.keycloak-adapter-subsystem",
             "org.jboss.as.security",
             // end legacy subsystems ^^^
-            // TODO nothing references this
+            // Special support feature
             "org.wildfly.security.http.sfbasic",
             // TODO move eclipse link support to an external feature pack
             "org.eclipse.persistence",
@@ -78,9 +78,6 @@ public abstract class LayersTestBase {
             // Perhaps via deployment descriptor? In any case, no layer provides them
             "org.wildfly.security.jakarta.client.resteasy",
             "org.wildfly.security.jakarta.client.webservices",
-            // This is added in the jaxrs subsystem to deployments if the MP config capability is met. The package is
-            // added in the microprofile-rest-client as well.
-            "org.jboss.resteasy.microprofile.config",
             // Alternative messaging protocols besides the std Artemis core protocol
             // Use of these depends on an attribute value setting
             "org.apache.activemq.artemis.protocol.amqp",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -91,8 +91,6 @@ public abstract class LayersTestBase {
             "org.jboss.narayana.rts",
             // TODO we need to add an xts layer
             "org.jboss.as.xts",
-            // TODO WFLY-16586 microprofile-reactive-streams-operators layer should provision this
-            "org.wildfly.reactive.dep.jts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
             // Unreferenced Infinispan modules
@@ -134,6 +132,8 @@ public abstract class LayersTestBase {
             // Legacy subsystems for which we will not provide layers
             "org.wildfly.extension.microprofile.metrics-smallrye",
             "org.wildfly.extension.microprofile.opentracing-smallrye",
+            // TODO WFLY-16586 microprofile-reactive-streams-operators layer should provision this
+            "org.wildfly.reactive.dep.jts",
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -92,9 +92,6 @@ public abstract class LayersTestBase {
             "org.jboss.as.xts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
-            // JGroups external protocols - AWS
-            "org.jgroups.aws",
-            "software.amazon.awssdk.s3",
             //xerces dependency is eliminated from different subsystems and use JDK JAXP instead
             "org.apache.xerces",
     };
@@ -191,6 +188,9 @@ public abstract class LayersTestBase {
             "org.infinispan.lock",
             "org.infinispan.query",
             "org.infinispan.query.core",
+            // WFLY-8770 jgroups-aws layer modules needed to configure the aws.S3_PING protocol are not referenced
+            "org.jgroups.aws",
+            "software.amazon.awssdk.s3",
     };
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -270,8 +270,6 @@ public abstract class LayersTestBase {
             // TODO we need to add an rts layer
             "org.wildfly.extension.rts",
             "org.jboss.narayana.rts",
-            //xerces dependency is eliminated from different subsystems and use JDK JAXP instead
-            "org.apache.xerces",
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -152,6 +152,12 @@ public abstract class LayersTestBase {
             // WFLY-8770 jgroups-aws layer modules needed to configure the aws.S3_PING protocol are not referenced
             "org.jgroups.aws",
             "software.amazon.awssdk.s3",
+            // Extension not included in the default config
+            "org.jboss.mod_cluster.container.spi",
+            "org.jboss.mod_cluster.core",
+            "org.jboss.mod_cluster.load.spi",
+            "org.wildfly.extension.mod_cluster",
+            "org.wildfly.mod_cluster.undertow"
     };
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -272,7 +272,6 @@ public abstract class LayersTestBase {
             "io.netty.netty-codec-http2",
             // TODO
             "io.netty.netty-resolver-dns",
-            "io.reactivex.rxjava2.rxjava",
             // injected by ee
             "jakarta.json.bind.api",
             // injected by jpa

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -186,8 +186,6 @@ public abstract class LayersTestBase {
             "org.apache.logging.log4j.api",
             "org.jboss.logmanager.log4j2",
             // injected by ee
-            "org.eclipse.yasson",
-            // injected by ee
             "org.wildfly.naming",
             // Injected by jaxrs
             "org.jboss.resteasy.resteasy-json-binding-provider",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -202,6 +202,8 @@ public abstract class LayersTestBase {
             "org.wildfly.naming",
             // Injected by jaxrs
             "org.jboss.resteasy.resteasy-json-binding-provider",
+            // Injected by jaxrs and also depended upon by narayano-rts, which is part of the non-OOTB rts subsystem
+            "org.jboss.resteasy.resteasy-json-p-provider",
             // The console ui content is not part of the kernel nor is it provided by an extension
             "org.jboss.as.console",
             // tooling

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -277,6 +277,8 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
             "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
             "io.vertx.client",
+            // Injected by jaxrs subsystem
+            "org.jboss.resteasy.microprofile.config"
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -211,29 +211,6 @@ public abstract class LayersTestBase {
             "org.wildfly.bootable-jar",
             // Extension not included in the default config
             "org.wildfly.extension.clustering.singleton",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.health-smallrye",
-            "org.eclipse.microprofile.health.api",
-            "io.smallrye.health",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.lra-coordinator",
-            "org.wildfly.extension.microprofile.lra-participant",
-            "org.jboss.narayana.rts.lra-coordinator",
-            "org.jboss.narayana.rts.lra-participant",
-            "org.eclipse.microprofile.lra.api",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.openapi-smallrye",
-            "org.eclipse.microprofile.openapi.api",
-            "io.smallrye.openapi",
-            "com.fasterxml.jackson.dataformat.jackson-dataformat-yaml",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.reactive-messaging-smallrye",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.telemetry",
-            // Extension not included in the default config
-            "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
-            "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
-            "io.vertx.client",
             // Dynamically added by ee-security and mp-jwt-smallrye DUPs but not referenced by subsystems.
             "org.wildfly.security.jakarta.security",
             // injected by sar
@@ -276,7 +253,31 @@ public abstract class LayersTestBase {
      * when testing provisioning from the wildfly or wildfly-preview feature packs.
      * Use this array for items common between the two feature packs.
      */
-    public static final String[] NOT_REFERENCED_EXPANSION = {};
+    public static final String[] NOT_REFERENCED_EXPANSION = {
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.health-smallrye",
+            "org.eclipse.microprofile.health.api",
+            "io.smallrye.health",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.lra-coordinator",
+            "org.wildfly.extension.microprofile.lra-participant",
+            "org.jboss.narayana.rts.lra-coordinator",
+            "org.jboss.narayana.rts.lra-participant",
+            "org.eclipse.microprofile.lra.api",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.openapi-smallrye",
+            "org.eclipse.microprofile.openapi.api",
+            "io.smallrye.openapi",
+            "com.fasterxml.jackson.dataformat.jackson-dataformat-yaml",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.reactive-messaging-smallrye",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.telemetry",
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.reactive-streams-operators-smallrye",
+            "org.wildfly.reactive.mutiny.reactive-streams-operators.cdi-provider",
+            "io.vertx.client",
+    };
 
     /**
      * Included in the return value of {@link #getExpectedUnreferenced()}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -147,8 +147,6 @@ public abstract class LayersTestBase {
             "org.hibernate.jipijapa-hibernate5",
             "org.jboss.as.jpa.openjpa",
             "org.apache.openjpa",
-            // TODO WFLY-16583 -- cruft
-            "javax.management.j2ee.api",
             // In wildfly-ee only referenced by the
             // unused-in-all-layers org.jboss.resteasy.resteasy-rxjava2
             "io.reactivex.rxjava2.rxjava"

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -168,8 +168,6 @@ public abstract class LayersTestBase {
             "org.eclipse.microprofile.fault-tolerance.api",
             "org.wildfly.extension.microprofile.fault-tolerance-smallrye",
             "org.wildfly.microprofile.fault-tolerance-smallrye.deployment",
-            // Used by Hibernate Search but only in preview TODO this doesn't seem right; NOT_REFERENCED should suffice
-            "org.hibernate.search.mapper.orm.coordination.outboxpolling",
     };
 
     /**
@@ -293,9 +291,6 @@ public abstract class LayersTestBase {
      */
     public static final String[] NOT_REFERENCED_WILDFLY_PREVIEW = {
             "org.wildfly.extension.metrics",
-            // Used by the hibernate search that's injected by jpa
-            "org.hibernate.search.mapper.orm.coordination.outboxpolling",
-            "org.apache.avro"
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -94,11 +94,6 @@ public abstract class LayersTestBase {
             "org.jboss.narayana.rts",
             // TODO we need to add an xts layer
             "org.jboss.as.xts",
-            // TODO we need to add the elytron-oidc-client layer to the config
-            "org.wildfly.extension.elytron-oidc-client",
-            "org.wildfly.security.elytron-http-oidc",
-            "org.wildfly.security.elytron-jose-jwk",
-            "org.wildfly.security.elytron-jose-util",
             // TODO WFLY-16586 microprofile-reactive-streams-operators layer should provision this
             "org.wildfly.reactive.dep.jts",
             // TODO should an undertow layer specify this?

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -72,7 +72,6 @@ public abstract class LayersTestBase {
             // This was brought in as part an RFE, WFLY-10632 & WFLY-10636. While the module is currently marked as private,
             // for now we should keep this module.
             "org.jboss.resteasy.resteasy-rxjava2",
-            "org.jboss.resteasy.resteasy-tracing-api",
             // TODO these implement SPIs from RESTEasy or JBoss WS but I don't know how they integrate
             // as there is no ref to them in any module.xml nor any in WF java code.
             // Perhaps via deployment descriptor? In any case, no layer provides them

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -141,12 +141,6 @@ public abstract class LayersTestBase {
             // No patching modules in layers
             "org.jboss.as.patching",
             "org.jboss.as.patching.cli",
-            // Misc alternative variants of JPA things that we don't provide via layers
-            "org.jboss.as.jpa.hibernate:4",
-            "org.hibernate:5.0",
-            "org.hibernate.jipijapa-hibernate5",
-            "org.jboss.as.jpa.openjpa",
-            "org.apache.openjpa",
             // In wildfly-ee only referenced by the
             // unused-in-all-layers org.jboss.resteasy.resteasy-rxjava2
             "io.reactivex.rxjava2.rxjava"

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -178,7 +178,6 @@ public abstract class LayersTestBase {
             "org.jboss.as.standalone",
             // injected by logging
             "org.jboss.logging.jul-to-slf4j-stub",
-            "org.jboss.resteasy.resteasy-client-microprofile",
             // Webservices tooling
             "org.jboss.ws.tools.common",
             "org.jboss.ws.tools.wsconsume",
@@ -268,7 +267,8 @@ public abstract class LayersTestBase {
             "com.google.protobuf",
             "io.opentelemetry.proto",
             // Injected by jaxrs subsystem
-            "org.jboss.resteasy.microprofile.config"
+            "org.jboss.resteasy.microprofile.config",
+            "org.jboss.resteasy.resteasy-client-microprofile",
     };
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -208,7 +208,7 @@ public abstract class LayersTestBase {
             // injected by ee
             "jakarta.json.bind.api",
             // injected by jpa
-            "org.hibernate.search.orm",
+            "org.hibernate.search.mapper.orm",
             "org.hibernate.search.backend.elasticsearch",
             "org.hibernate.search.backend.lucene",
             // Used by the hibernate search that's injected by jpa

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -92,14 +92,6 @@ public abstract class LayersTestBase {
             "org.jboss.as.xts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
-            // Unreferenced Infinispan modules
-            "org.infinispan.cdi.common",
-            "org.infinispan.cdi.embedded",
-            "org.infinispan.cdi.remote",
-            "org.infinispan.counter",
-            "org.infinispan.lock",
-            "org.infinispan.query",
-            "org.infinispan.query.core",
             // JGroups external protocols - AWS
             "org.jgroups.aws",
             "software.amazon.awssdk.s3",
@@ -191,6 +183,14 @@ public abstract class LayersTestBase {
             "org.jboss.ws.saaj-impl",
             // TODO just a testsuite utility https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers/topic/org.2Ejboss.2Ews.2Ecxf.2Ests.20module
             "org.jboss.ws.cxf.sts",
+            // WFLY-13520 Unreferenced Infinispan modules available for applications to depend upon
+            "org.infinispan.cdi.common",
+            "org.infinispan.cdi.embedded",
+            "org.infinispan.cdi.remote",
+            "org.infinispan.counter",
+            "org.infinispan.lock",
+            "org.infinispan.query",
+            "org.infinispan.query.core",
     };
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -105,7 +105,6 @@ public abstract class LayersTestBase {
             "io.opentelemetry.sdk",
             "io.opentelemetry.proto",
             "io.opentelemetry.otlp",
-            "io.opentelemetry.trace",
             // Micrometer is not included in standard configs
             "io.micrometer",
             "org.wildfly.extension.micrometer",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -112,8 +112,6 @@ public abstract class LayersTestBase {
      * only when testing provisioning directly from the wildfly-ee feature pack.
      */
     public static final String[] NO_LAYER_WILDFLY_EE = {
-            // Messaging broker not included in the messaging-activemq layer
-            "org.jboss.xnio.netty.netty-xnio-transport",
             // In wildfly-ee only referenced by the
             // unused-in-all-layers org.jboss.resteasy.resteasy-rxjava2
             "io.reactivex.rxjava2.rxjava"

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -205,11 +205,6 @@ public abstract class LayersTestBase {
      * only when testing provisioning directly from the wildfly-ee feature pack.
      */
     public static final String[] NOT_REFERENCED_WILDFLY_EE = {
-            // WFLY-18386 two io.netty.netty-codec... modules should be moved to wildfly feature pack
-            "io.netty.netty-codec-dns",
-            "io.netty.netty-codec-http2",
-            // TODO
-            "io.netty.netty-resolver-dns",
             // injected by ee
             "jakarta.json.bind.api",
             // injected by jpa

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -55,6 +55,10 @@ public abstract class LayersTestBase {
             "org.jboss.as.xts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
+            // Legacy extension not in ootb standalone.xml extension list
+            // and not in test-all-layers as it is admin-only
+            // TODO move to NO_LAYER_OR_REFERENCE_COMMON when the WFCORE-6591 is integrated
+            "org.jboss.as.security",
     };
 
     /**
@@ -148,8 +152,6 @@ public abstract class LayersTestBase {
             // WFLY-8770 jgroups-aws layer modules needed to configure the aws.S3_PING protocol are not referenced
             "org.jgroups.aws",
             "software.amazon.awssdk.s3",
-            // TODO Move this to NO_LAYER_OR_REFERENCE_COMMON as part of the WFLY-18519 fix
-            "org.jboss.as.security",
     };
 
 
@@ -242,7 +244,8 @@ public abstract class LayersTestBase {
             // TODO we need to add an agroal layer
             "org.wildfly.extension.datasources-agroal",
             "io.agroal",
-            // Legacy subsystems for which we will not provide layers
+            // Legacy subsystems for which we will not provide layers.
+            // Not in the ootb standalone.xml extension list
             "org.wildfly.extension.picketlink",
             "org.jboss.as.jsr77",
             "org.keycloak.keycloak-adapter-subsystem",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -163,11 +163,6 @@ public abstract class LayersTestBase {
     public static final String[] NO_LAYER_WILDFLY_PREVIEW = {
             // WFP standard config uses Micrometer instead of WF Metrics
             "org.wildfly.extension.metrics",
-            // MP Fault Tolerance has a dependency on MP Metrics
-            "io.smallrye.fault-tolerance",
-            "org.eclipse.microprofile.fault-tolerance.api",
-            "org.wildfly.extension.microprofile.fault-tolerance-smallrye",
-            "org.wildfly.microprofile.fault-tolerance-smallrye.deployment",
     };
 
     /**
@@ -252,6 +247,11 @@ public abstract class LayersTestBase {
      * Use this array for items common between the two feature packs.
      */
     public static final String[] NOT_REFERENCED_EXPANSION = {
+            // Extension not included in the default config
+            "org.wildfly.extension.microprofile.fault-tolerance-smallrye",
+            "org.wildfly.microprofile.fault-tolerance-smallrye.deployment",
+            "io.smallrye.fault-tolerance",
+            "org.eclipse.microprofile.fault-tolerance.api",
             // Extension not included in the default config
             "org.wildfly.extension.microprofile.health-smallrye",
             "org.eclipse.microprofile.health.api",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18332

Refactor to allow more understandable maintenance of the expected sets of modules that are unreferenced or not used in layers.

Update the expected sets to reflect current reality.

This update is a prerequisite for completing https://issues.redhat.com/browse/WFCORE-6456 as it corrects all the broken things found by the testing I'm adding for that.