### PR TITLE
[WFLY-18593] Revert Yasson back to 3.0.2. The version 3.0.3 contains …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <version.org.eclipse.microprofile.rest.client.api>3.0</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.microprofile.telemetry>1.0</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.0</version.org.eclipse.persistence.eclipselink>
-        <version.org.eclipse.yasson>3.0.3</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
         <version.org.elasticsearch.client.rest-client>8.10.2</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>


### PR DESCRIPTION
…a commit, https://github.com/eclipse-ee4j/yasson/pull/586, which closes input streams. This could cause issues where the user is expecting to be able to re-use the InputStream that was passed in.

https://issues.redhat.com/browse/WFLY-18593

Effectively reverts #17247