### PR TITLE
[WFLY-18906] Upgrade WildFly Core to 23.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>23.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.0.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue:

https://issues.redhat.com/browse/WFLY-18906


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.0.Beta5
Diff: https://github.com/wildfly/wildfly-core/compare/23.0.0.Beta4...23.0.0.Beta5

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6646'>WFCORE-6646</a>] -         Can&#39;t undefine &quot;use-identity-roles&quot; of /core-service=management/access=authorization
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6651'>WFCORE-6651</a>] -         Extension implementation in wildfly-subsystem should only register parsers enabled by the current stability level
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6653'>WFCORE-6653</a>] -         Missing maven-repo-files description on the help of management CLI installer command
</li>
</ul>
                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6654'>WFCORE-6654</a>] -         Upgrade WildFly Galleon plugins to 6.5.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6660'>WFCORE-6660</a>] -         Upgrade log4j2 from 2.22.0 to 2.22.1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6347'>WFCORE-6347</a>] -         Port subsystem development enhancements from wildfly-clustering-common to wildfly-core
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6635'>WFCORE-6635</a>] -         Make org.wildfly.core.launcher.* more extensible
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6648'>WFCORE-6648</a>] -         Mark &quot;read-config-as-xml&quot; as deprecated on Community stream 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6649'>WFCORE-6649</a>] -         Should --no-resolve-local-cache be the default
</li>
</ul>
</details>

