### PR TITLE
[WFLY-18770] Remove WFCORE-6591 workaround

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -55,10 +55,6 @@ public abstract class LayersTestBase {
             "org.jboss.as.xts",
             // TODO should an undertow layer specify this?
             "org.wildfly.event.logger",
-            // Legacy extension not in ootb standalone.xml extension list
-            // and not in test-all-layers as it is admin-only
-            // TODO move to NO_LAYER_OR_REFERENCE_COMMON when the WFCORE-6591 is integrated
-            "org.jboss.as.security",
     };
 
     /**
@@ -259,7 +255,10 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.picketlink",
             "org.jboss.as.jsr77",
             "org.keycloak.keycloak-adapter-subsystem",
-            // end legacy subsystems ^^^
+            // end legacy subsystems with no layer ^^^
+            // Legacy extension not in ootb standalone.xml extension list
+            // and not in test-all-layers as it is admin-only
+            "org.jboss.as.security",
             // TODO move eclipse link support to an external feature pack
             "org.eclipse.persistence",
             // RA not associated with any layer


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18770

The WFCORE-6591 issue is fixed in core, so we no longer need to work around it in testing full WF.

Merging this will allow https://github.com/wildfly/wildfly-core/pull/5611 to pass CI.

@yersan FYI.