### PR TITLE
[WFLY-18645] Upgrade openjdk-orb to 10.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
         <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
-        <version.org.jboss.openjdk-orb>9.0.2.Final</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>10.0.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.4.Final</version.org.jboss.resteasy.microprofile>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18645

Openjdk-orb was refactored to be built on jdk11, hence the major version bump. This change was triggered by
https://issues.redhat.com/browse/JBEAP-25755
