### PR TITLE
WFLY-18782 wildfly-model-test & commons-text should only be present in test scope

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -460,6 +460,7 @@
         <dependency>
            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-model-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18782

The org.wildfly.core:wildfly-model-test dependency in the testsuite/integration/ module should have a test scope.

The org.apache.commons:commons-text dependency should be excluded from the org.apache.activemq:artemis-server dependency, so that it's eliminated from the compile scope dependency tree. This module is not present in our jboss-modules so it's not expected to be needed at runtime.

...Waiting for CI results...