### PR TITLE
WFLY-18804 + WFLY-18805 + WFLY-18806 Upgrade to Hibernate Search 7.0

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -2816,7 +2816,7 @@
 
             <dependency>
                 <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-analyzers-common</artifactId>
+                <artifactId>lucene-analysis-common</artifactId>
                 <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>

--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -3387,7 +3387,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+                <artifactId>hibernate-search-mapper-orm</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>
@@ -3432,7 +3432,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-v5migrationhelper-orm-orm6</artifactId>
+                <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
                 <exclusions>

--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -60,7 +60,7 @@
 
             <dependency>
                 <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
+                <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <exclusions>
                     <exclusion>

--- a/boms/user/ee/pom.xml
+++ b/boms/user/ee/pom.xml
@@ -313,7 +313,7 @@
                                 </dependency>
                                 <dependency>
                                     <groupId>org.hibernate.search</groupId>
-                                    <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+                                    <artifactId>hibernate-search-mapper-orm</artifactId>
                                 </dependency>
                                 <dependency>
                                     <groupId>org.hibernate.search</groupId>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -1518,7 +1518,7 @@
 
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -1141,7 +1141,7 @@
 
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -15,7 +15,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.apache.lucene:lucene-analyzers-common}"/>
+        <artifact name="${org.apache.lucene:lucene-analysis-common}"/>
         <artifact name="${org.apache.lucene:lucene-core}"/>
         <artifact name="${org.apache.lucene:lucene-facet}"/>
         <artifact name="${org.apache.lucene:lucene-queries}"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -23,6 +23,6 @@
         <module name="org.hibernate.search.backend.elasticsearch" optional="true" services="import"/>
         <module name="org.hibernate.search.mapper.pojo" optional="true" services="import"/>
         <module name="org.hibernate.search.mapper.orm" optional="true" services="import"/>
-        <module name="org.hibernate.search.mapper.orm.coordination.outboxpolling" optional="true" services="import"/>
+        <module name="org.hibernate.search.mapper.orm.outboxpolling" optional="true" services="import"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -10,7 +10,7 @@
 <module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.orm">
 
     <resources>
-        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm-orm6}"/>
+        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm}"/>
     </resources>
 
     <dependencies>

--- a/jpa/hibernatesearch/pom.xml
+++ b/jpa/hibernatesearch/pom.xml
@@ -99,7 +99,7 @@
 
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -186,7 +186,7 @@ public class Configuration {
     /**
      * name of the Hibernate Search module providing the outbox-polling coordination strategy
      */
-    public static final String HIBERNATE_SEARCH_MODULE_MAPPER_ORM_COORDINATION_OUTBOXPOLLING = "org.hibernate.search.mapper.orm.coordination.outboxpolling";
+    public static final String HIBERNATE_SEARCH_MODULE_MAPPER_ORM_OUTBOXPOLLING = "org.hibernate.search.mapper.orm.outboxpolling";
 
     /**
      * name of the Hibernate Search module providing the Lucene backend

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/HibernateSearchProcessor.java
@@ -41,8 +41,8 @@ public class HibernateSearchProcessor implements DeploymentUnitProcessor {
     private static final ModuleIdentifier MODULE_MAPPER_ORM_DEFAULT =
             ModuleIdentifier.fromString(Configuration.HIBERNATE_SEARCH_MODULE_MAPPER_ORM);
 
-    private static final ModuleIdentifier MODULE_MAPPER_ORM_COORDINATION_OUTBOXPOLLING =
-            ModuleIdentifier.fromString(Configuration.HIBERNATE_SEARCH_MODULE_MAPPER_ORM_COORDINATION_OUTBOXPOLLING);
+    private static final ModuleIdentifier MODULE_MAPPER_ORM_OUTBOXPOLLING =
+            ModuleIdentifier.fromString(Configuration.HIBERNATE_SEARCH_MODULE_MAPPER_ORM_OUTBOXPOLLING);
     private static final ModuleIdentifier MODULE_BACKEND_LUCENE =
             ModuleIdentifier.fromString(Configuration.HIBERNATE_SEARCH_MODULE_BACKEND_LUCENE);
     private static final ModuleIdentifier MODULE_BACKEND_ELASTICSEARCH =
@@ -128,7 +128,7 @@ public class HibernateSearchProcessor implements DeploymentUnitProcessor {
         List<String> coordinationStrategies = HibernateSearchDeploymentMarker.getCoordinationStrategies(deploymentUnit);
         if (coordinationStrategies != null) {
             if (coordinationStrategies.contains(Configuration.HIBERNATE_SEARCH_COORDINATION_STRATEGY_VALUE_OUTBOX_POLLING)) {
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, MODULE_MAPPER_ORM_COORDINATION_OUTBOXPOLLING,
+                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, MODULE_MAPPER_ORM_OUTBOXPOLLING,
                         false, true, true, false));
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <version.org.eclipse.microprofile.telemetry>1.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.0</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>8.10.2</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.11.1</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.4</version.org.glassfish.jaxb>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.2.13.Final</version.org.hibernate>
-        <version.org.hibernate.search>6.2.2.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.0.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.21.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.9</version.org.apache.james.apache-mime4j>
         <version.org.apache.kafka>3.6.0</version.org.apache.kafka>
-        <version.org.apache.lucene>8.11.2</version.org.apache.lucene>
+        <version.org.apache.lucene>9.8.0</version.org.apache.lucene>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.3</version.org.apache.santuario>

--- a/preview/galleon-local/pom.xml
+++ b/preview/galleon-local/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
         </dependency>
 
         <dependency>

--- a/preview/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
+++ b/preview/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
@@ -26,6 +26,6 @@
 
         <!-- This package is the difference between this WildFly Preview version of the layer
              and the one in standard WildFly. Standard WildFly does not provide this module. -->
-        <package name="org.hibernate.search.mapper.orm.coordination.outboxpolling" optional="true"/>
+        <package name="org.hibernate.search.mapper.orm.outboxpolling" optional="true"/>
     </packages>
 </layer-spec>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/coordination/outboxpolling/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/coordination/outboxpolling/main/module.xml
@@ -4,23 +4,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<!-- Hibernate Search ORM Mapper - Coordination through outbox-polling:
-     Hibernate ORM integration using outbox polling as coordination strategy
-     for automatic indexing -->
-<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.orm.coordination.outboxpolling">
-
-    <resources>
-        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm-outbox-polling}"/>
-    </resources>
-
-    <dependencies>
-        <module name="jakarta.persistence.api"/>
-        <module name="jakarta.transaction.api"/>
-        <module name="org.jboss.logging" />
-        <module name="org.hibernate" />
-        <module name="org.hibernate.search.engine" export="true" />
-        <module name="org.hibernate.search.mapper.pojo" export="true" />
-        <module name="org.hibernate.search.mapper.orm" export="true" />
-        <module name="org.apache.avro" />
-    </dependencies>
-</module>
+<!-- The module was renamed in Hibernate Search 7.0. -->
+<module-alias xmlns="urn:jboss:module:1.9"
+              name="org.hibernate.search.mapper.orm.coordination.outboxpolling"
+              target-name="org.hibernate.search.mapper.orm.outboxpolling" />

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/coordination/outboxpolling/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/coordination/outboxpolling/main/module.xml
@@ -10,7 +10,7 @@
 <module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.orm.coordination.outboxpolling">
 
     <resources>
-        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm-coordination-outbox-polling-orm6}"/>
+        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm-outbox-polling}"/>
     </resources>
 
     <dependencies>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/outboxpolling/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/outboxpolling/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Hibernate Search ORM Mapper - Coordination through outbox-polling:
+     Hibernate ORM integration using outbox polling as coordination strategy
+     for automatic indexing -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.orm.outboxpolling">
+
+    <resources>
+        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm-outbox-polling}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="org.jboss.logging" />
+        <module name="org.hibernate" />
+        <module name="org.hibernate.search.engine" export="true" />
+        <module name="org.hibernate.search.mapper.pojo" export="true" />
+        <module name="org.hibernate.search.mapper.orm" export="true" />
+        <module name="org.apache.avro" />
+    </dependencies>
+</module>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -251,7 +251,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- The following are required at for JAXB on Java 11 -->

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -360,7 +360,7 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -370,7 +370,7 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-v5migrationhelper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -845,7 +845,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.hibernate.search</groupId>
-                                    <artifactId>hibernate-search-v5migrationhelper-orm-orm6</artifactId>
+                                    <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
                                     <version>${version.org.hibernate.search}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -14,7 +14,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.10.2";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.11.1";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -78,12 +78,12 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
-            <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
+            <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* [WFLY-18806](https://issues.redhat.com/browse/WFLY-18806): Upgrade to Lucene 9.8
* [WFLY-18805](https://issues.redhat.com/browse/WFLY-18805): Upgrade to Elasticsearch client 8.11
* [WFLY-18804](https://issues.redhat.com/browse/WFLY-18804): Upgrade to Hibernate Search 7.0

Creating as draft, because:

* ~~This only upgrades to Hibernate Search 7.0.0.CR2; the Final hasn't been released yet.~~ => Fixed
* We need to upgrade to Hibernate ORM 6.4 first (and probably at the same time, since Hibernate Search 6.2 isn't officially compatible with Hibernate ORM 6.4).