### PR TITLE
[WFLY-18533] Do not register the resteasy-validator-provider on deplo…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-core/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-core/main/module.xml
@@ -29,10 +29,8 @@
         <module name="jakarta.xml.bind.api"/>
         <module name="jakarta.ws.rs.api"/>
         <module name="com.ibm.async.asyncutil"/>
-        <module name="org.hibernate.validator" optional="true" services="import"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider" optional="true" services="export" export="true"/>
         <module name="org.reactivestreams"/>
     </dependencies>
 </module>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -146,16 +146,6 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-cdi</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-crypto</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
         </dependency>
 

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
@@ -70,7 +70,6 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
         //we need to add these from all deployments, as they could be using the Jakarta RESTful Web Services client
 
         addDependency(moduleSpecification, moduleLoader, RESTEASY_ATOM, true, false);
-        addDependency(moduleSpecification, moduleLoader, RESTEASY_VALIDATOR, true, false);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_CLIENT, true, deploymentBundlesClientBuilder);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_CLIENT_API, true, deploymentBundlesClientBuilder);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_CORE, true, deploymentBundlesClientBuilder);
@@ -96,6 +95,11 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
         if (support.hasCapability("org.wildfly.microprofile.config")) {
             addDependency(moduleSpecification, moduleLoader, MP_REST_CLIENT, true, false);
             addDependency(moduleSpecification, moduleLoader, "org.jboss.resteasy.microprofile.config", true, false);
+        }
+        // If bean-validation is available, add the support for the resteasy-validator
+        if (support.hasCapability("org.wildfly.bean-validation")) {
+            final ModuleDependency dep = new ModuleDependency(moduleLoader, RESTEASY_VALIDATOR, true, true, true, false);
+            moduleSpecification.addSystemDependency(dep);
         }
     }
 


### PR DESCRIPTION
…yments if bean validation is not registered. Remove the resteasy-validator-provider module dependency from the resteasy-core module. Also remove the unneeded module dependencies on the subsystem.

https://issues.redhat.com/browse/WFLY-18533

