### PR TITLE
[WFLY-18519] remove obsoleted optional org.jboss.as.security dependency in org.wildfly.extension.messaging-activemq module

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -89,8 +89,6 @@
         <module name="org.jboss.ironjacamar.impl"/>
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.as.connector"/>
-        <!-- Use of legacy security domain ends up using this module's class loader. -->
-        <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.jboss-transaction-spi"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18519

[WFLY-18519] remove obsoleted optional `org.jboss.as.security` dependency in `org.wildfly.extension.messaging-activemq` module