### PR TITLE
Add precision to a system property note in the admin guide

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Command_line_parameters.adoc
@@ -41,7 +41,7 @@ $JBOSS_HOME/bin/domain.sh --properties=/some/location/jboss.properties
 $JBOSS_HOME/bin/domain.sh -P=/some/location/jboss.properties
 ----
 
-Note however, that properties set this way are not processed as part of
+Note however, that properties set this way (`-D` and `-P`) are not processed as part of
 JVM launch. They are processed early in the boot process, but this
 mechanism should not be used for setting properties that control JVM
 behavior (e.g. java.net.perferIPv4Stack) or the behavior of the JBoss


### PR DESCRIPTION
This fell on my head when I tried to set the default locale with system properties like `user.language` by starting wildfly with `standalone.sh -Duser.language=en` since I interpreted the sentence to only refer to the -P option, not the -D option as well. I assumed that it was just appended to the JAVA_OPTS.

Thanks for submitting your Pull Request!

NOTE: I didn't create a JIRA issue for this minor change (yet). Should I do this anyway or is it fine the way it is? (In the former case I would also rewrite the commit message)

____
<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-0000](https://issues.redhat.com/browse/WFLY-0000)

<--- END OF WILDFLY GITHUB BOT REPORT --->