### PR TITLE
[WFLY-18454] Upgrade FasterXML Jackson to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <version.antlr>4.10</version.antlr>
         <version.com.carrotsearch.hppc>0.8.1</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.14.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.com.fasterxml.jackson.jr.jackson-jr-objects>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.jr.jackson-jr-objects>
         <version.com.github.ben-manes.caffeine>3.1.8</version.com.github.ben-manes.caffeine>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18454

Core PR: https://github.com/wildfly/wildfly-core/pull/5666
