### PR TITLE
[WFLY-18855] MicroProfile spec support table is out of date

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -112,24 +112,15 @@ WildFly {wildflyVersion} also provides support for a number of MicroProfile tech
 [cols=",,",options="header"]
 |=======================================================================
 |MicroProfile Technology |WildFly {wildflyVersion} Default Configuration |WildFly {wildflyVersion} MicroProfile Configuration
-
-|MicroProfile Config 3.0 |X |X
-
+|MicroProfile Config 3.1 |X |X
 |MicroProfile Fault Tolerance 4.0 |-- |X
-
 |MicroProfile Health 4.0 |-- |X
-
-|MicroProfile JWT Authentication 2.0 |X |X
-
-|MicroProfile Metrics 4.0 (deprecated in WildFly; will be replaced by link:Admin_Guide{outfilesuffix}#Micrometer_Metrics[Micrometer]) |-- |X
-
-|MicroProfile OpenAPI 3.0 |-- |X
-
+|MicroProfile JWT Authentication 2.1 |X |X
+|MicroProfile OpenAPI 3.1 |-- |X
 |MicroProfile Reactive Messaging 3.0 |-- |--
-
-|MicroProfile Streams Operators 3.0 |-- |--
-
 |MicroProfile Rest Client 3.0|X |X
+|MicroProfile Streams Operators 3.0 |-- |--
+|MicroProfile Telemetry 1.1|--|X
 
 |=======================================================================
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18855

Remove entry for MP Metrics
Add entry for MP Telemetry
Update versions for other specs