### PR TITLE
[WFLY-18707] Upgrade WildFly Core to 23.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>22.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.5.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18707


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/22.0.1.Final...23.0.0.Beta1

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6538'>WFCORE-6538</a>] -         KerberosNativeMgmtSaslTestCase.testGs2Krb5OverSsl intermittently fails
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6541'>WFCORE-6541</a>] -         Patch high level command should be completely disabled in standalone mode
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6548'>WFCORE-6548</a>] -         Unify test logging in elytron module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6552'>WFCORE-6552</a>] -         Windows: WARNING: package com.sun.net.internal.ssl not in java.base
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6559'>WFCORE-6559</a>] -         Installation manager could be unable to delete the candidate server when running in PowerShell
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6568'>WFCORE-6568</a>] -         Modify description in elytron of subsystem to its correct sentence
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6445'>WFCORE-6445</a>] -         Update ModuleSpecification.getMutableUserDependencies to resolve pending TODOs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6532'>WFCORE-6532</a>] -         Add security manager testing to scripts tests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6563'>WFCORE-6563</a>] -         Remove org.wildfly.build plugins from the poms
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6527'>WFCORE-6527</a>] -         Upgrade JGit from 6.6.1.202309021850-r to 6.7.0.202309050840-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6542'>WFCORE-6542</a>] -         Upgrade the Windows service tools
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6547'>WFCORE-6547</a>] -         Upgrade JBoss Marshalling to 2.1.3.SP1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6551'>WFCORE-6551</a>] -         Upgrade XNIO to 3.8.11.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6555'>WFCORE-6555</a>] -         CVE-2023-3223 Upgrade Undertow to 2.3.9.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6557'>WFCORE-6557</a>] -         CVE-2023-44487 Upgrade Netty to 4.1.100.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6562'>WFCORE-6562</a>] -         Upgrade Galleon to 5.2.1.Final and Galleon plugins to 6.5.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6564'>WFCORE-6564</a>] -         CVE-2023-44487 Upgrade Undertow to 2.3.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6567'>WFCORE-6567</a>] -         Upgrade Installation Manager API to 1.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6572'>WFCORE-6572</a>] -         Upgrade XNIO to 3.8.12.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6573'>WFCORE-6573</a>] -         Upgrade Eclipse Parsson from 1.1.4 to 1.1.5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6574'>WFCORE-6574</a>] -         Upgrade JBoss Parent to 40
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6575'>WFCORE-6575</a>] -         Upgrade Jakarta JSON from 2.1.2 to 2.1.3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6476'>WFCORE-6476</a>] -         Reducing logging level for failed internal read-only operation steps
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6556'>WFCORE-6556</a>] -         IllegalAccessWarnings on JDK11 in Elytron Subsystem
</li>
</ul>
</details>