### PR TITLE
Allow for 60 minutes for the build-only jobs to complete. When downlo…

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: WildFly Build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
   quick-build:
     name: WildFly Build -Dquickly
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
…ading dependencies, this could take more time.