### PR TITLE
[WFLY-18954] Deprecate javaee.api module in favor of wildflyee.api module

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
@@ -4,9 +4,22 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<!--
-    END USER MODULE USAGE: Alias for a private module.
-
-    This module is an alias for a private module and may be removed at any time.
--->
 <module-alias xmlns="urn:jboss:module:1.9" name="javaee.api" target-name="wildflyee.api"/>
+<!--
+     WARNING: This module is DEPRECATED and will be removed in a future release.
+
+     References to this module should be changed to the 'wildflyee.api' module for
+     which this module is an alias.
+
+     Note that despite its name this module does not expose javax.* package namespace
+     APIs from Jakarta EE 8 or earlier. It exposes the jakarta.* package namespace
+     APIs from the module it aliases.
+
+     This module only exists to ease migration from the old javax.* namespace to
+     the current jakarta.* namespace by allowing references to the old module names
+     to temporarily work. Such references should be updated.
+
+     (Note that an xml comment is used here instead of the usual 'jboss.api=deprecated'
+     property child element only because the 'module-alias' element and associated
+     Java classes do not support property child elements.)
+-->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18954

Upstream PR: https://github.com/wildfly/wildfly/pull/17560
