### PR TITLE
[WFLY-18937] Add git log data to the shared-wildfly-build.yml output

### DIFF
--- a/.github/workflows/shared-wildfly-build.yml
+++ b/.github/workflows/shared-wildfly-build.yml
@@ -58,6 +58,11 @@ on:
         required: true
         default: "wildfly/wildfly"
         type: string
+      git-log-number:
+        description: "Number of commits to display"
+        required: false
+        default: 5
+        type: number
 
 jobs:
   wildfly-build:
@@ -70,12 +75,15 @@ jobs:
         with:
           repository: ${{ inputs.wildfly-repo }}
           ref: ${{ inputs.wildfly-branch }}
+          fetch-depth: ${{ inputs.git-log-number }}
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
+      - name: Show Git commit logs
+        run: git log -n ${{ inputs.git-log-number }}
       - name: Build WildFly
         run: mvn -B clean install -DskipTests -Dcheckstyle.skip=true -Denforcer.skip=true
       - id: version


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18937 

[WFLY-18937] Add git log data to the shared-wildfly-build.yml output

https://github.com/soul2zimate/wildfly/actions/runs/7623464104/job/20763551236 step `Show Git commit logs` is a manual run to show top 10 commits.
