### PR TITLE
[WFLY-18549] Upgrade WildFly Core to 22.0.0.Beta3

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
@@ -4798,71 +4798,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-naming-client</artifactId>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                    <distribution>repo</distribution>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-cli</artifactId>
-            <licenses>
-                <license>
-                    <name>GNU Lesser General Public License v2.1 or later</name>
-                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-                    <distribution>repo</distribution>
-                </license>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                    <distribution>repo</distribution>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-elytron-integration</artifactId>
-            <licenses>
-                <license>
-                    <name>GNU Lesser General Public License v2.1 or later</name>
-                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-                    <distribution>repo</distribution>
-                </license>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                    <distribution>repo</distribution>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-event-logger</artifactId>
-            <licenses>
-                <license>
-                    <name>GNU Lesser General Public License v2.1 or later</name>
-                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-                    <distribution>repo</distribution>
-                </license>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                    <distribution>repo</distribution>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-version</artifactId>
-            <licenses>
-                <license>
-                    <name>GNU Lesser General Public License v2.1 or later</name>
-                    <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-                    <distribution>repo</distribution>
-                </license>
+            <licenses>`
                 <license>
                     <name>Apache License 2.0</name>
                     <url>http://www.apache.org/licenses/LICENSE-2.0</url>

--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>22.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>22.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18549

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/22.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/22.0.0.Beta2...22.0.0.Beta3

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6511'>WFCORE-6511</a>] -         Reimplement WFCORE-5493: Invoke DeploymentTransformer in operation &quot;full-replace-deployment&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6512'>WFCORE-6512</a>] -         Reimplement WFCORE-1386 Accept properties file in scripts for starting as a service
</li>
</ul>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4296'>WFCORE-4296</a>] -         Illegal reflective access by org.wildfly.extension.elytron.SSLDefinitions
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6491'>WFCORE-6491</a>] -         HostControllerBootOperationsTestCase fails intermittently when Security Manager is enabled
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6502'>WFCORE-6502</a>] -         setlocal usage in common.bat
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6506'>WFCORE-6506</a>] -         StringIndexOutOfBoundsException on JDK 21 GA release
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6472'>WFCORE-6472</a>] -         Removing the remoting subsystem transformers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6473'>WFCORE-6473</a>] -         Clean up domain mode logic related to remoting subsystem worker configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6493'>WFCORE-6493</a>] -         Add Guava as a test dependency to the Test Suite.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6510'>WFCORE-6510</a>] -         Change the WildFly Core license to ASL 2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6518'>WFCORE-6518</a>] -         Move createFilePermission methods from WF org.jboss.as.test.shared.integration.ejb.security.PermissionUtils to org.jboss.as.test.shared.PermissionUtils
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6495'>WFCORE-6495</a>] -         Upgrade FasterXML Jackson to 2.15.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6500'>WFCORE-6500</a>] -         Upgrade JBoss DMR 1.7.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6501'>WFCORE-6501</a>] -         Upgrade StAXMapper to 1.5.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6515'>WFCORE-6515</a>] -         Upgrade Jandex from 3.1.3 to 3.1.5
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6519'>WFCORE-6519</a>] -         Enable tests that hanged in the past due to https://bugs.openjdk.java.net/browse/JDK-8219658
</li>
</ul>
</details>
