### PR TITLE
31.x - [WFLY-19010] Elytron registry is in common module

### DIFF
--- a/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/MicroProfileReactiveMessagingSubsystemDefinition.java
+++ b/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/MicroProfileReactiveMessagingSubsystemDefinition.java
@@ -89,7 +89,7 @@ public class MicroProfileReactiveMessagingSubsystemDefinition extends Persistent
         protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             super.performBoottime(context, operation, model);
 
-            installKafkaElytronSSLContextRegistryServiceIfPresent(context);
+            installElytronSSLContextRegistryServiceIfPresent(context);
 
             context.addStep(new AbstractDeploymentChainStep() {
                 @Override
@@ -113,12 +113,12 @@ public class MicroProfileReactiveMessagingSubsystemDefinition extends Persistent
             MicroProfileReactiveMessagingLogger.LOGGER.activatingSubsystem();
         }
 
-        private void installKafkaElytronSSLContextRegistryServiceIfPresent(OperationContext context) {
+        private void installElytronSSLContextRegistryServiceIfPresent(OperationContext context) {
             ClassLoader cl = WildFlySecurityManager.getClassLoaderPrivileged(this.getClass());
             if (cl instanceof ModuleClassLoader) {
                 ModuleLoader loader = ((ModuleClassLoader)cl).getModule().getModuleLoader();
                 try {
-                    loader.loadModule("org.wildfly.reactive.messaging.kafka");
+                    loader.loadModule("org.wildfly.reactive.messaging.common");
                     ElytronSSLContextRegistry.setServiceRegistry(context.getServiceRegistry(false));
                 } catch (ModuleLoadException e) {
                     // Ignore, it means the module is not available so we don't install the service


### PR DESCRIPTION
Without this if only the amqp connector is provisioned, and not kafka there will be an error configuring ssl

https://issues.redhat.com/browse/WFLY-19010