### PR TITLE
[WFLY-18934] Upgrade WildFly Core to 23.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>23.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.0.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-18934

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/23.0.0.Beta5...23.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6531'>WFCORE-6531</a>] -         standalone.sh and possibly other scripts usage of eval
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6538'>WFCORE-6538</a>] -         KerberosNativeMgmtSaslTestCase.testGs2Krb5OverSsl intermittently fails
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6656'>WFCORE-6656</a>] -         CLI, shaded jar can&#39;t start embedded when logging json formater configured
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6665'>WFCORE-6665</a>] -         Missing http-upgrade-service when running Domain Mode test suite
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6669'>WFCORE-6669</a>] -         Various tests fail when env specifies JDK_JAVA_OPTIONS or JAVA_TOOL_OPTIONS
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5775'>WFCORE-5775</a>] -         Remove the org.wildfly.management.expression-resolver-extension-registry
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6627'>WFCORE-6627</a>] -         Make use of the SetRequestInformationCallbackServerMechanismFactory to set the request information during HTTP authentication
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6658'>WFCORE-6658</a>] -         Convert ControlledProcessStateService to the current MSC API
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6664'>WFCORE-6664</a>] -         Upgrade SLF4J from 2.0.9 to 2.0.11
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6667'>WFCORE-6667</a>] -         Upgrade WildFly Elytron to 2.2.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6176'>WFCORE-6176</a>] -         Replace AbstractAddStepHandler.Parameters.addRuntimeCapability with a fit to purpose API
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6347'>WFCORE-6347</a>] -         Port subsystem development enhancements from wildfly-clustering-common to wildfly-core
</li>
</ul>
</details>