### PR TITLE
WFLY-18281 Upgrade mod_cluster to 2.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <version.org.jboss.ironjacamar>3.0.4.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
-        <version.org.jboss.mod_cluster>2.0.2.Final</version.org.jboss.mod_cluster>
+        <version.org.jboss.mod_cluster>2.0.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>9.0.2.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-18281 - Upgrade mod_cluster to 2.0.3.Final
https://issues.redhat.com/browse/WFLY-16416 - mod_cluster: Contexts not registered on proxy when server started in suspend mode