### PR TITLE
[WFLY-16545] Make the Jakarta REST @ApplicationPath, @Provider and @P…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -29,6 +29,8 @@
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.web-common"/>
+        <!-- Required for the stability level -->
+        <module name="org.jboss.as.version"/>
         <!-- Only used if capability org.wildfly.weld is available -->
         <module name="org.jboss.as.weld.common" optional="true"/>
         <module name="org.wildfly.extension.undertow"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CDIBean.java
@@ -4,9 +4,12 @@
  */
 package org.jboss.as.test.integration.jaxrs.integration.cdi;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 /**
  * @author Stuart Douglas
  */
+@ApplicationScoped
 public class CDIBean {
 
     public String message() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CdiInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/cdi/CdiInjectionTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.cdi;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Application;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ApplicationScoped
+public class CdiInjectionTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, CdiInjectionTestCase.class.getSimpleName() + ".war")
+                .add(new StringAsset("<beans bean-discovery-mode=\"annotated\"></beans>"), "WEB-INF/beans.xml")
+                .addClasses(CDIApplication.class, CDIProvider.class, CDIResource.class, CDIBean.class);
+    }
+
+    @Inject
+    private Instance<Application> applicationInstance;
+
+    @Inject
+    private Instance<CDIProvider> providerInstance;
+
+    @Inject
+    private Instance<CDIResource> resourceInstance;
+
+    @Test
+    public void checkApplication() {
+        Assert.assertNotNull(applicationInstance);
+        final Bean<Application> bean = applicationInstance.getHandle().getBean();
+        checkBean(bean, ApplicationScoped.class, CDIApplication.class);
+    }
+
+    @Test
+    public void checkProvider() {
+        Assert.assertNotNull(providerInstance);
+        final Bean<CDIProvider> bean = providerInstance.getHandle().getBean();
+        checkBean(bean, ApplicationScoped.class, CDIProvider.class);
+    }
+
+    @Test
+    public void checkResource() {
+        Assert.assertNotNull(resourceInstance);
+        final Bean<CDIResource> bean = resourceInstance.getHandle().getBean();
+        checkBean(bean, RequestScoped.class, CDIResource.class);
+        final Set<InjectionPoint> injectionPoints = bean.getInjectionPoints();
+        Assert.assertFalse("Expected the CDIBean to be injected into the CDIResource", injectionPoints.isEmpty());
+        final InjectionPoint ip = injectionPoints.iterator().next();
+        final Annotated annotated = ip.getAnnotated();
+        Assert.assertEquals(String.format("Expected the injection point of the CDIResource.bean to be %s", CDIBean.class), annotated.getBaseType(), CDIBean.class);
+    }
+
+    private void checkBean(final Bean<?> bean, final Class<? extends Annotation> expectedScope, final Class<?> exepctedBeanClass) {
+        Assert.assertNotNull(String.format("Expected a bean of type %s, but was null.", exepctedBeanClass.getName()), bean);
+        final Class<?> foundScope = bean.getScope();
+        Assert.assertEquals(String.format("Expected a scope of @%s for bean %s, but found @%s", expectedScope.getSimpleName(), expectedScope.getName(), foundScope.getSimpleName()), expectedScope, foundScope);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.as.test.integration.jaxrs.validator;
 
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
+
 import java.net.URL;
 
 import jakarta.ws.rs.ApplicationPath;
@@ -14,6 +16,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+import org.hibernate.validator.HibernateValidatorPermission;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -50,7 +53,11 @@ public class BeanValidationIntegrationTestCase {
                 ValidatorResource.class,
                 AnotherValidatorResource.class,
                 YetAnotherValidatorResource.class
-            );
+            )
+            .addAsManifestResource(createPermissionsXmlAsset(
+                    // Required for validation in CDI beans
+                    HibernateValidatorPermission.ACCESS_PRIVATE_MEMBERS
+            ), "permissions.xml");
     }
 
     @ArquillianResource

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestEjb.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/multimodule/TestEjb.java
@@ -6,11 +6,13 @@
 package org.wildfly.test.integration.microprofile.openapi.service.multimodule;
 
 import jakarta.ejb.Stateless;
+import jakarta.enterprise.context.Dependent;
 
 /**
  * @author Joachim Grimm
  */
 @Stateless
+@Dependent
 public class TestEjb {
 
     public TestResponse hello(TestRequest request) {

--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/common/WorkRestATResource.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/common/WorkRestATResource.java
@@ -32,7 +32,7 @@ import org.jboss.jbossts.star.util.TxStatusMediaType;
 import org.jboss.jbossts.star.util.TxSupport;
 
 @Path(WorkRestATResource.PATH_SEGMENT)
-public final class WorkRestATResource {
+public class WorkRestATResource {
 
     public static final String PATH_SEGMENT = "txresource";
 

--- a/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
@@ -5,6 +5,9 @@
 
 package org.jboss.as.weld;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
+import java.util.Map;
 import java.util.function.Supplier;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
@@ -93,5 +96,34 @@ public interface WeldCapability {
      * a call to this method, calls to {@code isWeldDeployment(DeploymentUnit unit)} will return true.
      */
     void markAsWeldDeployment(DeploymentUnit unit);
+
+    /**
+     * Allows adding bean defining annotations to Weld.
+     *
+     * @param annotation the annotation to add as a bean defining annotation
+     *
+     * @return this WeldCapability
+     */
+    default WeldCapability addBeanDefiningAnnotation(final Class<? extends Annotation> annotation) {
+        return addBeanDefiningAnnotation(annotation, annotation.isAnnotationPresent(Inherited.class));
+    }
+
+    /**
+     * Allows adding bean defining annotations to Weld.
+     *
+     * @param annotation the annotation to add as a bean defining annotation
+     * @param inherited  whether the annotation should be {@linkplain  java.lang.annotation.Inherited inherited} or not
+     *
+     * @return this WeldCapability
+     */
+    WeldCapability addBeanDefiningAnnotation(Class<? extends Annotation> annotation, boolean inherited);
+
+    /**
+     * An unmodifiable map of bean defining annotations. The key of the map is the FQCN of the annotation. The value
+     * indicates whether the annotation should be {@linkplain java.lang.annotation.Inherited inherited}.
+     *
+     * @return a map of bean defining annotations
+     */
+    Map<String, Boolean> getBeanDefiningAnnotations();
 
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
@@ -4,6 +4,9 @@
  */
 package org.jboss.as.weld;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.spi.BeanManager;
@@ -22,8 +25,11 @@ import org.jboss.msc.service.ServiceBuilder;
  */
 public class WeldCapabilityImpl implements WeldCapability {
     static final WeldCapability INSTANCE = new WeldCapabilityImpl();
+    private final Map<String, Boolean> annotations;
 
-    private WeldCapabilityImpl() {}
+    private WeldCapabilityImpl() {
+        annotations = new ConcurrentHashMap<>();
+    }
 
     @Override
     public void registerExtensionInstance(final Extension extension, final DeploymentUnit unit) {
@@ -49,6 +55,16 @@ public class WeldCapabilityImpl implements WeldCapability {
         }
 
         return serviceBuilder;
+    }
+    @Override
+    public WeldCapability addBeanDefiningAnnotation(final Class<? extends Annotation> annotation, final boolean inherited) {
+        annotations.put(annotation.getName(), inherited);
+        return this;
+    }
+
+    @Override
+    public Map<String, Boolean> getBeanDefiningAnnotations() {
+        return Map.copyOf(annotations);
     }
 
     public boolean isPartOfWeldDeployment(final DeploymentUnit unit) {


### PR DESCRIPTION
…ath bean defining annotations.

https://issues.redhat.com/browse/WFLY-16545

We are only doing this at a community stability level at this point as it's a change in behavior. Per the [11.2.3](https://jakarta.ee/specifications/restful-ws/3.1/jakarta-restful-ws-spec-3.1#cdi) Jakarta REST Specification:

> In a product that supports CDI, implementations MUST support the use of CDI-style Beans as root resource classes, providers and Application subclasses. Providers and Application subclasses MUST be singletons or use application scope.

In resteasy-cdi there is currently a CDI portable extension which adds the scope of the bean, if not already defined, to the resource, provider or application. In future versions of Jakarta REST the specific annotations; `@ApplicationPath`, `@Provider` and `@Path` will be defined as bean defining annotations. Part of this PR is planning ahead for that.