### PR TITLE
[WFLY-18613] Upgrade WildFly Core to 22.0.0.Final

### DIFF
--- a/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/InvalidAttributeManagerDeclarationUnitTestCase.java
+++ b/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/InvalidAttributeManagerDeclarationUnitTestCase.java
@@ -22,10 +22,14 @@
 
 package org.wildfly.extension.picketlink.subsystem;
 
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import org.hamcrest.MatcherAssert;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -55,9 +59,13 @@ public class InvalidAttributeManagerDeclarationUnitTestCase extends AbstractSubs
 
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXml(getSubsystemXml());
 
-        KernelServices mainServices = builder.build();
-
-        assertFalse(mainServices.isSuccessfulBoot());
+        try {
+            KernelServices mainServices = builder.build();
+            fail("Expected boot failed");
+        } catch (OperationFailedException ex) {
+            final String failureDescription = ex.getFailureDescription().asString();
+            MatcherAssert.assertThat(failureDescription, allOf(containsString("WFLYPL0013:"), containsString("attribute-manager")));
+        }
     }
 
     protected AdditionalInitialization createAdditionalInitialization() {

--- a/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/RoleGeneratorDeclarationUnitTestCase.java
+++ b/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/RoleGeneratorDeclarationUnitTestCase.java
@@ -22,10 +22,14 @@
 
 package org.wildfly.extension.picketlink.subsystem;
 
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import org.hamcrest.MatcherAssert;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -55,9 +59,14 @@ public class RoleGeneratorDeclarationUnitTestCase extends AbstractSubsystemBaseT
 
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXml(getSubsystemXml());
 
-        KernelServices mainServices = builder.build();
+        try {
+            KernelServices mainServices = builder.build();
+            fail("Expected boot failed");
+        } catch (OperationFailedException ex) {
+            final String failureDescription = ex.getFailureDescription().asString();
+            MatcherAssert.assertThat(failureDescription, allOf(containsString("WFLYPL0013:"), containsString("role-generator")));
+        }
 
-        assertFalse(mainServices.isSuccessfulBoot());
     }
 
     protected AdditionalInitialization createAdditionalInitialization() {

--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>22.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>22.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18613


Includes:
https://issues.redhat.com/browse/WFLY-18522


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/22.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/22.0.0.Beta3...22.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6486'>WFCORE-6486</a>] -         CLIEmbedHostControllerTestCase fails randomly with JDK 17 Jobs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6505'>WFCORE-6505</a>] -         Avoid creating duplicate thread groups on server reload
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6525'>WFCORE-6525</a>] -         AuditLogBootingSyslogTest is not executed by default
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6544'>WFCORE-6544</a>] -         CVE-2023-4061 Management User RBAC permission allows unexpected reading of system-properties to an Unauthorized actor
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6407'>WFCORE-6407</a>] -         Remove AttributeDefinition arguments from AbstractAddStepHandler and AbstractWriteAttributeHandler
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6472'>WFCORE-6472</a>] -         Removing the remoting subsystem transformers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6529'>WFCORE-6529</a>] -         Update Eclipse IDE templates to use new copyright header
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6530'>WFCORE-6530</a>] -         Remove the obsolete COMMITMENT file
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6484'>WFCORE-6484</a>] -         Upgrade JGit from 6.6.0.202305301015-r to 6.6.1.202309021850-r (resolves CVE-2023-4759)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6516'>WFCORE-6516</a>] -         Upgrade JBoss Marshalling to 2.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6528'>WFCORE-6528</a>] -         Upgrade JBoss MSC to 1.5.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6546'>WFCORE-6546</a>] -         Upgrade JBoss Marshalling to 2.1.3.SP1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4916'>WFCORE-4916</a>] -         Unclear attribute name completion for LIST type
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6383'>WFCORE-6383</a>] -         Create new exception for boot errors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6520'>WFCORE-6520</a>] -         Remove testsuite useless code related to JDK 10 and below
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6521'>WFCORE-6521</a>] -         Use Runtime.version() method call instead of inspecting JVM properties to detect Java version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6524'>WFCORE-6524</a>] -         Do not duplicate managed deployment in content repository in tmp/vfs/temp directory
</li>
</ul>
</details>

