### PR TITLE
WFLY-18557 appclient -secmgr should be allowed under Java 21

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
@@ -116,8 +116,10 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
+setlocal EnableDelayedExpansion
 call "!DIRNAME!common.bat" :setSecurityManagerDefault
 set "JAVA_OPTS=!JAVA_OPTS! !SECURITY_MANAGER_CONFIG_OPTION!"
+setlocal DisableDelayedExpansion
 
 rem Set the module options
 set "MODULE_OPTS="

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
@@ -116,6 +116,9 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
+call "!DIRNAME!common.bat" :setSecurityManagerDefault
+set "JAVA_OPTS=!JAVA_OPTS! !SECURITY_MANAGER_CONFIG_OPTION!"
+
 rem Set the module options
 set "MODULE_OPTS="
 if "%SECMGR%" == "true" (

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.sh
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.sh
@@ -137,11 +137,18 @@ if $cygwin; then
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
+# Set default Security Manager configuration value
+setSecurityManagerDefault
+JAVA_OPTS="$JAVA_OPTS $SECURITY_MANAGER_CONFIG_OPTION"
+
 # Process the JAVA_OPTS failing if the java.security.manager is set.
 SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "java\.security\.manager"`
 if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
-    echo "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
-    exit 1
+    SECURITY_MANAGER_SET_TO_ALLOW=`echo $JAVA_OPTS | $GREP "java\.security\.manager=allow"`
+    if [ "x$SECURITY_MANAGER_SET_TO_ALLOW" = "x" ]; then
+        echo "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
+        exit 1
+    fi
 fi
 
 # Set up the module arguments


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18557

I tested the appclient.sh change locally but am not sure how to test the appclient.bat change as I don't have a Windows machine or vm setup.  Any suggestions?

I did include a change to the appclient.sh that did but I didn't make a similar change to appclient.bat:
```
SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "java\.security\.manager"`
if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
    SECURITY_MANAGER_SET_TO_ALLOW=`echo $JAVA_OPTS | $GREP "java\.security\.manager=allow"`
    if [ "x$SECURITY_MANAGER_SET_TO_ALLOW" = "x" ]; then
        echo "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
        exit 1
    fi
fi
```

So, we need to test the appclient.bat on Java 21 with the -secmgr option.