### PR TITLE
Allow 8 open dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-major', 'version-update:semver-minor']
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     registries:
       - maven-central
       - jboss-public-repository-group


### PR DESCRIPTION
It's taking quite a while on average to get dependabot PRs merged or rejected, so let's give it more room to suggest things.