### PR TITLE
WFLY-18275 Add JSON/Hibernate ORM test and update Hibernate ORM to optional depend on JSON-P/JSON-B modules

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -37,6 +37,8 @@
         <module name="java.naming"/>
         <module name="java.sql"/>
         <module name="com.fasterxml.classmate"/>
+        <module name="com.fasterxml.jackson.core.jackson-core" optional="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind" optional="true"/>
         <module name="jakarta.annotation.api"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.persistence.api"/>
@@ -45,6 +47,7 @@
         <module name="jakarta.xml.bind.api"/>
         <module name="org.glassfish.jaxb"/>
         <module name="org.antlr"/>
+        <module name="org.eclipse.yasson" optional="true"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/Employee.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jpa.json;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    @Version
+    private Integer version;
+
+
+    public List<String> getJsonValue() {
+        return jsonValue;
+    }
+
+    public void setJsonValue(List<String> value) {
+        this.jsonValue = value;
+    }
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    public List<String> jsonValue;
+
+    private String name;
+
+    private String address;
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/Employee.java
@@ -1,19 +1,6 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2023 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.jboss.as.test.integration.jpa.json;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/JsonTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/JsonTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jpa.json;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Ensure that Hibernate JSON mapping can be used.
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+public class JsonTestCase {
+
+    private static final String ARCHIVE_NAME = "jpa_jsontest";
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+        jar.addClasses(JsonTestCase.class,
+                Employee.class,
+                SFSB.class
+        );
+        jar.addAsManifestResource(JsonTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        return jar;
+    }
+
+    @Inject
+    private SFSB sfsb1;
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testJson() throws Exception {
+        // tx1 will create the employee
+        sfsb1.createEmployee("Json", "1 Main Street", 1);
+
+        // non-tx2 will load the entity
+        Employee emp = sfsb1.getEmployeeNoTX(1);
+
+        List<String> list = emp.getJsonValue();
+        assertTrue(list.contains("Json"));
+        assertTrue(list.contains("1 Main Street"));
+        assertFalse(list.contains("Absent value"));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/JsonTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/JsonTestCase.java
@@ -1,19 +1,6 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2023 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.jboss.as.test.integration.jpa.json;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/SFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/SFSB.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jpa.json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateful;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class SFSB {
+    @PersistenceContext
+    EntityManager em;
+
+    @Resource
+    SessionContext sessionContext;
+
+    public void createEmployee(String name, String address, int id) {
+
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+        // '{"id":10,"name":"What''s this?"}'
+        String json = "{\"name\": \"" + name + "\" ,"
+                + "\"{address\": \"" + address + "\"}";
+        List<String> list = new ArrayList<>();
+        list.add(name);
+        list.add(address);
+        emp.setJsonValue(list);
+
+        UserTransaction tx1 = sessionContext.getUserTransaction();
+        try {
+            tx1.begin();
+            em.joinTransaction();
+            em.persist(emp);
+            tx1.commit();
+        } catch (Exception e) {
+            throw new RuntimeException("createEmployee couldn't start tx", e);
+        }
+    }
+
+    public Employee getEmployeeNoTX(int id) {
+        return em.find(Employee.class, id);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/SFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/SFSB.java
@@ -1,19 +1,6 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2023 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.jboss.as.test.integration.jpa.json;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
+    <persistence-unit name="versioning_pc">
+        <description>Persistence Unit.</description>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <!-- property name="hibernate.type.json_format_mapper" value="MyJsonFormatMapper" / -->
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
@@ -1,20 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2023 Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
   -->
 
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18275

This is #17048 with an added commit to get the headers in the new files in line with https://github.com/wildfly/wildfly/pull/17214
