### PR TITLE
[WFLY-18798] Upgrade WildFly Core to 22.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>22.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>22.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18798


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/22.0.2.Final
Diff: https://github.com/wildfly/wildfly-core/compare/22.0.1.Final...22.0.2.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6578'>WFCORE-6578</a>] -         [CVE-2023-3171] WildFly heap exhaustion via deserialization
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6592'>WFCORE-6592</a>] -         NPE in ThreadFactoryService
</li>
</ul>
</details>
