### PR TITLE
[WFLY-18436] Rework layer metadata tests to also inspect decorators.

### DIFF
--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
@@ -249,12 +249,13 @@ public class AbstractLayerMetaDataTestCase {
     public class ExpectedLayers {
         private Set<String> layers = new HashSet<>();
         private Set<String> decoratorLayers = new HashSet<>();
+        private Set<String> excludedLayers = new HashSet<>();
 
         public ExpectedLayers() {
         }
 
         public ExpectedLayers(String layer) {
-            add(layer);
+            addLayer(layer);
         }
 
         public ExpectedLayers(String... layers) {
@@ -262,17 +263,27 @@ public class AbstractLayerMetaDataTestCase {
         }
 
         public ExpectedLayers(String layer, String decorator) {
-            add(layer, decorator);
+            addLayerAndDecorator(layer, decorator);
         }
 
-        public ExpectedLayers add(String layer) {
+        public ExpectedLayers addLayer(String layer) {
             this.layers.add(layer);
             return this;
         }
 
-        public ExpectedLayers add(String layer, String decorator) {
+        public ExpectedLayers addLayerAndDecorator(String layer, String decorator) {
             layers.add(layer);
             decoratorLayers.add(decorator);
+            return this;
+        }
+
+        public ExpectedLayers addDecorator(String decorator) {
+            decoratorLayers.add(decorator);
+            return this;
+        }
+
+        public ExpectedLayers excludedLayers(String...excludedDecorators) {
+            excludedLayers.addAll(Arrays.asList(excludedDecorators));
             return this;
         }
 

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.wildfly.glow.Arguments;
 import org.wildfly.glow.GlowMessageWriter;
 import org.wildfly.glow.GlowSession;
+import org.wildfly.glow.ScanArguments;
 import org.wildfly.glow.ScanResults;
 import org.wildfly.glow.maven.MavenResolver;
 
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class AbstractLayerMetaDataTestCase {
@@ -48,19 +50,7 @@ public class AbstractLayerMetaDataTestCase {
         Path glowXmlPath = Path.of("target/test-classes/glow");
         System.setProperty(URL_PROPERTY, glowXmlPath.toUri().toString());
         if (Files.exists(ARCHIVES_PATH)) {
-            Files.walkFileTree(ARCHIVES_PATH, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    Files.delete(file);
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                }
-            });
+            deleteArchivesDirectory();
         }
         Files.createDirectories(ARCHIVES_PATH);
     }
@@ -91,19 +81,53 @@ public class AbstractLayerMetaDataTestCase {
         return sb.toString();
     }
 
-    protected Set<String> checkLayersForArchive(Path archivePath, String...expectedLayers) throws Exception {
-        checkMethodCalled = true;
-        Arguments arguments = Arguments.scanBuilder().setBinaries(Collections.singletonList(archivePath)).build();
-        ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
-        Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
 
-        Assert.assertEquals(expectedLayers.length, foundLayers.size());
+    protected Set<String> checkLayersForArchive(Path archivePath, String...expectedLayers) {
+        return checkLayersForArchive(archivePath, null, expectedLayers);
+    }
+
+    protected Set<String> checkLayersForArchive(Path archivePath, ExpectedLayers expectedLayers) {
+        return checkLayersForArchive(archivePath, null, expectedLayers);
+    }
+
+    protected Set<String> checkLayersForArchive(Path archivePath, Consumer<ScanArguments.Builder> argumentsAugmenter, String...expectedLayers) {
+        return checkLayersForArchive(archivePath, argumentsAugmenter, new ExpectedLayers(expectedLayers));
+    }
+
+    protected Set<String> checkLayersForArchive(Path archivePath, Consumer<ScanArguments.Builder> argumentsAugmenter, ExpectedLayers expectedLayers) {
+        checkMethodCalled = true;
+        try {
+            checkMethodCalled = true;
+            ScanArguments.Builder argumentsBuilder = Arguments.scanBuilder().setBinaries(Collections.singletonList(archivePath));
+            if (argumentsAugmenter != null) {
+                argumentsAugmenter.accept(argumentsBuilder);
+            }
+            Arguments arguments = argumentsBuilder.build();
+            ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+
+            Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
+            Set<String> foundDecorators = scanResults.getDecorators().stream().map(l -> l.getName()).collect(Collectors.toSet());
+
+            checkLayers(expectedLayers.getExpectedFoundLayers(), foundLayers);
+            checkLayers(expectedLayers.getExpectedDecorators(), foundDecorators);
+
+            return foundLayers;
+        } catch (Exception e) {
+            if (e instanceof RuntimeException) throw (RuntimeException)e;
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private void checkLayers(Set<String> expectedLayers, Set<String> foundLayers) {
+        //foundLayers.removeAll(standardExpectedLayers);
+
+        Assert.assertEquals("\nExpected:\n" + expectedLayers + "\nActual:\n" + foundLayers,
+                expectedLayers.size(), foundLayers.size());
 
         for (String expectedLayer : expectedLayers) {
-            Assert.assertTrue(expectedLayer, foundLayers.contains(expectedLayer));
+            Assert.assertTrue(expectedLayer + ": " + foundLayers, foundLayers.contains(expectedLayer));
         }
-
-        return foundLayers;
     }
 
     protected ArchiveBuilder createArchiveBuilder(ArchiveType type) {
@@ -112,6 +136,24 @@ public class AbstractLayerMetaDataTestCase {
 
     protected ArchiveBuilder createArchiveBuilder(String name, ArchiveType type) {
         return new ArchiveBuilder(name, type);
+    }
+
+    private static void deleteArchivesDirectory() throws IOException {
+        if (Files.exists(ARCHIVES_PATH)) {
+            Files.walkFileTree(ARCHIVES_PATH, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
     }
 
     public class ArchiveBuilder {
@@ -200,6 +242,50 @@ public class AbstractLayerMetaDataTestCase {
 
         ArchiveType(String suffix) {
             this.suffix = suffix;
+        }
+    }
+
+
+    public class ExpectedLayers {
+        private Set<String> layers = new HashSet<>();
+        private Set<String> decoratorLayers = new HashSet<>();
+
+        public ExpectedLayers() {
+        }
+
+        public ExpectedLayers(String layer) {
+            add(layer);
+        }
+
+        public ExpectedLayers(String... layers) {
+            this.layers.addAll(Arrays.asList(layers));
+        }
+
+        public ExpectedLayers(String layer, String decorator) {
+            add(layer, decorator);
+        }
+
+        public ExpectedLayers add(String layer) {
+            this.layers.add(layer);
+            return this;
+        }
+
+        public ExpectedLayers add(String layer, String decorator) {
+            layers.add(layer);
+            decoratorLayers.add(decorator);
+            return this;
+        }
+
+        private Set<String> getExpectedFoundLayers() {
+            return layers;
+        }
+
+        private Set<String> getExpectedDecorators() {
+            Set<String> decorators = new HashSet<>();
+            for (String decorator : decoratorLayers) {
+                decorators.add(decorator);
+            }
+            return decorators;
         }
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/batch/jberet/BatchJBeretLayerTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/batch/jberet/BatchJBeretLayerTestCase.java
@@ -14,47 +14,51 @@ public class BatchJBeretLayerTestCase extends AbstractLayerMetaDataTestCase {
         // Not sure how to add an empty folder with shrinkwrap so do this manually
         Path p = ARCHIVES_PATH.resolve("batch-jberet-file.war");
         Files.createDirectories(p.resolve("WEB-INF/classes/META-INF/batch-jobs"));
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testBatchJBeretClassInRootPackage() throws Exception {
+    public void testBatchJBeretClassInRootPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(BatchClassFromApiPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testBatchJBeretClassInChunkPackage() throws Exception {
+    public void testBatchJBeretClassInChunkPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(BatchClassInApiChunkPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testBatchJBeretInChunkListenerPackage() throws Exception {
+    public void testBatchJBeretInChunkListenerPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(BatchClassInApiChunkListenerPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testBatchJBeretInListenerPackage() throws Exception {
+    public void testBatchJBeretInListenerPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(BatchClassInApiListenerPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testBatchJBeretInPartitionPackage() throws Exception {
+    public void testBatchJBeretInPartitionPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(BatchClassInApiPartitionPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "batch-jberet");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("batch-jberet", "batch-jberet"));
     }
 
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/bean/validation/BeanValidationLayerTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/bean/validation/BeanValidationLayerTestCase.java
@@ -10,79 +10,80 @@ import static org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestC
 public class BeanValidationLayerTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testBeanValidationAnnotationInRootPackageUsage() throws Exception {
+    public void testBeanValidationAnnotationInRootPackageUsage() {
         testClass(BeanValidationAnnotationInRootPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationAnnotationInConstraintValidationPackageUsage() throws Exception {
+    public void testBeanValidationAnnotationInConstraintValidationPackageUsage() {
         testClass(BeanValidationAnnotationInConstraintValidationPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationAnnotationInConstraintsPackageUsage() throws Exception {
+    public void testBeanValidationAnnotationInConstraintsPackageUsage() {
         testClass(BeanValidationAnnotationInConstraintsPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationAnnotationInGroupsPackageUsage() throws Exception {
+    public void testBeanValidationAnnotationInGroupsPackageUsage() {
         testClass(BeanValidationAnnotationInGroupsPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationAnnotationInValueExtractionPackageUsage() throws Exception {
+    public void testBeanValidationAnnotationInValueExtractionPackageUsage() {
         testClass(BeanValidationAnnotationInValueExtractionPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationAnnotatonInExecutablePackageUsage() throws Exception {
+    public void testBeanValidationAnnotatonInExecutablePackageUsage() {
         testClass(BeanValidationAnnotatonInExecutablePackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInRootPackageUsage() throws Exception {
+    public void testBeanValidationClassInRootPackageUsage() {
         testClass(BeanValidationClassInRootPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInBootstrapPackageUsage() throws Exception {
+    public void testBeanValidationClassInBootstrapPackageUsage() {
         testClass(BeanValidationClassInBootstrapPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInConstraintValidationPackageUsage() throws Exception {
+    public void testBeanValidationClassInConstraintValidationPackageUsage() {
         testClass(BeanValidationClassInConstraintValidationPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInExecutablePackageUsage() throws Exception {
+    public void testBeanValidationClassInExecutablePackageUsage() {
         testClass(BeanValidationClassInExecutablePackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInGroupsPackageUsage() throws Exception {
+    public void testBeanValidationClassInGroupsPackageUsage() {
         testClass(BeanValidationClassInGroupsPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInMetadataPackageUsage() throws Exception {
+    public void testBeanValidationClassInMetadataPackageUsage() {
         testClass(BeanValidationClassInMetadataPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInSpiPackageUsage() throws Exception {
+    public void testBeanValidationClassInSpiPackageUsage() {
         testClass(BeanValidationClassInSpiPackageUsage.class);
     }
 
     @Test
-    public void testBeanValidationClassInValueExtractionPackageUsage() throws Exception {
+    public void testBeanValidationClassInValueExtractionPackageUsage() {
         testClass(BeanValidationClassInValueExtractionPackageUsage.class);
     }
 
-    private void testClass(Class<?> clazz) throws Exception {
+    private void testClass(Class<?> clazz) {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(clazz)
                 .build();
+        // bean-validation is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "bean-validation");
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/cdi/CdiLayerTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/cdi/CdiLayerTestCase.java
@@ -11,35 +11,41 @@ import static org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestC
 public class CdiLayerTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testCdiDetectedFileInWar() throws Exception {
+    public void testCdiDetectedFileInWar() {
         Path p = createArchiveBuilder(WAR)
                 .addXml("beans.xml", "")
                 .build();
-        checkLayersForArchive(p, "cdi");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testCdiDetectedFileInJar() throws Exception {
+    public void testCdiDetectedFileInJar() {
         Path p = createArchiveBuilder(JAR)
                 .addXml("beans.xml", "")
                 .build();
-        checkLayersForArchive(p, "cdi");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testInjectPackage() throws Exception {
+    public void testInjectPackage() {
         Path p = createArchiveBuilder(WAR)
                 .addClasses(CdiInjectClass.class)
                 .build();
-        checkLayersForArchive(p, "cdi");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testEnterpriseContext() throws Exception {
+    public void testEnterpriseContext() {
         //This is in a sub-package of jakarta.enterprise.context
         Path p = createArchiveBuilder(WAR)
                 .addClasses(CdiEnterpriseContextClass.class)
                 .build();
+        // cdi is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        // cdi is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "cdi");
     }
 

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/datasources/DatasourcesLayerMetadataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/datasources/DatasourcesLayerMetadataTestCase.java
@@ -7,18 +7,22 @@ import java.nio.file.Path;
 
 public class DatasourcesLayerMetadataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testJavaSqlUsageDetected() throws Exception {
+    public void testJavaSqlUsageDetected() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JavaSqlUsage.class)
                 .build();
-        checkLayersForArchive(p, "datasources");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testJavaxSqlUsageDetected() throws Exception {
+    public void testJavaxSqlUsageDetected() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JavaxSqlUsage.class)
                 .build();
-        checkLayersForArchive(p, "datasources");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("datasources", "datasources"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/concurrency/EeConcurrencyLayerMetadataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/concurrency/EeConcurrencyLayerMetadataTestCase.java
@@ -7,11 +7,11 @@ import java.nio.file.Path;
 
 public class EeConcurrencyLayerMetadataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testEeConcurrencyUsageDetected() throws Exception {
+    public void testEeConcurrencyUsageDetected() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(EeConcurrencyClassUsage.class)
                 .build();
-        checkLayersForArchive(p, "ee-concurrency");
+        checkLayersForArchive(p, new ExpectedLayers("ee-concurrency", "ee-concurrency"));
     }
 
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/integration/EeIntegrationLayerMetadataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/integration/EeIntegrationLayerMetadataTestCase.java
@@ -22,51 +22,52 @@ public class EeIntegrationLayerMetadataTestCase extends AbstractLayerMetaDataTes
     }
 
     @Test
-    public void testJakartaXmlBindAnnotationAdaptersPackageAnnotationUsage() throws Exception {
+    public void testJakartaXmlBindAnnotationAdaptersPackageAnnotationUsage() {
         testWarWithClass(JakartaXmlBindAnnotationAdaptersPackageAnnotationUsage.class);
     }
 
     @Test
-    public void testJakartaXmlBindAnnotationPackageAnnotationUsage() throws Exception {
+    public void testJakartaXmlBindAnnotationPackageAnnotationUsage() {
         testWarWithClass(JakartaXmlBindAnnotationPackageAnnotationUsage.class);
     }
 
 
     @Test
-    public void testJakartaXmlBindRootPackageClassUsage() throws Exception {
+    public void testJakartaXmlBindRootPackageClassUsage() {
         testWarWithClass(JakartaXmlBindRootPackageClassUsage.class);
     }
 
     @Test
-    public void testJakartaXmlAnnotationPackageClassUsage() throws Exception {
+    public void testJakartaXmlAnnotationPackageClassUsage() {
         testWarWithClass(JakartaXmlAnnotationPackageClassUsage.class);
     }
 
     @Test
-    public void testJakartaXmlAnnotationAdaptersPackageClassUsage() throws Exception {
+    public void testJakartaXmlAnnotationAdaptersPackageClassUsage() {
         testWarWithClass(JakartaXmlAnnotationAdaptersPackageClassUsage.class);
     }
 
     @Test
-    public void testJakartaXmlBindAttachmentPackageClassUsage() throws Exception {
+    public void testJakartaXmlBindAttachmentPackageClassUsage() {
         testWarWithClass(JakartaXmlBindAttachmentPackageClassUsage.class);
     }
 
     @Test
-    public void testJakartaXmlBindHelpersPackageClassUsage() throws Exception {
+    public void testJakartaXmlBindHelpersPackageClassUsage() {
         // jakarta.xml.bind.helpers.AbstractMarshallerImpl
         testWarWithClass(JakartaXmlBindHelpersPackageClassUsage.class);
     }
 
     @Test
-    public void testJakartaXmlBindUtilPackageClassUsage() throws Exception {
+    public void testJakartaXmlBindUtilPackageClassUsage() {
         testWarWithClass(JakartaXmlBindUtilPackageClassUsage.class);
     }
 
-    private void testWarWithClass(Class<?> clazz) throws Exception {
+    private void testWarWithClass(Class<?> clazz) {
         Path p= createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
+        // ee-integration is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "ee-integration");
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/security/EeSecurityLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ee/security/EeSecurityLayerMetaDataTestCase.java
@@ -10,46 +10,46 @@ public class EeSecurityLayerMetaDataTestCase extends AbstractLayerMetaDataTestCa
     // jakarta.security.enterprise-api annotations/classes
 
     @Test
-    public void testSecurityEnterpriseRootPackageClass() throws Exception {
+    public void testSecurityEnterpriseRootPackageClass() {
         addClassAndCheck(SecurityEnterpriseRootPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseHttpPackageAnnotation() throws Exception {
+    public void testSecurityEnterpriseHttpPackageAnnotation() {
         addClassAndCheck(SecurityEnterpriseHttpPackageAnnotationUsage.class);
     }
 
-    @Test public void testSecurityEnterpriseHttpPackageClass() throws Exception {
+    @Test public void testSecurityEnterpriseHttpPackageClass() {
         addClassAndCheck(SecurityEnterpriseHttpPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseHttpOpenIdPackageAnnotation() throws Exception {
+    public void testSecurityEnterpriseHttpOpenIdPackageAnnotation() {
         addClassAndCheck(SecurityEnterpriseHttpOpenIdPackageAnnotationUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseHttpOpenIdPackageClass() throws Exception {
+    public void testSecurityEnterpriseHttpOpenIdPackageClass() {
         addClassAndCheck(SecurityEnterpriseHttpOpenIdPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseCredentialPackageClass() throws Exception {
+    public void testSecurityEnterpriseCredentialPackageClass() {
         addClassAndCheck(SecurityEnterpriseCredentialPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseIdentityStoreAnnotation() throws Exception {
+    public void testSecurityEnterpriseIdentityStoreAnnotation() {
         addClassAndCheck(SecurityEnterpriseIdentityStoreAnnotationUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseIdentityStoreClass() throws Exception {
+    public void testSecurityEnterpriseIdentityStoreClass() {
         addClassAndCheck(SecurityEnterpriseIdentityStoreClassUsage.class);
     }
 
     @Test
-    public void testSecurityEnterpriseIdentityStoreOpenIdClass() throws Exception {
+    public void testSecurityEnterpriseIdentityStoreOpenIdClass() {
         addClassAndCheck(SecurityEnterpriseIdentityStoreOpenIdClassUsage.class);
     }
 
@@ -57,37 +57,37 @@ public class EeSecurityLayerMetaDataTestCase extends AbstractLayerMetaDataTestCa
     // jakarta-authentication-api classes
 
     @Test
-    public void testSecurityAuthMessageRootPackageClass() throws Exception {
+    public void testSecurityAuthMessageRootPackageClass() {
         addClassAndCheck(SecurityAuthMessageRootPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityAuthMessageCallbackPackageClass() throws Exception {
+    public void testSecurityAuthMessageCallbackPackageClass() {
         addClassAndCheck(SecurityAuthMessageCallbackPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityAuthMessageConfigPackageClass() throws Exception {
+    public void testSecurityAuthMessageConfigPackageClass() {
         addClassAndCheck(SecurityAuthMessageConfigPackageClassUsage.class);
     }
 
     @Test
-    public void testSecurityAuthMessageModulePackageClass() throws Exception {
+    public void testSecurityAuthMessageModulePackageClass() {
         addClassAndCheck(SecurityAuthMessageModulePackageClassUsage.class);
     }
 
     //////////////////////////////////////////////////////////////////////
     // jakarta-authorization-api classes
     @Test
-    public void testSecurityJaccClass() throws Exception {
+    public void testSecurityJaccClass() {
         addClassAndCheck(SecurityJaccClassUsage.class);
     }
 
-    private void addClassAndCheck(Class<?> clazz) throws Exception {
+    private void addClassAndCheck(Class<?> clazz) {
         Path p =
                 createArchiveBuilder(ArchiveType.WAR)
                         .addClasses(clazz)
                         .build();
-        checkLayersForArchive(p, "ee-security");
+        checkLayersForArchive(p, new ExpectedLayers("ee-security", "ee-security"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/EjbLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/EjbLayerMetaDataTestCase.java
@@ -7,26 +7,30 @@ import java.nio.file.Path;
 
 public class EjbLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testMessageDrivenAnnotation() throws Exception {
+    public void testMessageDrivenAnnotation() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(MessageDrivenAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p, "ejb");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testRemoteAnnotation() throws Exception {
+    public void testRemoteAnnotation() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(RemoteAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p, "ejb");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testMessageDrivenContextClass() throws Exception {
+    public void testMessageDrivenContextClass() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(MessageDrivenContextClassUsage.class)
                 .build();
-        checkLayersForArchive(p, "ejb");
+        checkLayersForArchive(p);
+    }
+
+    public void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("ejb", "ejb"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/cache/EJBDistCacheHaProfileMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/cache/EJBDistCacheHaProfileMetaDataTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.wildfly.ee.feature.pack.layer.tests.ejb.cache;
+
+import org.junit.Test;
+import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
+import org.wildfly.ee.feature.pack.layer.tests.ejb.MessageDrivenAnnotationUsage;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class EJBDistCacheHaProfileMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+    @Test
+    public void testMessageDrivenAnnotationHaProfile() {
+        // The tests in the parent package test standard profile
+        Path p = createArchiveBuilder(ArchiveType.WAR)
+                .addClasses(MessageDrivenAnnotationUsage.class)
+                .build();
+        checkLayersForArchive(p,
+                builder -> builder.setExecutionProfiles(Collections.singleton("ha")),
+                new ExpectedLayers("ejb", "ejb")
+                        .addDecorator("ejb-dist-cache")
+                        .excludedLayers("ejb-local-cache"));
+    }
+}

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/lite/EjbLiteLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/lite/EjbLiteLayerMetaDataTestCase.java
@@ -8,19 +8,22 @@ import java.nio.file.Path;
 public class EjbLiteLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testEjbLiteAnnotationUsage() throws Exception {
+    public void testEjbLiteAnnotationUsage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(EjbLiteAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p,"ejb-lite");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testEjbLiteClassUsage() throws Exception {
+    public void testEjbLiteClassUsage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(EjbLiteClassUsage.class)
                 .build();
-        checkLayersForArchive(p,"ejb-lite");
+        checkLayersForArchive(p);
     }
 
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p,new ExpectedLayers("ejb-lite", "ejb-lite"));
+    }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/lite/cache/EJBLiteDistCacheHaProfileMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/ejb/lite/cache/EJBLiteDistCacheHaProfileMetaDataTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.wildfly.ee.feature.pack.layer.tests.ejb.lite.cache;
+
+import org.junit.Test;
+import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
+import org.wildfly.ee.feature.pack.layer.tests.ejb.lite.EjbLiteAnnotationUsage;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class EJBLiteDistCacheHaProfileMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+
+    @Test
+    public void testAnnotationHaProfile() {
+        // The tests in the parent package test standard profile
+        Path p = createArchiveBuilder(ArchiveType.WAR)
+                .addClasses(EjbLiteAnnotationUsage.class)
+                .build();
+        checkLayersForArchive(p,
+                builder -> builder.setExecutionProfiles(Collections.singleton("ha")),
+                new ExpectedLayers("ejb-lite", "ejb-lite")
+                        .addDecorator("ejb-dist-cache")
+                        .excludedLayers("ejb-local-cache"));
+    }
+}

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/elytron/oidc/client/ElytronOidcClientLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/elytron/oidc/client/ElytronOidcClientLayerMetaDataTestCase.java
@@ -7,11 +7,11 @@ import java.nio.file.Path;
 
 public class ElytronOidcClientLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testXmlAuthMethod() throws Exception {
+    public void testXmlAuthMethod() {
         String xml = createXmlElementWithContent("OIDC", "web-app", "login-config", "auth-method");
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("web.xml", xml)
                 .build();
-        checkLayersForArchive(p, "elytron-oidc-client");
+        checkLayersForArchive(p, new ExpectedLayers("elytron-oidc-client", "elytron-oidc-client"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/embedded/activemq/EmbeddedActiveMqLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/embedded/activemq/EmbeddedActiveMqLayerMetaDataTestCase.java
@@ -7,23 +7,26 @@ import java.nio.file.Path;
 
 public class EmbeddedActiveMqLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testJmsDestinationsInJmxXmlInWar() throws Exception {
+    public void testJmsDestinationsInJmxXmlInWar() {
         String xml = createXml();
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("test-jms.xml", xml)
                 .build();
-        checkLayersForArchive(p, "embedded-activemq");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testJmsDestinationsInJmxXmlInJar() throws Exception {
+    public void testJmsDestinationsInJmxXmlInJar() {
         String xml = createXml();
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("test-jms.xml", xml)
                 .build();
-        checkLayersForArchive(p, "embedded-activemq");
+        checkLayersForArchive(p);
     }
 
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("embedded-activemq", "embedded-activemq"));
+    }
 
     private String createXml() {
         return createXmlElementWithContent(null, "messaging-deployment", "server", "jms-destinations");

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/datasource/H2DatasourceLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/datasource/H2DatasourceLayerMetaDataTestCase.java
@@ -7,20 +7,27 @@ import java.nio.file.Path;
 
 public class H2DatasourceLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testPersistenceXmlEntryInWebInfClasesMetaInf() throws Exception {
+    public void testPersistenceXmlEntryInWebInfClasesMetaInf() {
         String xml = createXmlElementWithContent("java:jboss/datasources/ExampleDS", "persistence", "persistence-unit", "jta-data-source");
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("persistence.xml", xml, true)
                 .build();
-        checkLayersForArchive(p, "h2-datasource", "jpa");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testPersistenceXmlEntryInMetaInf() throws Exception {
+    public void testPersistenceXmlEntryInMetaInf() {
         String xml = createXmlElementWithContent("java:jboss/datasources/ExampleDS", "persistence", "persistence-unit", "jta-data-source");
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("persistence.xml", xml)
                 .build();
-        checkLayersForArchive(p, "h2-datasource", "jpa");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p,
+                new ExpectedLayers("h2-datasource", "h2-datasource")
+                        .add("jpa", "jpa"));
+
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/datasource/H2DatasourceLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/datasource/H2DatasourceLayerMetaDataTestCase.java
@@ -27,7 +27,7 @@ public class H2DatasourceLayerMetaDataTestCase extends AbstractLayerMetaDataTest
     private void checkLayersForArchive(Path p) {
         checkLayersForArchive(p,
                 new ExpectedLayers("h2-datasource", "h2-datasource")
-                        .add("jpa", "jpa"));
+                        .addLayerAndDecorator("jpa", "jpa"));
 
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
@@ -7,36 +7,40 @@ import java.nio.file.Path;
 
 public class H2DriverLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testH2DriverNonXaInWar() throws Exception {
+    public void testH2DriverNonXaInWar() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("test-ds.xml", nonXaXml())
                 .build();
-        checkLayersForArchive(p, "h2-driver");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testH2DriverNonXaInJar() throws Exception {
+    public void testH2DriverNonXaInJar() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("test-ds.xml", nonXaXml())
                 .build();
-        checkLayersForArchive(p, "h2-driver");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testH2DriverXaInWar() throws Exception {
+    public void testH2DriverXaInWar() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("test-ds.xml", xaXml())
                 .build();
-        checkLayersForArchive(p, "h2-driver");
+        checkLayersForArchive(p);
 
     }
 
     @Test
-    public void testH2DriverXaInJar() throws Exception {
+    public void testH2DriverXaInJar() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("test-ds.xml", xaXml())
                 .build();
-        checkLayersForArchive(p, "h2-driver");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("h2-driver", "h2-driver"));
     }
 
     private String nonXaXml() {

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/hibernate/search/HibernateSearchLayerTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/hibernate/search/HibernateSearchLayerTestCase.java
@@ -11,10 +11,10 @@ import static org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestC
 @Indexed
 public class HibernateSearchLayerTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testHibernateSearchDetected() throws Exception {
+    public void testHibernateSearchDetected() {
         Path p = createArchiveBuilder(JAR)
                 .addClasses(this.getClass())
                 .build();
-        checkLayersForArchive(p, "hibernate-search");
+        checkLayersForArchive(p, new ExpectedLayers("hibernate-search", "hibernate-search"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/hibernate/search/HibernateSearchLayerTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/hibernate/search/HibernateSearchLayerTestCase.java
@@ -1,7 +1,7 @@
 package org.wildfly.ee.feature.pack.layer.tests.hibernate.search;
 
-import org.junit.Test;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.junit.Test;
 import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
 
 import java.nio.file.Path;

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jaxrs/JaxrsLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jaxrs/JaxrsLayerMetaDataTestCase.java
@@ -7,39 +7,43 @@ import java.nio.file.Path;
 
 public class JaxrsLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testJaxrsAnnotationFromRootPackage() throws Exception {
+    public void testJaxrsAnnotationFromRootPackage() {
         testOneClassInWar(JaxrsRootPackageAnnotationUsage.class);
     }
 
     @Test
-    public void testJaxrsClassFromRootPackage() throws Exception {
+    public void testJaxrsClassFromRootPackage() {
         testOneClassInWar(JaxrsRootPackageClassUsage.class);
     }
 
     @Test
-    public void testJaxrsAnnotationFromCorePackage() throws Exception {
+    public void testJaxrsAnnotationFromCorePackage() {
         testOneClassInWar(JaxrsCorePackageAnnotationUsage.class);
     }
 
     @Test
-    public void testJaxrsClassFromCorePackage() throws Exception {
+    public void testJaxrsClassFromCorePackage() {
         testOneClassInWar(JaxrsCorePackageClassUsage.class);
     }
 
     @Test
-    public void testApplicationInWebXml() throws Exception {
+    public void testApplicationInWebXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml(
                         "web.xml",
                         createXmlElementWithContent("jakarta.ws.rs.core.Application", "web-app", "servlet", "servlet-class"))
                 .build();
-        checkLayersForArchive(p, "jaxrs", "servlet");
+        checkLayersForArchive(p,
+                new ExpectedLayers("jaxrs", "jaxrs")
+                        // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
+                        .add("servlet"));
     }
 
-    private void testOneClassInWar(Class<?> clazz) throws Exception {
+    private void testOneClassInWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "jaxrs");
+        checkLayersForArchive(p, new ExpectedLayers("jaxrs", "jaxrs"));
     }
+
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jaxrs/JaxrsLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jaxrs/JaxrsLayerMetaDataTestCase.java
@@ -36,7 +36,7 @@ public class JaxrsLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
         checkLayersForArchive(p,
                 new ExpectedLayers("jaxrs", "jaxrs")
                         // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
-                        .add("servlet"));
+                        .addLayer("servlet"));
     }
 
     private void testOneClassInWar(Class<?> clazz) {

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jpa/JpaLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jpa/JpaLayerMetaDataTestCase.java
@@ -6,52 +6,50 @@ import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
 import java.nio.file.Path;
 
 public class JpaLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
-    /*
-<prop name="org.wildfly.rule.expected-file" value="[/META-INF/persistence.xml,/WEB-INF/classes/META-INF/persistence.xml]"/>
-<prop name="org.wildfly.rule.annotations" value="jakarta.persistence"/>
-<prop name="org.wildfly.rule.class" value="jakarta.persistence"/>
-
-     */
     @Test
-    public void testMetaInfPersistenceXml() throws Exception {
+    public void testMetaInfPersistenceXml() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("persistence.xml", "")
                 .build();
-        checkLayersForArchive(p, "jpa");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testWebInfClassesMetaInfPersistenceXml() throws Exception {
+    public void testWebInfClassesMetaInfPersistenceXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("persistence.xml", "", true)
                 .build();
-        checkLayersForArchive(p, "jpa");
+        checkLayersForArchive(p);
     }
 
 
     @Test
-    public void testAnnotationFromRootPackage() throws Exception {
+    public void testAnnotationFromRootPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JpaAnnotationFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "jpa");
+        checkLayersForArchive(p);
     }
 
 
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JpaClassFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "jpa");
+        checkLayersForArchive(p);
     }
 
 
     @Test
-    public void testClassFromCriteriaPackage() throws Exception {
+    public void testClassFromCriteriaPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JpaClassFromCriteriaPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "jpa");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("jpa", "jpa"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jpa/distributed/JpaDistributedHaProfileMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jpa/distributed/JpaDistributedHaProfileMetaDataTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.wildfly.ee.feature.pack.layer.tests.jpa.distributed;
+
+import org.junit.Test;
+import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
+import org.wildfly.ee.feature.pack.layer.tests.jpa.JpaClassFromCriteriaPackageUsage;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class JpaDistributedHaProfileMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+    @Test
+    public void testClassFromCriteriaPackage() {
+        // The test in the parent package covers the standard profile
+        Path p = createArchiveBuilder(AbstractLayerMetaDataTestCase.ArchiveType.WAR)
+                .addClasses(JpaClassFromCriteriaPackageUsage.class)
+                .build();
+        checkLayersForArchive(p,
+                builder -> builder.setExecutionProfiles(Collections.singleton("ha")),
+                new AbstractLayerMetaDataTestCase.ExpectedLayers("jpa", "jpa-distributed")
+                        .excludedLayers("jpa"));
+    }
+
+}

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsf/JsfLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsf/JsfLayerMetaDataTestCase.java
@@ -6,53 +6,52 @@ import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
 import java.nio.file.Path;
 
 public class JsfLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
-    /*
-<prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet/servlet-class,jakarta.faces.webapp.FacesServlet"/>
-<prop name="org.wildfly.rule.expected-file" value="/WEB-INF/faces-config.xml"/>
-<prop name="org.wildfly.rule.annotations" value="jakarta.faces.annotation"/>
-<prop name="org.wildfly.rule.class" value="jakarta.faces.*"/>
-     */
-
     @Test
-    public void testFacesServletInWebXml() throws Exception {
+    public void testFacesServletInWebXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml(
                         "web.xml",
                         createXmlElementWithContent("jakarta.faces.webapp.FacesServlet", "web-app", "servlet", "servlet-class"))
                 .build();
-        checkLayersForArchive(p, "jsf", "servlet");
+        checkLayersForArchive(p,
+                new ExpectedLayers("jsf", "jsf")
+                        // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
+                        .add("servlet"));
     }
 
     @Test
-    public void testFacesConfigXml() throws Exception {
+    public void testFacesConfigXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("faces-config.xml", "")
                 .build();
-        checkLayersForArchive(p, "jsf");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testAnnotation() throws Exception {
+    public void testAnnotation() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JsfAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p, "jsf");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JsfClassFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "jsf");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassFromNestedPackage() throws Exception {
+    public void testClassFromNestedPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JsfClassFromNestedPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "jsf");
+        checkLayersForArchive(p);
+    }
 
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("jsf", "jsf"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsf/JsfLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsf/JsfLayerMetaDataTestCase.java
@@ -16,7 +16,7 @@ public class JsfLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
         checkLayersForArchive(p,
                 new ExpectedLayers("jsf", "jsf")
                         // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
-                        .add("servlet"));
+                        .addLayer("servlet"));
     }
 
     @Test

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsonb/JsonbLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsonb/JsonbLayerMetaDataTestCase.java
@@ -9,41 +9,43 @@ import java.util.Set;
 
 public class JsonbLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testAnnotationUsage() throws Exception {
+    public void testAnnotationUsage() {
         testSingleClassWar(JsonbAnnotationUsage.class);
     }
 
     @Test
-    public void testClassFromRootPackageUsage() throws Exception {
+    public void testClassFromRootPackageUsage() {
         testSingleClassWar(JsonbClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testClassFromAdapterPackageUsage() throws Exception {
+    public void testClassFromAdapterPackageUsage() {
         testSingleClassWar(JsonbClassFromAdapterPackageUsage.class);
     }
 
     @Test
-    public void testClassFromConfigPackageUsage() throws Exception {
+    public void testClassFromConfigPackageUsage() {
         testSingleClassWar(JsonbClassFromConfigPackageUsage.class);
     }
 
     @Test
-    public void testClassFromSerializerPackageUsage() throws Exception {
+    public void testClassFromSerializerPackageUsage() {
         testSingleClassWar(JsonbClassFromSerializerPackageUsage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(clazz)
                 .build();
         checkLayersForArchiveDontContainJsonp(p);
     }
 
-    private void checkLayersForArchiveDontContainJsonp(Path p) throws Exception {
+    private void checkLayersForArchiveDontContainJsonp(Path p) {
         // Some extra checks here, since jsonp has the jakarta.json package
         // while jsonb uses jakarta.json.bind. We want to make sure the rule
         // for jsonp is tight enough to not inadvertently recommending jsonb as well
+
+        //jsonb is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         Set<String> set = checkLayersForArchive(p, "jsonb");
         Assert.assertFalse(set.contains("jsonp"));
     }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsonp/JsonpLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/jsonp/JsonpLayerMetaDataTestCase.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 public class JsonpLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testClassFromRootPackageUsage() throws Exception {
+    public void testClassFromRootPackageUsage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JsonpClassFromRootPackageUsage.class)
                 .build();
@@ -16,10 +16,11 @@ public class JsonpLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     }
 
     @Test
-    public void testClassFromStreamPackageUsage() throws Exception {
+    public void testClassFromStreamPackageUsage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(JsonpClassFromStreamPackageUsage.class)
                 .build();
+        // jsonp is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "jsonp");
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/mail/MailLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/mail/MailLayerMetaDataTestCase.java
@@ -7,39 +7,39 @@ import java.nio.file.Path;
 
 public class MailLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testAnnotationFromRootPackageUsage() throws Exception {
+    public void testAnnotationFromRootPackageUsage() {
         testSingleClassWar(MailAnnotationFromRootPackageUsage.class);
     }
 
     @Test
-    public void testClassFromRootPackageUsage() throws Exception {
+    public void testClassFromRootPackageUsage() {
         testSingleClassWar(MailClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testClassFromEventPackageUsage() throws Exception {
+    public void testClassFromEventPackageUsage() {
         testSingleClassWar(MailClassFromEventPackageUsage.class);
     }
 
     @Test
-    public void testClassFromInternetPackageUsage() throws Exception {
+    public void testClassFromInternetPackageUsage() {
         testSingleClassWar(MailClassFromInternetPackageUsage.class);
     }
 
     @Test
-    public void testClassFromSearchPackageUsage() throws Exception {
+    public void testClassFromSearchPackageUsage() {
         testSingleClassWar(MailClassFromSearchPackageUsage.class);
     }
 
     @Test
-    public void testClassFromUtilPackageUsage() throws Exception {
+    public void testClassFromUtilPackageUsage() {
         testSingleClassWar(MailClassFromUtilPackageUsage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "mail");
+        checkLayersForArchive(p, new ExpectedLayers("mail", "mail"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/messaging/activemq/MessagingActiveMqLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/messaging/activemq/MessagingActiveMqLayerMetaDataTestCase.java
@@ -8,18 +8,22 @@ import java.nio.file.Path;
 public class MessagingActiveMqLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testAnnotationUsage() throws Exception {
+    public void testAnnotationUsage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(MessagingActiveMqAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p,"messaging-activemq");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassUsage() throws Exception {
+    public void testClassUsage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(MessagingActiveMqClassUsage.class)
                 .build();
-        checkLayersForArchive(p,"messaging-activemq");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("messaging-activemq", "messaging-activemq"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/naming/NamingLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/naming/NamingLayerMetaDataTestCase.java
@@ -10,10 +10,11 @@ public class NamingLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     javax.naming.Context context;
 
     @Test
-    public void testNamingClassUsage() throws Exception {
+    public void testNamingClassUsage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(this.getClass())
                 .build();
+        // naming is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "naming");
     }
 

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/pojo/PojoLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/pojo/PojoLayerMetaDataTestCase.java
@@ -7,26 +7,30 @@ import java.nio.file.Path;
 
 public class PojoLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testJarMetaInfBeansXml() throws Exception {
+    public void testJarMetaInfBeansXml() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("one-jboss-beans.xml", "")
                 .build();
-        checkLayersForArchive(p, "pojo");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testWarWebInfBeansXml() throws Exception {
+    public void testWarWebInfBeansXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("xjboss-beans.xml", "")
                 .build();
-        checkLayersForArchive(p, "pojo");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testWarWebInfClassesMetaInfBeansXml() throws Exception {
+    public void testWarWebInfClassesMetaInfBeansXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("jboss-beans.xml", "", true)
                 .build();
-        checkLayersForArchive(p, "pojo");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("pojo", "pojo"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/resource/adapters/ResourceAdaptersLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/resource/adapters/ResourceAdaptersLayerMetaDataTestCase.java
@@ -7,18 +7,22 @@ import java.nio.file.Path;
 
 public class ResourceAdaptersLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testRaXml() throws Exception {
+    public void testRaXml() {
         Path p = createArchiveBuilder(ArchiveType.RAR)
                 .addXml("ra.xml", "")
                 .build();
-        checkLayersForArchive(p, "resource-adapters");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testIronjacamarXml() throws Exception {
+    public void testIronjacamarXml() {
         Path p = createArchiveBuilder(ArchiveType.RAR)
                 .addXml("ironjacamar.xml", "")
                 .build();
-        checkLayersForArchive(p, "resource-adapters");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("resource-adapters", "resource-adapters"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/sar/SarLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/sar/SarLayerMetaDataTestCase.java
@@ -7,10 +7,10 @@ import java.nio.file.Path;
 
 public class SarLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testMetaInfJbossServiceXml() throws Exception {
+    public void testMetaInfJbossServiceXml() {
         Path p = createArchiveBuilder(ArchiveType.SAR)
                 .addXml("jboss-service.xml", "")
                 .build();
-        checkLayersForArchive(p, "sar");
+        checkLayersForArchive(p, new ExpectedLayers("sar", "sar"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/servlet/ServletLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/servlet/ServletLayerMetaDataTestCase.java
@@ -7,61 +7,61 @@ import java.nio.file.Path;
 
 public class ServletLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
-
-
     @Test
-    public void testServletAnnotation() throws Exception {
+    public void testServletAnnotation() {
         // No sub packages for this one
         testSingleClassWar(ServletAnnotationUsage.class);
     }
 
     @Test
-    public void testWebsocketAnnotationFromRootPackage() throws Exception {
+    public void testWebsocketAnnotationFromRootPackage() {
         testSingleClassWar(WebsocketAnnotationFromRootPackageUsage.class);
     }
 
     @Test
-    public void testWebsocketAnnotationFromServerPackage() throws Exception {
+    public void testWebsocketAnnotationFromServerPackage() {
         testSingleClassWar(WebsocketAnnotationFromServerPackageUsage.class);
     }
 
     @Test
-    public void testServletInWebXml() throws Exception {
+    public void testServletInWebXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("web.xml", createXmlElementWithContent("", "web-app", "servlet"))
                 .build();
+        // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "servlet");
     }
 
     @Test
-    public void testServletClassFromRootPackage() throws Exception {
+    public void testServletClassFromRootPackage() {
         testSingleClassWar(ServletClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testServletClassFromDescriptorPackage() throws Exception {
+    public void testServletClassFromDescriptorPackage() {
         testSingleClassWar(ServletClassFromDescriptorPackageUsage.class);
     }
 
     @Test
-    public void testServletClassFromHttpPackage() throws Exception {
+    public void testServletClassFromHttpPackage() {
         testSingleClassWar(ServletClassFromDescriptorPackageUsage.class);
     }
 
     @Test
-    public void testWebsocketClassFromRootPackage() throws Exception {
+    public void testWebsocketClassFromRootPackage() {
         testSingleClassWar(WebSocketClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testWebsocketClassFromServerPackage() throws Exception {
+    public void testWebsocketClassFromServerPackage() {
         testSingleClassWar(WebSocketClassFromServerPackageUsage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
+        // servlet is a dependency of the ee-core-profile-server so it doesn't show up as a decorator
         checkLayersForArchive(p, "servlet");
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/singleton/ha/SingletonHaHaProfileLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/singleton/ha/SingletonHaHaProfileLayerMetaDataTestCase.java
@@ -1,0 +1,22 @@
+package org.wildfly.ee.feature.pack.layer.tests.singleton.ha;
+
+import org.junit.Test;
+import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class SingletonHaHaProfileLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+    @Test
+    public void testSingletonDeploymentXmlInMetaInf() {
+        // The tests in ../local test the standard profile
+        Path p = createArchiveBuilder(ArchiveType.JAR)
+                .addXml("singleton-deployment.xml", "")
+                .build();
+
+        checkLayersForArchive(p,
+                builder -> builder.setExecutionProfiles(Collections.singleton("ha")),
+                new ExpectedLayers("singleton-local", "singleton-ha")
+                        .excludedLayers("singleton-local"));
+    }
+}

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/singleton/local/SingletonLocalLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/singleton/local/SingletonLocalLayerMetaDataTestCase.java
@@ -7,42 +7,46 @@ import java.nio.file.Path;
 
 public class SingletonLocalLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testSingletonDeploymentXmlInMetaInf() throws Exception {
+    public void testSingletonDeploymentXmlInMetaInf() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addXml("singleton-deployment.xml", "")
                 .build();
-        checkLayersForArchive(p, "singleton-local");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testSingletonDeploymentXmlInWebInfClassesMetaInf() throws Exception {
+    public void testSingletonDeploymentXmlInWebInfClassesMetaInf() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("singleton-deployment.xml", "", true)
                 .build();
-        checkLayersForArchive(p, "singleton-local");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testSingletonDeploymentClassUsageFromRootPackage() throws Exception {
+    public void testSingletonDeploymentClassUsageFromRootPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(SingletonLocalClassFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "singleton-local");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testSingletonDeploymentClassUsageFromElectionPackage() throws Exception {
+    public void testSingletonDeploymentClassUsageFromElectionPackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(SingletonLocalClassFromElectionPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "singleton-local");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testSingletonDeploymentClassUsageFromServicePackage() throws Exception {
+    public void testSingletonDeploymentClassUsageFromServicePackage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(SingletonLocalClassFromServicePackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "singleton-local");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("singleton-local", "singleton-local"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/transactions/TransactionsLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/transactions/TransactionsLayerMetaDataTestCase.java
@@ -8,20 +8,24 @@ import java.nio.file.Path;
 public class TransactionsLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testTransactionAnnotationUsage() throws Exception {
+    public void testTransactionAnnotationUsage() {
         // No nested packages for this one
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(TransactionAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p, "transactions");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testTransactionClassUsage() throws Exception {
+    public void testTransactionClassUsage() {
         // No nested packages for this one
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(TransactionClassUsage.class)
                 .build();
-        checkLayersForArchive(p, "transactions");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("transactions", "transactions"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/web/clustering/WebClusteringHaProfileLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/web/clustering/WebClusteringHaProfileLayerMetaDataTestCase.java
@@ -1,0 +1,28 @@
+package org.wildfly.ee.feature.pack.layer.tests.web.clustering;
+
+import org.junit.Test;
+import org.wildfly.ee.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
+import org.wildfly.glow.ScanArguments;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+public class WebClusteringHaProfileLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+
+    @Test
+    public void testDistributableInWebXml() {
+        Path p = createArchiveBuilder(ArchiveType.WAR)
+                .addXml("web.xml", createXmlElementWithContent("", "web-app", "distributable"))
+                .build();
+        checkLayersForArchive(p,
+                new Consumer<ScanArguments.Builder>() {
+                    @Override
+                    public void accept(ScanArguments.Builder builder) {
+                        builder.setExecutionProfiles(Collections.singleton("ha"));
+                    }
+                },
+                new ExpectedLayers("web-passivation", "web-clustering")
+                        .excludedLayers("web-passivation"));
+    }
+}

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/web/passivation/WebPassivationLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/web/passivation/WebPassivationLayerMetaDataTestCase.java
@@ -8,10 +8,10 @@ import java.nio.file.Path;
 public class WebPassivationLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testDistributableInWebXml() throws Exception {
+    public void testDistributableInWebXml() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addXml("web.xml", createXmlElementWithContent("", "web-app", "distributable"))
                 .build();
-        checkLayersForArchive(p, "web-passivation");
+        checkLayersForArchive(p, new ExpectedLayers("web-passivation", "web-passivation"));
     }
 }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/webservices/WebServicesLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/webservices/WebServicesLayerMetaDataTestCase.java
@@ -7,59 +7,60 @@ import java.nio.file.Path;
 
 public class WebServicesLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testAnnotationInRootJwsPackage() throws Exception {
+    public void testAnnotationInRootJwsPackage() {
         testSingleWar(AnnotationInRootJwsPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationInJwsSoapPackage() throws Exception {
+    public void testAnnotationInJwsSoapPackage() {
         testSingleWar(AnnotationInJwsSoapPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationInRootXmlPackage() throws Exception {
+    public void testAnnotationInRootXmlPackage() {
         testSingleWar(AnnotationInRootXmlPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationInXmlChildPackage() throws Exception {
+    public void testAnnotationInXmlChildPackage() {
         testSingleWar(AnnotationInXmlChildPackageUsage.class);
     }
 
     @Test
-    public void testClassInRootXmlPackage() throws Exception {
+    public void testClassInRootXmlPackage() {
         testSingleWar(ClassInRootXmlPackageUsage.class);
     }
 
     @Test
-    public void testClassInXmlHandlerSoapPackage() throws Exception {
+    public void testClassInXmlHandlerSoapPackage() {
         testSingleWar(ClassInXmlHandlerSoapPackageUsage.class);
     }
 
     @Test
-    public void testClassInXmlHandlerPackage() throws Exception {
+    public void testClassInXmlHandlerPackage() {
         testSingleWar(ClassInXmlHandlerPackageUsage.class);
     }
 
     @Test
-    public void testClassInXmlHttpPackage() throws Exception {
+    public void testClassInXmlHttpPackage() {
         testSingleWar(ClassInXmlHttpPackageUsage.class);
     }
 
     @Test
-    public void testClassInXmlSoapPackage() throws Exception {
+    public void testClassInXmlSoapPackage() {
         testSingleWar(ClassInXmlSoapPackageUsage.class);
     }
 
     @Test
-    public void testClassInXmlWsaddressingPackage() throws Exception {
+    public void testClassInXmlWsaddressingPackage() {
         testSingleWar(ClassInXmlWsaddressingPackageUsage.class);
     }
 
-    private void testSingleWar(Class<?> clazz) throws Exception {
+    private void testSingleWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "webservices");
+        checkLayersForArchive(p, new ExpectedLayers("webservices", "webservices"));
     }
+
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/AbstractLayerMetaDataTestCase.java
@@ -107,6 +107,7 @@ public class AbstractLayerMetaDataTestCase {
 
             Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
             Set<String> foundDecorators = scanResults.getDecorators().stream().map(l -> l.getName()).collect(Collectors.toSet());
+            Set<String> excludedLayers = scanResults.getExcludedLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
 
             checkLayers(expectedLayers.getExpectedFoundLayers(), foundLayers);
             checkLayers(expectedLayers.getExpectedDecorators(), foundDecorators);
@@ -249,12 +250,13 @@ public class AbstractLayerMetaDataTestCase {
     public class ExpectedLayers {
         private Set<String> layers = new HashSet<>();
         private Set<String> decoratorLayers = new HashSet<>();
+        private Set<String> excludedLayers = new HashSet<>();
 
         public ExpectedLayers() {
         }
 
         public ExpectedLayers(String layer) {
-            add(layer);
+            addLayer(layer);
         }
 
         public ExpectedLayers(String... layers) {
@@ -262,18 +264,27 @@ public class AbstractLayerMetaDataTestCase {
         }
 
         public ExpectedLayers(String layer, String decorator) {
-            add(layer, decorator);
+            addLayerAndDecorator(layer, decorator);
         }
 
-        public ExpectedLayers add(String layer) {
+        public ExpectedLayers addLayer(String layer) {
             this.layers.add(layer);
             return this;
         }
 
-        public ExpectedLayers add(String layer, String decorator) {
+        public ExpectedLayers addLayerAndDecorator(String layer, String decorator) {
             layers.add(layer);
             decoratorLayers.add(decorator);
             return this;
+        }
+
+        public ExpectedLayers addDecorator(String decorator) {
+            decoratorLayers.add(decorator);
+            return this;
+        }
+
+        public void excludedLayers(String...excludedDecorators) {
+            excludedLayers.addAll(Arrays.asList(excludedDecorators));
         }
 
         private Set<String> getExpectedFoundLayers() {

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/config/MicroProfileConfigLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/config/MicroProfileConfigLayerMetaDataTestCase.java
@@ -6,45 +6,49 @@ import org.wildfly.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
 import java.nio.file.Path;
 
 public class MicroProfileConfigLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
-    //<prop name="org.wildfly.rule.expected-file" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties]"/>
+
     @Test
-    public void testAnnotationUsage() throws Exception {
+    public void testAnnotationUsage() {
         // Only package containing annotations
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(MicroProfileConfigAnnotationUsage.class)
                 .build();
-        checkLayersForArchive(p, "microprofile-config");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassFromRootPackageUsage() throws Exception {
+    public void testClassFromRootPackageUsage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(MicroProfileConfigClassFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "microprofile-config");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassFromSpiPackageUsage() throws Exception {
+    public void testClassFromSpiPackageUsage() {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(MicroProfileConfigClassFromSpiPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "microprofile-config");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testMetaInfMicroProfileConfigProperties() throws Exception {
+    public void testMetaInfMicroProfileConfigProperties() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addFileToInf("microprofile-config.properties", "")
                 .build();
-        checkLayersForArchive(p, "microprofile-config");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testWebInfClassesMetaInfMicroProfileConfigProperties() throws Exception{
+    public void testWebInfClassesMetaInfMicroProfileConfigProperties(){
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addFileToInf("microprofile-config.properties", "", true)
                 .build();
-        checkLayersForArchive(p, "microprofile-config");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-config", "microprofile-config"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/fault/tolerance/MicroProfileFaultToleranceLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/fault/tolerance/MicroProfileFaultToleranceLayerMetaDataTestCase.java
@@ -7,26 +7,26 @@ import java.nio.file.Path;
 
 public class MicroProfileFaultToleranceLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testAnnotationUsage() throws Exception {
+    public void testAnnotationUsage() {
         // Only package containing annotations
         testSingleClassWar(MicroProfileFaultToleranceAnnotationUsage.class);
     }
 
     @Test
-    public void testClassFromRootPackageUsage() throws Exception {
+    public void testClassFromRootPackageUsage() {
         testSingleClassWar(MicroProfileFaultToleranceClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testClassFromExceptionsPackageUsage() throws Exception {
+    public void testClassFromExceptionsPackageUsage() {
         testSingleClassWar(MicroProfileFaultToleranceClassFromExceptionsPackageUsage.class);
     }
 
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-fault-tolerance");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-fault-tolerance", "microprofile-fault-tolerance"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/health/MicroProfileHealthLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/health/MicroProfileHealthLayerMetaDataTestCase.java
@@ -8,23 +8,23 @@ import java.nio.file.Path;
 public class MicroProfileHealthLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testMicroProfileHealthAnnotationUsage() throws Exception {
+    public void testMicroProfileHealthAnnotationUsage() {
         // There is only one package with annotations
         testSingleClassWar(MicroProfileHealthAnnotationUsage.class);
     }
 
     @Test
-    public void testMicroProfileHealthClassUsage() throws Exception {
+    public void testMicroProfileHealthClassUsage() {
         // There is only one package with classes (the .spi child package is for implementors only)
         // There is only one package with annotations
         testSingleClassWar(MicroProfileHealthClassUsage.class);
     }
 
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(AbstractLayerMetaDataTestCase.ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-health");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-health", "microprofile-health"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/jwt/MicroProfileJwtLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/jwt/MicroProfileJwtLayerMetaDataTestCase.java
@@ -8,29 +8,29 @@ import java.nio.file.Path;
 public class MicroProfileJwtLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testAuthPackageAnnotation() throws Exception {
+    public void testAuthPackageAnnotation() {
         testSingleClassWar(MicroProfileJwtAuthPackageAnnotation.class);
     }
 
     @Test
-    public void testJwtPackageAnnotation() throws Exception {
+    public void testJwtPackageAnnotation() {
         testSingleClassWar(MicroProfileJwtJwtPackageAnnotation.class);
     }
 
     @Test
-    public void testJwtPackageClass() throws Exception {
+    public void testJwtPackageClass() {
         testSingleClassWar(MicroProfileJwtJwtPackageClass.class);
     }
 
     @Test
-    public void testJwtConfigPackageClass() throws Exception {
+    public void testJwtConfigPackageClass() {
         testSingleClassWar(MicroProfileJwtJwtConfigPackageAnnotation.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-jwt");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-jwt", "microprofile-jwt"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/lra/MicroProfileLraLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/lra/MicroProfileLraLayerMetaDataTestCase.java
@@ -7,31 +7,31 @@ import java.nio.file.Path;
 
 public class MicroProfileLraLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         testSingleClassWar(MicroProfileLraClassFromRootPackageUsage.class);
     }
 
 
     @Test
-    public void testAnnotationFromAnnotationPackage() throws Exception {
+    public void testAnnotationFromAnnotationPackage() {
         testSingleClassWar(MicroProfileLraAnnotationFromAnnotationPackageUsage.class);
     }
 
     @Test
-    public void testClassFromAnnotationPackage() throws Exception {
+    public void testClassFromAnnotationPackage() {
         testSingleClassWar(MicroProfileLraClassFromAnnotationPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationFromAnnotationWsRsPackage() throws Exception {
+    public void testAnnotationFromAnnotationWsRsPackage() {
         testSingleClassWar(MicroProfileLraAnnotationFromAnnotationWsRsPackageUsage.class);
     }
 
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(AbstractLayerMetaDataTestCase.ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-lra-participant");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-lra-participant", "microprofile-lra-participant"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/openapi/MicroProfileOpenApiLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/openapi/MicroProfileOpenApiLayerMetaDataTestCase.java
@@ -53,31 +53,31 @@ public class MicroProfileOpenApiLayerMetaDataTestCase extends AbstractLayerMetaD
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-openapi");
+        checkOpenApi(p);
     }
 
     @Test
     public void testConfiguredOasModelReaderMetaInf() throws Exception {
         Path p = createArchive(ArchiveType.JAR, "microprofile-config.properties", "mp.openapi.model.reader=x\n");
-        checkLayersForArchive(p, "microprofile-config", "microprofile-openapi");
+        checkOpenApiAndConfig(p);
     }
 
     @Test
     public void testConfiguredOasModelReaderWebInfClassesMetaInf() throws Exception {
         Path p = createArchive(ArchiveType.WAR, "microprofile-config.properties", "mp.openapi.model.reader=x\n");
-        checkLayersForArchive(p, "microprofile-config", "microprofile-openapi");
+        checkOpenApiAndConfig(p);
     }
 
     @Test
     public void testConfiguredOasFilterMetaInf() throws Exception {
         Path p = createArchive(ArchiveType.JAR, "microprofile-config.properties", "mp.openapi.filter=x\n");
-        checkLayersForArchive(p, "microprofile-config", "microprofile-openapi");
+        checkOpenApiAndConfig(p);
     }
 
     @Test
     public void testConfiguredOasFilterWebInfClassesMetaInf() throws Exception {
         Path p = createArchive(ArchiveType.WAR, "microprofile-config.properties", "mp.openapi.filter=x\n");
-        checkLayersForArchive(p, "microprofile-config", "microprofile-openapi");
+        checkOpenApiAndConfig(p);
     }
 
     @Test
@@ -130,6 +130,17 @@ public class MicroProfileOpenApiLayerMetaDataTestCase extends AbstractLayerMetaD
 
     private void testArchiveWithFile(ArchiveType archiveType, String filename, String contents) throws Exception {
         Path p = createArchive(archiveType, filename, contents);
-        checkLayersForArchive(p, "microprofile-openapi");
+        checkOpenApi(p);
+    }
+
+    private void checkOpenApi(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-openapi", "microprofile-openapi"));
+    }
+
+    private void checkOpenApiAndConfig(Path p) {
+        checkLayersForArchive(p,
+                new ExpectedLayers("microprofile-openapi", "microprofile-openapi")
+                        // microprofile-config doesn't show up as a decorator since it is a dependency of microprofile-openapi
+                        .add("microprofile-config"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/openapi/MicroProfileOpenApiLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/openapi/MicroProfileOpenApiLayerMetaDataTestCase.java
@@ -141,6 +141,6 @@ public class MicroProfileOpenApiLayerMetaDataTestCase extends AbstractLayerMetaD
         checkLayersForArchive(p,
                 new ExpectedLayers("microprofile-openapi", "microprofile-openapi")
                         // microprofile-config doesn't show up as a decorator since it is a dependency of microprofile-openapi
-                        .add("microprofile-config"));
+                        .addLayer("microprofile-config"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/MicroProfileReactiveMessagingLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/MicroProfileReactiveMessagingLayerMetaDataTestCase.java
@@ -7,29 +7,29 @@ import java.nio.file.Path;
 
 public class MicroProfileReactiveMessagingLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testAnnotationFromRootPackage() throws Exception {
+    public void testAnnotationFromRootPackage() {
         testSingleClassWar(MicroProfileReactiveMessagingAnnotationFromRootPackage.class);
     }
 
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         testSingleClassWar(MicroProfileReactiveMessagingClassFromRootPackage.class);
     }
 
     @Test
-    public void testAnnotationFromSpiPackage() throws Exception {
+    public void testAnnotationFromSpiPackage() {
         testSingleClassWar(MicroProfileReactiveMessagingAnnotationFromSpiPackage.class);
     }
 
     @Test
-    public void testClassFromSpiPackage() throws Exception {
+    public void testClassFromSpiPackage() {
         testSingleClassWar(MicroProfileReactiveMessagingClassFromSpiPackage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-reactive-messaging");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-reactive-messaging", "microprofile-reactive-messaging"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/kafka/MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/kafka/MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase.java
@@ -6,48 +6,41 @@ import org.wildfly.feature.pack.layer.tests.AbstractLayerMetaDataTestCase;
 import java.nio.file.Path;
 
 public class MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
-    /*
-    <prop name="org.wildfly.rule.properties-file-match-mp-kafka-property" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.connector.smallrye-kafka.*"/>
-    <prop name="org.wildfly.rule.properties-file-match-mp-kafka-outgoing" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.outgoing.*.connector,smallrye-kafka"/>
-    <prop name="org.wildfly.rule.properties-file-match-mp-kafka-incoming" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.incoming.*.connector,smallrye-kafka"/>
-
-     */
-
     @Test
-    public void testGlobalPropertyInWebInfClassesMetaInf() throws Exception {
+    public void testGlobalPropertyInWebInfClassesMetaInf() {
         testArchiveWithFile(ArchiveType.WAR, "mp.messaging.connector.smallrye-kafka.sasl.mechanism=PLAIN");
     }
 
     @Test
-    public void testGlobalPropertyInWebInf() throws Exception {
+    public void testGlobalPropertyInWebInf() {
         testArchiveWithFile(ArchiveType.JAR, "mp.messaging.connector.smallrye-kafka.sasl.mechanism=PLAIN");
     }
 
     @Test
-    public void testOutgoingInWebInfClassesMetaInf() throws Exception {
+    public void testOutgoingInWebInfClassesMetaInf() {
         testArchiveWithFile(ArchiveType.WAR, "mp.messaging.outgoing.name.connector=smallrye-kafka");
     }
 
 
     @Test
-    public void testOutgoingInWebInf() throws Exception {
+    public void testOutgoingInWebInf() {
         testArchiveWithFile(ArchiveType.JAR, "mp.messaging.outgoing.name.connector=smallrye-kafka");
     }
 
 
     @Test
-    public void testIncomingInWebInfClassesMetaInf() throws Exception {
+    public void testIncomingInWebInfClassesMetaInf() {
         testArchiveWithFile(ArchiveType.WAR, "mp.messaging.incoming.name.connector=smallrye-kafka");
     }
 
 
     @Test
-    public void testIncomingInWebInf() throws Exception {
+    public void testIncomingInWebInf() {
         testArchiveWithFile(ArchiveType.JAR, "mp.messaging.incoming.name.connector=smallrye-kafka");
     }
 
 
-    private void testArchiveWithFile(ArchiveType archiveType, String contents) throws Exception {
+    private void testArchiveWithFile(ArchiveType archiveType, String contents) {
         ArchiveBuilder builder = createArchiveBuilder(archiveType);
         if (contents == null) {
             contents = "";
@@ -62,6 +55,9 @@ public class MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase extends Abs
             throw new IllegalStateException("Unhandled archiveType " + archiveType);
         }
         Path p = builder.build();
-        checkLayersForArchive(p, "microprofile-config", "microprofile-reactive-messaging-kafka");
+        checkLayersForArchive(p,
+                // microprofile-config doesn't show up as a decorator since it is a dependency of microprofile-reactive-messaging-kafka
+                new ExpectedLayers("microprofile-config")
+                        .add("microprofile-reactive-messaging-kafka", "microprofile-reactive-messaging-kafka"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/kafka/MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/messaging/kafka/MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase.java
@@ -58,6 +58,6 @@ public class MicroProfileReactiveMessagingKafkaLayerMetaDataTestCase extends Abs
         checkLayersForArchive(p,
                 // microprofile-config doesn't show up as a decorator since it is a dependency of microprofile-reactive-messaging-kafka
                 new ExpectedLayers("microprofile-config")
-                        .add("microprofile-reactive-messaging-kafka", "microprofile-reactive-messaging-kafka"));
+                        .addLayerAndDecorator("microprofile-reactive-messaging-kafka", "microprofile-reactive-messaging-kafka"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/streams/operators/MicroProfileReactiveStreamsOperatorsLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/reactive/streams/operators/MicroProfileReactiveStreamsOperatorsLayerMetaDataTestCase.java
@@ -7,18 +7,22 @@ import java.nio.file.Path;
 
 public class MicroProfileReactiveStreamsOperatorsLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(ReactiveStreamsOperatorsClassFromRootPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "microprofile-reactive-streams-operators");
+        checkLayersForArchive(p);
     }
 
     @Test
-    public void testClassFromSpiPackage() throws Exception {
+    public void testClassFromSpiPackage() {
         Path p = createArchiveBuilder(ArchiveType.JAR)
                 .addClasses(ReactiveStreamsOperatorsClassFromSpiPackageUsage.class)
                 .build();
-        checkLayersForArchive(p, "microprofile-reactive-streams-operators");
+        checkLayersForArchive(p);
+    }
+
+    private void checkLayersForArchive(Path p) {
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-reactive-streams-operators", "microprofile-reactive-streams-operators"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/rest/client/MicroProfileRestClientLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/microprofile/rest/client/MicroProfileRestClientLayerMetaDataTestCase.java
@@ -8,34 +8,34 @@ import java.nio.file.Path;
 public class MicroProfileRestClientLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testClassFromRootPackage() throws Exception {
+    public void testClassFromRootPackage() {
         testSingleClassWar(MicroProfileRestClientClassFromRootPackageUsage.class);
     }
 
     @Test
-    public void testClassFromExtPackage() throws Exception {
+    public void testClassFromExtPackage() {
         testSingleClassWar(MicroProfileRestClientClassFromExtPackageUsage.class);
     }
 
     @Test
-    public void testClassFromSpiPackage() throws Exception {
+    public void testClassFromSpiPackage() {
         testSingleClassWar(MicroProfileRestClientClassFromSpiPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationFromAnnotationsPackage() throws Exception {
+    public void testAnnotationFromAnnotationsPackage() {
         testSingleClassWar(MicroProfileRestClientAnnotationFromAnnotationsPackageUsage.class);
     }
 
     @Test
-    public void testAnnotationFromInjectPackage() throws Exception {
+    public void testAnnotationFromInjectPackage() {
         testSingleClassWar(MicroProfileRestClientAnnotationFromInjectPackageUsage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "microprofile-rest-client");
+        checkLayersForArchive(p, new ExpectedLayers("microprofile-rest-client", "microprofile-rest-client"));
     }
 }

--- a/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/opentelemetry/OpenTelemetryLayerMetaDataTestCase.java
+++ b/galleon-pack/layer-metadata-tests/src/test/java/org/wildfly/feature/pack/layer/tests/opentelemetry/OpenTelemetryLayerMetaDataTestCase.java
@@ -8,134 +8,134 @@ import java.nio.file.Path;
 public class OpenTelemetryLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
 
     @Test
-    public void testAnnotationInInstrumentationAnnotationsPackage() throws Exception {
+    public void testAnnotationInInstrumentationAnnotationsPackage() {
         testSingleClassWar(OpenTelemetryAnnotationInInstrumentationAnnotationsPackageUsage.class);
     }
 
     @Test
-    public void testClassInApiBaggagePackage() throws Exception {
+    public void testClassInApiBaggagePackage() {
         testSingleClassWar(OpenTelemetryClassInApiBaggagePackageUsage.class);
     }
 
     @Test
-    public void testClassInApiBaggagePropagationPackage() throws Exception {
+    public void testClassInApiBaggagePropagationPackage() {
         testSingleClassWar(OpenTelemetryClassInApiBaggagePropagationPackageUsage.class);
     }
 
     @Test
-    public void testClassInApiCommonPackage() throws Exception {
+    public void testClassInApiCommonPackage() {
         testSingleClassWar(OpenTelemetryClassInApiCommonPackageUsage.class);
     }
 
     @Test
-    public void testClassInApiMetricsPackage() throws Exception {
+    public void testClassInApiMetricsPackage() {
         testSingleClassWar(OpenTelemetryClassInApiMetricsPackageUsage.class);
     }
 
     @Test
-    public void testClassInApiTracePackage() throws Exception {
+    public void testClassInApiTracePackage() {
         testSingleClassWar(OpenTelemetryClassInApiTracePackageUsage.class);
     }
 
     @Test
-    public void testClassInApiTracePropagationPackage() throws Exception {
+    public void testClassInApiTracePropagationPackage() {
         testSingleClassWar(OpenTelemetryClassInApiTracePropagationPackageUsage.class);
     }
 
     @Test
-    public void testClassInApiLogsPackage() throws Exception {
+    public void testClassInApiLogsPackage() {
         testSingleClassWar(OpenTelemetryClassInApiLogsPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkPackage() throws Exception {
+    public void testClassInSdkPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkCommonPackage() throws Exception {
+    public void testClassInSdkCommonPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkCommonPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkAutoConfigurePackage() throws Exception {
+    public void testClassInSdkAutoConfigurePackage() {
         testSingleClassWar(OpenTelemetryClassInSdkAutoConfigurePackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkAutoConfigureSpiPackage() throws Exception {
+    public void testClassInSdkAutoConfigureSpiPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkAutoConfigureSpiPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkAutoConfigureSpiLogsPackage() throws Exception {
+    public void testClassInSdkAutoConfigureSpiLogsPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkAutoConfigureSpiLogsPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkAutoConfigureSpiMetricsPackage() throws Exception {
+    public void testClassInSdkAutoConfigureSpiMetricsPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkAutoConfigureSpiMetricsPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkAutoConfigureSpiTracesPackage() throws Exception {
+    public void testClassInSdkAutoConfigureSpiTracesPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkAutoConfigureSpiTracesPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkLogsPackage() throws Exception {
+    public void testClassInSdkLogsPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkLogsPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkLogsDataPackage() throws Exception {
+    public void testClassInSdkLogsDataPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkLogsDataPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkLogsExportPackage() throws Exception {
+    public void testClassInSdkLogsExportPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkLogsExportPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkMetricsPackage() throws Exception {
+    public void testClassInSdkMetricsPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkMetricsPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkMetricsDataPackage() throws Exception {
+    public void testClassInSdkMetricsDataPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkMetricsDataPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkMetricsExportPackage() throws Exception {
+    public void testClassInSdkMetricsExportPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkMetricsExportPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkTracePackage() throws Exception {
+    public void testClassInSdkTracePackage() {
         testSingleClassWar(OpenTelemetryClassInSdkTracePackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkTraceDataPackage() throws Exception {
+    public void testClassInSdkTraceDataPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkTraceDataPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkTraceExportPackage() throws Exception {
+    public void testClassInSdkTraceExportPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkTraceExportPackageUsage.class);
     }
 
     @Test
-    public void testClassInSdkTraceSamplersPackage() throws Exception {
+    public void testClassInSdkTraceSamplersPackage() {
         testSingleClassWar(OpenTelemetryClassInSdkTraceSamplersPackageUsage.class);
     }
 
-    private void testSingleClassWar(Class<?> clazz) throws Exception {
+    private void testSingleClassWar(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)
                 .build();
-        checkLayersForArchive(p, "opentelemetry");
+        checkLayersForArchive(p, new ExpectedLayers("opentelemetry", "opentelemetry"));
     }
 }


### PR DESCRIPTION
Some cleanup

https://issues.redhat.com/browse/WFLY-18436

Follows up on #17181