### PR TITLE
[31.x] [WFLY-19032] Upgrade snappy-java to 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,7 @@
         <preview.version.org.wildfly.wildfly-ee-9-deployment-transformer>1.0.0.Final</preview.version.org.wildfly.wildfly-ee-9-deployment-transformer>
         <version.software.amazon.awssdk>2.20.126</version.software.amazon.awssdk>
         <version.software.amazon.eventstream>1.0.1</version.software.amazon.eventstream>
-        <version.org.xerial.snappy.snappy-java>1.1.8.4</version.org.xerial.snappy.snappy-java>
+        <version.org.xerial.snappy.snappy-java>1.1.10.5</version.org.xerial.snappy.snappy-java>
         <version.sun.jaxb>${version.org.glassfish.jaxb}</version.sun.jaxb>
         <version.wsdl4j>1.6.3</version.wsdl4j>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
Upstream PR https://github.com/wildfly/wildfly/pull/17629
https://issues.redhat.com/browse/WFLY-19032
