### PR TITLE
[WFLY-18526] integrates BOMs in the Server's repo

### DIFF
--- a/boms/user/README.adoc
+++ b/boms/user/README.adoc
@@ -1,0 +1,31 @@
+= WildFly BOMs
+
+The WildFly BOMs project provides Maven BOM files, which includes dependency management compatible with (same version) WildFly. These files manage the version of the dependencies you may need to build, test or debug your project, ensuring you always get a compatible stack.
+
+The following BOMs are available:
+
+* EJB Client (Maven coordinates "org.wildfly:wildfly-ejb-client-bom", built by ./client/ejb-client/pom.xml)
+* JAXWS Client (Maven coordinates "org.wildfly:wildfly-jaxws-client-bom", built by ./client/jaxws-client/pom.xml)
+* JMS Client (Maven coordinates "org.wildfly:wildfly-jms-client-bom", built by ./client/jms-client/pom.xml)
+* EE (Maven coordinates "org.wildfly.bom:wildfly-ee", built by ./ee/pom.xml)
+* EE with Tools (Maven coordinates "org.wildfly.bom:wildfly-ee-with-tools", built by ./ee/ee-with-tools/pom.xml)
+* MicroProfile (Maven coordinates "org.wildfly.bom:wildfly-microprofile", built by ./microprofile/pom.xml)
+
+== Usage
+
+To use a BOM, import into your dependency management. For example, if you want to import the traditional server's dependency management with tools, provided by the "EE With Tools" BOM, use:
+
+[source, xml]
+----
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.bom</groupId>
+            <artifactId>wildfly-ee-with-tools</artifactId>
+            <version>${wildfly.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement> 
+----

--- a/boms/user/client/ejb-client/pom.xml
+++ b/boms/user/client/ejb-client/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-client</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-ejb-client-bom-builder</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly BOMs: EJB Client Builder</name>
+
+    <description>
+        This artifact builds a bill of materials (BOM) for EJB client usage.
+    </description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>${ee.maven.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>org.wildfly</bomGroupId>
+                            <bomArtifactId>wildfly-ejb-client-bom</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: EJB Client</bomName>
+                            <bomDescription>This artifact provides a bill of materials (BOM) for remoting based EJB usage. Importing this bom into your project will give you the maven artifacts you need to perform remote EJB calls.</bomDescription>
+                            <bomWithDependencies>true</bomWithDependencies>
+                            <licenses>true</licenses>
+                            <inheritExclusions>UNMANAGED</inheritExclusions>
+                            <includeDependencies>
+                                <!-- ejb client, the main artifact -->
+                                <dependency>
+                                    <groupId>org.jboss</groupId>
+                                    <artifactId>jboss-ejb-client</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec -->
+                                <dependency>
+                                    <groupId>jakarta.resource</groupId>
+                                    <artifactId>jakarta.resource-api</artifactId>
+                                </dependency>
+                                <!-- http ejb client, extension of main artifact -->
+                                <dependency>
+                                    <groupId>org.wildfly.wildfly-http-client</groupId>
+                                    <artifactId>wildfly-http-ejb-client</artifactId>
+                                </dependency>
+                                <!-- TODO review removal, artifact for server side ejb apps and already included by EE BOM -->
+                                <dependency>
+                                    <groupId>org.jboss.ejb3</groupId>
+                                    <artifactId>jboss-ejb3-ext-api</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/boms/user/client/jaxws-client/pom.xml
+++ b/boms/user/client/jaxws-client/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-client</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jaxws-client-bom-builder</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly BOMs: JAXWS Client Builder</name>
+
+    <description>
+        This artifact builds a bill of materials (BOM) for JAXWS client usage.
+    </description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>${ee.maven.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>org.wildfly</bomGroupId>
+                            <bomArtifactId>wildfly-jaxws-client-bom</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: JAXWS Client</bomName>
+                            <bomDescription>This artifact provides a bill of materials (BOM) for JAXWS client usage.</bomDescription>
+                            <bomWithDependencies>true</bomWithDependencies>
+                            <licenses>true</licenses>
+                            <inheritExclusions>UNMANAGED</inheritExclusions>
+                            <excludeDependencies>
+                                <dependency>
+                                    <groupId>log4j</groupId>
+                                    <artifactId>log4j</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>jcl-over-slf4j</artifactId>
+                                </dependency>
+                            </excludeDependencies>
+                            <includeDependencies>
+                                <dependency>
+                                    <groupId>org.jboss.ws.cxf</groupId>
+                                    <artifactId>jbossws-cxf-client</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.spec.jakarta.xml.ws</groupId>
+                                    <artifactId>jboss-jakarta-xml-ws-api_4.0_spec</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec -->
+                                <dependency>
+                                    <groupId>jakarta.annotation</groupId>
+                                    <artifactId>jakarta.annotation-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.slf4j</groupId>
+                                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.logmanager</groupId>
+                                    <artifactId>jboss-logmanager</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/boms/user/client/jms-client/pom.xml
+++ b/boms/user/client/jms-client/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-client</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jms-client-bom-builder</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly BOMs: JMS Client Builder</name>
+
+    <description>
+        This artifact builds a bill of materials (BOM) for JMS client usage.
+    </description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>${ee.maven.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>org.wildfly</bomGroupId>
+                            <bomArtifactId>wildfly-jms-client-bom</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: JMS Client</bomName>
+                            <bomDescription>This artifact provides a bill of materials (BOM) for JMS client usage.</bomDescription>
+                            <bomWithDependencies>true</bomWithDependencies>
+                            <licenses>true</licenses>
+                            <inheritExclusions>UNMANAGED</inheritExclusions>
+                            <includeDependencies>
+                                <!-- artemis jakarta jms client, the main artifact -->
+                                <!-- replaces org.apache.activemq:artemis-jms-client -->
+                                <dependency>
+                                    <groupId>org.apache.activemq</groupId>
+                                    <artifactId>artemis-jakarta-client</artifactId>
+                                </dependency>
+                                <!-- required to allow Artemis client to connect to HornetQ servers -->
+                                <dependency>
+                                    <groupId>org.apache.activemq</groupId>
+                                    <artifactId>artemis-hqclient-protocol</artifactId>
+                                </dependency>
+                                <!-- Required by the artemis-core-client, replaces geronimo's json spec artifact -->
+                                <dependency>
+                                    <groupId>org.glassfish</groupId>
+                                    <artifactId>jakarta.json</artifactId>
+                                </dependency>
+                                <!-- Required by jakarta.json -->                                
+                                <dependency>
+                                    <groupId>jakarta.json</groupId>
+                                    <artifactId>jakarta.json-api</artifactId>
+                                </dependency>                                
+                                <!-- Required by the artemis-jms-client -->
+                                <!-- replaces org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec  -->
+                                <dependency>
+                                    <groupId>jakarta.jms</groupId>
+                                    <artifactId>jakarta.jms-api</artifactId>
+                                </dependency>
+                                <!-- TODO review -->
+                                <dependency>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>jcl-over-slf4j</artifactId>
+                                </dependency>
+                                <!-- client for usage through jndi -->
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-naming-client</artifactId>
+                                </dependency>
+                                <!-- provides the jms client properties -->
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-client-properties</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/boms/user/client/pom.xml
+++ b/boms/user/client/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-client</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly BOMs: Client Aggregator</name>
+
+    <modules>
+        <module>ejb-client</module>
+		<module>jaxws-client</module>
+        <module>jms-client</module>
+    </modules>
+
+</project>

--- a/boms/user/ee/ee-with-tools/pom.xml
+++ b/boms/user/ee/ee-with-tools/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-ee-builder</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+
+    <artifactId>wildfly-ee-with-tools-builder</artifactId>
+
+    <name>WildFly BOMs: EE with Tools Builder</name>
+    <description>This artifact builds a bill of materials (BOM) for WildFly EE with Deployment and Testing Tools</description>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- imports the related server's test BOM -->
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-test-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- The WildFly plugin deploys your war to a local WildFly container -->
+                <!-- To use, set the JBOSS_HOME environment variable and
+                    run: mvn package wildfly:deploy -->
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>wildfly-ee</artifactId>
+                                <version>${project.version}</version>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>${project.groupId}</bomGroupId>
+                            <bomArtifactId>wildfly-ee-with-tools</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: EE with Tools</bomName>
+                            <bomDescription>Dependency Management for WildFly EE with Deployment and Testing Tools.</bomDescription>
+                            <licenses>true</licenses>
+                            <inheritExclusions>NONE</inheritExclusions>
+                            <includeTransitives>false</includeTransitives>
+                            <includeDependencies>
+                                <dependency>
+                                    <groupId>com.h2database</groupId>
+                                    <artifactId>h2</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>junit</groupId>
+                                    <artifactId>junit</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.httpcomponents</groupId>
+                                    <artifactId>httpclient</artifactId>
+                                </dependency>
+                                <!-- Arquillian support for JBoss WildFly container -->
+                                <dependency>
+                                    <groupId>org.wildfly.arquillian</groupId>
+                                    <artifactId>wildfly-arquillian-common</artifactId>
+                                </dependency>
+                                <!-- Note: Managed version of container allows Arquillian to control startup and shutdown of the container -->
+                                <dependency>
+                                    <groupId>org.wildfly.arquillian</groupId>
+                                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                                </dependency>
+                                <!-- Note: Remote version of container allows Arquillian to connect to already running container -->
+                                <dependency>
+                                    <groupId>org.wildfly.arquillian</groupId>
+                                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.container</groupId>
+                                    <artifactId>arquillian-container-test-spi</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.junit</groupId>
+                                    <artifactId>arquillian-junit-container</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.junit5</groupId>
+                                    <artifactId>arquillian-junit5-container</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.protocol</groupId>
+                                    <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                            <versionRefDependencies>
+                                <dependency>
+                                    <groupId>org.wildfly.arquillian</groupId>
+                                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                                    <version>org.wildfly.arquillian:wildfly-arquillian-container-managed:jar</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.protocol</groupId>
+                                    <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+                                    <version>org.jboss.arquillian.container:arquillian-container-test-spi:jar</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.arquillian.junit5</groupId>
+                                    <artifactId>arquillian-junit5-container</artifactId>
+                                    <version>org.jboss.arquillian.container:arquillian-container-test-spi:jar</version>
+                                </dependency>
+                            </versionRefDependencies>
+                            <includePlugins>
+                                <includePlugin>org.wildfly.plugins:wildfly-maven-plugin</includePlugin>
+                            </includePlugins>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/boms/user/ee/pom.xml
+++ b/boms/user/ee/pom.xml
@@ -1,0 +1,488 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2022, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+
+    <artifactId>wildfly-ee-builder</artifactId>
+
+    <name>WildFly BOMs: EE Builder</name>
+    <description>This artifact builds a bill of materials (BOM) for WildFly EE Dependency Management</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- base import of server's dep management -->
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Wildfly client dependency sets -->
+            <!-- The ejb, jaxws and jms client BOMs should be used as a normal dependency with
+                 <type>pom</type>.  This adds a set of dependencies to the build.
+                 This is in contrast to dependency management using the "import"
+                 scope which manages dependency versions, but does not add the
+                 dependencies to the build classpath. -->
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-ejb-client-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-jaxws-client-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-jms-client-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
+            <version>${ee.maven.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>${project.groupId}</bomGroupId>
+                            <bomArtifactId>wildfly-ee</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: EE</bomName>
+                            <bomDescription>WildFly EE Dependency Management.</bomDescription>
+                            <licenses>true</licenses>
+                            <inheritExclusions>UNMANAGED</inheritExclusions>
+                            <includeTransitives>true</includeTransitives>
+                            <includeDependencies>
+                                <!-- Jakarta EE original and forked APIs -->
+                                <!-- replaces com.sun.activation:jakarta.activation -->
+                                <dependency>
+                                    <groupId>jakarta.activation</groupId>
+                                    <artifactId>jakarta.activation-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec -->
+                                <dependency>
+                                    <groupId>jakarta.annotation</groupId>
+                                    <artifactId>jakarta.annotation-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.0_spec -->
+                                <dependency>
+                                    <groupId>jakarta.authentication</groupId>
+                                    <artifactId>jakarta.authentication-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec -->
+                                <dependency>
+                                    <groupId>jakarta.authorization</groupId>
+                                    <artifactId>jakarta.authorization-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.batch:jboss-batch-api_1.0_spec -->
+                                <dependency>
+                                    <groupId>jakarta.batch</groupId>
+                                    <artifactId>jakarta.batch-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec -->
+                                <dependency>
+                                    <groupId>jakarta.ejb</groupId>
+                                    <artifactId>jakarta.ejb-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.el:jboss-el-api_3.0_spec -->
+                                <dependency>
+                                    <groupId>org.jboss.spec.jakarta.el</groupId>
+                                    <artifactId>jboss-el-api_5.0_spec</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.enterprise</groupId>
+                                    <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec -->
+                                <dependency>
+                                    <groupId>jakarta.enterprise.concurrent</groupId>
+                                    <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+                                </dependency>
+                                <!-- new in the BOM -->
+                                <dependency>
+                                    <groupId>jakarta.enterprise</groupId>
+                                    <artifactId>jakarta.enterprise.lang-model</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.faces:jboss-jsf-api_2.3_spec -->
+                                <dependency>
+                                    <groupId>jakarta.faces</groupId>
+                                    <artifactId>jakarta.faces-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.inject</groupId>
+                                    <artifactId>jakarta.inject-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec -->
+                                <dependency>
+                                    <groupId>jakarta.interceptor</groupId>
+                                    <artifactId>jakarta.interceptor-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec  -->
+                                <dependency>
+                                    <groupId>jakarta.jms</groupId>
+                                    <artifactId>jakarta.jms-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.json</groupId>
+                                    <artifactId>jakarta.json-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.json.bind</groupId>
+                                    <artifactId>jakarta.json.bind-api</artifactId>
+                                </dependency>
+                                <!-- replaces com.sun.mail:jakarta.mail -->                                
+                                <dependency>
+                                    <groupId>jakarta.mail</groupId>
+                                    <artifactId>jakarta.mail-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.persistence</groupId>
+                                    <artifactId>jakarta.persistence-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec -->                                
+                                <dependency>
+                                    <groupId>jakarta.resource</groupId>
+                                    <artifactId>jakarta.resource-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.security.enterprise</groupId>
+                                    <artifactId>jakarta.security.enterprise-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec -->
+                                <dependency>
+                                    <groupId>jakarta.servlet</groupId>
+                                    <artifactId>jakarta.servlet-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.servlet.jsp:jboss-jsp-api_2.3_spec -->
+                                <dependency>
+                                    <groupId>jakarta.servlet.jsp</groupId>
+                                    <artifactId>jakarta.servlet.jsp-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.apache.taglibs:taglibs-standard-spec -->
+                                <dependency>
+                                    <groupId>jakarta.servlet.jsp.jstl</groupId>
+                                    <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec  -->
+                                <dependency>
+                                    <groupId>jakarta.transaction</groupId>
+                                    <artifactId>jakarta.transaction-api</artifactId>
+                                </dependency>
+                                <!-- already present -->
+                                <dependency>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec  -->
+                                <dependency>
+                                    <groupId>jakarta.xml.bind</groupId>
+                                    <artifactId>jakarta.xml.bind-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.xml.ws:jboss-jaxws-api_2.3_spec and javax.jws:jsr181-api -->                                
+                                <dependency>
+                                    <groupId>org.jboss.spec.jakarta.xml.ws</groupId>
+                                    <artifactId>jboss-jakarta-xml-ws-api_4.0_spec</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec -->
+                                <dependency>
+                                    <groupId>jakarta.websocket</groupId>
+                                    <artifactId>jakarta.websocket-api</artifactId>
+                                </dependency>
+                                <!-- new in the BOM -->
+                                <dependency>
+                                    <groupId>jakarta.websocket</groupId>
+                                    <artifactId>jakarta.websocket-client-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec -->
+                                <dependency>
+                                    <groupId>jakarta.ws.rs</groupId>
+                                    <artifactId>jakarta.ws.rs-api</artifactId>
+                                </dependency>
+                                <!-- org.jboss.spec.javax.management.j2ee:jboss-j2eemgmt-api_1.1_spec (and ee9 sucessor) was dropped from specs -->
+                                <!-- replaces org.jboss.spec.javax.xml.soap:jboss-saaj-api_1.4_spec -->
+                                <dependency>
+                                    <groupId>org.jboss.spec.jakarta.xml.soap</groupId>
+                                    <artifactId>jboss-saaj-api_3.0_spec</artifactId>
+                                </dependency>
+
+                                <!-- include client BOMs -->
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-ejb-client-bom</artifactId>
+                                    <type>pom</type>
+                                    <transitive>false</transitive>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-jaxws-client-bom</artifactId>
+                                    <type>pom</type>
+                                    <transitive>false</transitive>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-jms-client-bom</artifactId>
+                                    <type>pom</type>
+                                    <transitive>false</transitive>
+                                </dependency>
+
+                                <!-- Server components -->
+                                <!-- include hibernate -->
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-core</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-envers</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-backend-lucene</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-engine</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.search</groupId>
+                                    <artifactId>hibernate-search-util-common</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.validator</groupId>
+                                    <artifactId>hibernate-validator</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.validator</groupId>
+                                    <artifactId>hibernate-validator-cdi</artifactId>
+                                </dependency>
+                                <!-- TODO hibernate extras via version ref, should we keep them? -->
+                                <dependency>
+                                    <groupId>org.hibernate.validator</groupId>
+                                    <artifactId>hibernate-validator-annotation-processor</artifactId>
+                                </dependency>
+                                <!-- replaces org.hibernate:hibernate-jpamodelgen -->
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                </dependency>
+                                <!-- include ispn -->                        
+                                <dependency>
+                                    <groupId>org.infinispan</groupId>
+                                    <artifactId>infinispan-core-jakarta</artifactId>
+                                </dependency>
+                                <!-- include jboss logging -->
+                                <dependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-processor</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>commons-logging-jboss-logging</artifactId>
+                                </dependency>
+                                <!-- include narayana -->
+                                <dependency>
+                                    <groupId>org.jboss.narayana.xts</groupId>
+                                    <artifactId>jbossxts</artifactId>
+                                    <classifier>api</classifier>
+                                </dependency>
+                                <!-- include resteasy -->
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-atom-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-jaxb-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-jackson2-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-core</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-core-spi</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-client</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-client-api</artifactId>
+                                </dependency>
+                                <!-- seems to be needed by resteasy clients, yet excluded by wildcard on wfly dep management -->
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-multipart-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-json-binding-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-json-p-provider</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-jsapi</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.jboss.resteasy</groupId>
+                                    <artifactId>resteasy-validator-provider</artifactId>
+                                </dependency>
+								<!-- Disabled, as RESTEasy Spring is currently only available
+								     through WildFly Preview
+                                <dependency>
+                                    <groupId>org.jboss.resteasy.spring</groupId>
+                                    <artifactId>resteasy-spring</artifactId>
+                                </dependency>
+								-->
+                                <dependency>
+                                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                                    <artifactId>jackson-datatype-jsr310</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                                    <artifactId>jackson-datatype-jdk8</artifactId>
+                                </dependency>
+                                <!-- include security: elytron  -->
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron</artifactId>
+                                </dependency>
+                                <!-- other server components to include -->
+                                <dependency>
+                                    <groupId>org.wildfly.discovery</groupId>
+                                    <artifactId>wildfly-discovery-client</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.client</groupId>
+                                    <artifactId>wildfly-client-config</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.common</groupId>
+                                    <artifactId>wildfly-common</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>wildfly-clustering-singleton-api</artifactId>
+                                </dependency>
+                                <!-- other JBoss APIs to include -->
+                                <dependency>
+                                    <groupId>org.jboss.ejb3</groupId>
+                                    <artifactId>jboss-ejb3-ext-api</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                            <versionRefDependencies>                            
+                                <dependency>
+                                    <groupId>org.hibernate.validator</groupId>
+                                    <artifactId>hibernate-validator-annotation-processor</artifactId>
+                                    <version>org.hibernate.validator:hibernate-validator:jar</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <version>org.hibernate.orm:hibernate-core:jar</version>
+                                </dependency>
+                            </versionRefDependencies>                            
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <modules>
+        <module>ee-with-tools</module>
+    </modules>
+
+</project>

--- a/boms/user/microprofile/pom.xml
+++ b/boms/user/microprofile/pom.xml
@@ -1,0 +1,190 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+
+    <artifactId>wildfly-microprofile-builder</artifactId>
+
+    <name>WildFly BOMs: MicroProfile Builder</name>
+    <description>This artifact builds a bill of materials (BOM) for MicroProfile Dependency Management</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- base import of server's dep management -->
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-expansion-bom</artifactId>
+                <version>${full.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-galleon-pack</artifactId>
+            <version>${full.maven.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-bom-builder-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>${project.groupId}</bomGroupId>
+                            <bomArtifactId>wildfly-microprofile</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly BOMs: MicroProfile</bomName>
+                            <bomDescription>MicroProfile Dependency Management.</bomDescription>
+                            <licenses>true</licenses>
+                            <inheritExclusions>UNMANAGED</inheritExclusions>
+                            <includeTransitives>true</includeTransitives>
+                            <includeDependencies>
+                                <!-- Import MicroProfile APIs -->
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.config</groupId>
+                                    <artifactId>microprofile-config-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+                                    <artifactId>microprofile-fault-tolerance-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.health</groupId>
+                                    <artifactId>microprofile-health-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.jwt</groupId>
+                                    <artifactId>microprofile-jwt-auth-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.lra</groupId>
+                                    <artifactId>microprofile-lra-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.openapi</groupId>
+                                    <artifactId>microprofile-openapi-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.rest.client</groupId>
+                                    <artifactId>microprofile-rest-client-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
+                                    <artifactId>microprofile-reactive-messaging-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+                                    <artifactId>microprofile-reactive-streams-operators-api</artifactId>
+                                </dependency>
+                                <!-- include OpenTelemetry API -->
+                                <dependency>
+                                    <groupId>io.opentelemetry</groupId>
+                                    <artifactId>opentelemetry-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>io.opentelemetry</groupId>
+                                    <artifactId>opentelemetry-context</artifactId>
+                                </dependency>
+                                <!-- include Micrometer API -->
+                                <dependency>
+                                    <groupId>io.micrometer</groupId>
+                                    <artifactId>micrometer-core</artifactId>
+                                </dependency>
+                                <!-- include jakarta specs APIs -->
+                                <dependency>
+                                    <groupId>jakarta.annotation</groupId>
+                                    <artifactId>jakarta.annotation-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>jakarta.enterprise</groupId>
+                                    <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>jakarta.interceptor</groupId>
+                                    <artifactId>jakarta.interceptor-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>jakarta.json</groupId>
+                                    <artifactId>jakarta.json-api</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>jakarta.json.bind</groupId>
+                                    <artifactId>jakarta.json.bind-api</artifactId>
+                                </dependency>
+                                <!-- replaces org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec -->
+                                <dependency>
+                                    <groupId>jakarta.ws.rs</groupId>
+                                    <artifactId>jakarta.ws.rs-api</artifactId>
+                                </dependency>
+                                <!-- include Kafka client API -->
+                                <dependency>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-clients</artifactId>
+                                </dependency>
+                                <!-- include reactive-streams -->
+                                <dependency>
+                                    <groupId>org.reactivestreams</groupId>
+                                    <artifactId>reactive-streams</artifactId>
+                                </dependency>
+                                <!-- include SmallRye Kafka API -->
+                                <dependency>
+                                    <groupId>io.smallrye.reactive</groupId>
+                                    <artifactId>smallrye-reactive-messaging-kafka-api</artifactId>
+                                </dependency>
+                            </includeDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/boms/user/pom.xml
+++ b/boms/user/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>30.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.bom</groupId>
+    <artifactId>wildfly</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly BOMs: Parent Aggregator</name>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-bom-builder-plugin</artifactId>
+                    <version>${version.org.wildfly.bom-builder-plugin}</version>
+                    <configuration>
+                        <includeRepositories>
+                            <id>jboss-public-repository-group</id>
+                        </includeRepositories>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <modules>
+        <module>client</module>
+        <module>ee</module>
+        <module>microprofile</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>boms/standard-expansion</module>
         <module>boms/standard-test</module>
         <module>boms/standard-test-expansion</module>
+        <module>boms/user</module>
         <module>build</module>
         <module>client/properties</module>
         <module>client/shade</module>
@@ -315,6 +316,7 @@
         <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Alpha6</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
+        <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18526
Follows up on #17201 , which was lacking the BOMs modules in the maven project, and the setup of bom builder dependencies (towards galleon packs) to ensure all BOMs needed artifacts were built. This PR also brings back ee-with-tools BOM, but only containing managed artifacts/versions. 
