### PR TITLE
[WFLY-18729]: Upgrade Netty from 4.1.100.Final to 4.1.104.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
         <version.io.agroal>2.0</version.io.agroal>
         <version.io.grpc>1.58.0</version.io.grpc>
         <version.io.micrometer>1.12.0</version.io.micrometer>
-        <version.io.netty>4.1.100.Final</version.io.netty>
+        <version.io.netty>4.1.104.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.29.0</version.io.opentelemetry.opentelemetry>
         <version.io.opentelemetry.proto>0.20.0-alpha</version.io.opentelemetry.proto>
         <version.io.opentelemetry.opentelemetry-semconv>1.21.0-alpha</version.io.opentelemetry.opentelemetry-semconv>
@@ -526,7 +526,7 @@
         <version.org.jboss.ws.cxf>7.0.0.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>2.0.0.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>5.0.0.Final</version.org.jboss.ws.spi>
-        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
         <version.org.jgroups>5.2.19.Final</version.org.jgroups>
         <version.org.jgroups.aws>3.0.0.Final</version.org.jgroups.aws>


### PR DESCRIPTION
 * Upgrade netty from 4.1.100.Final to 4.1.104.Final
 * Upgrade netty-xnio-transport from 0.1.09 to 0.1.10 for netty compatibility.

Issue: https://issues.redhat.com/browse/WFLY-18729