### PR TITLE
Fix for WFLY-18746, Revisit telemetry layers inclusion rules

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
@@ -6,11 +6,7 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-telemetry">
     <props>
-        <prop name="org.wildfly.rule.annotations" value="io.opentelemetry.instrumentation.annotations"/>
-        <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*,io.opentelemetry.sdk.*"/>
-        <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
-        <prop name="org.wildfly.rule.add-on" value="observability,microprofile-telemetry"/>
-        <prop name="org.wildfly.rule.add-on-description" value="Support for MicroProfile Telemetry."/>
+        <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
     </props>
     <dependencies>
         <layer name="cdi"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
@@ -8,9 +8,6 @@
     <props>
         <prop name="org.wildfly.rule.annotations" value="io.opentelemetry.instrumentation.annotations"/>
         <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*,io.opentelemetry.sdk.*"/>
-        <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
-        <prop name="org.wildfly.rule.add-on" value="observability,opentelemetry"/>
-        <prop name="org.wildfly.rule.add-on-description" value="Support for OpenTelemetry."/>
     </props>
     <dependencies>
         <layer name="cdi"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18746

* microprofile-telemetry shouldn't contain rules related to opentelemetry API usage. This layer is provisioned if all its dependencies are discovered.
* opentelemetry and microprofile-telemetry layers are not add-ons.
