### PR TITLE
[WFLY-18240]: org.apache.activemq.artemis is required as an explicit …

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.client">
+    <resources>
+        <artifact name="${org.apache.activemq:artemis-core-client}"/>
+        <artifact name="${org.apache.activemq:artemis-selector}"/>
+        <artifact name="${org.apache.activemq:artemis-hqclient-protocol}"/>
+        <artifact name="${org.apache.activemq:artemis-jakarta-client}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.management"/>
+        <module name="java.management.rmi"/>
+        <module name="java.naming"/>
+        <module name="java.rmi"/>
+        <module name="org.apache.activemq.artemis.commons"/>
+        <!-- export is required to get  access to InVMConnectorFactory -->
+        <module name="org.apache.activemq.artemis" optional="true" export="true"/>
+        <!-- Import is required to get  access to SSLContext Factory for Elytron -->
+        <module name="org.wildfly.extension.messaging-activemq" services="import" export="true"/>
+        <module name="com.google.guava"/>
+        <module name="javax.json.api"/>
+        <module name="io.netty.netty-buffer"/>
+        <module name="io.netty.netty-transport"/>
+        <module name="io.netty.netty-handler"/>
+        <module name="io.netty.netty-handler-proxy"/>
+        <module name="io.netty.netty-codec"/>
+        <module name="io.netty.netty-codec-socks"/>
+        <module name="io.netty.netty-common"/>
+        <module name="io.netty.netty-resolver"/>
+        <module name="io.netty.netty-transport-native-epoll"/>
+        <module name="io.netty.netty-transport-native-kqueue"/>
+        <module name="io.netty.netty-codec-http"/>
+        <module name="org.jgroups"/>
+        <module name="org.slf4j"/>
+        <module name="jakarta.resource.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.jms.api" />
+        <module name="sun.jdk"/>
+        <!-- supported protocols (in addition to the CORE protocol) -->
+        <module name="org.apache.activemq.artemis.protocol.amqp" services="import" optional="true"/>
+        <module name="org.apache.activemq.artemis.protocol.hornetq" services="import" optional="true"/>
+        <module name="org.apache.activemq.artemis.protocol.stomp" services="import" optional="true"/>
+    </dependencies>
+</module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/commons/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/commons/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.commons">
+    <resources>
+        <artifact name="${org.apache.activemq:artemis-commons}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.management"/>
+        <module name="java.management.rmi"/>
+        <module name="org.apache.commons.beanutils" />
+        <module name="org.slf4j"/>
+        <module name="java.desktop"/>
+        <module name="io.netty.netty-buffer"/>
+        <module name="io.netty.netty-transport"/>
+        <module name="io.netty.netty-handler"/>
+        <module name="io.netty.netty-handler-proxy"/>
+        <module name="io.netty.netty-codec"/>
+        <module name="io.netty.netty-codec-socks"/>
+        <module name="io.netty.netty-common"/>
+        <module name="io.netty.netty-resolver"/>
+        <module name="io.netty.netty-transport-native-epoll"/>
+        <module name="io.netty.netty-transport-native-kqueue"/>
+        <module name="io.netty.netty-codec-http"/>
+        <!-- WFLY-6301 This module can be used to load user-created classes that are
+             used by Artemis resources (e.g. connector-service, transformers, etc.)
+        -->
+        <module name="org.apache.activemq.artemis.addons" optional="true" export="true"/>
+    </dependencies>
+</module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -28,7 +28,6 @@
 
     <resources>
         <resource-root path="lib"/>
-        <artifact name="${org.apache.activemq:artemis-commons}"/>
         <artifact name="${org.apache.activemq:artemis-journal}"/>
         <artifact name="${org.apache.activemq:activemq-artemis-native}"/>
     </resources>
@@ -41,6 +40,7 @@
         <module name="java.logging"/>
         <module name="java.management"/>
         <module name="jdk.unsupported"/>
+        <module name="org.apache.activemq.artemis.commons" services="import"/>
         <module name="org.apache.commons.beanutils" />
         <module name="org.jctools"/>
         <module name="org.slf4j"/>
@@ -49,10 +49,6 @@
         <module name="io.netty.netty-resolver"/>
         <module name="io.netty.netty-transport"/>
         <module name="io.netty.netty-handler"/>
-        <!-- WFLY-6301 This module can be used to load user-created classes that are
-             used by Artemis resources (e.g. connector-service, transformers, etc.)
-        -->
-        <module name="org.apache.activemq.artemis.addons" optional="true" export="true"/>
     </dependencies>
 
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -22,30 +22,17 @@
             exposed by this module are subject to change or removal at any time.
 
             This module should not be directly depended upon by deployments.
+            You should use the "org.apache.activemq.artemis.client" instead.
         -->
-        <!--
-            NOTE: The previous comment reflects the intent of the WildFly project
-            that this module be marked as jboss-api=private, i.e. not to be directly
-            depended upon by deployments. However, we have identified valid use cases
-            where such a dependency is needed (see https://issues.redhat.com/browse/WFLY-18240).
-            While we evaluate whether those use cases can be handled while leaving
-            this module as private, we are temporarily marking it as "deprecated"
-            in order to make users aware its status may be changing in a later release.
-        -->
-        <property name="jboss.api" value="deprecated"/>
+        <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.apache.activemq:artemis-core-client}"/>
-        <artifact name="${org.apache.activemq:artemis-selector}"/>
         <artifact name="${org.apache.activemq:artemis-server}"/>
         <artifact name="${org.apache.activemq:artemis-cli}"/>
         <artifact name="${org.apache.activemq:artemis-dto}"/>
-        <artifact name="${org.apache.activemq:artemis-hqclient-protocol}"/>
         <artifact name="${org.apache.activemq:artemis-jdbc-store}"/>
-        <artifact name="${org.apache.activemq:artemis-jakarta-client}"/>
         <artifact name="${org.apache.activemq:artemis-jakarta-server}"/>
-        <artifact name="${org.apache.activemq:artemis-jakarta-service-extensions}"/>
     </resources>
 
     <dependencies>
@@ -66,6 +53,9 @@
         <module name="internal.javax.json.api.ee8" services="import"/>
         <module name="org.apache.commons.beanutils" />
         <module name="org.apache.commons.collections" />
+        <module name="org.apache.activemq.artemis.commons" services="import" export="true"/>
+        <module name="org.apache.activemq.artemis.client" services="import"/>
+        <module name="org.apache.activemq.artemis.service-extensions" services="import" />
         <module name="org.apache.activemq.artemis.journal" export="true"/>
         <module name="org.jboss.jts"/>
         <module name="org.jctools"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
@@ -49,7 +49,8 @@
         <module name="io.netty.netty-transport-native-kqueue"/>
         <module name="io.netty.netty-codec-http"/>
         <!-- required to load ActiveMQ protocol SPI -->
-        <module name="org.apache.activemq.artemis"/>
+        <module name="org.apache.activemq.artemis" optional="true"/>
+        <module name="org.apache.activemq.artemis.client"/>
         <module name="org.slf4j"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/hornetq/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/hornetq/main/module.xml
@@ -32,7 +32,9 @@
 
     <dependencies>
         <!-- required to load ActiveMQ protocol SPI -->
-        <module name="org.apache.activemq.artemis"/>
+        <module name="org.apache.activemq.artemis" optional="true"/>
+        <module name="org.apache.activemq.artemis.client"/>
+        <module name="org.slf4j"/>
         <!--<module name="io.netty"/>-->
         <module name="io.netty.netty-buffer"/>
         <module name="io.netty.netty-transport"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/stomp/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/stomp/main/module.xml
@@ -32,7 +32,8 @@
 
     <dependencies>
         <!-- required to load ActiveMQ protocol SPI -->
-        <module name="org.apache.activemq.artemis"/>
+        <module name="org.apache.activemq.artemis" optional="true"/>
+        <module name="org.apache.activemq.artemis.client"/>
         <module name="org.slf4j"/>
         <!--<module name="io.netty"/>-->
         <module name="io.netty.netty-buffer"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -20,27 +20,16 @@
         <module name="java.management"/>
         <module name="java.naming"/>
         <module name="jakarta.transaction.api"/>
-        <!--<module name="io.netty"/>-->
-        <module name="io.netty.netty-buffer"/>
-        <module name="io.netty.netty-codec"/>
-        <module name="io.netty.netty-codec-http"/>
-        <module name="io.netty.netty-codec-socks"/>
-        <module name="io.netty.netty-common"/>
-        <module name="io.netty.netty-handler"/>
-        <module name="io.netty.netty-handler-proxy"/>
-        <module name="io.netty.netty-resolver"/>
-        <module name="io.netty.netty-transport"/>
-        <module name="io.netty.netty-transport-native-epoll"/>
-        <module name="io.netty.netty-transport-native-kqueue"/>
         <module name="jakarta.jms.api" />
         <module name="jakarta.resource.api"/>
-        <module name="org.apache.activemq.artemis"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.jts"/>
         <!-- allow to create a RA that connects to a remote Artemis server -->
         <module name="org.wildfly.naming-client" optional="true"/>
         <module name="org.jgroups"/>
         <module name="org.slf4j"/>
+        <module name="org.apache.activemq.artemis.service-extensions" services="import" export="true"/>
+        <module name="org.apache.activemq.artemis.commons"/>
         <module name="org.wildfly.extension.messaging-activemq" services="import"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/service-extensions/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/service-extensions/main/module.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.apache.activemq.artemis.service-extensions">
+    <resources>
+        <artifact name="${org.apache.activemq:artemis-jakarta-service-extensions}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.jms.api" />
+        <module name="jakarta.resource.api"/>
+        <module name="org.jboss.jboss-transaction-spi"/>
+        <module name="org.jboss.jts"/>
+        <module name="org.wildfly.extension.messaging-activemq" services="import"/>
+        <module name="org.apache.activemq.artemis.client"/>
+        <module name="org.apache.activemq.artemis.commons"/>
+        <module name="org.slf4j"/>
+    </dependencies>
+</module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.jts.integration"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="jakarta.resource.api"/>
-        <module name="org.apache.activemq.artemis.journal"/>
+        <module name="org.apache.activemq.artemis.journal" optional="true"/>
         <module name="javax.orb.api"/>
         <module name="jakarta.enterprise.api"/>
         <module name="org.jboss.weld.core"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -49,8 +49,9 @@
         <module name="jakarta.json.api"/>
         <module name="jakarta.resource.api"/>
         <module name="jakarta.transaction.api"/>
-        <module name="org.apache.activemq.artemis" services="import"/>
-        <module name="org.apache.activemq.artemis.ra"/>
+        <module name="org.apache.activemq.artemis" services="import" optional="true"/>
+        <module name="org.apache.activemq.artemis.client" services="import" export="true"/>
+        <module name="org.apache.activemq.artemis.ra" export="true"/>
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>
         <!-- required to provide high-level Jakarta Messaging CLI commands loaded by the extension -->

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
@@ -16,7 +16,6 @@ import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
 
 import org.apache.activemq.artemis.api.core.management.ActiveMQComponentControl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -156,11 +155,11 @@ public abstract class AbstractActiveMQComponentControlHandler<T extends ActiveMQ
     /**
      * Gets the {@link ActiveMQComponentControl} implementation used by this handler.
      *
-     * @param activeMQServer the ActiveMQ server installed in the runtime
+     * @param activeMQBroker the ActiveMQ server installed in the runtime
      * @param address the address being invoked
      * @return the runtime ActiveMQ control object associated with the given address
      */
-    protected abstract T getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address);
+    protected abstract T getActiveMQComponentControl(ActiveMQBroker activeMQBroker, PathAddress address);
 
     protected abstract String getDescriptionPrefix();
 
@@ -260,7 +259,7 @@ public abstract class AbstractActiveMQComponentControlHandler<T extends ActiveMQ
     protected final T getActiveMQComponentControl(final OperationContext context, final ModelNode operation, final boolean forWrite) throws OperationFailedException {
         final ServiceName artemisServiceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> artemisService = context.getServiceRegistry(forWrite).getService(artemisServiceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(artemisService.getValue());
+        ActiveMQBroker server = ActiveMQBroker.class.cast(artemisService.getValue());
         PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         return getActiveMQComponentControl(server, address);
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractQueueControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AbstractQueueControlHandler.java
@@ -20,7 +20,6 @@ import static org.wildfly.extension.messaging.activemq.OperationDefinitionHelper
 import static org.wildfly.extension.messaging.activemq.OperationDefinitionHelper.runtimeReadOnlyOperation;
 import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
 
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
@@ -234,7 +233,7 @@ public abstract class AbstractQueueControlHandler<T> extends AbstractRuntimeOnly
         final ServiceName activeMQServiceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         boolean readOnly = context.getResourceRegistration().getOperationFlags(PathAddress.EMPTY_ADDRESS, operationName).contains(OperationEntry.Flag.READ_ONLY);
         ServiceController<?> activeMQService = context.getServiceRegistry(!readOnly).getService(activeMQServiceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(activeMQService.getValue());
+        ActiveMQBroker server = ActiveMQBroker.class.cast(activeMQService.getValue());
         final DelegatingQueueControl<T> control = getQueueControl(server, queueName);
 
         if (control == null) {
@@ -378,7 +377,7 @@ public abstract class AbstractQueueControlHandler<T> extends AbstractRuntimeOnly
         };
     }
 
-    protected abstract DelegatingQueueControl<T> getQueueControl(ActiveMQServer server, String queueName);
+    protected abstract DelegatingQueueControl<T> getQueueControl(ActiveMQBroker server, String queueName);
 
     protected abstract Object handleAdditionalOperation(final String operationName, final ModelNode operation,
                                                         final OperationContext context, T queueControl) throws OperationFailedException;

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AcceptorControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AcceptorControlHandler.java
@@ -7,7 +7,6 @@ package org.wildfly.extension.messaging.activemq;
 
 import org.apache.activemq.artemis.api.core.management.AcceptorControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.PathAddress;
 
 /**
@@ -20,9 +19,9 @@ public class AcceptorControlHandler extends AbstractActiveMQComponentControlHand
     public static final AcceptorControlHandler INSTANCE = new AcceptorControlHandler();
 
     @Override
-    protected AcceptorControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
+    protected AcceptorControl getActiveMQComponentControl(ActiveMQBroker activeMQBroker, PathAddress address) {
         final String resourceName = address.getLastElement().getValue();
-        return AcceptorControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.ACCEPTOR + resourceName));
+        return AcceptorControl.class.cast(activeMQBroker.getResource(ResourceNames.ACCEPTOR + resourceName));
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQActivationService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQActivationService.java
@@ -45,8 +45,8 @@ public class ActiveMQActivationService implements Service<Void> {
     public static boolean isActiveMQServerActive(ServiceRegistry serviceRegistry, ServiceName activeMQServerServiceName) {
         ServiceController<?> service = serviceRegistry.getService(activeMQServerServiceName);
         if (service != null) {
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-            if (server.isStarted() && server.isActive()) {
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
+            if (server.isActive()) {
                 return true;
             }
         }
@@ -75,7 +75,7 @@ public class ActiveMQActivationService implements Service<Void> {
         final ServiceName activMQServerServiceName = MessagingServices.getActiveMQServiceName(pathAddress(operation.get(OP_ADDR)));
         final ServiceController<?> controller = context.getServiceRegistry(false).getService(activMQServerServiceName);
         if(controller != null) {
-            return ActiveMQServer.class.cast(controller.getValue());
+            return ActiveMQServer.class.cast(ActiveMQBroker.class.cast(controller.getValue()).getDelegate());
         }
         return null;
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.messaging.activemq;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.core.security.SecurityAuth;
+
+/**
+ * Wrapper interface to expose methods from {@link org.apache.activemq.artemis.core.server.ActiveMQServer}
+ * and {@link org.apache.activemq.artemis.core.server.management.ManagementService} that are needed by a
+ * {@code /subsystem=messaging-activemq/server=*} resource or its children."
+
+ * @author Emmanuel Hugonnet (c) 2023 Red Hat, Inc.
+ */
+public interface ActiveMQBroker {
+
+    /**
+     * To get an untyped access to {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @return the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}
+     */
+    Object getDelegate();
+
+    /**
+     * @return the server node id.
+     */
+    SimpleString getNodeID();
+
+    /**
+     * Add a connection configuration to the current {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @param string: the name of the connector.
+     * @param tc: the trnasport configurartion.
+     */
+    void addConnectorConfiguration(String string, TransportConfiguration tc);
+
+    /**
+     * Creates a Queue on the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @param address: the queue address.
+     * @param routingType: the queue routing type (anycast or mulicast).
+     * @param queueName: the name of the queue.
+     * @param filter: the filter.
+     * @param durable
+     * @param temporary
+     * @throws Exception
+     */
+    void  createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
+                     boolean durable, boolean temporary) throws Exception;
+
+    /**
+     * Destroys a queue from the underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @param queueName
+     * @param session
+     * @param checkConsumerCount
+     * @throws Exception
+     */
+    void destroyQueue(SimpleString queueName, SecurityAuth session, boolean checkConsumerCount) throws Exception;
+
+    /**
+     * Returns the current state of the server: true - if the server is started and active - false otherwise.
+     * @return the current state of the server: true - if the server is started and active - false otherwise.
+     */
+    boolean isActive();
+
+    /**
+     * Returns true if the resource exists - false otherwise.
+     * @param resourceName: the name of the reosurce.
+     * @return true if the resource exists - false otherwise.
+     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(java.lang.String).
+     */
+    boolean hasResource(String resourceName);
+
+    /**
+     * Returns the untyped resource with the specified name- null if none exists.
+     * @param resourceName: the name of the resource.
+     * @return the untyped resource with the specified name- null if none exists.
+     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResource(java.lang.String).
+     */
+    Object getResource(String resourceName);
+
+    /**
+     * Returns an untyped array of the resources of this type - an empty arry if none exists.
+     * @param resourceType: the type of resources.
+     * @return an untyped array of the resources of this type - an empty arry if none exists.
+     * @see org.apache.activemq.artemis.core.server.management.ManagementService#getResources(java.lang.Class).
+     */
+    Object[] getResources(Class<?> resourceType);
+
+    /**
+     * Returns he {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl} to manage the
+     * underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
+     * @return the {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl}
+     */
+    ActiveMQServerControl getActiveMQServerControl();
+}

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.messaging.activemq;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.core.security.SecurityAuth;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+
+/**
+ * Implementation of the wrapper over {@link org.apache.activemq.artemis.core.server.ActiveMQServer} and
+ * {@link org.apache.activemq.artemis.core.server.management.ManagementService}.
+ * @author Emmanuel Hugonnet (c) 2023 Red Hat, Inc.
+ */
+public class ActiveMQBrokerImpl implements ActiveMQBroker {
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+
+    private final ActiveMQServer delegate;
+
+    public ActiveMQBrokerImpl(org.apache.activemq.artemis.core.server.ActiveMQServer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public SimpleString getNodeID() {
+        return delegate.getNodeID();
+    }
+
+    @Override
+    public void addConnectorConfiguration(String string, TransportConfiguration tc) {
+        delegate.getConfiguration().addConnectorConfiguration(string, tc);
+    }
+
+    @Override
+    public void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter, boolean durable, boolean temporary) throws Exception {
+        delegate.createQueue(address, routingType, queueName, filter, durable, temporary);
+    }
+
+    @Override
+    public void destroyQueue(SimpleString queueName, SecurityAuth session, boolean checkConsumerCount) throws Exception {
+        delegate.destroyQueue(queueName, session, checkConsumerCount);
+    }
+
+    @Override
+    public boolean isActive() {
+        return delegate.isStarted() && delegate.isActive();
+    }
+
+    @Override
+    public boolean hasResource(String resourceName) {
+        return delegate.getManagementService() != null && delegate.getManagementService().getResource(resourceName) != null;
+    }
+
+    @Override
+    public Object getResource(String resourceName) {
+        if (delegate.getManagementService() != null) {
+            return delegate.getManagementService().getResource(resourceName);
+        }
+        return null;
+    }
+
+    @Override
+    public Object[] getResources(Class<?> resourceType) {
+        if (delegate.getManagementService() != null) {
+            return delegate.getManagementService().getResources(resourceType);
+        }
+        return EMPTY_ARRAY;
+    }
+
+    @Override
+    public ActiveMQServerControl getActiveMQServerControl() {
+        return delegate.getActiveMQServerControl();
+    }
+
+}

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQResourceAdapter.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQResourceAdapter.java
@@ -4,7 +4,6 @@
  */
 package org.wildfly.extension.messaging.activemq;
 
-
 import java.security.AccessController;
 import jakarta.resource.spi.work.ExecutionContext;
 import jakarta.resource.spi.work.Work;
@@ -13,6 +12,7 @@ import jakarta.resource.spi.work.WorkListener;
 import jakarta.resource.spi.work.WorkManager;
 
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.ra.ConnectionFactoryProperties;
 import org.jboss.as.naming.context.NamespaceContextSelector;
 import org.jboss.as.server.CurrentServiceContainer;
@@ -66,6 +66,16 @@ public class ActiveMQResourceAdapter extends org.apache.activemq.artemis.ra.Acti
 
     private static ServiceContainer currentServiceContainer() {
         return (System.getSecurityManager() == null) ? CurrentServiceContainer.getServiceContainer() : AccessController.doPrivileged(CurrentServiceContainer.GET_ACTION);
+    }
+
+    /**
+     * Workaround for WFLY-18756 until https://issues.apache.org/jira/browse/ARTEMIS-4508 is merged and released.
+     */
+    @Override
+    public ActiveMQConnectionFactory createRecoveryActiveMQConnectionFactory(final ConnectionFactoryProperties overrideProperties) {
+        ActiveMQConnectionFactory cf = super.createRecoveryActiveMQConnectionFactory(overrideProperties);
+        cf.setUseTopologyForLoadBalancing(this.isUseTopologyForLoadBalancing());
+        return cf;
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
@@ -114,13 +114,13 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
 
         if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
-            ActiveMQServer server = null;
+            ActiveMQBroker server = null;
             if (context.getRunningMode() == RunningMode.NORMAL) {
                 ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
                 if (service == null || service.getState() != ServiceController.State.UP) {
                     throw MessagingLogger.ROOT_LOGGER.activeMQServerNotInstalled(serviceName.getSimpleName());
                 }
-                server = ActiveMQServer.class.cast(service.getValue());
+                server = ActiveMQBroker.class.cast(service.getValue());
             }
             handleReadAttribute(context, operation, server);
             return;
@@ -337,9 +337,10 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
                 this);
     }
 
-    private void handleReadAttribute(OperationContext context, ModelNode operation, final ActiveMQServer server) throws OperationFailedException {
+    private void handleReadAttribute(OperationContext context, ModelNode operation, final ActiveMQBroker broker) throws OperationFailedException {
         final String name = operation.require(ModelDescriptionConstants.NAME).asString();
 
+        ActiveMQServer server = broker == null ? null : ActiveMQServer.class.cast(broker.getDelegate());
         if (STARTED.getName().equals(name)) {
             boolean started = server != null ? server.isStarted() : false;
             context.getResult().set(started);
@@ -377,7 +378,7 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
         if (service == null || service.getState() != ServiceController.State.UP) {
             throw MessagingLogger.ROOT_LOGGER.activeMQServerNotInstalled(serviceName.getSimpleName());
         }
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
         return server.getActiveMQServerControl();
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlWriteHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlWriteHandler.java
@@ -13,7 +13,6 @@ import static org.jboss.as.controller.security.CredentialReference.rollbackCrede
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.CREDENTIAL_REFERENCE;
 
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -118,7 +117,7 @@ public class ActiveMQServerControlWriteHandler extends AbstractWriteAttributeHan
     }
 
     private void applyOperationToActiveMQService(ModelNode operation, String attributeName, ModelNode newValue, ServiceController<?> activeMQServiceController) {
-        ActiveMQServerControl serverControl = ActiveMQServer.class.cast(activeMQServiceController.getValue()).getActiveMQServerControl();
+        ActiveMQServerControl serverControl = ActiveMQBroker.class.cast(activeMQServiceController.getValue()).getActiveMQServerControl();
         if (serverControl == null) {
             PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
             throw ControllerLogger.ROOT_LOGGER.managementResourceNotFound(address);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerResource.java
@@ -16,8 +16,6 @@ import java.util.Set;
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.PlaceholderResource;
@@ -34,7 +32,7 @@ import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 public class ActiveMQServerResource implements Resource {
 
     private final Resource delegate;
-    private volatile ServiceController<ActiveMQServer> activeMQServerServiceController;
+    private volatile ServiceController<ActiveMQBroker> activeMQServerServiceController;
 
     public ActiveMQServerResource() {
         this(Factory.create());
@@ -44,11 +42,11 @@ public class ActiveMQServerResource implements Resource {
         this.delegate = delegate;
     }
 
-    public ServiceController<ActiveMQServer> getActiveMQServerServiceController() {
+    public ServiceController<ActiveMQBroker> getActiveMQServerServiceController() {
         return activeMQServerServiceController;
     }
 
-    public void setActiveMQServerServiceController(ServiceController<ActiveMQServer> activeMQServerServiceController) {
+    public void setActiveMQServerServiceController(ServiceController<ActiveMQBroker> activeMQServerServiceController) {
         this.activeMQServerServiceController = activeMQServerServiceController;
     }
 
@@ -81,7 +79,7 @@ public class ActiveMQServerResource implements Resource {
     @Override
     public Resource getChild(PathElement element) {
         if (CORE_ADDRESS.equals(element.getKey())) {
-            return hasAddressControl(element) ? new CoreAddressResource(element.getValue(), getManagementService()) : null;
+            return hasAddressControl(element) ? new CoreAddressResource(element.getValue(), getActiveMQBroker()) : null;
         } else if (RUNTIME_QUEUE.equals(element.getKey())) {
             return hasQueueControl(element.getValue()) ? PlaceholderResource.INSTANCE : null;
         } else {
@@ -93,7 +91,7 @@ public class ActiveMQServerResource implements Resource {
     public Resource requireChild(PathElement element) {
         if (CORE_ADDRESS.equals(element.getKey())) {
             if (hasAddressControl(element)) {
-                return new CoreAddressResource(element.getValue(), getManagementService());
+                return new CoreAddressResource(element.getValue(), getActiveMQBroker());
             }
             throw new NoSuchResourceException(element);
         } else if (RUNTIME_QUEUE.equals(element.getKey())) {
@@ -123,7 +121,7 @@ public class ActiveMQServerResource implements Resource {
             if (address.size() > 1) {
                 throw new NoSuchResourceException(address.getElement(1));
             }
-            return new CoreAddressResource(address.getElement(0).getValue(), getManagementService());
+            return new CoreAddressResource(address.getElement(0).getValue(), getActiveMQBroker());
         } else if (address.size() > 0 && RUNTIME_QUEUE.equals(address.getElement(0).getKey())) {
             if (address.size() > 1) {
                 throw new NoSuchResourceException(address.getElement(1));
@@ -163,7 +161,7 @@ public class ActiveMQServerResource implements Resource {
         if (CORE_ADDRESS.equals(childType)) {
             Set<ResourceEntry> result = new HashSet<ResourceEntry>();
             for (String name : getCoreAddressNames()) {
-                result.add(new CoreAddressResource.CoreAddressResourceEntry(name, getManagementService()));
+                result.add(new CoreAddressResource.CoreAddressResourceEntry(name, getActiveMQBroker()));
             }
             return result;
         } else if (RUNTIME_QUEUE.equals(childType)) {
@@ -222,22 +220,22 @@ public class ActiveMQServerResource implements Resource {
     }
 
     private boolean hasAddressControl(PathElement element) {
-        final ManagementService managementService = getManagementService();
-        return managementService == null ? false : managementService.getResource(ResourceNames.ADDRESS + element.getValue()) != null;
+        final ActiveMQBroker broker = getActiveMQBroker();
+        return broker == null ? false : broker.getResource(ResourceNames.ADDRESS + element.getValue()) != null;
     }
 
     private boolean hasQueueControl(String name) {
-        final ManagementService managementService = getManagementService();
-        return managementService == null ? false : managementService.getResource(ResourceNames.QUEUE + name) != null;
+        final ActiveMQBroker broker = getActiveMQBroker();
+        return broker == null ? false : broker.getResource(ResourceNames.QUEUE + name) != null;
     }
 
     private Set<String> getCoreAddressNames() {
-        final ManagementService managementService = getManagementService();
-        if (managementService == null) {
+        final ActiveMQBroker broker = getActiveMQBroker();
+        if (broker == null) {
             return Collections.emptySet();
         } else {
             Set<String> result = new HashSet<String>();
-            for (Object obj : managementService.getResources(AddressControl.class)) {
+            for (Object obj : broker.getResources(AddressControl.class)) {
                 AddressControl ac = AddressControl.class.cast(obj);
                 result.add(ac.getAddress());
             }
@@ -246,12 +244,12 @@ public class ActiveMQServerResource implements Resource {
     }
 
     private Set<String> getCoreQueueNames() {
-        final ManagementService managementService = getManagementService();
-        if (managementService == null) {
+        final ActiveMQBroker broker = getActiveMQBroker();
+        if (broker == null) {
             return Collections.emptySet();
         } else {
             Set<String> result = new HashSet<String>();
-            for (Object obj : managementService.getResources(QueueControl.class)) {
+            for (Object obj : broker.getResources(QueueControl.class)) {
                 QueueControl qc = QueueControl.class.cast(obj);
                 result.add(qc.getName());
             }
@@ -259,12 +257,12 @@ public class ActiveMQServerResource implements Resource {
         }
     }
 
-    private ManagementService getManagementService() {
+    private ActiveMQBroker getActiveMQBroker() {
         if (activeMQServerServiceController == null
                 || activeMQServerServiceController.getState() != ServiceController.State.UP) {
             return null;
         } else {
-            return activeMQServerServiceController.getValue().getManagementService();
+            return activeMQServerServiceController.getValue();
         }
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -59,7 +59,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  * @author scott.stark@jboss.org
  * @author Emanuel Muckenhuber
  */
-class ActiveMQServerService implements Service<ActiveMQServer> {
+class ActiveMQServerService implements Service<ActiveMQBroker> {
 
     /** */
     private static final String HOST = "host";
@@ -308,12 +308,12 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
     }
 
     @Override
-    public synchronized ActiveMQServer getValue() throws IllegalStateException {
+    public synchronized ActiveMQBroker getValue() throws IllegalStateException {
         final ActiveMQServer server = this.server;
         if (server == null) {
             throw new IllegalStateException();
         }
-        return server;
+        return new ActiveMQBrokerImpl(server);
     }
 
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressControlHandler.java
@@ -20,7 +20,6 @@ import static org.wildfly.extension.messaging.activemq.ManagementUtil.reportRole
 
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -105,7 +104,7 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
         final String addressName = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-        return AddressControl.class.cast(server.getManagementService().getResource(ResourceNames.ADDRESS + addressName));
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
+        return AddressControl.class.cast(server.getResource(ResourceNames.ADDRESS + addressName));
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsResolveHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsResolveHandler.java
@@ -87,7 +87,7 @@ public class AddressSettingsResolveHandler extends AbstractRuntimeOnlyHandler {
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(address);
 
         ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+        ActiveMQServer server = ActiveMQServer.class.cast(ActiveMQBroker.class.cast(service.getValue()).getDelegate());
 
         final String activeMQAddress = ACTIVEMQ_ADDRESS.resolveModelAttribute(context, operation).asString();
         AddressSettings settings = server.getAddressSettingsRepository().getMatch(activeMQAddress);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
@@ -82,7 +82,7 @@ public class BridgeAdd extends AbstractAddStepHandler {
             BridgeConfiguration bridgeConfig = createBridgeConfiguration(context, name, model);
 
             //noinspection RedundantClassCall
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
             createBridge(bridgeConfig, server);
 
         }
@@ -172,7 +172,8 @@ public class BridgeAdd extends AbstractAddStepHandler {
         return result;
     }
 
-    static void createBridge(BridgeConfiguration bridgeConfig, ActiveMQServer server) throws OperationFailedException {
+    static void createBridge(BridgeConfiguration bridgeConfig, ActiveMQBroker broker) throws OperationFailedException {
+        ActiveMQServer server = ActiveMQServer.class.cast(broker.getDelegate());
         checkStarted(server);
         clearIO(server);
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeControlHandler.java
@@ -7,7 +7,6 @@ package org.wildfly.extension.messaging.activemq;
 
 import org.apache.activemq.artemis.api.core.management.BridgeControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.PathAddress;
 
 /**
@@ -20,9 +19,9 @@ public class BridgeControlHandler extends AbstractActiveMQComponentControlHandle
     public static final BridgeControlHandler INSTANCE = new BridgeControlHandler();
 
     @Override
-    protected BridgeControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
+    protected BridgeControl getActiveMQComponentControl(ActiveMQBroker activeMQBroker, PathAddress address) {
         final String resourceName = address.getLastElement().getValue();
-        return BridgeControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.BRIDGE + resourceName));
+        return BridgeControl.class.cast(activeMQBroker.getResource(ResourceNames.BRIDGE + resourceName));
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BridgeRemove.java
@@ -6,7 +6,6 @@
 package org.wildfly.extension.messaging.activemq;
 
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -39,7 +38,7 @@ public class BridgeRemove extends AbstractRemoveStepHandler {
         final ServiceController<?> service = registry.getService(serviceName);
         if (service != null && service.getState() == ServiceController.State.UP) {
 
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
             try {
                 server.getActiveMQServerControl().destroyBridge(name);
             } catch (RuntimeException e) {
@@ -61,7 +60,7 @@ public class BridgeRemove extends AbstractRemoveStepHandler {
 
             final String name = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
             final BridgeConfiguration bridgeConfiguration = BridgeAdd.createBridgeConfiguration(context, name, model);
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
             BridgeAdd.createBridge(bridgeConfiguration, server);
         }
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
@@ -9,7 +9,6 @@ import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.
 
 import org.apache.activemq.artemis.api.core.management.BaseBroadcastGroupControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -28,9 +27,9 @@ public class BroadcastGroupControlHandler extends AbstractActiveMQComponentContr
     }
 
     @Override
-    protected BaseBroadcastGroupControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
+    protected BaseBroadcastGroupControl getActiveMQComponentControl(ActiveMQBroker activeMQBroker, PathAddress address) {
         final String resourceName = address.getLastElement().getValue();
-        return BaseBroadcastGroupControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.BROADCAST_GROUP + resourceName));
+        return BaseBroadcastGroupControl.class.cast(activeMQBroker.getResource(ResourceNames.BROADCAST_GROUP + resourceName));
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -6,7 +6,6 @@
 package org.wildfly.extension.messaging.activemq;
 
 import javax.net.ssl.SSLContext;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
@@ -44,7 +43,7 @@ public class Capabilities {
      *
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/main/org/wildfly/messaging/activemq/server/capability.adoc">Capability documentation</a>
      */
-    static final RuntimeCapability<Void> ACTIVEMQ_SERVER_CAPABILITY = RuntimeCapability.Builder.of(ACTIVEMQ_SERVER_CAPABILITY_NAME, true, ActiveMQServer.class)
+    static final RuntimeCapability<Void> ACTIVEMQ_SERVER_CAPABILITY = RuntimeCapability.Builder.of(ACTIVEMQ_SERVER_CAPABILITY_NAME, true, ActiveMQBroker.class)
             //.addRuntimeOnlyRequirements(JMX_CAPABILITY) -- has no function so don't use it
             .build();
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionControlHandler.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.management.ClusterConnectionControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -28,9 +27,9 @@ public class ClusterConnectionControlHandler extends AbstractActiveMQComponentCo
     }
 
     @Override
-    protected ClusterConnectionControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
+    protected ClusterConnectionControl getActiveMQComponentControl(ActiveMQBroker activeMQServer, PathAddress address) {
         final String resourceName = address.getLastElement().getValue();
-        return ClusterConnectionControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.CORE_CLUSTER_CONNECTION + resourceName));
+        return ClusterConnectionControl.class.cast(activeMQServer.getResource(ResourceNames.CORE_CLUSTER_CONNECTION + resourceName));
     }
 
     @Override

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorService.java
@@ -6,12 +6,12 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HOST;
+
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.network.ClientMapping;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.network.OutboundSocketBinding;
@@ -27,7 +27,7 @@ import org.jboss.msc.service.StopContext;
  */
 class ConnectorService implements Service {
 
-    private final Supplier<ActiveMQServer> serverSupplier;
+    private final Supplier<ActiveMQBroker> serverSupplier;
     private final Supplier<SocketBinding> socketBindingSupplier;
     private final Supplier<OutboundSocketBinding> outboundSocketBindingSupplier;
     private final String factoryClass;
@@ -35,7 +35,7 @@ class ConnectorService implements Service {
     private final Map<String, Object> extraParameters;
     private final String name;
 
-    ConnectorService(Supplier<ActiveMQServer> serverSupplier, Supplier<SocketBinding> socketBindingSupplier, Supplier<OutboundSocketBinding> outboundSocketBindingSupplier, String factoryClass, Map<String, Object> parameters, Map<String, Object> extraParameters, String name) {
+    ConnectorService(Supplier<ActiveMQBroker> serverSupplier, Supplier<SocketBinding> socketBindingSupplier, Supplier<OutboundSocketBinding> outboundSocketBindingSupplier, String factoryClass, Map<String, Object> parameters, Map<String, Object> extraParameters, String name) {
         this.serverSupplier = serverSupplier;
         this.socketBindingSupplier = socketBindingSupplier;
         this.outboundSocketBindingSupplier = outboundSocketBindingSupplier;
@@ -79,7 +79,7 @@ class ConnectorService implements Service {
             }
         }
         try {
-            serverSupplier.get().getConfiguration().addConnectorConfiguration(name, new TransportConfiguration(factoryClass, parameters, name, extraParameters));
+            serverSupplier.get().addConnectorConfiguration(name, new TransportConfiguration(factoryClass, parameters, name, extraParameters));
         } catch (Exception ex) {
             throw new StartException(ex);
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressResource.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
@@ -30,11 +29,11 @@ import org.jboss.dmr.ModelNode;
 public class CoreAddressResource implements Resource {
 
     private final String name;
-    private final ManagementService managementService;
+    private final ActiveMQBroker broker;
 
-    public CoreAddressResource(final String name, final ManagementService managementService) {
+    public CoreAddressResource(final String name, final ActiveMQBroker broker) {
         this.name = name;
-        this.managementService = managementService;
+        this.broker = broker;
     }
 
     @Override
@@ -138,7 +137,7 @@ public class CoreAddressResource implements Resource {
 
     @Override
     public Resource clone() {
-        return new CoreAddressResource(name, managementService);
+        return new CoreAddressResource(name, broker);
     }
 
     private Set<String> getSecurityRoles() {
@@ -155,10 +154,10 @@ public class CoreAddressResource implements Resource {
     }
 
     private AddressControl getAddressControl() {
-        if (managementService == null) {
+        if (broker == null) {
             return null;
         }
-        Object obj = managementService.getResource(ResourceNames.ADDRESS + name);
+        Object obj = broker.getResource(ResourceNames.ADDRESS + name);
         return AddressControl.class.cast(obj);
     }
 
@@ -171,11 +170,11 @@ public class CoreAddressResource implements Resource {
 
         final PathElement path;
         // we keep a ref on the management service to be able to clone it... is there a more elegant way?
-        private final ManagementService managementService2;
+        private final ActiveMQBroker broker2;
 
-        public CoreAddressResourceEntry(final String name, final ManagementService managementService) {
-            super(name, managementService);
-            managementService2 = managementService;
+        public CoreAddressResourceEntry(final String name, final ActiveMQBroker broker) {
+            super(name, broker);
+            broker2 = broker;
             path = PathElement.pathElement(CommonAttributes.CORE_ADDRESS, name);
         }
 
@@ -191,7 +190,7 @@ public class CoreAddressResource implements Resource {
 
         @Override
         public CoreAddressResourceEntry clone() {
-            return new CoreAddressResourceEntry(path.getValue(), managementService2);
+            return new CoreAddressResourceEntry(path.getValue(), broker2);
         }
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
@@ -9,7 +9,6 @@ package org.wildfly.extension.messaging.activemq;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.config.TransformerConfiguration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -57,7 +56,7 @@ public class DivertAdd extends AbstractAddStepHandler {
 
             DivertConfiguration divertConfiguration = createDivertConfiguration(context, name, model);
 
-            ActiveMQServerControl serverControl = ActiveMQServer.class.cast(service.getValue()).getActiveMQServerControl();
+            ActiveMQServerControl serverControl = ActiveMQBroker.class.cast(service.getValue()).getActiveMQServerControl();
             createDivert(name, divertConfiguration, serverControl);
 
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/DivertRemove.java
@@ -6,7 +6,6 @@
 package org.wildfly.extension.messaging.activemq;
 
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -39,7 +38,7 @@ public class DivertRemove extends AbstractRemoveStepHandler {
         final ServiceController<?> service = registry.getService(serviceName);
         if (service != null && service.getState() == ServiceController.State.UP) {
 
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
             try {
                 server.getActiveMQServerControl().destroyDivert(name);
             } catch (RuntimeException e) {
@@ -62,7 +61,7 @@ public class DivertRemove extends AbstractRemoveStepHandler {
             final String name = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
             final DivertConfiguration divertConfiguration = DivertAdd.createDivertConfiguration(context, name, model);
 
-            ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
             DivertAdd.createDivert(name, divertConfiguration, server.getActiveMQServerControl());
         }
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
@@ -45,7 +45,7 @@ public class GroupingHandlerAdd extends AbstractAddStepHandler {
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> service = registry.getService(serviceName);
         if (service != null) {
-            final ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+            final ActiveMQServer server = ActiveMQServer.class.cast(ActiveMQBroker.class.cast(service.getValue()).getDelegate());
             if (server.getGroupingHandler() != null) {
                 throw new OperationFailedException(MessagingLogger.ROOT_LOGGER.childResourceAlreadyExists(CommonAttributes.GROUPING_HANDLER));
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -105,7 +105,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
 
         MessagingLogger.ROOT_LOGGER.registeredHTTPUpgradeHandler(ACTIVEMQ_REMOTING, acceptorName);
         ServiceController<?> activeMQService = context.getController().getServiceContainer().getService(MessagingServices.getActiveMQServiceName(activeMQServerName));
-        ActiveMQServer activeMQServer = ActiveMQServer.class.cast(activeMQService.getValue());
+        ActiveMQServer activeMQServer = ActiveMQServer.class.cast(ActiveMQBroker.class.cast(activeMQService.getValue()).getDelegate());
 
         httpUpgradeListener = switchToMessagingProtocol(activeMQServer, acceptorName, getProtocol());
         upgradeSupplier.get().addProtocol(getProtocol(),

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
@@ -10,7 +10,6 @@ package org.wildfly.extension.messaging.activemq;
 
 import java.util.function.Supplier;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -61,7 +60,7 @@ public class QueueAdd extends AbstractAddStepHandler {
             final ServiceName queueServiceName = MessagingServices.getQueueBaseServiceName(serviceName).append(queueName);
             final ServiceBuilder sb = context.getServiceTarget().addService(queueServiceName);
             sb.requires(ActiveMQActivationService.getServiceName(serviceName));
-            Supplier<ActiveMQServer> serverSupplier = sb.requires(serviceName);
+            Supplier<ActiveMQBroker> serverSupplier = sb.requires(serviceName);
             final QueueService service = new QueueService(serverSupplier, queueConfiguration, false, true);
             sb.setInitialMode(Mode.PASSIVE);
             sb.setInstance(service);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueControlHandler.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -117,13 +116,14 @@ public class QueueControlHandler extends AbstractQueueControlHandler<QueueContro
     }
 
     @Override
-    protected DelegatingQueueControl<QueueControl> getQueueControl(ActiveMQServer server, String queueName) {
-        final QueueControl control = QueueControl.class.cast(server.getManagementService().getResource(ResourceNames.QUEUE + queueName));
+    protected DelegatingQueueControl<QueueControl> getQueueControl(ActiveMQBroker server, String queueName) {
+        final QueueControl control = QueueControl.class.cast(server.getResource(ResourceNames.QUEUE + queueName));
         if (control == null) {
             return null;
         }
         return new DelegatingQueueControl<QueueControl>() {
 
+            @Override
             public QueueControl getDelegate() {
                 return control;
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueReadAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueReadAttributeHandler.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -84,8 +83,8 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
 
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(context.getCurrentAddress());
         ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-        QueueControl control = QueueControl.class.cast(server.getManagementService().getResource(ResourceNames.QUEUE + queueName));
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
+        QueueControl control = QueueControl.class.cast(server.getResource(ResourceNames.QUEUE + queueName));
 
         if (control == null) {
             throw ControllerLogger.ROOT_LOGGER.managementResourceNotFound(context.getCurrentAddress());
@@ -141,7 +140,7 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
     }
 
     private static List<String> getStorageAttributeNames() {
-        List<String> names = new ArrayList<String>();
+        List<String> names = new ArrayList<>();
         for (SimpleAttributeDefinition attr : QueueDefinition.ATTRIBUTES) {
           names.add(attr.getName());
         }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueRemove.java
@@ -10,7 +10,6 @@ package org.wildfly.extension.messaging.activemq;
 
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.dmr.ModelNode;
@@ -40,7 +39,7 @@ class QueueRemove extends AbstractRemoveStepHandler {
         } else {
             ServiceController<?> serverService = context.getServiceRegistry(false).getService(serviceName);
             try {
-                ((ActiveMQServer) serverService.getValue()).destroyQueue(new SimpleString(name), null, false);
+                ((ActiveMQBroker) serverService.getValue()).destroyQueue(new SimpleString(name), null, false);
             } catch (Exception ex) {
                 MessagingLogger.ROOT_LOGGER.failedToDestroy("queue", name);
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
@@ -8,7 +8,6 @@ package org.wildfly.extension.messaging.activemq;
 import java.util.function.Supplier;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -22,12 +21,12 @@ import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
  */
 class QueueService implements Service<Void> {
 
-    private final Supplier<ActiveMQServer> activeMQServerSupplier;
+    private final Supplier<ActiveMQBroker> activeMQServerSupplier;
     private final CoreQueueConfiguration queueConfiguration;
     private final boolean temporary;
     private final boolean createQueue;
 
-    public QueueService(final Supplier<ActiveMQServer> activeMQServerSupplier, final CoreQueueConfiguration queueConfiguration, final boolean temporary, final boolean createQueue) {
+    public QueueService(final Supplier<ActiveMQBroker> activeMQServerSupplier, final CoreQueueConfiguration queueConfiguration, final boolean temporary, final boolean createQueue) {
         if(queueConfiguration == null) {
             throw MessagingLogger.ROOT_LOGGER.nullVar("queueConfiguration");
         }
@@ -42,7 +41,7 @@ class QueueService implements Service<Void> {
     public synchronized void start(StartContext context) throws StartException {
         if (createQueue) {
             try {
-                final ActiveMQServer server = this.activeMQServerSupplier.get();
+                final ActiveMQBroker server = this.activeMQServerSupplier.get();
                 MessagingLogger.ROOT_LOGGER.debugf("Deploying queue on server %s with address: %s ,  name: %s, filter: %s ands durable: %s, temporary: %s",
                         server.getNodeID(), new SimpleString(queueConfiguration.getAddress()), new SimpleString(queueConfiguration.getName()),
                         SimpleString.toSimpleString(queueConfiguration.getFilterString()), queueConfiguration.isDurable(), temporary);
@@ -65,7 +64,7 @@ class QueueService implements Service<Void> {
     @Override
     public synchronized void stop(StopContext context) {
         try {
-            final ActiveMQServer server = this.activeMQServerSupplier.get();
+            final ActiveMQBroker server = this.activeMQServerSupplier.get();
             server.destroyQueue(new SimpleString(queueConfiguration.getName()), null, false);
             MessagingLogger.ROOT_LOGGER.debugf("Destroying queue from server %s queue with name: %s",server.getNodeID() , new SimpleString(queueConfiguration.getName()));
         } catch(Exception e) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleReadAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/SecurityRoleReadAttributeHandler.java
@@ -10,7 +10,6 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.NAME;
 
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -46,8 +45,8 @@ public class SecurityRoleReadAttributeHandler extends AbstractRuntimeOnlyHandler
 
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-        AddressControl control = AddressControl.class.cast(server.getManagementService().getResource(ResourceNames.ADDRESS + addressName));
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
+        AddressControl control = AddressControl.class.cast(server.getResource(ResourceNames.ADDRESS + addressName));
 
         if (control == null) {
             PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -131,7 +131,6 @@ import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
 import org.apache.activemq.artemis.core.security.Role;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerPolicy;
@@ -468,7 +467,7 @@ class ServerAdd extends AbstractAddStepHandler {
                         final ServiceName queueServiceName = activeMQServiceName.append(queueConfiguration.getName());
                         final ServiceBuilder sb = context.getServiceTarget().addService(queueServiceName);
                         sb.requires(ActiveMQActivationService.getServiceName(activeMQServiceName));
-                        Supplier<ActiveMQServer> serverSupplier = sb.requires(activeMQServiceName);
+                        Supplier<ActiveMQBroker> serverSupplier = sb.requires(activeMQServiceName);
                         final QueueService queueService = new QueueService(serverSupplier, queueConfiguration, false, false);
                         sb.setInitialMode(Mode.PASSIVE);
                         sb.setInstance(queueService);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -28,7 +28,6 @@ import java.util.function.BiConsumer;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.server.NetworkHealthCheck;
-import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerPolicy;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -51,6 +50,7 @@ import static org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidat
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.AliasEntry;
+import org.jboss.as.controller.registry.RuntimePackageDependency;
 import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ReplicationPrimaryDefinition;
@@ -945,7 +945,8 @@ public class ServerDefinition extends PersistentResourceDefinition {
         super(new SimpleResourceDefinition.Parameters(MessagingExtension.SERVER_PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.SERVER))
                 .setAddHandler(new ServerAdd(broadcastCommandDispatcherFactoryInstaller))
                 .setRemoveHandler(ServerRemove.INSTANCE)
-                .addCapabilities(Capabilities.ACTIVEMQ_SERVER_CAPABILITY));
+                .addCapabilities(Capabilities.ACTIVEMQ_SERVER_CAPABILITY)
+                .setAdditionalPackages(RuntimePackageDependency.required("org.apache.activemq.artemis"), RuntimePackageDependency.required("org.apache.activemq.artemis.journal")));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -1060,4 +1061,9 @@ public class ServerDefinition extends PersistentResourceDefinition {
     private enum JournalType {
         NIO, ASYNCIO;
     }
+
+    private enum CriticalAnalyzerPolicy {
+        HALT, SHUTDOWN, LOG;
+    }
+
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -37,7 +37,6 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -405,7 +404,7 @@ public class TransportConfigOperationHandlers {
                 socketBindingSupplier = builder.requiresCapability(SOCKET_BINDING_CAPABILITY_NAME, SocketBinding.class, socketBindingName);
             }
         }
-        Supplier<ActiveMQServer> serverSupplier = builder.requires(MessagingServices.getActiveMQServiceName(context.getCurrentAddress()));
+        Supplier<ActiveMQBroker> serverSupplier = builder.requires(MessagingServices.getActiveMQServiceName(context.getCurrentAddress()));
         builder.setInstance(new ConnectorService(serverSupplier, socketBindingSupplier, outboundSocketBindingSupplier, factoryClass, parameters, extraParameters, context.getCurrentAddressValue()));
         builder.install();
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicySynchronizationStatusReadHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicySynchronizationStatusReadHandler.java
@@ -8,7 +8,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -21,6 +20,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.messaging.activemq.ActiveMQBroker;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 
@@ -70,7 +70,7 @@ public class HAPolicySynchronizationStatusReadHandler extends AbstractRuntimeOnl
         if (service == null || service.getState() != ServiceController.State.UP) {
             throw MessagingLogger.ROOT_LOGGER.activeMQServerNotInstalled(serviceName.getSimpleName());
         }
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
         return server.getActiveMQServerControl();
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
@@ -66,7 +66,7 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
         serviceBuilder.install();
     }
 
-    static ConnectionFactoryConfiguration createConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
+    private static ConnectionFactoryConfiguration createConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
 
         final List<String> entries = Common.ENTRIES.unwrap(context, model);
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
@@ -7,6 +7,9 @@ package org.wildfly.extension.messaging.activemq.jms;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ELYTRON_SSL_CONTEXT_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.SOCKET_BINDING_CAPABILITY;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CALL_FAILOVER_TIMEOUT;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CALL_TIMEOUT;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CLIENT_ID;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_DISCOVERY_GROUP;
@@ -49,7 +52,6 @@ import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes.External.ENABLE_AMQ1_PREFIX;
 
 import javax.net.ssl.SSLContext;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 
 /**
@@ -73,7 +75,7 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
         boolean ha = HA.resolveModelAttribute(context, model).asBoolean();
         boolean enable1Prefixes = ENABLE_AMQ1_PREFIX.resolveModelAttribute(context, model).asBoolean();
         final ModelNode discoveryGroupName = Common.DISCOVERY_GROUP.resolveModelAttribute(context, model);
-        final ConnectionFactoryConfiguration config = ConnectionFactoryAdd.createConfiguration(context, name, model);
+        final ExternalConnectionFactoryConfiguration config = createConfiguration(context, name, model);
         JMSFactoryType jmsFactoryType = ConnectionFactoryType.valueOf(ConnectionFactoryAttributes.Regular.FACTORY_TYPE.resolveModelAttribute(context, model).asString()).getType();
         List<String> connectorNames = Common.CONNECTORS.unwrap(context, model);
         ServiceBuilder<?> builder = context.getServiceTarget()
@@ -139,6 +141,91 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
             MessagingLogger.ROOT_LOGGER.debugf("Referencing %s with JNDI name %s", serviceName, entry);
             BinderServiceUtil.installBinderService(context.getServiceTarget(), entry, service, serviceName);
         }
+    }
+
+    static ExternalConnectionFactoryConfiguration createConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
+
+        final List<String> entries = Common.ENTRIES.unwrap(context, model);
+
+        final ExternalConnectionFactoryConfiguration config = new ExternalConnectionFactoryConfiguration()
+                .setName(name)
+                .setHA(false)
+                .setBindings(entries.toArray(String[]::new));
+
+        config.setHA(HA.resolveModelAttribute(context, model).asBoolean());
+        config.setAutoGroup(Common.AUTO_GROUP.resolveModelAttribute(context, model).asBoolean());
+        config.setBlockOnAcknowledge(Common.BLOCK_ON_ACKNOWLEDGE.resolveModelAttribute(context, model).asBoolean());
+        config.setBlockOnDurableSend(Common.BLOCK_ON_DURABLE_SEND.resolveModelAttribute(context, model).asBoolean());
+        config.setBlockOnNonDurableSend(Common.BLOCK_ON_NON_DURABLE_SEND.resolveModelAttribute(context, model).asBoolean());
+        config.setCacheLargeMessagesClient(Common.CACHE_LARGE_MESSAGE_CLIENT.resolveModelAttribute(context, model).asBoolean());
+        config.setCallTimeout(CALL_TIMEOUT.resolveModelAttribute(context, model).asLong());
+        config.setClientFailureCheckPeriod(Common.CLIENT_FAILURE_CHECK_PERIOD.resolveModelAttribute(context, model).asInt());
+        config.setCallFailoverTimeout(CALL_FAILOVER_TIMEOUT.resolveModelAttribute(context, model).asLong());
+        final ModelNode clientId = CLIENT_ID.resolveModelAttribute(context, model);
+        if (clientId.isDefined()) {
+            config.setClientID(clientId.asString());
+        }
+        config.setCompressLargeMessages(Common.COMPRESS_LARGE_MESSAGES.resolveModelAttribute(context, model).asBoolean());
+        config.setConfirmationWindowSize(Common.CONFIRMATION_WINDOW_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setConnectionTTL(Common.CONNECTION_TTL.resolveModelAttribute(context, model).asLong());
+        List<String> connectorNames = Common.CONNECTORS.unwrap(context, model);
+        config.setConnectorNames(connectorNames);
+        config.setConsumerMaxRate(Common.CONSUMER_MAX_RATE.resolveModelAttribute(context, model).asInt());
+        config.setConsumerWindowSize(Common.CONSUMER_WINDOW_SIZE.resolveModelAttribute(context, model).asInt());
+        final ModelNode discoveryGroupName = Common.DISCOVERY_GROUP.resolveModelAttribute(context, model);
+        if (discoveryGroupName.isDefined()) {
+            config.setDiscoveryGroupName(discoveryGroupName.asString());
+        }
+
+        config.setDupsOKBatchSize(Common.DUPS_OK_BATCH_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setFailoverOnInitialConnection(Common.FAILOVER_ON_INITIAL_CONNECTION.resolveModelAttribute(context, model).asBoolean());
+
+        final ModelNode groupId = Common.GROUP_ID.resolveModelAttribute(context, model);
+        if (groupId.isDefined()) {
+            config.setGroupID(groupId.asString());
+        }
+
+        final ModelNode lbcn = Common.CONNECTION_LOAD_BALANCING_CLASS_NAME.resolveModelAttribute(context, model);
+        if (lbcn.isDefined()) {
+            config.setLoadBalancingPolicyClassName(lbcn.asString());
+        }
+        config.setMaxRetryInterval(Common.MAX_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong());
+        config.setMinLargeMessageSize(Common.MIN_LARGE_MESSAGE_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setPreAcknowledge(Common.PRE_ACKNOWLEDGE.resolveModelAttribute(context, model).asBoolean());
+        config.setProducerMaxRate(Common.PRODUCER_MAX_RATE.resolveModelAttribute(context, model).asInt());
+        config.setProducerWindowSize(Common.PRODUCER_WINDOW_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setReconnectAttempts(Common.RECONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt());
+        config.setRetryInterval(Common.RETRY_INTERVAL.resolveModelAttribute(context, model).asLong());
+        config.setRetryIntervalMultiplier(Common.RETRY_INTERVAL_MULTIPLIER.resolveModelAttribute(context, model).asDouble());
+        config.setScheduledThreadPoolMaxSize(Common.SCHEDULED_THREAD_POOL_MAX_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setThreadPoolMaxSize(Common.THREAD_POOL_MAX_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setTransactionBatchSize(Common.TRANSACTION_BATCH_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setUseGlobalPools(Common.USE_GLOBAL_POOLS.resolveModelAttribute(context, model).asBoolean());
+        config.setLoadBalancingPolicyClassName(Common.CONNECTION_LOAD_BALANCING_CLASS_NAME.resolveModelAttribute(context, model).asString());
+        final ModelNode clientProtocolManagerFactory = Common.PROTOCOL_MANAGER_FACTORY.resolveModelAttribute(context, model);
+        if (clientProtocolManagerFactory.isDefined()) {
+            config.setProtocolManagerFactoryStr(clientProtocolManagerFactory.asString());
+        }
+        if (model.hasDefined(DESERIALIZATION_BLOCKLIST.getName())) {
+            List<String> deserializationBlockList = DESERIALIZATION_BLOCKLIST.unwrap(context, model);
+            if (!deserializationBlockList.isEmpty()) {
+                config.setDeserializationBlackList(String.join(",", deserializationBlockList));
+            }
+        }
+        if (model.hasDefined(DESERIALIZATION_ALLOWLIST.getName())) {
+            List<String> deserializationAllowList = DESERIALIZATION_ALLOWLIST.unwrap(context, model);
+            if (!deserializationAllowList.isEmpty()) {
+                config.setDeserializationWhiteList(String.join(",", deserializationAllowList));
+            }
+        }
+        JMSFactoryType jmsFactoryType = ConnectionFactoryType.valueOf(ConnectionFactoryAttributes.Regular.FACTORY_TYPE.resolveModelAttribute(context, model).asString()).getType();
+        config.setFactoryType(jmsFactoryType);
+
+        config.setInitialMessagePacketSize(Common.INITIAL_MESSAGE_PACKET_SIZE.resolveModelAttribute(context, model).asInt());
+        config.setEnableSharedClientID(true);
+        config.setEnable1xPrefixes(true);
+        config.setUseTopologyForLoadBalancing(Common.USE_TOPOLOGY.resolveModelAttribute(context, model).asBoolean());
+        return config;
     }
 
     static DiscoveryGroupConfiguration getDiscoveryGroup(final OperationContext context, final String name) throws OperationFailedException {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryConfiguration.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryConfiguration.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.messaging.activemq.jms;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+
+/**
+ * Simple Configuration holder class for external connection factories.
+ * @author Emmanuel Hugonnet (c) 2023 Red Hat, Inc.
+ */
+class ExternalConnectionFactoryConfiguration {
+
+   private String name = null;
+
+   private boolean persisted = false;
+
+   private String[] bindings = null;
+
+   private List<String> connectorNames = null;
+
+   private String discoveryGroupName = null;
+
+   private String clientID = null;
+
+   private boolean ha = ActiveMQClient.DEFAULT_HA;
+
+   private long clientFailureCheckPeriod = ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD;
+
+   private long connectionTTL = ActiveMQClient.DEFAULT_CONNECTION_TTL;
+
+   private long callTimeout = ActiveMQClient.DEFAULT_CALL_TIMEOUT;
+
+   private long callFailoverTimeout = ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT;
+
+   private boolean cacheLargeMessagesClient = ActiveMQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT;
+
+   private int minLargeMessageSize = ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE;
+
+   private boolean compressLargeMessage = ActiveMQClient.DEFAULT_COMPRESS_LARGE_MESSAGES;
+
+   private int compressionLevel = ActiveMQClient.DEFAULT_COMPRESSION_LEVEL;
+
+   private int consumerWindowSize = ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
+
+   private int consumerMaxRate = ActiveMQClient.DEFAULT_CONSUMER_MAX_RATE;
+
+   private int confirmationWindowSize = ActiveMQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE;
+
+   private int producerWindowSize = ActiveMQClient.DEFAULT_PRODUCER_WINDOW_SIZE;
+
+   private int producerMaxRate = ActiveMQClient.DEFAULT_PRODUCER_MAX_RATE;
+
+   private boolean blockOnAcknowledge = ActiveMQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE;
+
+   private boolean blockOnDurableSend = ActiveMQClient.DEFAULT_BLOCK_ON_DURABLE_SEND;
+
+   private boolean blockOnNonDurableSend = ActiveMQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND;
+
+   private boolean autoGroup = ActiveMQClient.DEFAULT_AUTO_GROUP;
+
+   private boolean preAcknowledge = ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE;
+
+   private String loadBalancingPolicyClassName = ActiveMQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME;
+
+   private int transactionBatchSize = ActiveMQClient.DEFAULT_ACK_BATCH_SIZE;
+
+   private int dupsOKBatchSize = ActiveMQClient.DEFAULT_ACK_BATCH_SIZE;
+
+   private long initialWaitTimeout = ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT;
+
+   private boolean useGlobalPools = ActiveMQClient.DEFAULT_USE_GLOBAL_POOLS;
+
+   private int scheduledThreadPoolMaxSize = ActiveMQClient.DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE;
+
+   private int threadPoolMaxSize = ActiveMQClient.DEFAULT_THREAD_POOL_MAX_SIZE;
+
+   private long retryInterval = ActiveMQClient.DEFAULT_RETRY_INTERVAL;
+
+   private double retryIntervalMultiplier = ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER;
+
+   private long maxRetryInterval = ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL;
+
+   private int reconnectAttempts = ActiveMQClient.DEFAULT_RECONNECT_ATTEMPTS;
+
+   private String groupID = null;
+
+   private String protocolManagerFactoryStr;
+
+   private JMSFactoryType factoryType = JMSFactoryType.CF;
+
+   private String deserializationBlackList;
+
+   private String deserializationWhiteList;
+
+   private int initialMessagePacketSize = ActiveMQClient.DEFAULT_INITIAL_MESSAGE_PACKET_SIZE;
+
+   private boolean enable1xPrefixes = ActiveMQJMSClient.DEFAULT_ENABLE_1X_PREFIXES;
+
+   private boolean enableSharedClientID = ActiveMQClient.DEFAULT_ENABLED_SHARED_CLIENT_ID;
+
+   private boolean useTopologyForLoadBalancing = ActiveMQClient.DEFAULT_USE_TOPOLOGY_FOR_LOADBALANCING;
+
+
+   public ExternalConnectionFactoryConfiguration() {
+   }
+
+   public String[] getBindings() {
+      return bindings;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setBindings(final String... bindings) {
+      this.bindings = bindings;
+      return this;
+   }
+
+
+   public String getName() {
+      return name;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setName(String name) {
+      this.name = name;
+      return this;
+   }
+
+
+   public boolean isPersisted() {
+      return persisted;
+   }
+
+   /**
+    * @return the discoveryGroupName
+    */
+
+   public String getDiscoveryGroupName() {
+      return discoveryGroupName;
+   }
+
+   /**
+    * @param discoveryGroupName the discoveryGroupName to set
+    */
+
+   public ExternalConnectionFactoryConfiguration setDiscoveryGroupName(String discoveryGroupName) {
+      this.discoveryGroupName = discoveryGroupName;
+      return this;
+   }
+
+
+   public List<String> getConnectorNames() {
+      return connectorNames;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConnectorNames(final List<String> connectorNames) {
+      this.connectorNames = connectorNames;
+      return this;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConnectorNames(final String... names) {
+      return this.setConnectorNames(Arrays.asList(names));
+   }
+
+
+   public boolean isHA() {
+      return ha;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setHA(final boolean ha) {
+      this.ha = ha;
+      return this;
+   }
+
+
+   public String getClientID() {
+      return clientID;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setClientID(final String clientID) {
+      this.clientID = clientID;
+      return this;
+   }
+
+
+   public long getClientFailureCheckPeriod() {
+      return clientFailureCheckPeriod;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setClientFailureCheckPeriod(final long clientFailureCheckPeriod) {
+      this.clientFailureCheckPeriod = clientFailureCheckPeriod;
+      return this;
+   }
+
+
+   public long getConnectionTTL() {
+      return connectionTTL;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConnectionTTL(final long connectionTTL) {
+      this.connectionTTL = connectionTTL;
+      return this;
+   }
+
+
+   public long getCallTimeout() {
+      return callTimeout;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setCallTimeout(final long callTimeout) {
+      this.callTimeout = callTimeout;
+      return this;
+   }
+
+
+   public long getCallFailoverTimeout() {
+      return callFailoverTimeout;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setCallFailoverTimeout(long callFailoverTimeout) {
+      this.callFailoverTimeout = callFailoverTimeout;
+      return this;
+   }
+
+
+   public boolean isCacheLargeMessagesClient() {
+      return cacheLargeMessagesClient;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setCacheLargeMessagesClient(final boolean cacheLargeMessagesClient) {
+      this.cacheLargeMessagesClient = cacheLargeMessagesClient;
+      return this;
+   }
+
+
+   public int getMinLargeMessageSize() {
+      return minLargeMessageSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setMinLargeMessageSize(final int minLargeMessageSize) {
+      this.minLargeMessageSize = minLargeMessageSize;
+      return this;
+   }
+
+
+   public int getCompressionLevel() {
+      return compressionLevel;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setCompressionLevel(final int compressionLevel) {
+      this.compressionLevel = compressionLevel;
+      return this;
+   }
+
+
+   public int getConsumerWindowSize() {
+      return consumerWindowSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConsumerWindowSize(final int consumerWindowSize) {
+      this.consumerWindowSize = consumerWindowSize;
+      return this;
+   }
+
+
+   public int getConsumerMaxRate() {
+      return consumerMaxRate;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConsumerMaxRate(final int consumerMaxRate) {
+      this.consumerMaxRate = consumerMaxRate;
+      return this;
+   }
+
+
+   public int getConfirmationWindowSize() {
+      return confirmationWindowSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setConfirmationWindowSize(final int confirmationWindowSize) {
+      this.confirmationWindowSize = confirmationWindowSize;
+      return this;
+   }
+
+
+   public int getProducerMaxRate() {
+      return producerMaxRate;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setProducerMaxRate(final int producerMaxRate) {
+      this.producerMaxRate = producerMaxRate;
+      return this;
+   }
+
+
+   public int getProducerWindowSize() {
+      return producerWindowSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setProducerWindowSize(final int producerWindowSize) {
+      this.producerWindowSize = producerWindowSize;
+      return this;
+   }
+
+
+   public boolean isBlockOnAcknowledge() {
+      return blockOnAcknowledge;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setBlockOnAcknowledge(final boolean blockOnAcknowledge) {
+      this.blockOnAcknowledge = blockOnAcknowledge;
+      return this;
+   }
+
+
+   public boolean isBlockOnDurableSend() {
+      return blockOnDurableSend;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setBlockOnDurableSend(final boolean blockOnDurableSend) {
+      this.blockOnDurableSend = blockOnDurableSend;
+      return this;
+   }
+
+
+   public boolean isBlockOnNonDurableSend() {
+      return blockOnNonDurableSend;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setBlockOnNonDurableSend(final boolean blockOnNonDurableSend) {
+      this.blockOnNonDurableSend = blockOnNonDurableSend;
+      return this;
+   }
+
+
+   public boolean isAutoGroup() {
+      return autoGroup;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setAutoGroup(final boolean autoGroup) {
+      this.autoGroup = autoGroup;
+      return this;
+   }
+
+
+   public boolean isPreAcknowledge() {
+      return preAcknowledge;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setPreAcknowledge(final boolean preAcknowledge) {
+      this.preAcknowledge = preAcknowledge;
+      return this;
+   }
+
+
+   public String getLoadBalancingPolicyClassName() {
+      return loadBalancingPolicyClassName;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setLoadBalancingPolicyClassName(final String loadBalancingPolicyClassName) {
+      this.loadBalancingPolicyClassName = loadBalancingPolicyClassName;
+      return this;
+   }
+
+
+   public int getTransactionBatchSize() {
+      return transactionBatchSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setTransactionBatchSize(final int transactionBatchSize) {
+      this.transactionBatchSize = transactionBatchSize;
+      return this;
+   }
+
+
+   public int getDupsOKBatchSize() {
+      return dupsOKBatchSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setDupsOKBatchSize(final int dupsOKBatchSize) {
+      this.dupsOKBatchSize = dupsOKBatchSize;
+      return this;
+   }
+
+   public long getInitialWaitTimeout() {
+      return initialWaitTimeout;
+   }
+
+   public ExternalConnectionFactoryConfiguration setInitialWaitTimeout(final long initialWaitTimeout) {
+      this.initialWaitTimeout = initialWaitTimeout;
+      return this;
+   }
+
+
+   public boolean isUseGlobalPools() {
+      return useGlobalPools;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setUseGlobalPools(final boolean useGlobalPools) {
+      this.useGlobalPools = useGlobalPools;
+      return this;
+   }
+
+
+   public int getScheduledThreadPoolMaxSize() {
+      return scheduledThreadPoolMaxSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setScheduledThreadPoolMaxSize(final int scheduledThreadPoolMaxSize) {
+      this.scheduledThreadPoolMaxSize = scheduledThreadPoolMaxSize;
+      return this;
+   }
+
+
+   public int getThreadPoolMaxSize() {
+      return threadPoolMaxSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setThreadPoolMaxSize(final int threadPoolMaxSize) {
+      this.threadPoolMaxSize = threadPoolMaxSize;
+      return this;
+   }
+
+
+   public long getRetryInterval() {
+      return retryInterval;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setRetryInterval(final long retryInterval) {
+      this.retryInterval = retryInterval;
+      return this;
+   }
+
+
+   public double getRetryIntervalMultiplier() {
+      return retryIntervalMultiplier;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setRetryIntervalMultiplier(final double retryIntervalMultiplier) {
+      this.retryIntervalMultiplier = retryIntervalMultiplier;
+      return this;
+   }
+
+
+   public long getMaxRetryInterval() {
+      return maxRetryInterval;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setMaxRetryInterval(final long maxRetryInterval) {
+      this.maxRetryInterval = maxRetryInterval;
+      return this;
+   }
+
+
+   public int getReconnectAttempts() {
+      return reconnectAttempts;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setReconnectAttempts(final int reconnectAttempts) {
+      this.reconnectAttempts = reconnectAttempts;
+      return this;
+   }
+
+   @Deprecated
+
+   public boolean isFailoverOnInitialConnection() {
+      return false;
+   }
+
+   @Deprecated
+
+   public ExternalConnectionFactoryConfiguration setFailoverOnInitialConnection(final boolean failover) {
+      return this;
+   }
+
+
+   public String getGroupID() {
+      return groupID;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setGroupID(final String groupID) {
+      this.groupID = groupID;
+      return this;
+   }
+
+
+   public boolean isEnable1xPrefixes() {
+      return enable1xPrefixes;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setEnable1xPrefixes(final boolean enable1xPrefixes) {
+      this.enable1xPrefixes = enable1xPrefixes;
+      return this;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setFactoryType(final JMSFactoryType factoryType) {
+      this.factoryType = factoryType;
+      return this;
+   }
+
+
+   public JMSFactoryType getFactoryType() {
+      return factoryType;
+   }
+
+
+   public String getDeserializationBlackList() {
+      return deserializationBlackList;
+   }
+
+
+   public void setDeserializationBlackList(String blackList) {
+      this.deserializationBlackList = blackList;
+   }
+
+
+   public String getDeserializationWhiteList() {
+      return this.deserializationWhiteList;
+   }
+
+
+   public void setDeserializationWhiteList(String whiteList) {
+      this.deserializationWhiteList = whiteList;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setCompressLargeMessages(boolean compressLargeMessage) {
+      this.compressLargeMessage = compressLargeMessage;
+      return this;
+   }
+
+
+   public boolean isCompressLargeMessages() {
+      return this.compressLargeMessage;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setProtocolManagerFactoryStr(String protocolManagerFactoryStr) {
+      this.protocolManagerFactoryStr = protocolManagerFactoryStr;
+      return this;
+   }
+
+
+   public String getProtocolManagerFactoryStr() {
+      return protocolManagerFactoryStr;
+   }
+
+
+   public int getInitialMessagePacketSize() {
+      return initialMessagePacketSize;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setInitialMessagePacketSize(int size) {
+      this.initialMessagePacketSize = size;
+      return this;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setEnableSharedClientID(boolean enabled) {
+      this.enableSharedClientID = enabled;
+      return this;
+   }
+
+
+   public boolean isEnableSharedClientID() {
+      return enableSharedClientID;
+   }
+
+
+   public ExternalConnectionFactoryConfiguration setUseTopologyForLoadBalancing(boolean useTopologyForLoadBalancing) {
+      this.useTopologyForLoadBalancing = useTopologyForLoadBalancing;
+      return this;
+   }
+
+
+   public boolean getUseTopologyForLoadBalancing() {
+      return useTopologyForLoadBalancing;
+   }
+
+}

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryService.java
@@ -15,7 +15,6 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
 import org.jboss.as.network.ManagedBinding;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
@@ -50,16 +49,16 @@ public class ExternalConnectionFactoryService implements Service<ConnectionFacto
     // mapping between the {discovery}-groups and the command dispatcher factory they use
     private final Map<String, Supplier<BroadcastCommandDispatcherFactory>> commandDispatcherFactories;
     private ActiveMQConnectionFactory factory;
-    private final ConnectionFactoryConfiguration config;
+    private final ExternalConnectionFactoryConfiguration config;
 
     ExternalConnectionFactoryService(DiscoveryGroupConfiguration groupConfiguration,
             Map<String, Supplier<BroadcastCommandDispatcherFactory>> commandDispatcherFactories,
-            Map<String, Supplier<SocketBinding>> groupBindings, Map<String, String> clusterNames, JMSFactoryType type, boolean ha, boolean enable1Prefixes, ConnectionFactoryConfiguration config) {
+            Map<String, Supplier<SocketBinding>> groupBindings, Map<String, String> clusterNames, JMSFactoryType type, boolean ha, boolean enable1Prefixes, ExternalConnectionFactoryConfiguration config) {
         this(ha, enable1Prefixes, type, groupConfiguration, Collections.emptyMap(), Collections.emptyMap(),commandDispatcherFactories, groupBindings, Collections.emptyMap(), clusterNames, null, config);
     }
 
     ExternalConnectionFactoryService(TransportConfiguration[] connectors, Map<String, Supplier<SocketBinding>> socketBindings,
-            Map<String, Supplier<OutboundSocketBinding>> outboundSocketBindings, Map<String, Supplier<SSLContext>> sslContexts, JMSFactoryType type, boolean ha, boolean enable1Prefixes, ConnectionFactoryConfiguration config) {
+            Map<String, Supplier<OutboundSocketBinding>> outboundSocketBindings, Map<String, Supplier<SSLContext>> sslContexts, JMSFactoryType type, boolean ha, boolean enable1Prefixes, ExternalConnectionFactoryConfiguration config) {
         this(ha, enable1Prefixes, type, null, socketBindings, outboundSocketBindings, Collections.emptyMap(), Collections.emptyMap(), sslContexts, Collections.emptyMap(), connectors, config);
     }
 
@@ -74,7 +73,7 @@ public class ExternalConnectionFactoryService implements Service<ConnectionFacto
             Map<String, Supplier<SSLContext>> sslContexts,
             Map<String, String> clusterNames,
             TransportConfiguration[] connectors,
-            ConnectionFactoryConfiguration config) {
+            ExternalConnectionFactoryConfiguration config) {
         assert (connectors != null && connectors.length > 0) || groupConfiguration != null;
         this.ha = ha;
         this.enable1Prefixes = enable1Prefixes;

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueControlHandler.java
@@ -11,12 +11,12 @@ import static org.wildfly.extension.messaging.activemq.jms.JMSQueueService.JMS_Q
 
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.AbstractQueueControlHandler;
+import org.wildfly.extension.messaging.activemq.ActiveMQBroker;
 
 /**
  * Handler for runtime operations that invoke on a ActiveMQ {@link QueueControl}.
@@ -43,15 +43,15 @@ public class JMSQueueControlHandler extends AbstractQueueControlHandler<QueueCon
     }
 
     @Override
-    protected DelegatingQueueControl<QueueControl> getQueueControl(ActiveMQServer server, String queueName){
+    protected DelegatingQueueControl<QueueControl> getQueueControl(ActiveMQBroker server, String queueName){
         String name = queueName;
         if (queueName.startsWith(JMS_QUEUE_PREFIX)) {
             name = queueName.substring(JMS_QUEUE_PREFIX.length());
         }
-        QueueControl queueControl = QueueControl.class.cast(server.getManagementService().getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + name));
+        QueueControl queueControl = QueueControl.class.cast(server.getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + name));
         if (queueControl == null) {
             //For backward compatibility
-            queueControl = QueueControl.class.cast(server.getManagementService().getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + queueName));
+            queueControl = QueueControl.class.cast(server.getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + queueName));
             if (queueControl == null) {
                 return null;
             }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueReadAttributeHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueReadAttributeHandler.java
@@ -13,7 +13,6 @@ import static org.wildfly.extension.messaging.activemq.jms.JMSQueueService.JMS_Q
 
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -25,6 +24,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.messaging.activemq.ActiveMQBroker;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
@@ -113,8 +113,8 @@ public class JMSQueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
 
         ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
-        ActiveMQServer server = ActiveMQServer.class.cast(service.getValue());
-        QueueControl control = QueueControl.class.cast(server.getManagementService().getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + queueName));
+        ActiveMQBroker server = ActiveMQBroker.class.cast(service.getValue());
+        QueueControl control = QueueControl.class.cast(server.getResource(ResourceNames.QUEUE + JMS_QUEUE_PREFIX + queueName));
         return control;
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
@@ -9,18 +9,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
 import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
 import static org.jboss.as.server.Services.requireServerExecutor;
+import static org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeFactory.createJMSBridge;
+import static org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeFactory.resolveContextProperties;
 
-import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
-import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
-import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
-import org.apache.activemq.artemis.jms.bridge.JMSBridge;
-import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
-import org.apache.activemq.artemis.jms.bridge.impl.JMSBridgeImpl;
-import org.apache.activemq.artemis.jms.bridge.impl.JNDIConnectionFactoryFactory;
-import org.apache.activemq.artemis.jms.bridge.impl.JNDIDestinationFactory;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -28,25 +22,16 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
-import org.jboss.modules.ModuleLoadException;
-import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.common.function.ExceptionSupplier;
-import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
-import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 import org.wildfly.security.credential.source.CredentialSource;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Jakarta Messaging Bridge add update.
@@ -77,10 +62,8 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
 
-                String moduleName = resolveAttribute(JMSBridgeDefinition.MODULE, context, model);
-                final JMSBridge bridge = createJMSBridge(context, model);
-
-                final String bridgeName = address.getLastElement().getValue();
+                String moduleName = JMSBridgeDefinition.MODULE.resolveModelAttribute(context, model).asStringOrNull();
+                final String bridgeName = context.getCurrentAddressValue();
                 final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
 
                 final ServiceBuilder jmsBridgeServiceBuilder = context.getServiceTarget().addService(bridgeServiceName);
@@ -99,7 +82,7 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
                 // corresponds to a local Artemis server, the pool will be cleaned up after the Jakarta Messaging bridge is stopped.
                 jmsBridgeServiceBuilder.requires(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL);
                 // adding credential source supplier which will later resolve password from CredentialStore using credential-reference
-                final JMSBridgeService bridgeService = new JMSBridgeService(moduleName, bridgeName, bridge, executorSupplier,
+                final JMSBridgeService bridgeService = new JMSBridgeService(moduleName, bridgeName, createJMSBridge(context, model), executorSupplier,
                         getCredentialStoreReference(JMSBridgeDefinition.SOURCE_CREDENTIAL_REFERENCE, context, model, jmsBridgeServiceBuilder),
                         getCredentialStoreReference(JMSBridgeDefinition.TARGET_CREDENTIAL_REFERENCE, context, model, jmsBridgeServiceBuilder));
                 jmsBridgeServiceBuilder.setInstance(bridgeService);
@@ -129,88 +112,6 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
         builder.requires(ContextNames.bindInfoFor(jndiName).getBinderServiceName());
     }
 
-    private JMSBridge createJMSBridge(OperationContext context, ModelNode model) throws OperationFailedException {
-        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
-        final String sourceConnectionFactoryName = JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
-        final ConnectionFactoryFactory sourceCff = new JNDIConnectionFactoryFactory(sourceContextProperties , sourceConnectionFactoryName);
-        final String sourceDestinationName = JMSBridgeDefinition.SOURCE_DESTINATION.resolveModelAttribute(context, model).asString();
-        final DestinationFactory sourceDestinationFactory = new JNDIDestinationFactory(sourceContextProperties, sourceDestinationName);
-
-        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
-        final String targetConnectionFactoryName = JMSBridgeDefinition.TARGET_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
-        final ConnectionFactoryFactory targetCff = new JNDIConnectionFactoryFactory(targetContextProperties, targetConnectionFactoryName);
-        final String targetDestinationName = JMSBridgeDefinition.TARGET_DESTINATION.resolveModelAttribute(context, model).asString();
-        final DestinationFactory targetDestinationFactory = new JNDIDestinationFactory(targetContextProperties, targetDestinationName);
-
-        final String sourceUsername = resolveAttribute(JMSBridgeDefinition.SOURCE_USER, context, model);
-        final String sourcePassword = resolveAttribute(JMSBridgeDefinition.SOURCE_PASSWORD, context, model);
-        final String targetUsername = resolveAttribute(JMSBridgeDefinition.TARGET_USER, context, model);
-        final String targetPassword = resolveAttribute(JMSBridgeDefinition.TARGET_PASSWORD, context, model);
-
-        final String selector = resolveAttribute(CommonAttributes.SELECTOR, context, model);
-        final long failureRetryInterval = JMSBridgeDefinition.FAILURE_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
-        final int maxRetries = JMSBridgeDefinition.MAX_RETRIES.resolveModelAttribute(context, model).asInt();
-        final QualityOfServiceMode qosMode = QualityOfServiceMode.valueOf( JMSBridgeDefinition.QUALITY_OF_SERVICE.resolveModelAttribute(context, model).asString());
-        final int maxBatchSize = JMSBridgeDefinition.MAX_BATCH_SIZE.resolveModelAttribute(context, model).asInt();
-        final long maxBatchTime = JMSBridgeDefinition.MAX_BATCH_TIME.resolveModelAttribute(context, model).asLong();
-        final String subName =  resolveAttribute(JMSBridgeDefinition.SUBSCRIPTION_NAME, context, model);
-        final String clientID = resolveAttribute(JMSBridgeDefinition.CLIENT_ID, context, model);
-        final boolean addMessageIDInHeader = JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER.resolveModelAttribute(context, model).asBoolean();
-
-        final String moduleName = resolveAttribute(JMSBridgeDefinition.MODULE, context, model);
-
-        final ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-        try {
-            // if a module is specified, use it to instantiate the JMSBridge to ensure its ExecutorService
-            // will use the correct class loader to execute its threads
-            if (moduleName != null) {
-                Module module = Module.getCallerModuleLoader().loadModule(ModuleIdentifier.fromString(moduleName));
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
-            }
-            return new JMSBridgeImpl(sourceCff,
-                    targetCff,
-                    sourceDestinationFactory,
-                    targetDestinationFactory,
-                    sourceUsername,
-                    sourcePassword,
-                    targetUsername,
-                    targetPassword,
-                    selector,
-                    failureRetryInterval,
-                    maxRetries,
-                    qosMode,
-                    maxBatchSize,
-                    maxBatchTime,
-                    subName,
-                    clientID,
-                    addMessageIDInHeader).setBridgeName(context.getCurrentAddressValue());
-        } catch (ModuleNotFoundException e) {
-            throw MessagingLogger.ROOT_LOGGER.moduleNotFound(moduleName, e.getMessage(), e);
-        } catch (ModuleLoadException e) {
-            throw MessagingLogger.ROOT_LOGGER.unableToLoadModule(moduleName, e);
-        } finally {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-        }
-    }
-
-    private Properties resolveContextProperties(AttributeDefinition attribute, OperationContext context, ModelNode model) throws OperationFailedException {
-        final ModelNode contextModel = attribute.resolveModelAttribute(context, model);
-        final Properties contextProperties = new Properties();
-        if (contextModel.isDefined()) {
-            for (Property property : contextModel.asPropertyList()) {
-                contextProperties.put(property.getName(), property.getValue().asString());
-            }
-        }
-        return contextProperties;
-    }
-
-    /**
-     * Return null if the resolved attribute is not defined
-     */
-    private String resolveAttribute(SimpleAttributeDefinition attr, OperationContext context, ModelNode model) throws OperationFailedException {
-        final ModelNode node = attr.resolveModelAttribute(context, model);
-        return node.isDefined() ? node.asString() : null;
-    }
 
     private static ExceptionSupplier<CredentialSource, Exception> getCredentialStoreReference(ObjectTypeAttributeDefinition credentialReferenceAttributeDefinition, OperationContext context, ModelNode model, ServiceBuilder<?> serviceBuilder, String... modelFilter) throws OperationFailedException {
         if (model.hasDefined(credentialReferenceAttributeDefinition.getName())) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeFactory.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.messaging.activemq.jms.bridge;
+
+import java.util.Properties;
+import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
+import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
+import org.apache.activemq.artemis.jms.bridge.JMSBridge;
+import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
+import org.apache.activemq.artemis.jms.bridge.impl.JMSBridgeImpl;
+import org.apache.activemq.artemis.jms.bridge.impl.JNDIConnectionFactoryFactory;
+import org.apache.activemq.artemis.jms.bridge.impl.JNDIDestinationFactory;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleNotFoundException;
+import org.wildfly.extension.messaging.activemq.CommonAttributes;
+import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+public class JMSBridgeFactory {
+
+    public static JMSBridge createJMSBridge(OperationContext context, ModelNode model) throws OperationFailedException {
+        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
+        final String sourceConnectionFactoryName = JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory sourceCff = new JNDIConnectionFactoryFactory(sourceContextProperties , sourceConnectionFactoryName);
+        final String sourceDestinationName = JMSBridgeDefinition.SOURCE_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory sourceDestinationFactory = new JNDIDestinationFactory(sourceContextProperties, sourceDestinationName);
+
+        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
+        final String targetConnectionFactoryName = JMSBridgeDefinition.TARGET_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory targetCff = new JNDIConnectionFactoryFactory(targetContextProperties, targetConnectionFactoryName);
+        final String targetDestinationName = JMSBridgeDefinition.TARGET_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory targetDestinationFactory = new JNDIDestinationFactory(targetContextProperties, targetDestinationName);
+
+        final String sourceUsername = JMSBridgeDefinition.SOURCE_USER.resolveModelAttribute(context, model).asStringOrNull();
+        final String sourcePassword = JMSBridgeDefinition.SOURCE_PASSWORD.resolveModelAttribute(context, model).asStringOrNull();
+        final String targetUsername = JMSBridgeDefinition.TARGET_USER.resolveModelAttribute(context, model).asStringOrNull();
+        final String targetPassword = JMSBridgeDefinition.TARGET_PASSWORD.resolveModelAttribute(context, model).asStringOrNull();
+
+        final String selector = CommonAttributes.SELECTOR.resolveModelAttribute(context, model).asStringOrNull();
+        final long failureRetryInterval = JMSBridgeDefinition.FAILURE_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final int maxRetries = JMSBridgeDefinition.MAX_RETRIES.resolveModelAttribute(context, model).asInt();
+        final QualityOfServiceMode qosMode = QualityOfServiceMode.valueOf( JMSBridgeDefinition.QUALITY_OF_SERVICE.resolveModelAttribute(context, model).asString());
+        final int maxBatchSize = JMSBridgeDefinition.MAX_BATCH_SIZE.resolveModelAttribute(context, model).asInt();
+        final long maxBatchTime = JMSBridgeDefinition.MAX_BATCH_TIME.resolveModelAttribute(context, model).asLong();
+        final String subName =  JMSBridgeDefinition.SUBSCRIPTION_NAME.resolveModelAttribute(context, model).asStringOrNull();
+        final String clientID = JMSBridgeDefinition.CLIENT_ID.resolveModelAttribute(context, model).asStringOrNull();
+        final boolean addMessageIDInHeader = JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER.resolveModelAttribute(context, model).asBoolean();
+
+        final String moduleName = JMSBridgeDefinition.MODULE.resolveModelAttribute(context, model).asStringOrNull();
+
+        final ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            // if a module is specified, use it to instantiate the JMSBridge to ensure its ExecutorService
+            // will use the correct class loader to execute its threads
+            if (moduleName != null) {
+                org.jboss.modules.Module module = org.jboss.modules.Module.getCallerModuleLoader().loadModule(ModuleIdentifier.fromString(moduleName));
+                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
+            }
+            return new JMSBridgeImpl(sourceCff,
+                    targetCff,
+                    sourceDestinationFactory,
+                    targetDestinationFactory,
+                    sourceUsername,
+                    sourcePassword,
+                    targetUsername,
+                    targetPassword,
+                    selector,
+                    failureRetryInterval,
+                    maxRetries,
+                    qosMode,
+                    maxBatchSize,
+                    maxBatchTime,
+                    subName,
+                    clientID,
+                    addMessageIDInHeader).setBridgeName(context.getCurrentAddressValue());
+        } catch (ModuleNotFoundException e) {
+            throw MessagingLogger.ROOT_LOGGER.moduleNotFound(moduleName, e.getMessage(), e);
+        } catch (ModuleLoadException e) {
+            throw MessagingLogger.ROOT_LOGGER.unableToLoadModule(moduleName, e);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
+        }
+    }
+
+    public static Properties resolveContextProperties(AttributeDefinition attribute, OperationContext context, ModelNode model) throws OperationFailedException {
+        final ModelNode contextModel = attribute.resolveModelAttribute(context, model);
+        final Properties contextProperties = new Properties();
+        if (contextModel.isDefined()) {
+            for (Property property : contextModel.asPropertyList()) {
+                contextProperties.put(property.getName(), property.getValue().asString());
+            }
+        }
+        return contextProperties;
+    }
+}

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeRemove.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeRemove.java
@@ -5,12 +5,10 @@
 
 package org.wildfly.extension.messaging.activemq.jms.bridge;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.jboss.dmr.ModelNode;
@@ -30,15 +28,14 @@ class JMSBridgeRemove extends AbstractRemoveStepHandler {
     private JMSBridgeRemove() {
     }
 
+    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        final String bridgeName = address.getLastElement().getValue();
-        context.removeService(MessagingServices.getJMSBridgeServiceName(bridgeName));
+        context.removeService(MessagingServices.getJMSBridgeServiceName(context.getCurrentAddressValue()));
     }
 
+    @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        final String bridgeName = address.getLastElement().getValue();
+        final String bridgeName = context.getCurrentAddressValue();
 
         final ServiceRegistry registry = context.getServiceRegistry(true);
         final ServiceName jmsBridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
@@ -35,6 +35,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.messaging.activemq.ActiveMQActivationService;
+import org.wildfly.extension.messaging.activemq.ActiveMQBroker;
 import org.wildfly.extension.messaging.activemq.jms.JMSServices;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 
@@ -138,7 +139,7 @@ public class LegacyConnectionFactoryService implements Service<ConnectionFactory
                 TransportConstants.NETTY_CONNECT_TIMEOUT);
     }
 
-    private final InjectedValue<ActiveMQServer> injectedActiveMQServer = new InjectedValue<ActiveMQServer>();
+    private final InjectedValue<ActiveMQBroker> injectedActiveMQServer = new InjectedValue<ActiveMQBroker>();
     private final HornetQConnectionFactory uncompletedConnectionFactory;
     private final String discoveryGroupName;
     private final List<String> connectors;
@@ -154,7 +155,7 @@ public class LegacyConnectionFactoryService implements Service<ConnectionFactory
 
     @Override
     public void start(StartContext context) throws StartException {
-        ActiveMQServer activeMQServer = injectedActiveMQServer.getValue();
+        ActiveMQServer activeMQServer = ActiveMQServer.class.cast(injectedActiveMQServer.getValue().getDelegate());
 
         DiscoveryGroupConfiguration discoveryGroupConfiguration = null;
         if (discoveryGroupName != null) {
@@ -238,7 +239,7 @@ public class LegacyConnectionFactoryService implements Service<ConnectionFactory
 
         final ServiceBuilder sb = serviceTarget.addService(serviceName, service);
         sb.requires(ActiveMQActivationService.getServiceName(activeMQServerServiceName));
-        sb.addDependency(activeMQServerServiceName, ActiveMQServer.class, service.injectedActiveMQServer);
+        sb.addDependency(activeMQServerServiceName, ActiveMQBroker.class, service.injectedActiveMQServer);
         sb.setInitialMode(ServiceController.Mode.PASSIVE);
         sb.install();
         return service;

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -2931,6 +2931,10 @@
                                         <!-- Override the standard module path that points at the shared module set from dist -->
                                         <module.path>${project.build.directory}/wildfly/modules${path.separator}${basedir}/target/modules</module.path>
                                     </systemPropertyVariables>
+                                    <excludes combine.children="append">
+                                        <!-- JSM queues and topics declared on an XML deployment file won't work without embedded broker  -->
+                                        <exclude>org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSManagementTestCase.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
 
@@ -3558,6 +3562,8 @@
                                         <exclude>org/jboss/as/test/integration/weld/modules/deployment/ModuleBeanDiscoveryModeTest.java</exclude>
                                         <exclude>org/jboss/as/test/integration/weld/modules/export/ExportedModuleTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jca/classloading/custommodule/DatasourceCustomModulesTestCase.java</exclude>
+                                        <!-- JSM queues and topics declared on an XML deployment file won't work without embedded broker  -->
+                                        <exclude>org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSManagementTestCase.java</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>
@@ -3581,7 +3587,13 @@
                                         <include>org/jboss/as/test/integration/jpa/**/NonTransactionalEmTestCase.java</include>
                                         <!-- WebJPATestCase is currently the only test that does not need EJB -->
                                         <include>org/jboss/as/test/integration/jpa/**/WebJPATestCase.java</include>
+                                        <!-- WebJPATestCase is currently the only test that does not need EJB -->
+                                        <include>org/jboss/as/test/integration/jpa/**/WebJPATestCase.java</include>
                                     </includes>
+                                    <excludes>
+                                        <!-- JSM queues and topics declared on an XML deployment file won't work without embedded broker  -->
+                                        <exclude>org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSManagementTestCase.java</exclude>
+                                    </excludes>
                                     <classpathDependencyExcludes>
                                         <classpathDependencyExclude>
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
@@ -78,7 +78,7 @@ public class MDB20MessageSelectorTestCase extends AbstractMDB2xTestCase {
         ejbJar.addClasses(JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addAsManifestResource(MDB20MessageSelectorTestCase.class.getPackage(), "ejb-jar-20-message-selector.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20MessageSelectorTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
-        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr,  org.apache.activemq.artemis\n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.apache.activemq.artemis.client\n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
@@ -76,7 +76,7 @@ public class MDB20QueueTestCase extends AbstractMDB2xTestCase {
         ejbJar.addClasses(JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addAsManifestResource(MDB20QueueTestCase.class.getPackage(), "ejb-jar-20.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20QueueTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
-        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.apache.activemq.artemis \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.apache.activemq.artemis.client \n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
@@ -92,7 +92,7 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
         ejbJar.addClasses(JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "ejb-jar-20-topic.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "jboss-ejb3-topic.xml", "jboss-ejb3.xml");
-        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.jboss.remoting, org.apache.activemq.artemis\n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.jboss.remoting, org.apache.activemq.artemis.client\n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(createPermissionsXmlAsset(
                 new PropertyPermission("ts.timeout.factor", "read"),
                 new RemotingPermission("createEndpoint"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryClientMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryClientMappingTestCase.java
@@ -114,7 +114,7 @@ public class ConnectionFactoryClientMappingTestCase {
                 "<jboss-deployment-structure>\n" +
                         "  <deployment>\n" +
                         "    <dependencies>\n" +
-                        "      <module name=\"org.apache.activemq.artemis\"/>\n" +
+                        "      <module name=\"org.apache.activemq.artemis.client\"/>\n" +
                         "    </dependencies>\n" +
                         "  </deployment>\n" +
                         "</jboss-deployment-structure>"), "META-INF/jboss-deployment-structure.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryClientMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryClientMappingTestCase.java
@@ -112,7 +112,7 @@ public class ExternalConnectionFactoryClientMappingTestCase {
                 "<jboss-deployment-structure>\n" +
                         "  <deployment>\n" +
                         "    <dependencies>\n" +
-                        "      <module name=\"org.apache.activemq.artemis\"/>\n" +
+                        "      <module name=\"org.apache.activemq.artemis.client\"/>\n" +
                         "    </dependencies>\n" +
                         "  </deployment>\n" +
                         "</jboss-deployment-structure>"), "META-INF/jboss-deployment-structure.xml");

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/ArtemisMessagingTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/ArtemisMessagingTestCase.java
@@ -59,7 +59,7 @@ public class ArtemisMessagingTestCase {
     public static JavaArchive createDeployment() throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "messaging-example.jar");
         jar.addAsManifestResource(new StringAsset("Manifest-Version: 1.0\n" +
-                "Dependencies: org.apache.activemq.artemis, org.jboss.dmr, org.jboss.as.controller-client\n"), "MANIFEST.MF");
+                "Dependencies: org.apache.activemq.artemis.client, org.jboss.dmr, org.jboss.as.controller-client\n"), "MANIFEST.MF");
         jar.addClass(ArtemisMessagingTestCase.class);
         return jar;
     }


### PR DESCRIPTION
…dependency for some deployments

 * Creating a org.apache.activemq.artemis.client module
 * Adding a org.apache.activemq.artemis.service-extensions module
 * Making the org.apache.activemq.artemis optional
 * Adding a ActiveMQBroker and ActiveMQBrokerImpl classes to wrap the ActiveMQServer so that we don't have direct references to it

Issue: https://issues.redhat.com/browse/WFLY-18240