### PR TITLE
WFLY-18966: bump licenses-plugin to 2.4.1.Final, delete unneeded entries

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/license/licenses.xml
@@ -55,33 +55,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
-            <licenses>
-                <license>
-                    <name>BSD 3-Clause "New" or "Revised" License</name>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <licenses>
-                <license>
-                    <name>BSD 3-Clause "New" or "Revised" License</name>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>stax2-api</artifactId>
-            <licenses>
-                <license>
-                    <name>BSD 2-clause "Simplified" License</name>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <groupId>org.cryptacular</groupId>
             <artifactId>cryptacular</artifactId>
             <licenses>

--- a/galleon-pack/galleon-shared/src/main/resources/license/licenses.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/license/licenses.xml
@@ -5,15 +5,5 @@
   -->
 
 <licenseSummary>
-    <dependencies>
-        <dependency>
-            <groupId>com.github.luben</groupId>
-            <artifactId>zstd-jni</artifactId>
-            <licenses>
-                <license>
-                    <name>BSD 2-clause "Simplified" License</name>
-                </license>
-            </licenses>
-        </dependency>
-    </dependencies>
+    <dependencies />
 </licenseSummary>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>6.5.4.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>10.0.0.Final</version.org.wildfly.jar.plugin>
-        <version.org.wildfly.licenses.plugin>2.4.0.Final</version.org.wildfly.licenses.plugin>
+        <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>4.2.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
         <version.xml.plugin>1.0.2</version.xml.plugin>


### PR DESCRIPTION
Issue: [WFLY-18966](https://issues.redhat.com/browse/WFLY-18966)