### PR TITLE
[WFLY-18969] Give the Apache Lucene module access to jdk.unsupported

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -25,8 +25,9 @@
 
     <dependencies>
         <module name="java.logging"/>
-        <module name="jdk.management"/> <!-- WFLY-18922: necessary for Lucene's memory usage estimates -->
-        <module name="com.carrotsearch.hppc" />
         <module name="java.xml"/>
+        <module name="jdk.management"/>
+        <module name="jdk.unsupported"/>
+        <module name="com.carrotsearch.hppc" />
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18969

Upstream PR: https://github.com/wildfly/wildfly/pull/17566
