### PR TITLE
Fix for WFLY-18741, Add a github action shared file to build and test WildFly

### DIFF
--- a/.github/workflows/shared-wildfly-build-and-test.yml
+++ b/.github/workflows/shared-wildfly-build-and-test.yml
@@ -1,0 +1,148 @@
+# A workflow that can be called from other workflows as a way to build and test a SNAPSHOT of WildFly with overridden dependencies.
+
+# Input parameters:
+# * test-arguments: An optional argument allowing to provide arguments to configure testing. Note that '-DallTests' should not be passed as not all tests will work on GitHub Actions.
+# * build-arguments: Arguments used during build. That is where you can override the version of the dependency.
+# * maven-repo-path: The path to a tar.gz file of a maven repo that contains the built dependency(ies) you are using.
+# * maven-repo-name: The name that identifies the maven repo to be downloaded.
+# * java-versions: A string containing a JSON array of JDK versions. For example: "['11', '17']"
+# * os: A string containing a JSON array of operating systems. For example: "['ubuntu-latest', 'windows-latest']"
+# 
+# Example Usage (WildFly main branch is built and tested with a custom build of a dependency named 'my-dependency'.
+#
+#jobs:  
+#  my-dependency-build:
+#    name: my-dependency
+#    runs-on: ubuntu-latest
+#    outputs:
+#      my-dependency-version: ${{ steps.version.outputs.my-dependency-version }}
+#    strategy:
+#      fail-fast: false
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Set up JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '11'
+#          distribution: 'temurin'
+#          cache: 'maven'
+#      - name: Build and Test my-dependency
+#        run: mvn -U -B -ntp clean install
+#        shell: bash
+#      - id: version
+#        run: echo "my-dependency-version=$(mvn -B help:evaluate -Dexpression=project.version -DforceStdout -q)" >> $GITHUB_OUTPUT
+#      - name: Archive the repository
+#        run:  |
+#          cd ~
+#          find ./.m2/repository -type d -name "*SNAPSHOT" -print0 | xargs -0 tar -czf ~/my-dependency-maven-repository.tar.gz  
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: my-dependency-maven-repository
+#          path: ~/my-dependency-maven-repository.tar.gz
+#          retention-days: 5
+#
+#  wildfly-build-and-test-galleon-layers:
+#    name: Galleon Linux - JDK11
+#    uses: wildfly/wildfly/.github/workflows/shared-wildfly-build-and-test.yml@main
+#    with:
+#      test-arguments: '-Dts.layers -Dts.galleon'
+#      build-arguments: '-Dversion.org.wildfly.my-dependency=${{needs.my-dependency-build.outputs.my-dependency-version}}'
+#      os: "['ubuntu-latest']"
+#      java-versions: "['11']"
+#      maven-repo-name: my-dependency-maven-repository
+#      maven-repo-path: my-dependency-maven-repository.tar.gz
+#    needs: my-dependency-build
+
+name: Build and Test WildFly
+
+on:
+  workflow_call:
+    inputs:
+      test-arguments:
+        description: "Test arguments"
+        required: false
+        default: ""
+        type: string
+      build-arguments:
+        description: "Build arguments"
+        required: true
+        type: string
+      maven-repo-path:
+        description: "Maven repo path to extract to local cache"
+        required: true
+        type: string
+      maven-repo-name:
+        description: "Maven repo name to extract to local cache"
+        required: true
+        type: string
+      java-versions:
+        description: "JDK versions array"
+        required: true
+        type: string
+      os:
+        description: "OS array"
+        required: true
+        type: string
+
+jobs:
+  wildfly-build-and-test:
+    name: ${{ matrix.os }}-jdk${{ matrix.java }} ${{ inputs.test-arguments }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+        java: ${{ fromJson(inputs.java-versions) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: wildfly/wildfly
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.maven-repo-name }}
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: |
+         tar -xzf ${{ inputs.maven-repo-path }} -C ~
+      - name: Build and Test WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }}
+        run: mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }}
+        shell: bash
+        # We need this due to long file names on Windows: https://github.com/actions/upload-artifact/issues/240
+      - name: Find reports
+        if: failure()
+        run: |
+          {
+            echo 'SUREFIRE_REPORTS<<EOF'
+            find . -path '**/surefire-reports/*.xml'
+            echo EOF
+          } >> "$GITHUB_ENV"
+        shell: bash
+      - name: Find server logs
+        if: failure()
+        run: |
+          {
+            echo 'SERVER_LOGS<<EOF'
+            find . -path '**/server.log'
+            echo EOF
+          } >> "$GITHUB_ENV"
+        shell: bash
+      - name: Upload Test Reports on Failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: ${{ env.SUREFIRE_REPORTS }}
+      - name: Upload Server Logs on Failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: server-logs-${{ matrix.os }}-${{ matrix.java }}
+          path: ${{ env.SERVER_LOGS }}
+


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18741

An example of the Galleon plugins Github Actions: https://github.com/jfdenise/galleon-plugins/blob/main/.github/workflows/ci.yml
An Action run: https://github.com/jfdenise/galleon-plugins/actions/runs/6862670363

Another Action run example from Galleon project this time (just validate that build + -Dts.layers tests are passing): https://github.com/jfdenise/galleon/actions/runs/6864936818