### PR TITLE
[WFLY-18779] Upgrade WildFly Core to 23.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>23.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18779


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/23.0.0.Beta1...23.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6578'>WFCORE-6578</a>] -         [CVE-2023-3171] WildFly heap exhaustion via deserialization
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6591'>WFCORE-6591</a>] -         Core modules still have dependencies on org.jboss.as.security
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6592'>WFCORE-6592</a>] -         NPE in ThreadFactoryService
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6597'>WFCORE-6597</a>] -         WFCORE-4296 - Illegal reflective access by org.wildfly.extension.elytron.SSLDefinitions when started by ps1 script
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6601'>WFCORE-6601</a>] -         ModuleSpecification.setSystemDependency does not reset the allDependencies list
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6604'>WFCORE-6604</a>] -         JMX can&#39;t set default value for an attribute of ModelType.LIST
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6607'>WFCORE-6607</a>] -         ModuleSpecification.addSystemDependency treats a duplicate add as an excluded dependency
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6608'>WFCORE-6608</a>] -         Inconsistent user dependency views in ModuleSpecification
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6332'>WFCORE-6332</a>] -         Better handling of licenses
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6599'>WFCORE-6599</a>] -         Control the maven repos used by dependabot
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6606'>WFCORE-6606</a>] -         WildFly main is failing some of Jakarta EE 10 Platform TCK Connector tests that depend on appclient deploying an ear with resource archive deployment dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6609'>WFCORE-6609</a>] -         Remove obsolete JMockit from Elytron tests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6617'>WFCORE-6617</a>] -         Clean out ts.elytron profile cruft
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6620'>WFCORE-6620</a>] -         Bump the kernel management API version to 24.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6625'>WFCORE-6625</a>] -         Remove org.glassfish:jakarta.json license info
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6577'>WFCORE-6577</a>] -         Upgrade Galleon to 5.2.2.Final and Galleon plugins to 6.5.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6582'>WFCORE-6582</a>] -         Upgrade WildFly Galleon plugins to 6.5.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6584'>WFCORE-6584</a>] -         Upgrade wildfly-common to 1.7.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6585'>WFCORE-6585</a>] -         Upgrade snakeyaml to 2.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6586'>WFCORE-6586</a>] -         Upgrade SSHD from 2.10.0 to 2.11.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6587'>WFCORE-6587</a>] -         Upgrade Apache Commons CLI from 1.5.0 to 1.6.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6590'>WFCORE-6590</a>] -         Upgrade commons-lang3 from 3.12.0 to 3.13.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6618'>WFCORE-6618</a>] -         Upgrade BouncyCastle from 1.76 to 1.77
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6621'>WFCORE-6621</a>] -         Upgrade Byteman to 4.0.22
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6255'>WFCORE-6255</a>] -         Deployment scanner does not undeploy failed archives
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6600'>WFCORE-6600</a>] -         Limit logging level of com.networknt.schema
</li>
</ul>
</details>