### PR TITLE
WFLY-18727 ATTRIBUTE granularity distributed sessions should always replicate on setAttribute(...)

### DIFF
--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/attributes/fine/FineSessionAttributes.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/attributes/fine/FineSessionAttributes.java
@@ -90,10 +90,9 @@ public class FineSessionAttributes<K, V> extends SimpleImmutableSessionAttribute
 
         Object result = this.attributes.put(name, value);
 
-        if (value != result) {
-            synchronized (this.updates) {
-                this.updates.put(name, value);
-            }
+        // Always trigger attribute update, even if called with an existing reference
+        synchronized (this.updates) {
+            this.updates.put(name, value);
         }
 
         return result;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18727