### PR TITLE
WFLY-18922 Give the Apache Lucene module access to jdk.management

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -25,6 +25,7 @@
 
     <dependencies>
         <module name="java.logging"/>
+        <module name="jdk.management"/> <!-- WFLY-18922: necessary for Lucene's memory usage estimates -->
         <module name="com.carrotsearch.hppc" />
         <module name="java.xml"/>
     </dependencies>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18922

I checked manually (through debug mode and by checking `server.log`) that this solves the problem: `org.apache.lucene.util.RamUsageEstimator` now has access to what it needs and no longer logs a warning.