### PR TITLE
WFLY-18413 Ensure PropertyChangeListener is removed when MetricRegistration is unregistered

### DIFF
--- a/metrics/src/main/java/org/wildfly/extension/metrics/MetricCollector.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/MetricCollector.java
@@ -83,6 +83,13 @@ public class MetricCollector {
             }
         };
         this.processStateNotifier.addPropertyChangeListener(listener);
+        Runnable cleanupTask = new Runnable() {
+            @Override
+            public void run() {
+                processStateNotifier.removePropertyChangeListener(listener);
+            }
+        };
+        registration.addCleanUpTask(cleanupTask);
         // If server is already running, we won't get a change event so register now
         if (ControlledProcessState.State.RUNNING == this.processStateNotifier.getCurrentState()) {
             registration.register();

--- a/metrics/src/main/java/org/wildfly/extension/metrics/MetricRegistration.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/MetricRegistration.java
@@ -29,6 +29,7 @@ public class MetricRegistration {
     private final List<Runnable> registrationTasks = new ArrayList<>();
     private final List<MetricID> unregistrationTasks = new ArrayList<>();
     private final MetricRegistry registry;
+    private final List<Runnable> cleanUpTasks = new ArrayList<>();
 
     public MetricRegistration(MetricRegistry registry) {
         this.registry = registry;
@@ -52,6 +53,10 @@ public class MetricRegistration {
             }
             unregistrationTasks.clear();
         }
+        for (Runnable cleanupTask : cleanUpTasks) {
+            cleanupTask.run();
+        }
+        cleanUpTasks.clear();
     }
 
     public void registerMetric(WildFlyMetric metric, WildFlyMetricMetadata metadata) {
@@ -64,5 +69,9 @@ public class MetricRegistration {
 
     public void addUnregistrationTask(MetricID metricID) {
         unregistrationTasks.add(metricID);
+    }
+
+    void addCleanUpTask(Runnable task) {
+        cleanUpTasks.add(task);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18413

There is a PropertyChangeListener instance registered during MetricCollector#collectResourceMetrics() call that is never unregistered. This leads to MetricRegistration and the listener instances accumulating during application redeployments.