### PR TITLE
[WFLY-18450] Upgrade WildFly Core to 22.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>22.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>22.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-18450

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/22.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/22.0.0.Beta1...22.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5305'>WFCORE-5305</a>] -         Response warnings don&#39;t propagate up in read-resource response assembly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6375'>WFCORE-6375</a>] -         Sync model operations fail when an HC with stopped managed servers registers back in the domain
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6434'>WFCORE-6434</a>] -         Managed servers could ignore restart/reload required operations when HC reconnects to the domain
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6458'>WFCORE-6458</a>] -         $HOSTNAME being set to &quot;&quot; prevents qualified hostname resolution
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6470'>WFCORE-6470</a>] -         Unexpected classloader when registering MBeans that are part of a deployment
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6477'>WFCORE-6477</a>] -         Possible NPE in YAMLExtension for some resource without a add operation
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6457'>WFCORE-6457</a>] -         Enable dependabot for updating patch dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6460'>WFCORE-6460</a>] -         Fix the naming of build directory in Readme.md
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6461'>WFCORE-6461</a>] -         Replace PermissionUtils use of xom 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6464'>WFCORE-6464</a>] -         Update CustomCredentialSecurityFactoryImpl to no longer rely on private Elytron API
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6466'>WFCORE-6466</a>] -         Split LayersTest.test in two
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6478'>WFCORE-6478</a>] -         Enable manual start of github actions CI workflow
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6462'>WFCORE-6462</a>] -         Upgrade xom to version 1.3.9
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6467'>WFCORE-6467</a>] -         Upgrade XNIO to 3.8.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6468'>WFCORE-6468</a>] -         Upgrade Undertow to 2.3.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6475'>WFCORE-6475</a>] -         Upgrade WildFly Elytron to 2.2.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6480'>WFCORE-6480</a>] -         Upgrade org.codehaus.mojo:xml-maven-plugin from 1.0.1 to 1.1.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6482'>WFCORE-6482</a>] -         Upgrade Jandex from 3.1.2 to 3.1.3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6349'>WFCORE-6349</a>] -         YAML config file names should be logged at startup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6450'>WFCORE-6450</a>] -         Allow jboss.server.name property resolution from Host Controller when used as a JVM option on a managed server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6454'>WFCORE-6454</a>] -         Use TCP/IP process communication for surefire plugin
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6476'>WFCORE-6476</a>] -         Reducing logging level for failed internal read-only operation steps
</li>
</ul>
</details>