### PR TITLE
WFLY-18616 SEVERE log noise when deplying a JSF application - JSF1030…

### DIFF
--- a/jsf/injection/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
+++ b/jsf/injection/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
@@ -1,6 +1,1 @@
-#
-# Copyright The WildFly Authors
-# SPDX-License-Identifier: Apache-2.0
-#
-
 org.jboss.as.jsf.injection.JSFInjectionProvider:org.jboss.as.jsf.injection.JSFInjectionProvider


### PR DESCRIPTION
…: The specified InjectionProvider implementation '# SPDX-License-Identifier' cannot be loaded.

Resolves
https://issues.redhat.com/browse/WFLY-18616

TLDR Caused by https://github.com/wildfly/wildfly/pull/17214 - This happens because the service loading mechanism in com.sun.faces.spi.InjectionProviderFactory#getServiceEntries doesn't account for commented lines (for instance the com.sun.faces.spi.ServiceFactoryUtils#getServiceEntries does perform sanitation or parsed out providers com.sun.faces.spi.ServiceFactoryUtils#cleanupServiceLine).