### PR TITLE
[WFLY-14769] Access checking for txn namespace lookup

### DIFF
--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -236,6 +236,12 @@ vi:ts=4:sw=4:expandtab
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-integration</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.wildfly.transaction</groupId>
             <artifactId>wildfly-transaction-client</artifactId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/BMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/BMTSLSB.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@Stateless
+@TransactionManagement(value = TransactionManagementType.BEAN)
+public class BMTSLSB {
+
+    @PostConstruct
+    void onConstruct() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void checkUserTransactionAvailability() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private void checkUserTransactionAccess() throws NamingException {
+        final String remoteUserTransactionName = "txn:RemoteUserTransaction";
+        final UserTransaction remoteUserTransaction = InitialContext.doLookup(remoteUserTransactionName);
+        if (remoteUserTransaction == null) {
+            throw new RuntimeException("UserTransaction lookup at " + remoteUserTransactionName + " returned null in a BMT bean");
+        }
+        final String localUserTransactionName = "txn:LocalUserTransaction";
+        final UserTransaction localUserTransaction = InitialContext.doLookup(localUserTransactionName);
+        if (localUserTransaction == null) {
+            throw new RuntimeException("UserTransaction lookup at " + localUserTransaction + " returned null in a BMT bean");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/CMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/CMTSLSB.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import org.jboss.logging.Logger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@Stateless
+public class CMTSLSB {
+
+    private static final Logger logger = Logger.getLogger(CMTSLSB.class);
+
+    @PostConstruct
+    void onConstruct() {
+        this.checkUserTransactionAccess();
+    }
+
+    public void checkUserTransactionAccessDenial() {
+        this.checkUserTransactionAccess();
+    }
+
+    private void checkUserTransactionAccess() {
+        try {
+            final String remoteUserTransactionName = "txn:RemoteUserTransaction";
+            InitialContext.doLookup(remoteUserTransactionName);
+            throw new RuntimeException("UserTransaction lookup at " + remoteUserTransactionName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.trace("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+        try {
+            final String localUserTransactionName = "txn:LocalUserTransaction";
+            InitialContext.doLookup(localUserTransactionName);
+            throw new RuntimeException("UserTransaction lookup at " + localUserTransactionName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.trace("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/TransactionNamespaceAccessTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/txnaccess/TransactionNamespaceAccessTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.txnaccess;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.context.ContextPermission;
+
+import javax.naming.InitialContext;
+
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@RunWith(Arquillian.class)
+public class TransactionNamespaceAccessTestCase {
+
+    private static final String MODULE_NAME = "transaction-namespace-access-test-case";
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(TransactionNamespaceAccessTestCase.class.getPackage())
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new ContextPermission("org.wildfly.transaction.client.context.remote", "get")
+                ), "permissions.xml");
+        return jar;
+    }
+
+    @Test
+    public void testUserTransactionLookupInCMT() throws Exception {
+        final CMTSLSB cmtSlsb = InitialContext.doLookup("java:module/" + CMTSLSB.class.getSimpleName() + "!" + CMTSLSB.class.getName());
+        cmtSlsb.checkUserTransactionAccessDenial();
+    }
+
+    @Test
+    public void testUserTransactionLookupInBMT() throws Exception {
+        final BMTSLSB bmtslsb = InitialContext.doLookup("java:module/" + BMTSLSB.class.getSimpleName() + "!" + BMTSLSB.class.getName());
+        bmtslsb.checkUserTransactionAvailability();
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-14769

This is a simpler solution which injects access check to transaction-client library and does not modify naming subsystem.
