### PR TITLE
[WFLY-18590] SimpleTimerMDBTestCase: change waiting time

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/SimpleTimerMDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/SimpleTimerMDBTestCase.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.jms.auxiliary.CreateTopicSetupTask;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -38,6 +39,7 @@ public class SimpleTimerMDBTestCase {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testTimerServiceSimple.war");
         war.addPackage(SimpleTimerMDBTestCase.class.getPackage());
         war.addClass(CreateTopicSetupTask.class);
+        war.addClass(TimeoutUtil.class);
         return war;
 
     }
@@ -53,7 +55,7 @@ public class SimpleTimerMDBTestCase {
     public void testTimedObjectTimeoutMethod() throws Exception {
         InitialContext ctx = new InitialContext();
         sendMessage();
-        Assert.assertTrue(TimedObjectTimerServiceMDB.awaitTimerCall());
+        Assert.assertTrue(TimedObjectTimerServiceMDB.awaitTimerCall(TimeoutUtil.adjust(2000)));
     }
 
     //the timer is created when the

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/TimedObjectTimerServiceMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/TimedObjectTimerServiceMDB.java
@@ -35,9 +35,9 @@ public class TimedObjectTimerServiceMDB implements TimedObject , MessageListener
         timerService.createTimer(100, null);
     }
 
-    public static boolean awaitTimerCall() {
+    public static boolean awaitTimerCall(int timeout) {
         try {
-            latch.await(2, TimeUnit.SECONDS);
+            latch.await(timeout, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18585

The bug is hard to reproduce and even if I managed to do this I can't see any obvious failures in the log. Maybe we can try giving the bean more waiting time and see if it helps.