### PR TITLE
[WFLY-18713] Upgrade RESTEasy to 6.2.6.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
         <version.org.jboss.mod_cluster>2.0.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>10.0.0.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.6.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.4.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.0.4.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18713
