### PR TITLE
[WFLY-18742] Provisioning micrometer and opentelemetry layers issue

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/otlp/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/opentelemetry/otlp/main/module.xml
@@ -16,6 +16,7 @@
     <dependencies>
         <module name="io.opentelemetry.api"/>
         <module name="io.opentelemetry.context"/>
+        <module name="io.opentelemetry.sdk"/>
         <module name="com.squareup.okhttp3"/>
         <module name="org.slf4j"/>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18742

Add module dependency to provide access to missing class in failing test