### PR TITLE
[WFLY-18524] Update various alias modules

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/enterprise/api/main/module.xml
@@ -30,7 +30,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="org.glassfish.expressly" export="true"/>
         <module name="jakarta.inject.api" export="true"/>
         <module name="jakarta.interceptor.api" export="true"/>
         <!-- This is so that all modules depending on CDI automatically get access to annotations such as @PreDestroy -->

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/faces/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/faces/api/main/module.xml
@@ -66,7 +66,7 @@
             </exports>
         </module>
 
-        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="org.glassfish.expressly" export="true"/>
 
         <!--TODO remove the WELD dependencies from this module, they should be in implementation module only. See comments on https://github.com/wildfly/wildfly/pull/16155 for possible causes-->
         <module name="org.jboss.weld.api"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/faces/impl/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/faces/impl/main/module.xml
@@ -48,7 +48,7 @@
         <module name="java.xml"/>
 
 
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/servlet/jsp/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/servlet/jsp/api/main/module.xml
@@ -31,6 +31,6 @@
     <dependencies>
         <module name="java.desktop"/>
         <module name="jakarta.servlet.api" export="true"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="org.glassfish.expressly" export="true"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
@@ -81,7 +81,7 @@
         <module name="jakarta.servlet.api"/>
         <module name="javax.wsdl4j.api"/>
         <module name="jakarta.xml.bind.api" services="import"/>
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="jakarta.xml.soap.api"/>
         <module name="jakarta.xml.ws.api"/>
         <module name="org.apache.commons.lang3"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -51,7 +51,7 @@
         <module name="jakarta.resource.api" />
         <module name="javax.wsdl4j.api" />
         <module name="jakarta.xml.bind.api" services="import"/>
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="com.sun.xml.messaging.saaj" export="true" services="export"/>
         <module name="jakarta.xml.soap.api" />
         <module name="jakarta.xml.ws.api" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/services-sts/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/services-sts/main/module.xml
@@ -59,7 +59,7 @@
         <module name="jakarta.servlet.api" />
         <module name="javax.wsdl4j.api" />
         <module name="jakarta.xml.bind.api" services="import"/>
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="jakarta.xml.soap.api" />
         <module name="jakarta.xml.ws.api" />
         <module name="org.apache.commons.lang3" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/ws-security/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/cxf/ws-security/main/module.xml
@@ -30,7 +30,7 @@
 
     <dependencies>
         <module name="asm.asm" />
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="java.logging" />
         <module name="java.security.jgss" />
         <module name="java.xml" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
@@ -40,7 +40,7 @@
       <module name="org.apache.commons.codec"/>
       <module name="org.slf4j"/>
       <module name="jakarta.xml.bind.api" services="import"/>
-      <module name="com.sun.xml.bind" services="import"/>
+      <module name="org.glassfish.jaxb" services="import"/>
       <module name="java.xml"/>
       <module name="java.xml.crypto"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
@@ -37,7 +37,7 @@
       <module name="jdk.security.jgss"/>
       <module name="java.security.jgss"/>
       <module name="jakarta.xml.bind.api" services="import"/>
-      <module name="com.sun.xml.bind" services="import"/>
+      <module name="org.glassfish.jaxb" services="import"/>
       <module name="com.sun.xml.messaging.saaj" export="true" services="export"/>
       <module name="org.apache.commons.codec"/>
       <module name="org.apache.commons.logging"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
@@ -46,7 +46,7 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.infinispan.hibernate-cache" services="import"/>
         <module name="org.jboss.as.jpa.spi"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
         <module name="org.wildfly.clustering.marshalling.protostream"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -46,7 +46,7 @@
         <module name="org.glassfish.jaxb"/>
         <module name="org.antlr"/>
         <module name="org.jboss.as.jpa.spi"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.hibernate.jipijapa-hibernate6" services="import"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
 
         <!-- Optional dependencies to import services (used for resolution of bean references in particular). -->
         <module name="org.hibernate.search.backend.lucene" optional="true" services="import"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/jipijapa-hibernatesearch/main/module.xml
@@ -34,7 +34,7 @@
 
     <dependencies>
         <module name="jakarta.persistence.api"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.hibernate.search.mapper.orm"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -35,7 +35,7 @@
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="org.jboss.logging" />
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.hibernate.search.engine" export="true" />
         <module name="org.hibernate.search.mapper.pojo" export="true" />
         <module name="org.hibernate" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
@@ -30,7 +30,7 @@
 
     <dependencies>
         <module name="org.jboss.logging" />
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="java.sql" export="true" /> <!-- For java.sql.Date, etc. -->
         <module name="org.hibernate.search.engine" export="true" />
         <module name="org.hibernate.commons-annotations" export="true" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -36,7 +36,7 @@
     <module name="jakarta.persistence.api"/>
     <module name="jakarta.validation.api"/>
     <module name="jakarta.xml.bind.api"/>
-    <module name="org.glassfish.jakarta.el"/>
+    <module name="org.glassfish.expressly"/>
     <module name="org.jboss.logging"/>
     <module name="org.jboss.weld.core"/>
     <module name="org.jboss.weld.spi"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -41,7 +41,7 @@
         <module name="org.infinispan.component.annotations"/>
         <module name="org.infinispan.protostream"/>
         <module name="org.infinispan.protostream.types"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <!-- WFLY-14283 Allow Infinispan to resolve exceptions containing JBoss Marshalling TraceInformation -->
         <module name="org.jboss.marshalling" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -81,7 +81,7 @@
         <module name="org.wildfly.clustering.server.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.common"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -63,7 +63,7 @@
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.ironjacamar.impl"/>
         <module name="org.jboss.ironjacamar.jdbcadapters"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.jts.integration"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -44,7 +44,7 @@
         <module name="jakarta.interceptor.api"/>
         <module name="jakarta.security.jacc.api"/>
         <module name="jakarta.transaction.api" optional="true"/>
-        <module name="org.glassfish.javax.enterprise.concurrent"/>
+        <module name="org.glassfish.jakarta.enterprise.concurrent"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -52,7 +52,7 @@
         <module name="org.wildfly.extension.request-controller" />
         <module name="org.jboss.as.server" />
         <module name="org.jboss.invocation"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -87,7 +87,7 @@
         <module name="org.jboss.iiop-client"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.ironjacamar.api"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <!-- For recovery manager (com.arjuna.ats.jbossatx.jta.RecoveryManagerService) -->
         <module name="org.jboss.jts.integration"/>
         <module name="org.jboss.logging"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -51,7 +51,7 @@
         <module name="org.wildfly.extension.undertow"/>
         <module name="io.undertow.core"/>
         <module name="io.undertow.servlet"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.web"/>
         <module name="org.jboss.modules"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -59,7 +59,7 @@
         <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.invocation"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
@@ -36,7 +36,7 @@
         <module name="java.sql"/>
         <module name="jakarta.persistence.api"/>
         <module name="jakarta.transaction.api"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
@@ -46,7 +46,7 @@
         <module name="org.jboss.as.web-common"/>
         <!-- Only used if capability org.wildfly.weld is available -->
         <module name="org.jboss.as.weld.common" optional="true"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
@@ -45,7 +45,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -55,7 +55,7 @@
         <module name="org.wildfly.iiop-openjdk"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.transaction.client"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.modules"/>
         <module name="org.wildfly.security.manager"/>
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -44,7 +44,7 @@
         <module name="jakarta.servlet.api"/>
         <module name="jakarta.xml.ws.api"/>
         <module name="org.jboss.invocation"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.web"/>
         <module name="org.jboss.metadata.ear"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -32,7 +32,7 @@
         <module name="asm.asm" export="true"/>
         <module name="javax.wsdl4j.api" export="true"/>
         <module name="jakarta.xml.ws.api" export="true"/>
-        <module name="com.sun.xml.bind" services="export" export="true"/>
+        <module name="org.glassfish.jaxb" services="export" export="true"/>
         <module name="org.jboss.ws.api" export="true"/>
         <module name="org.jboss.ws.spi" export="true"/>
         <module name="org.jboss.ws.common" services="import" export="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -58,7 +58,7 @@
         <module name="jakarta.transaction.api"/>
         <module name="jakarta.validation.api"/>
         <module name="org.glassfish.jakarta.el" />
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <!-- Only needed if capability 'org.wildfly.legacy-security.server-security-manager' is present -->

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -57,7 +57,7 @@
         <module name="jakarta.servlet.jsp.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="jakarta.validation.api"/>
-        <module name="org.glassfish.jakarta.el" />
+        <module name="org.glassfish.expressly" />
         <module name="io.smallrye.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -54,7 +54,7 @@
         <module name="org.jboss.xts"/>
         <!-- need this to get the SPIProviderResolver  -->
         <module name="org.jboss.ws.spi"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.weld.core" />
         <module name="org.jboss.modules"/>
         <module name="jakarta.enterprise.api"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
@@ -34,7 +34,7 @@
 
     <dependencies>
         <module name="jakarta.xml.bind.api"/>
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.commons.beanutils"/>
         <module name="java.xml"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
@@ -29,7 +29,7 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.xml.bind"/>
+        <module name="org.glassfish.jaxb"/>
         <module name="jakarta.xml.bind.api"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.servlet.api"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -29,7 +29,7 @@
     </resources>
 
     <dependencies>
-        <module name="com.sun.xml.bind"/>
+        <module name="org.glassfish.jaxb"/>
         <module name="jakarta.xml.bind.api"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.servlet.api"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -44,7 +44,7 @@
     <module name="jakarta.servlet.api"/>
     <module name="jakarta.transaction.api"/>
     <module name="jakarta.validation.api"/>
-    <module name="org.glassfish.jakarta.el" />
+    <module name="org.glassfish.expressly" />
     <module name="org.jboss.classfilewriter"/>
     <module name="org.jboss.weld.api" export="true"/>
     <module name="org.jboss.weld.spi" export="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -39,7 +39,7 @@
         <module name="jakarta.servlet.api" />
         <module name="jakarta.xml.bind.api" />
         <module name="jakarta.security.auth.message.api"/>
-        <module name="com.sun.xml.bind" services="import"/>
+        <module name="org.glassfish.jaxb" services="import"/>
         <module name="jakarta.xml.ws.api" />
         <module name="org.jboss.ws.api" />
         <module name="org.jboss.ws.spi" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
@@ -42,7 +42,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/ee-security/main/module.xml
@@ -47,6 +47,6 @@
         <module name="org.glassfish.soteria" />
         <module name="jakarta.security.enterprise.api" />
         <module name="jakarta.enterprise.api" />
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -81,7 +81,7 @@
         <module name="org.jboss.as.server"/>
         <!-- Only used if capability org.wildfly.weld is available -->
         <module name="org.jboss.as.weld.common" optional="true"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -49,7 +49,7 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.jts"/>
         <module name="jakarta.servlet.api"/>
         <module name="io.undertow.core"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -52,7 +52,7 @@
         <module name="jakarta.servlet.api"/>
         <module name="jakarta.servlet.jsp.api"/>
         <module name="jakarta.websocket.api"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.wildfly.clustering.service"/>

--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -59,7 +59,7 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             "javax.rmi.api",
             "jakarta.xml.bind.api",
             GLASSFISH_EL,
-            "org.glassfish.javax.enterprise.concurrent"
+            "org.glassfish.jakarta.enterprise.concurrent"
     };
 
 

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
@@ -50,7 +50,7 @@
         <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.eclipse.microprofile.openapi.api"/>
 
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
 
         <module name="org.yaml.snakeyaml"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/lra-participant/main/module.xml
@@ -44,7 +44,7 @@
     <!-- lra-client -->
     <module name="jakarta.enterprise.api"/>
     <!-- lra-proxy-api -->
-    <module name="org.jboss.jandex" />
+    <module name="io.smallrye.jandex"/>
     <!-- narayana-lra -->
     <module name="org.eclipse.microprofile.config.api"/>
     <module name="io.smallrye.config"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/fault-tolerance-smallrye/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/fault-tolerance-smallrye/main/module.xml
@@ -42,7 +42,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.weld.common"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/jwt-smallrye/main/module.xml
@@ -40,6 +40,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.wildfly.security.elytron-jwt" />
         <module name="jakarta.enterprise.api" />
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
     </dependencies>
 </module>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-participant/main/module.xml
@@ -33,7 +33,7 @@
   <dependencies>
     <module name="org.eclipse.microprofile.lra.api"/>
     <module name="org.jboss.narayana.rts.lra-participant"/>
-    <module name="org.jboss.jandex" />
+    <module name="io.smallrye.jandex"/>
 
     <module name="jakarta.enterprise.api" />
     <module name="org.jboss.as.jaxrs"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
@@ -53,7 +53,7 @@
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.web-common"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.web"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
@@ -37,7 +37,7 @@
         <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.jandex"/>
+        <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
@@ -35,7 +35,7 @@
         <module name="java.logging"/>
         <module name="java.sql"/>
         <module name="java.xml"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="org.glassfish.expressly" export="true"/>
     </dependencies>
 
     <resources>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
@@ -43,7 +43,7 @@
         <module name="java.sql"/>
         <module name="java.xml"/>
         <module name="jakarta.faces.api:${jsf-impl-name}-${jsf-version}"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
     </dependencies>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
@@ -33,7 +33,7 @@
         <module name="java.logging"/>
         <module name="java.sql"/>
         <module name="java.xml"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
+        <module name="org.glassfish.expressly" export="true"/>
 
         <!-- extra dependencies for MyFaces 1.1
         <module name="org.apache.commons.logging"/>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
@@ -47,7 +47,7 @@
         <module name="java.naming"/>
         <module name="java.sql"/>
         <module name="java.xml"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
 

--- a/jsf/subsystem/src/test/resources/modules/jakarta/faces/impl/main/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/jakarta/faces/impl/main/module.xml
@@ -38,7 +38,7 @@
         <module name="jakarta.json.api"/>
         <module name="jakarta.ejb.api"/>
         <module name="jakarta.xml.bind.api"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="java.xml"/>
     </dependencies>
 

--- a/jsf/subsystem/src/test/resources/modules/jakarta/faces/impl/myfaces/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/jakarta/faces/impl/myfaces/module.xml
@@ -38,7 +38,7 @@
         <module name="jakarta.ejb.api"/>
         <module name="jakarta.servlet.jstl.api"/>
         <module name="jakarta.xml.bind.api"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="java.xml"/>
 
         <!-- extra dependencies for MyFaces -->

--- a/jsf/subsystem/src/test/resources/modules2/jakarta/faces/impl/myfaces2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/jakarta/faces/impl/myfaces2/module.xml
@@ -38,7 +38,7 @@
         <module name="jakarta.json.api"/>
         <module name="jakarta.ejb.api"/>
         <module name="jakarta.xml.bind.api"/>
-        <module name="org.glassfish.jakarta.el"/>
+        <module name="org.glassfish.expressly"/>
         <module name="java.xml"/>
 
         <!-- extra dependencies for MyFaces -->

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
@@ -62,7 +62,7 @@ public class LRAParticipantDeploymentDependencyProcessor implements DeploymentUn
         ModuleDependency lraParticipantDependency = new ModuleDependency(moduleLoader, "org.jboss.narayana.rts.lra-participant", false, false, true, false);
         lraParticipantDependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
         moduleSpecification.addSystemDependency(lraParticipantDependency);
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.jboss.jandex", false, false, true, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "io.smallrye.jandex", false, false, true, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.jboss.as.weld.common", false, false, true, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.jboss.resteasy.resteasy-cdi", false, false, true, false));
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18524

This substitute various alias modules:

`io.smallrye.jandex` for `org.jboss.jandex`
`org.glassfish.jakarta.enterprise.concurrent` for `org.glassfish.javax.enterprise.concurrent`
`org.glassfish.jaxb` for `com.sun.xml.bind`
`org.glassfish.expressly` for `org.glassfish.jakarta.el`