### PR TITLE
WFLY-19020 Application client applications should be able to deploy persistence units

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -64,10 +64,8 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
     private static final String JAR_FILE_EXTENSION = ".jar";
     private static final String LIB_FOLDER = "lib";
 
-    private final boolean appClientContainerMode;
+    public PersistenceUnitParseProcessor() {
 
-    public PersistenceUnitParseProcessor(boolean appclient) {
-        appClientContainerMode = appclient;
     }
 
     @Override
@@ -84,8 +82,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
     private void handleJarDeployment(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        if (!isEarDeployment(deploymentUnit) && !isWarDeployment(deploymentUnit) &&
-                (!appClientContainerMode || DeploymentTypeMarker.isType(DeploymentType.APPLICATION_CLIENT, deploymentUnit)) ) {
+        if (!isEarDeployment(deploymentUnit) && !isWarDeployment(deploymentUnit) ) {
 
             // handle META-INF/persistence.xml
             // ordered list of PUs
@@ -108,7 +105,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
     private void handleWarDeployment(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        if (!appClientContainerMode && isWarDeployment(deploymentUnit)) {
+        if (isWarDeployment(deploymentUnit)) {
 
             int puCount;
             // ordered list of PUs

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -75,7 +75,7 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
                         new JBossAllXmlParserRegisteringProcessor<>(JPAJarJBossAllParser.ROOT_ELEMENT, JpaAttachments.DEPLOYMENT_SETTINGS_KEY, new JPAJarJBossAllParser()));
 
                 // handles parsing of persistence.xml
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor(appclient));
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor());
 
                 // handles persistence unit / context annotations in components
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_PERSISTENCE_ANNOTATION, new JPAAnnotationProcessor());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/Employee.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.appclient.basic;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase.java
@@ -8,6 +8,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.ee.appclient.util.AppClientWrapper;
+import org.jboss.as.test.integration.jpa.packaging.Employee;
+import org.jboss.as.test.integration.jpa.packaging.PersistenceUnitPackagingTestCase;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -39,6 +41,8 @@ public class SimpleApplicationClientTestCase extends AbstractSimpleApplicationCl
 
         final JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "lib.jar");
         lib.addClasses(AppClientSingletonRemote.class, AppClientWrapper.class, CallbackHandler.class);
+        lib.addClasses(Employee.class);
+        lib.addAsManifestResource(PersistenceUnitPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsLibrary(lib);
         final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejb.addClasses(SimpleApplicationClientTestCase.class, AppClientStateSingleton.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase2.java
@@ -8,6 +8,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.ee.appclient.util.AppClientWrapper;
+import org.jboss.as.test.integration.jpa.packaging.Employee;
+import org.jboss.as.test.integration.jpa.packaging.PersistenceUnitPackagingTestCase;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -39,6 +41,8 @@ public class SimpleApplicationClientTestCase2 extends AbstractSimpleApplicationC
 
         final JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "lib.jar");
         lib.addClasses(AppClientSingletonRemote.class, AppClientWrapper.class, CallbackHandler.class, ClientInterceptor.class);
+        lib.addClasses(Employee.class);
+        lib.addAsManifestResource(PersistenceUnitPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsLibrary(lib);
         final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejb.addClasses(SimpleApplicationClientTestCase2.class, AppClientStateSingleton.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/persistence.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="mainPu">
+        <description>Persistence Unit.</description>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="false"/>
+    <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+    <property name="wildfly.jpa.twophasebootstrap" value="true"/>
+    <property name="hibernate.cache.use_second_level_cache" value="true" />
+    <property name="jakarta.persistence.sharedCache.mode" value="ALL" />
+    <property name="hibernate.cache.use_query_cache" value="false"/>
+
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19020

Application client applications should be able to deploy persistence units (note that they won't have a second level cache enabled).