### PR TITLE
[WFLY-18697] Switch ejb subsystem test dep from groovy-all to groovy

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -81,10 +81,15 @@
 
             <dependency>
                 <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>${version.groovy-all}</version>
-                <type>pom</type>
+                <artifactId>groovy</artifactId>
+                <version>${version.org.apache.groovy}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -410,15 +410,8 @@ projects that depend on this project.-->
 
         <dependency>
             <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <type>pom</type>
+            <artifactId>groovy</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.groovy</groupId>
-                    <artifactId>groovy-test-junit5</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,6 @@
         <version.com.beust>1.78</version.com.beust>
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
         <version.dom4j>2.1.3</version.dom4j>
-        <version.groovy-all>4.0.15</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
         <legacy.version.io.netty>4.0.13.Final</legacy.version.io.netty>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
@@ -329,6 +328,7 @@
         <version.jsoup>1.15.3</version.jsoup>
         <version.junit>4.13.1</version.junit>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
+        <version.org.apache.groovy>4.0.15</version.org.apache.groovy>
         <version.org.awaitility.awaitility>4.0.2</version.org.awaitility.awaitility>
         <version.org.codehaus.plexus.plexus-utils>3.5.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jetty>9.4.52.v20230823</version.org.eclipse.jetty>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
         <version.com.beust>1.78</version.com.beust>
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
         <version.dom4j>2.1.3</version.dom4j>
-        <version.groovy-all>4.0.4</version.groovy-all>
+        <version.groovy-all>4.0.15</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
         <legacy.version.io.netty>4.0.13.Final</legacy.version.io.netty>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18697

This also includes the dependabot upgrade commit from #17272. Reviewing that is what led me to file WFLY-18697.