### PR TITLE
[WFLY-18800] Remove un-needed mechanism-configurations parameter from CLIENT_CERT example

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -640,7 +640,7 @@ principal from _ksRealm_ but other approaches may also be used.
 
 [source,options="nowrap"]
 ----
-/subsystem=elytron/http-authentication-factory=exampleCertHttpAuth:add(http-server-mechanism-factory=global,security-domain=exampleCertSD,mechanism-configurations=[{mechanism-name=CLIENT_CERT,mechanism-realm-configurations=[{realm-name=exampleApplicationDomain}]}])
+/subsystem=elytron/http-authentication-factory=exampleCertHttpAuth:add(http-server-mechanism-factory=global,security-domain=exampleCertSD,mechanism-configurations=[{mechanism-name=CLIENT_CERT}])
 ----
 
 [[configure-an-application-security-domain-in-the-undertow-subsystem.]]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18800
