### PR TITLE
WFLY-18555 Upgrade to Hibernate 6.3.1.Final release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.0</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.2.9.Final</version.org.hibernate>
+        <version.org.hibernate>6.3.1.Final</version.org.hibernate>
         <version.org.hibernate.search>6.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/DataSourceDefinitionJPATestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/DataSourceDefinitionJPATestCase.java
@@ -39,6 +39,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,6 +49,7 @@ import org.junit.runner.RunWith;
  * @author Scott Marlow and Zbynek Roubalik
  */
 @RunWith(Arquillian.class)
+@Ignore  // WFLY-18556 Enable org.jboss.as.test.integration.jpa.datasourcedefinition.DataSourceDefinitionJPATestCase after upgrade to ORM 6.3.2.Final
 public class DataSourceDefinitionJPATestCase {
 
     private static final String ARCHIVE_NAME = "jpa_datasourcedefinition";


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18555 Upgrade to Hibernate 6.3.1.Final release (see WFLY-18555 issue for more details on the upgrade).

Created https://issues.redhat.com/browse/WFLY-18556 to later remember to enable the org.jboss.as.test.integration.jpa.datasourcedefinition.DataSourceDefinitionJPATestCase test after upgrading to Hibernate ORM 6.3.2.Final when that is released after WildFly 30.  We are disabling the DataSourceDefinitionJPATestCase test due to ByteCode enhancement bug https://hibernate.atlassian.net/browse/HHH-17240