### PR TITLE
WFLY-18457 Fix ThreadGroup leaks in clustering modules following server reload

### DIFF
--- a/clustering/context/src/main/java/org/wildfly/clustering/context/DefaultExecutorService.java
+++ b/clustering/context/src/main/java/org/wildfly/clustering/context/DefaultExecutorService.java
@@ -51,6 +51,7 @@ public class DefaultExecutorService extends ContextualExecutorService {
     };
 
     public DefaultExecutorService(Class<?> targetClass, Function<ThreadFactory, ExecutorService> factory) {
-        super(factory.apply(new DefaultThreadFactory(targetClass)), DefaultContextualizerFactory.INSTANCE.createContextualizer(targetClass));
+        // Use thread group of current thread
+        super(factory.apply(new DefaultThreadFactory(targetClass, Thread.currentThread()::getThreadGroup)), DefaultContextualizerFactory.INSTANCE.createContextualizer(targetClass));
     }
 }

--- a/clustering/ee/cache/src/main/java/org/wildfly/clustering/ee/cache/scheduler/LocalScheduler.java
+++ b/clustering/ee/cache/src/main/java/org/wildfly/clustering/ee/cache/scheduler/LocalScheduler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -45,6 +46,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Paul Ferraro
  */
 public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(LocalScheduler.class);
 
     private final ScheduledExecutorService executor;
     private final ScheduledEntries<T, Instant> entries;
@@ -54,7 +56,7 @@ public class LocalScheduler<T> implements Scheduler<T, Instant>, Runnable {
     private volatile Map.Entry<Map.Entry<T, Instant>, Future<?>> futureEntry = null;
 
     public LocalScheduler(ScheduledEntries<T, Instant> entries, Predicate<T> task, Duration closeTimeout) {
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, new DefaultThreadFactory(this.getClass()));
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, THREAD_FACTORY);
         executor.setKeepAliveTime(1L, TimeUnit.MINUTES);
         executor.allowCoreThreadTimeOut(true);
         executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/SchedulerTopologyChangeListener.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/scheduler/SchedulerTopologyChangeListener.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -57,9 +58,10 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 @Listener
 public class SchedulerTopologyChangeListener<I, K extends Key<I>, V> implements ListenerRegistrar {
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(SchedulerTopologyChangeListener.class);
 
     private final Cache<K, V> cache;
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(new DefaultThreadFactory(SchedulerTopologyChangeListener.class));
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(THREAD_FACTORY);
     private final AtomicReference<Future<?>> scheduleTaskFuture = new AtomicReference<>();
     private final Consumer<Locality> cancelTask;
     private final BiConsumer<Locality, Locality> scheduleTask;

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -55,11 +56,12 @@ import org.wildfly.clustering.infinispan.distribution.Locality;
  * @author Paul Ferraro
  */
 public class TimerScheduler<I, C> extends AbstractCacheEntryScheduler<I, ImmutableTimerMetaData> {
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(TimerScheduler.class);
 
     private final TimerFactory<I, C> factory;
 
     public TimerScheduler(TimerFactory<I, C> factory, TimerManager<I, TransactionBatch> manager, Supplier<Locality> locality, Duration closeTimeout, TimerRegistry<I> registry) {
-        this(factory, manager, locality, closeTimeout, registry, new SortedScheduledEntries<>(), Executors.newSingleThreadExecutor(new DefaultThreadFactory(TimerScheduler.class)));
+        this(factory, manager, locality, closeTimeout, registry, new SortedScheduledEntries<>(), Executors.newSingleThreadExecutor(THREAD_FACTORY));
     }
 
     private TimerScheduler(TimerFactory<I, C> factory, TimerManager<I, TransactionBatch> manager, Supplier<Locality> locality, Duration closeTimeout, TimerRegistry<I> registry, ScheduledEntries<I, Instant> entries, ExecutorService executor) {

--- a/clustering/infinispan/embedded/spi/src/main/java/org/wildfly/clustering/infinispan/affinity/impl/DefaultKeyAffinityService.java
+++ b/clustering/infinispan/embedded/spi/src/main/java/org/wildfly/clustering/infinispan/affinity/impl/DefaultKeyAffinityService.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -75,6 +76,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 
     static final int DEFAULT_QUEUE_SIZE = 100;
     private static final Logger LOGGER = Logger.getLogger(DefaultKeyAffinityService.class);
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(DefaultKeyAffinityService.class);
 
     private final Cache<? extends K, ?> cache;
     private final KeyGenerator<? extends K> generator;
@@ -139,7 +141,7 @@ public class DefaultKeyAffinityService<K> implements KeyAffinityService<K>, Supp
 
     @Override
     public void start() {
-        this.executor = Executors.newCachedThreadPool(new DefaultThreadFactory(this.getClass()));
+        this.executor = Executors.newCachedThreadPool(THREAD_FACTORY);
         this.accept(this.cache.getAdvancedCache().getDistributionManager().getCacheTopology().getWriteConsistentHash());
         this.cache.addListener(this);
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/executors/DefaultNonBlockingThreadFactory.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/executors/DefaultNonBlockingThreadFactory.java
@@ -33,15 +33,7 @@ import org.wildfly.clustering.context.DefaultThreadFactory;
  */
 public class DefaultNonBlockingThreadFactory extends DefaultThreadFactory implements NonBlockingResource {
 
-    public DefaultNonBlockingThreadFactory(Class<?> targetClass) {
-        super(targetClass);
-    }
-
     public DefaultNonBlockingThreadFactory(ThreadFactory factory) {
         super(factory);
-    }
-
-    public DefaultNonBlockingThreadFactory(ThreadFactory factory, Class<?> targetClass) {
-        super(factory, targetClass);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/ClientThreadPoolServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/ClientThreadPoolServiceConfigurator.java
@@ -53,6 +53,7 @@ import org.wildfly.clustering.service.ServiceConfigurator;
  * @author Radoslav Husar
  */
 public class ClientThreadPoolServiceConfigurator extends ComponentServiceConfigurator<ExecutorFactoryConfiguration> {
+    private static final ThreadFactory THREAD_FACTORY = new DaemonThreadFactory(DefaultAsyncExecutorFactory.THREAD_NAME);
 
     private final ThreadPoolDefinition definition;
 
@@ -75,7 +76,7 @@ public class ClientThreadPoolServiceConfigurator extends ComponentServiceConfigu
             @Override
             public ExecutorService getExecutor(Properties property) {
                 BlockingQueue<Runnable> queue = queueLength == 0 ? new SynchronousQueue<>() : new LinkedBlockingQueue<>(queueLength);
-                ThreadFactory factory = new DefaultThreadFactory(new DaemonThreadFactory(DefaultAsyncExecutorFactory.THREAD_NAME));
+                ThreadFactory factory = new DefaultThreadFactory(THREAD_FACTORY);
                 if (nonBlocking) {
                     factory = new DefaultNonBlockingThreadFactory(factory);
                 }

--- a/clustering/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/dispatcher/ChannelCommandDispatcherFactory.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -85,10 +86,11 @@ public class ChannelCommandDispatcherFactory implements AutoCloseableCommandDisp
 
     static final Optional<Object> NO_SUCH_SERVICE = Optional.of(NoSuchService.INSTANCE);
     static final ExceptionSupplier<Object, Exception> NO_SUCH_SERVICE_SUPPLIER = Functions.constantExceptionSupplier(NoSuchService.INSTANCE);
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(ChannelCommandDispatcherFactory.class);
 
     private final ConcurrentMap<Address, Node> members = new ConcurrentHashMap<>();
     private final Map<Object, CommandDispatcherContext<?, ?>> contexts = new ConcurrentHashMap<>();
-    private final ExecutorService executorService = Executors.newCachedThreadPool(new DefaultThreadFactory(this.getClass()));
+    private final ExecutorService executorService = Executors.newCachedThreadPool(THREAD_FACTORY);
     private final ServiceExecutor executor = new StampedLockServiceExecutor();
     private final Map<GroupListener, ExecutorService> listeners = new ConcurrentHashMap<>();
     private final AtomicReference<View> view = new AtomicReference<>();

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionFactory.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionFactory.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -66,6 +67,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 @ClientListener
 public class HotRodSessionFactory<MC, AV, LC> extends CompositeSessionFactory<MC, AV, LC> implements Registrar<Consumer<ImmutableSession>> {
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(HotRodSessionFactory.class);
 
     private final RemoteCache<SessionCreationMetaDataKey, SessionCreationMetaDataEntry<LC>> creationMetaDataCache;
     private final RemoteCache<SessionAccessMetaDataKey, SessionAccessMetaData> accessMetaDataCache;
@@ -90,7 +92,7 @@ public class HotRodSessionFactory<MC, AV, LC> extends CompositeSessionFactory<MC
         this.attributesRemover = attributesFactory;
         this.creationMetaDataCache = config.getCache();
         this.accessMetaDataCache= config.getCache();
-        this.executor = Executors.newFixedThreadPool(config.getExpirationThreadPoolSize(), new DefaultThreadFactory(this.getClass()));
+        this.executor = Executors.newFixedThreadPool(config.getExpirationThreadPoolSize(), THREAD_FACTORY);
         this.creationMetaDataCache.addClientListener(this);
         this.nearCacheEnabled = this.creationMetaDataCache.getRemoteCacheContainer().getConfiguration().remoteCaches().get(this.creationMetaDataCache.getName()).nearCacheMode().enabled();
     }

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.server.suspend.ServerActivity;
@@ -56,6 +57,7 @@ import io.undertow.servlet.api.Deployment;
 public class UndertowEventHandlerAdapterService implements UndertowEventListener, Service, Runnable, ServerActivity {
     // No logger interface for this module and no reason to create one for this class only
     private static final Logger log = Logger.getLogger("org.jboss.mod_cluster.undertow");
+    private static final ThreadFactory THREAD_FACTORY = new DefaultThreadFactory(UndertowEventHandlerAdapterService.class);
 
     private final UndertowEventHandlerAdapterConfiguration configuration;
     private final Set<Context> contexts = new HashSet<>();
@@ -89,7 +91,7 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
         }
 
         // Start the periodic STATUS thread
-        this.executor = Executors.newScheduledThreadPool(1, new DefaultThreadFactory(UndertowEventHandlerAdapterService.class));
+        this.executor = Executors.newScheduledThreadPool(1, THREAD_FACTORY);
         this.executor.scheduleWithFixedDelay(this, 0, this.configuration.getStatusInterval().toMillis(), TimeUnit.MILLISECONDS);
         this.configuration.getSuspendController().registerActivity(this);
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18457

Alternative to https://github.com/wildfly/wildfly/pull/17192 for clustering modules, with the following changes:
* Uses static references for ThreadFactory instances rather than ThreadGroup, where appropriate.
  * Includes all uses of DefaultThreadFactory
  * Resolves SecurityManager issues with https://github.com/wildfly/wildfly/pull/17192
* Modifies DefaultExecutorService to use ThreadGroup of calling thread