### PR TITLE
Fix for WFLY-18687, Some add-ons in Galleon layer metadata are missing a description

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
@@ -8,7 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="management,wildfly-cli"/>
-        <prop name="org.wildfly.rule.add-on-description" value="Server command line tools: jboss-cli, add-user, elytron-tool"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Server command line tools: jboss-cli, add-user, elytron-tool."/>
     </props>
     <dependencies>
         <layer name="management" optional="true"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="ejb,http-invoker"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for invoking Jakarta Enterprise Beans over HTTP."/>
     </props>
     <dependencies>
         <layer name="ejb-lite"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
@@ -10,6 +10,7 @@
         <prop name="org.wildfly.rule.add-on" value="messaging,embedded-activemq"/>
         <prop name="org.wildfly.rule.add-on-cardinality" value="1"/>
         <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/*-jms.xml,/META-INF/*-jms.xml],/messaging-deployment/server/jms-destinations"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for an embedded Apache Activemq Artemis Jakarta Messaging broker."/>
     </props>
     <dependencies>
         <layer name="messaging-activemq"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
@@ -10,6 +10,7 @@
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
         <prop name="org.wildfly.rule.bring-datasource" value="java:jboss/datasources/ExampleDS"/>
         <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/classes/META-INF/persistence.xml,/META-INF/persistence.xml],/persistence/persistence-unit/jta-data-source,java:jboss/datasources/ExampleDS"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for an H2 datasource."/>
     </props>
     <dependencies>
         <layer name="datasources"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
@@ -9,6 +9,7 @@
         <prop name="org.wildfly.rule.add-on" value="database,h2-database:default"/>
         <prop name="org.wildfly.rule.add-on-fix-no-default-datasource" value=""/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for an H2 datasource set as the ee subsystem default datasource."/>
     </props>
     <dependencies>
         <layer name="datasources"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
@@ -9,6 +9,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="observability,health"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for runtime health checks."/>
     </props>
     <dependencies>
         <layer name="management"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="rpc,iiop" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="none" />
+        <prop name="org.wildfly.rule.add-on-description" value="Support for IIOP."/>
     </props>
     <dependencies>
         <layer name="base-server"/> 

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="management,jdr"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for the JBoss Diagnostic Reporting (JDR)."/>
     </props>
     <dependencies>
         <layer name="base-server"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jgroups-aws/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jgroups-aws/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:jgroups"/>
         <prop name="org.wildfly.rule.add-on" value="clustering,jgroups-aws"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Brings in JBoss Modules modules required to configure the 'aws.S3_PING' discovery protocol."/>
     </props>
     <!--
     This layer only brings in modules required to configure the 'aws.S3_PING' discovery protocol:

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
@@ -9,6 +9,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="observability,metrics"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for base metrics from the WildFly Management Model and JVM MBeans."/>
     </props>
     <dependencies>
         <layer name="management"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
@@ -7,6 +7,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="clustering,mod_cluster" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:undertow" />
+        <prop name="org.wildfly.rule.add-on-description" value="Support for mod_cluster integration."/>
     </props>
     <dependencies>
         <layer name="web-server"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:messaging-activemq"/>
         <prop name="org.wildfly.rule.add-on" value="messaging,remote-activemq"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for connections to a remote Apache Activemq Artemis Jakarta Messaging broker."/>
     </props>
     <dependencies>
         <layer name="messaging-activemq"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="security,ssl"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for the Undertow HTTPS listener."/>
     </props>
     <dependencies>
         <layer name="elytron"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
@@ -8,7 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on" value="web,load-balancer"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
-        <prop name="org.wildfly.rule.add-on-description" value="An undertow load balancer"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for Undertow configured as a load balancer."/>
     </props>
     <dependencies>
         <layer name="base-server"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
@@ -7,6 +7,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
         <prop name="org.wildfly.rule.add-on" value="observability,micrometer"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for Micrometer."/>
     </props>
     <dependencies>
         <layer name="cdi"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
@@ -8,6 +8,7 @@
     <props>
         <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
         <prop name="org.wildfly.rule.add-on" value="lra,lra-coordinator"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for MicroProfile LRA Coordinator."/>
     </props>
     <dependencies>
         <layer name="cdi"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
@@ -12,6 +12,7 @@
         <prop name="org.wildfly.rule.properties-file-match-oas-model-reader" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.openapi.model.reader,*"/>
         <prop name="org.wildfly.rule.properties-file-match-oas-filter" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.openapi.filter,*"/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/openapi.yml,/META-INF/openapi.yaml,/META-INF/openapi.json,/WEB-INF/classes/META-INF/openapi.yml,/WEB-INF/classes/META-INF/openapi.yaml,/WEB-INF/classes/META-INF/openapi.json]"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for MicroProfile OpenAPI."/>
     </props>
     <dependencies>
         <layer name="jaxrs"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
@@ -10,6 +10,7 @@
         <prop name="org.wildfly.rule.properties-file-match-mp-kafka-property" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.connector.smallrye-kafka.*"/>
         <prop name="org.wildfly.rule.properties-file-match-mp-kafka-outgoing" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.outgoing.*.connector,smallrye-kafka"/>
         <prop name="org.wildfly.rule.properties-file-match-mp-kafka-incoming" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.incoming.*.connector,smallrye-kafka"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for the MicroProfile Reactive Messaging Kafka connector."/>
     </props>
     <dependencies>
         <layer name="microprofile-reactive-messaging"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
@@ -10,6 +10,7 @@
         <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*,io.opentelemetry.sdk.*"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
         <prop name="org.wildfly.rule.add-on" value="observability,microprofile-telemetry"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for MicroProfile Telemetry."/>
     </props>
     <dependencies>
         <layer name="cdi"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
@@ -10,6 +10,7 @@
         <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*,io.opentelemetry.sdk.*"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
         <prop name="org.wildfly.rule.add-on" value="observability,opentelemetry"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Support for OpenTelemetry."/>
     </props>
     <dependencies>
         <layer name="cdi"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18687