### PR TITLE
WFLY-19029 Hibernate ORM 6.4+ should export services to consumer classpath

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
@@ -23,7 +23,7 @@
         <module name="jakarta.validation.api"/>
         <module name="jakarta.xml.bind.api"/>
 
-        <module name="org.hibernate"/>
+        <module name="org.hibernate" services="import"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.infinispan.core" services="import"/>
         <module name="org.infinispan.protostream"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -44,4 +44,11 @@
         <!-- If the PostgreSQL JDBC driver classes are accessible, Hibernate ORM will use them to tailor PostgresDialect and CockroachDialect behavior -->
         <module name="org.postgresql.jdbc" optional="true"/>
     </dependencies>
+
+    <provides>
+        <service name="org.hibernate.bytecode.spi.BytecodeProvider">
+            <with-class name="org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl"/>
+        </service>
+    </provides>
+
 </module>


### PR DESCRIPTION
[ Updated, this is now [https://issues.redhat.com/browse/WFLY-19029](https://issues.redhat.com/browse/WFLY-19029) ]

Hi @scottmarlow , leaving this as a draft here:

@mbladel has a fix in Hibernate ORM which you'll also need (so this should be adapted as ORM version 6.4.4 is released)

My changes to the modules here are not strictly required to make those failing tests pass, but I'd still recommend including these so as to ensure the services are loaded even when ORM is being initialized in some other way, e.g. by a 3rd party framework.

See also:
 - https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/Adapting.20WildFly.20module.20for.20Hibernate.20ORM
 - https://hibernate.atlassian.net/browse/HHH-17705