### PR TITLE
Fix for WFLY-18897, testsuite manual-expansion is missing the parsson dependency

### DIFF
--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -73,6 +73,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-test-runner</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Issue:  https://issues.redhat.com/browse/WFLY-18897

This is to fix the impact of removing parsson dependency from WildFly core CLI. As this PR shows https://github.com/wildfly/wildfly-core/pull/5819, the testsuite/integration/manual-expansion requires the parsson dependency that is currently resolved from CLI dependency. 

Making the dependency explicit.

