### PR TITLE
[WFLY-18997] Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in connector subsystem

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionAnnotationProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionAnnotationProcessor.java
@@ -28,12 +28,6 @@ public class ConnectionFactoryDefinitionAnnotationProcessor extends ResourceDefi
     private static final DotName CONNECTION_FACTORY_DEFINITION = DotName.createSimple(ConnectionFactoryDefinition.class.getName());
     private static final DotName CONNECTION_FACTORY_DEFINITIONS = DotName.createSimple(ConnectionFactoryDefinitions.class.getName());
 
-    private final boolean legacySecurityAvailable;
-
-    public ConnectionFactoryDefinitionAnnotationProcessor(boolean legacySecurityAvailable) {
-        this.legacySecurityAvailable = legacySecurityAvailable;
-    }
-
     @Override
     protected DotName getAnnotationDotName() {
         return CONNECTION_FACTORY_DEFINITION;
@@ -61,7 +55,6 @@ public class ConnectionFactoryDefinitionAnnotationProcessor extends ResourceDefi
                 AnnotationElement.PROPERTIES));
         directConnectionFactoryInjectionSource.setTransactionSupportLevel(asTransactionSupportLocal(annotationInstance,
                 ConnectionFactoryDefinitionInjectionSource.TRANSACTION_SUPPORT));
-        directConnectionFactoryInjectionSource.setLegacySecurityAvailable(legacySecurityAvailable);
         return directConnectionFactoryInjectionSource;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionDescriptorProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionDescriptorProcessor.java
@@ -23,12 +23,6 @@ import static org.jboss.as.ee.logging.EeLogger.ROOT_LOGGER;
  */
 public class ConnectionFactoryDefinitionDescriptorProcessor extends ResourceDefinitionDescriptorProcessor {
 
-    private final boolean legacySecurityAvailable;
-
-    public ConnectionFactoryDefinitionDescriptorProcessor(boolean legacySecurityAvailable) {
-        this.legacySecurityAvailable = legacySecurityAvailable;
-    }
-
     @Override
     protected void processEnvironment(RemoteEnvironment environment, ResourceDefinitionInjectionSources injectionSources) throws DeploymentUnitProcessingException {
         final ConnectionFactoriesMetaData metaDatas = environment.getConnectionFactories();
@@ -72,7 +66,6 @@ public class ConnectionFactoryDefinitionDescriptorProcessor extends ResourceDefi
                     break;
             }
         }
-        resourceDefinitionInjectionSource.setLegacySecurityAvailable(legacySecurityAvailable);
         resourceDefinitionInjectionSource.addProperties(metaData.getProperties());
         return resourceDefinitionInjectionSource;
     }

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionInjectionSource.java
@@ -52,8 +52,6 @@ public class ConnectionFactoryDefinitionInjectionSource extends ResourceDefiniti
 
     private TransactionSupport.TransactionSupportLevel transactionSupport;
 
-    private boolean legacySecurityAvailable;
-
     public ConnectionFactoryDefinitionInjectionSource(final String jndiName, final String interfaceName, final String resourceAdapter) {
         super(jndiName);
         this.interfaceName = interfaceName;
@@ -85,7 +83,7 @@ public class ConnectionFactoryDefinitionInjectionSource extends ResourceDefiniti
         DirectConnectionFactoryActivatorService service = new DirectConnectionFactoryActivatorService(jndiName, interfaceName, resourceAdapter,
                                                                     raId, maxPoolSize, minPoolSize,
                                                                     properties, transactionSupport,
-                                                                    module, bindInfo, legacySecurityAvailable);
+                                                                    module, bindInfo);
         ServiceName serviceName =  DirectConnectionFactoryActivatorService.SERVICE_NAME_BASE.append(jndiName);
         final ServiceBuilder sb = phaseContext.getServiceTarget().addService(serviceName, service);
         sb.addDependency(ConnectorServices.IRONJACAMAR_MDR, AS7MetadataRepository.class, service.getMdrInjector());
@@ -144,10 +142,6 @@ public class ConnectionFactoryDefinitionInjectionSource extends ResourceDefiniti
 
     public void setTransactionSupportLevel(TransactionSupport.TransactionSupportLevel transactionSupport) {
         this.transactionSupport = transactionSupport;
-    }
-
-    public void setLegacySecurityAvailable(boolean legacySecurityAvailable) {
-        this.legacySecurityAvailable = legacySecurityAvailable;
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
@@ -41,12 +41,10 @@ import org.jboss.msc.service.ServiceTarget;
 public class RaDeploymentActivator {
 
     private final boolean appclient;
-    private final boolean legacySecurityAvailable;
     private final MdrService mdrService = new MdrService();
 
-    public RaDeploymentActivator(final boolean appclient, final boolean legacySecurityAvailable) {
+    public RaDeploymentActivator(final boolean appclient) {
         this.appclient = appclient;
-        this.legacySecurityAvailable = legacySecurityAvailable;
     }
 
     public void activateServices(final ServiceTarget serviceTarget) {
@@ -87,7 +85,7 @@ public class RaDeploymentActivator {
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_IRON_JACAMAR_DEPLOYMENT,
                 new IronJacamarDeploymentParsingProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RESOURCE_DEF_ANNOTATION_CONNECTION_FACTORY,
-                new ConnectionFactoryDefinitionAnnotationProcessor(legacySecurityAvailable));
+                new ConnectionFactoryDefinitionAnnotationProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RESOURCE_DEF_ANNOTATION_ADMINISTERED_OBJECT,
                 new AdministeredObjectDefinitionAnnotationProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_RAR_CONFIG, new RarDependencyProcessor());
@@ -95,7 +93,7 @@ public class RaDeploymentActivator {
         if (!appclient)
             updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_RAR_SERVICES_DEPS, new RaXmlDependencyProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_RESOURCE_DEF_XML_CONNECTION_FACTORY,
-                new ConnectionFactoryDefinitionDescriptorProcessor(legacySecurityAvailable));
+                new ConnectionFactoryDefinitionDescriptorProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_RESOURCE_DEF_XML_ADMINISTERED_OBJECT,
                 new AdministeredObjectDefinitionDescriptorProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_RA_NATIVE, new RaNativeProcessor());

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
@@ -73,15 +73,13 @@ public class DirectConnectionFactoryActivatorService implements org.jboss.msc.se
 
     private final ContextNames.BindInfo bindInfo;
 
-    private boolean legacySecurityAvailable;
-
     /**
      * create an instance *
      */
     public DirectConnectionFactoryActivatorService(String jndiName, String interfaceName, String resourceAdapter,
                                                    String raId, int maxPoolSize, int minPoolSize,
                                                    Map<String, String> properties, TransactionSupport.TransactionSupportLevel transactionSupport,
-                                                   Module module, ContextNames.BindInfo bindInfo, boolean legacySecurityAvailable) {
+                                                   Module module, ContextNames.BindInfo bindInfo) {
         this.jndiName = jndiName;
         this.interfaceName = interfaceName;
         this.resourceAdapter = resourceAdapter;
@@ -94,7 +92,6 @@ public class DirectConnectionFactoryActivatorService implements org.jboss.msc.se
         this.transactionSupport = transactionSupport;
         this.module = module;
         this.bindInfo = bindInfo;
-        this.legacySecurityAvailable = legacySecurityAvailable;
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -50,8 +50,7 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) {
         final boolean appclient = context.getProcessType() == ProcessType.APPLICATION_CLIENT;
-        final boolean legacySecurityAvailable = context.getCapabilityServiceSupport().hasCapability("org.wildfly.legacy-security");
-        final RaDeploymentActivator raDeploymentActivator = new RaDeploymentActivator(appclient, legacySecurityAvailable);
+        final RaDeploymentActivator raDeploymentActivator = new RaDeploymentActivator(appclient);
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 raDeploymentActivator.activateProcessors(processorTarget);

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -174,7 +174,6 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
             cfdis.setMaxPoolSize(maxPoolSize);
             cfdis.setMinPoolSize(minPoolSize);
             cfdis.setTransactionSupportLevel(transactional ? TransactionSupport.TransactionSupportLevel.XATransaction : TransactionSupport.TransactionSupportLevel.NoTransaction);
-            cfdis.setLegacySecurityAvailable(legacySecurityAvailable);
             // transfer all the generic properties + the additional properties specific to the JMSConnectionFactoryDefinition
             for (Map.Entry<String, String> property : properties.entrySet()) {
                 cfdis.addProperty(property.getKey(), property.getValue());


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19006

Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in connector subsystem