### PR TITLE
[WFLY-18759] Move MicroProfile tck artifacts from boms/common-expansion to boms/standard-test-expansion

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -1086,13 +1086,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.config</groupId>
-                <artifactId>microprofile-config-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.config.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
@@ -1104,13 +1097,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-                <artifactId>microprofile-fault-tolerance-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.fault-tolerance.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>
@@ -1124,13 +1110,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.health</groupId>
-                <artifactId>microprofile-health-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.health.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
@@ -1143,22 +1122,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.jwt</groupId>
-                <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.jwt.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.jwt</groupId>
-                <artifactId>microprofile-jwt-auth-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.jwt.api}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
-
 
             <dependency>
                 <groupId>org.eclipse.microprofile.lra</groupId>
@@ -1171,13 +1134,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.lra</groupId>
-                <artifactId>microprofile-lra-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.lra.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
@@ -1189,12 +1145,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.openapi</groupId>
-                <artifactId>microprofile-openapi-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.openapi}</version>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>
@@ -1219,22 +1169,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
-                <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <!--
-                        Depends on org.reactivestreams:reactive-streams-tck which in turn has a dependency
-                        on an ancient version of this spi
-                     -->
-                    <exclusion>
-                        <groupId>org.jboss.arquillian.test</groupId>
-                        <artifactId>arquillian-test-spi</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
@@ -1247,12 +1181,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
-                <artifactId>microprofile-reactive-messaging-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
@@ -1264,19 +1192,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.rest.client</groupId>
-                <artifactId>microprofile-rest-client-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
-                <scope>test</scope>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.telemetry.tracing</groupId>
-                <artifactId>microprofile-telemetry-tracing-tck</artifactId>
-                <version>${version.org.eclipse.microprofile.telemetry}</version>
-                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
             </dependency>
 
             <dependency>

--- a/boms/standard-test-expansion/pom.xml
+++ b/boms/standard-test-expansion/pom.xml
@@ -39,6 +39,96 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Microprofile TCK test dependencies -->
+            <dependency>
+                <groupId>org.eclipse.microprofile.config</groupId>
+                <artifactId>microprofile-config-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.config.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+                <artifactId>microprofile-fault-tolerance-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.fault-tolerance.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.health</groupId>
+                <artifactId>microprofile-health-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.health.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.jwt</groupId>
+                <artifactId>microprofile-jwt-auth-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.jwt</groupId>
+                <artifactId>microprofile-jwt-auth-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.lra</groupId>
+                <artifactId>microprofile-lra-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.lra.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.openapi</groupId>
+                <artifactId>microprofile-openapi-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.openapi}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+                <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.reactive-streams-operators.api}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!--
+                        Depends on org.reactivestreams:reactive-streams-tck which in turn has a dependency
+                        on an ancient version of this spi
+                     -->
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.test</groupId>
+                        <artifactId>arquillian-test-spi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
+                <artifactId>microprofile-reactive-messaging-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.reactive-messaging.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.rest.client</groupId>
+                <artifactId>microprofile-rest-client-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.telemetry.tracing</groupId>
+                <artifactId>microprofile-telemetry-tracing-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.telemetry}</version>
+                <scope>test</scope>
+                <!-- Don't exclude all TCK dependencies, only specific ones that cause problems -->
+            </dependency>
+            <!-- End Microprofile TCK test dependencies -->
+
             <!-- Required by Wiremock for the MicroProfile REST Client TCK -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18759

This PR tires to move microprofile tck dependencies to `boms/standard-test-expanion/`, and it also adds `<scope>test</scope>` to the dependencies of:
* org.eclipse.microprofile.openapi:microprofile-openapi-tck
* org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck
* org.eclipse.microprofile.telemetry.tracing:microprofile-telemetry-tracing-tck

where they were not, but I think they should be.