### PR TITLE
Fix for WFLY-18648, Upgrade Galleon to 5.2.1.Final and Galleon plugins to 6.5.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,14 +296,14 @@
         <version.ant.junit>1.10.13</version.ant.junit>
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.10</version.org.jacoco>
-        <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.2.1.Final</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Alpha6</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>6.4.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>6.5.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>10.0.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.maven.plugins>2.3.1.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>4.1.0.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18648
