### PR TITLE
[WFLY-19028] Upgrade openjdk-orb to 10.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
         <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.0.4.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.0.Final</version.org.jboss.narayana>
-        <version.org.jboss.openjdk-orb>10.0.0.Final</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.7.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.5.Final</version.org.jboss.resteasy.microprofile>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19028

This upgrade is because JDK22 related modifications.

cc @ropalka 
