### PR TITLE
[WFLY-18940] Upgrade WildFly Core to 23.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>23.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.0.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-18940

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/23.0.0.Final...23.0.1.Final

---

<details>
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6676'>WFCORE-6676</a>] -         CVE-2023-48795 Upgrade SSHD from 2.11.0 to 2.12.0
</li>
</ul>
</details>