### PR TITLE
[WFLY-18930][WFLY-18931] Upgrade mvc-krazo integration to 0.8.2.Final; fix observability layer doc

### DIFF
--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -481,6 +481,7 @@ link:#gal.base-server[base-server] +
 |
 link:#gal.microprofile-config[microprofile-config] (optional) +
 link:#gal.microprofile-health[microprofile-health] (optional) +
+link:#gal.microprofile-telemetry[microprofile-telemetry] (optional) +
 
 |[[gal.opentelemetry]]opentelemetry
 |Support for OpenTelemetry

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -469,6 +469,7 @@ link:#gal.web-server[web-server] +
 link:#gal.bean-validation[bean-validation] +
 link:#gal.cdi[cdi] +
 link:#gal.jaxrs-core[jaxrs-core] +
+link:#gal.jsf[jsf] (optional) +
 
 |[[gal.naming]]naming
 |Support for JNDI.

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.core>23.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
-        <preview.version.org.wildfly.mvc.krazo>0.8.0.Final</preview.version.org.wildfly.mvc.krazo>
+        <preview.version.org.wildfly.mvc.krazo>0.8.2.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.transaction.client>3.0.3.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18930

Since ^^^ touches the Galleon_layers.adoc file, I noticed and also fixed https://issues.redhat.com/browse/WFLY-18931