### PR TITLE
WFLY-18457 Remove custom ThreadGroup from Weld's executor services

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldExecutorServices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldExecutorServices.java
@@ -71,8 +71,7 @@ public class WeldExecutorServices extends AbstractExecutorServices implements Se
 
     @Override
     public void start(final StartContext context) throws StartException {
-        final ThreadGroup threadGroup = new ThreadGroup("Weld ThreadGroup");
-        final ThreadFactory factory = new JBossThreadFactory(threadGroup, Boolean.FALSE, null, THREAD_NAME_PATTERN, null, null);
+        final ThreadFactory factory = new JBossThreadFactory(null, Boolean.FALSE, null, THREAD_NAME_PATTERN, null, null);
         // set TCCL to null for new threads to make sure no deployment classloader leaks through this executor's TCCL
         // Weld does not mind having null TCCL in this executor
         this.executor = new WeldExecutor(bound, runnable -> {


### PR DESCRIPTION
WFLY Jira - https://issues.redhat.com/browse/WFLY-18457

This is linked to a WELD Jira, namely [WELD-2755](https://issues.redhat.com/browse/WELD-2755) which attempts to remove custom thread groups from Weld as we do not leverage them in any way and there is a memory leak connected to them (see the linked issue).
Weld PR with the same goal - https://github.com/weld/core/pull/2881