### PR TITLE
[WFLY-19009] Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in undertow subsystem

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
@@ -37,7 +37,6 @@ public final class Capabilities {
      */
 
     public static final String REF_IO_WORKER = "org.wildfly.io.worker";
-    public static final String REF_LEGACY_SECURITY = "org.wildfly.legacy-security";
     public static final String REF_SECURITY_DOMAIN = "org.wildfly.security.security-domain";
     public static final String REF_SOCKET_BINDING = "org.wildfly.network.socket-binding";
     public static final String REF_SSL_CONTEXT = "org.wildfly.security.ssl-context";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/SecurityDomainResolvingProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/SecurityDomainResolvingProcessor.java
@@ -6,12 +6,10 @@
 package org.wildfly.extension.undertow.deployment;
 
 import static org.jboss.as.server.security.SecurityMetaData.ATTACHMENT_KEY;
-import static org.wildfly.extension.undertow.Capabilities.REF_LEGACY_SECURITY;
 import static org.wildfly.extension.undertow.deployment.UndertowAttachments.RESOLVED_SECURITY_DOMAIN;
 
 import java.util.function.Predicate;
 
-import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -77,16 +75,8 @@ public class SecurityDomainResolvingProcessor implements DeploymentUnitProcessor
                     securityMetaData.setSecurityDomain(securityDomainName);
                 }
                 deploymentUnit.putAttachment(RESOLVED_SECURITY_DOMAIN, securityDomain);
-            } else if (legacySecurityInstalled(deploymentUnit)) {
-                deploymentUnit.putAttachment(RESOLVED_SECURITY_DOMAIN, securityDomain);
             }
         }
-    }
-
-    private static boolean legacySecurityInstalled(final DeploymentUnit deploymentUnit) {
-        final CapabilityServiceSupport capabilities = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-
-        return capabilities.hasCapability(REF_LEGACY_SECURITY);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -9,7 +9,6 @@ import static org.jboss.as.ee.component.Attachments.STARTUP_COUNTDOWN;
 import static org.jboss.as.server.security.SecurityMetaData.ATTACHMENT_KEY;
 import static org.jboss.as.server.security.VirtualDomainMarkerUtility.isVirtualDomainRequired;
 import static org.jboss.as.web.common.VirtualHttpServerMechanismFactoryMarkerUtility.isVirtualMechanismFactoryRequired;
-import static org.wildfly.extension.undertow.Capabilities.REF_LEGACY_SECURITY;
 import static org.wildfly.extension.undertow.logging.UndertowLogger.ROOT_LOGGER;
 
 import java.net.MalformedURLException;
@@ -442,8 +441,7 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor, Fun
 
         // adding Jakarta Authorization service
         final boolean elytronJacc = capabilitySupport.hasCapability(ELYTRON_JACC_CAPABILITY_NAME);
-        final boolean legacyJacc = !elytronJacc && capabilitySupport.hasCapability(REF_LEGACY_SECURITY);
-        if(legacyJacc || elytronJacc) {
+        if(elytronJacc) {
             WarJACCDeployer deployer = new WarJACCDeployer();
             JaccService<WarMetaData> jaccService = deployer.deploy(deploymentUnit, jaccContextId);
             if (jaccService != null) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19009

[WFLY-19009] Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in undertow subsystem