### PR TITLE
[WFLY-18673] GitHub Actions Run Reductions

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -39,6 +39,11 @@ on:
         default: 120
         type: number
 
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -4,39 +4,10 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: WildFly Build
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Clear any possible SNAPSHOT dependencies in the local maven repository
-        run: |
-          LOCAL_REPO="$HOME/.m2/repository"
-          echo "Cleaning SNAPSHOTS from $LOCAL_REPO"
-          if [ -d "$LOCAL_REPO" ]; then find "$LOCAL_REPO" -name "*SNAPSHOT*" | xargs -I {} rm -rfv "{}"; fi
-        shell: bash
-      - name: Build with Maven Java 11 - ${{ matrix.os }}
-        run: mvn clean install -U -B -DallTests -DskipTests
   quick-build:
     name: WildFly Build -Dquickly
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,5 +23,5 @@ jobs:
           echo "Cleaning SNAPSHOTS from $LOCAL_REPO"
           if [ -d "$LOCAL_REPO" ]; then find "$LOCAL_REPO" -name "*SNAPSHOT*" | xargs -I {} rm -rfv "{}"; fi
         shell: bash
-      - name: Build with Maven Java 11 - ${{ matrix.os }} -Dquickly
+      - name: Build with Maven Java 11 -Dquickly
         run: mvn -U -B -Dquickly

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -3,6 +3,11 @@ name: WildFly Build
 on:
   pull_request:
 
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   quick-build:
     name: WildFly Build -Dquickly

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -2,6 +2,10 @@ name: WildFly Build
 
 on:
   pull_request:
+    branches:
+      - '**'
+    paths:
+      - "**/pom.xml"
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -3,6 +3,27 @@ on:
   pull_request_target:
     branches:
       - main
+    paths-ignore:
+      - ".mvn/**"
+      - "docs/**"
+      - ".github/workflows/build-manual.yml"
+      - ".github/workflows/shared-wildfly-build.yml"
+      - '.gitattributes'
+      - '.gitignore'
+      - '.gitleaks.toml'
+      - 'build.bat'
+      - 'build.sh'
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "integration-tests.bat"
+      - "integration-tests.sh"
+      - "LICENSE.txt"
+      - "mvnw"
+      - "mvnw.cmd"
+      - "README.md"
+      - "SECURITY.md"
+      - "**/README.md"
+      - "**/README.adoc"
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -3,6 +3,11 @@ on:
   pull_request_target:
     branches:
       - main
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 env:
   # Repository where the cloud tests will be run
   REPOSITORY: wildfly-extras/wildfly-cloud-tests

--- a/.github/workflows/dep-diff-pull_request.yml
+++ b/.github/workflows/dep-diff-pull_request.yml
@@ -5,7 +5,9 @@ name: Dependency Tree Input Builder
 on:
   pull_request:
     branches:
-    - main
+      - main
+    paths:
+      - "**/pom.xml"
 env:
   # The modules to check for dependencies. If there is more than one they are comma separated
   MODULES_TO_CHECK: ee-feature-pack/galleon-shared,ee-feature-pack/galleon-local,galleon-pack/galleon-shared,galleon-pack/galleon-local,galleon-pack,ee-feature-pack/common,microprofile/galleon-common,servlet-feature-pack/common,elytron-oidc-client/galleon-common

--- a/.github/workflows/jdk-jre-build.yml
+++ b/.github/workflows/jdk-jre-build.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   wildfly-jre-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/jdk-jre-build.yml
+++ b/.github/workflows/jdk-jre-build.yml
@@ -4,7 +4,51 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".mvn/**"
+      - "docs/**"
+      - ".github/workflows/build-manual.yml"
+      - ".github/workflows/shared-wildfly-build.yml"
+      - '.gitattributes'
+      - '.gitignore'
+      - '.gitleaks.toml'
+      - 'build.bat'
+      - 'build.sh'
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "integration-tests.bat"
+      - "integration-tests.sh"
+      - "LICENSE.txt"
+      - "mvnw"
+      - "mvnw.cmd"
+      - "README.md"
+      - "SECURITY.md"
+      - "**/README.md"
+      - "**/README.adoc"
   pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - ".mvn/**"
+      - "docs/**"
+      - ".github/workflows/build-manual.yml"
+      - ".github/workflows/shared-wildfly-build.yml"
+      - '.gitattributes'
+      - '.gitignore'
+      - '.gitleaks.toml'
+      - 'build.bat'
+      - 'build.sh'
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "integration-tests.bat"
+      - "integration-tests.sh"
+      - "LICENSE.txt"
+      - "mvnw"
+      - "mvnw.cmd"
+      - "README.md"
+      - "SECURITY.md"
+      - "**/README.md"
+      - "**/README.adoc"
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/jdk-jre-build.yml
+++ b/.github/workflows/jdk-jre-build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17', '21-ea']
+        java: ['11', '17', '21']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Reduce the number of jobs that run per PR. Ignore specific files for CI runs and ensure previous runs are cancelled if a branch/PR is updated and a push is done.

https://issues.redhat.com/browse/WFLY-18673
