### PR TITLE
WFLY-18625 CVE-2023-44487 Upgrade Netty to 4.1.100.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.io.agroal>2.0</version.io.agroal>
         <version.io.micrometer>1.9.13</version.io.micrometer>
-        <version.io.netty>4.1.99.Final</version.io.netty>
+        <version.io.netty>4.1.100.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.20.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentelemetry.proto>0.19.0-alpha</version.io.opentelemetry.proto>
         <version.io.perfmark>0.23.0</version.io.perfmark>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18625
https://access.redhat.com/security/cve/CVE-2023-44487