### PR TITLE
Revert "[WFLY-15426] Temporarily disabling WS RM test"

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsrm/ReliableServiceTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsrm/ReliableServiceTestCase.java
@@ -20,7 +20,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.wsf.stack.cxf.client.UseNewBusFeature;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,7 +28,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("[WFLY-15426] Fix failing ReliableServiceTestCase")
 public class ReliableServiceTestCase {
 
     private static final Logger log = Logger.getLogger(ReliableServiceTestCase.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15426

Reading the comment from @jimma at https://issues.redhat.com/browse/WFLY-15426?focusedId=22777343&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22777343 I get the impression this ignored test might pass now, so, let's see what happens when the ignore is reverted.