### PR TITLE
[WFLY-18163] Make it possible to use JaasSecurityRealm via a custom-realm resource

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -9,26 +9,46 @@
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly28.0"/>
+        <param name="host-release" value="WildFly28.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly29.0"/>
+        <param name="host-release" value="WildFly29.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly30.0"/>
+        <param name="host-release" value="WildFly30.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly31.0"/>
+        <param name="host-release" value="WildFly31.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -10,30 +10,50 @@
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;]"/>
+               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly28.0"/>
+        <param name="host-release" value="WildFly28.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly29.0"/>
+        <param name="host-release" value="WildFly29.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly30.0"/>
+        <param name="host-release" value="WildFly30.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly31.0"/>
+        <param name="host-release" value="WildFly31.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -10,48 +10,54 @@
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly28.0"/>
         <param name="host-release" value="WildFly28.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly29.0"/>
         <param name="host-release" value="WildFly29.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly30.0"/>
         <param name="host-release" value="WildFly30.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly31.0"/>
+        <param name="host-release" value="WildFly31.0"/>
+        <param name="excluded-extensions"
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -72,7 +72,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
     private final boolean isFullDistribution = AssumeTestGroupUtil.isFullDistribution();
     private final boolean isPreviewGalleonPack = AssumeTestGroupUtil.isWildFlyPreview();
 
-    private static final String MAJOR = "31.";
+    private static final String MAJOR = "32.";
 
     /**
      * Maintains the list of expected extensions for each host-exclude name for previous releases.
@@ -198,7 +198,8 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.jboss.as.web"
                 ), true),
         WILDFLY_30_0("WildFly30.0", WILDFLY_29_0, List.of(), List.of(), true),
-        CURRENT(MAJOR, WILDFLY_30_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
+        WILDFLY_31_0("WildFly31.0", WILDFLY_30_0, List.of(), List.of(), true),
+        CURRENT(MAJOR, WILDFLY_31_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
 
         private static List<String> getCurrentAddedExtensions() {
             // If an extension is added to this list, also check if it is supplied only by wildfly-galleon-pack. If so, add it also

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -206,7 +206,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
             // to the internal mpExtensions Set defined on this class.
             // Don't add here extensions supplied only by the wildfly-preview-feature-pack because we are not tracking different releases
             // of wildfly preview. In such a case, add them to previewExtensions set defined below.
-            return List.of();
+            return List.of("org.wildfly.extension.elytron.jaas-realm");
         }
         private static List<String> getCurrentRemovedExtensions() {
             // TODO If we decide to remove these modules from WFP, uncomment this.

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JaasCustomRealmTest-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JaasCustomRealmTest-web.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <servlet>
+        <servlet-name>SimpleServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.security.common.servlets.SimpleServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>SimpleServlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Role1</web-resource-name>
+            <url-pattern>/role1</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role1</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Role2</web-resource-name>
+            <url-pattern>/role2</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role2</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>JAAS VIA CUSTOM REALM TEST</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>Role1</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Role2</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JaasCustomRealmTest.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/JaasCustomRealmTest.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.realm;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.cli.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.net.URL;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JaasCustomRealmTest {
+
+    @ClassRule
+    public static TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private static final String NAME = JaasCustomRealmTest.class.getSimpleName();
+
+    /**
+     * Creates WAR with a secured servlet and BASIC authentication configured in web.xml deployment descriptor.
+     */
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addClasses(SimpleServlet.class)
+                .addAsWebInfResource(JaasCustomRealmTest.class.getPackage(), NAME + "-web.xml", "web.xml")
+                .addAsWebInfResource(JaasCustomRealmTest.class.getPackage(), "jaas-jboss-web.xml", "jaas-jboss-web.xml");
+    }
+
+    @BeforeClass
+    public static void prepareSecurityRealmThatUsesJaasRealmViaCustomRealm() throws Exception {
+        Assume.assumeTrue("Galleon layer does not provide org.wildfly.extension.elytron.jaas-realm module", System.getProperty("ts.layers") == null);
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "testJaas.jar")
+                .addAsResource(new StringAsset("Dependencies: org.wildfly.security"), "META-INF/MANIFEST.MF")
+                .addClass(TestLoginModule.class)
+                .addClass(TestCallbackHandler.class);
+        File jarFile = new File(tmpDir.getRoot(), "testJaas.jar");
+        jar.as(ZipExporter.class).exportTo(jarFile, true);
+        CLIWrapper cli = new CLIWrapper(true);
+        // ignore error on windows where the testJaas.jar might exist from previous run
+        cli.sendLine("module add --name=jaasLoginModule "
+                + " --resources=" + jarFile.getAbsolutePath()
+                + " --dependencies=org.wildfly.security.elytron", true);
+        cli.sendLine("/subsystem=elytron/custom-realm=customJaasRealm:add(module=org.wildfly.extension.elytron.jaas-realm ," +
+                "class-name=org.wildfly.extension.elytron.JaasCustomSecurityRealmWrapper," +
+                "configuration={entry=Entry1," +
+                "module=jaasLoginModule," +
+                "callback-handler=org.wildfly.test.integration.elytron.realm.TestCallbackHandler," +
+                "path=" + JaasCustomRealmTest.class.getResource("jaas-login.config").getFile() + "})");
+        cli.sendLine("/subsystem=elytron/security-domain=JAASSecurityDomain:add(" +
+                "realms=[{realm=customJaasRealm}]," +
+                "default-realm=customJaasRealm,permission-mapper=default-permission-mapper)");
+        cli.sendLine("/subsystem=elytron/http-authentication-factory=example-fs-http-auth:add(http-server-mechanism-factory=global," +
+                "security-domain=JAASSecurityDomain,mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=customJaasRealm}]}])");
+        cli.sendLine("/subsystem=undertow/application-security-domain=JAASSecurityDomain:add(http-authentication-factory=example-fs-http-auth)");
+        cli.sendLine("reload");
+    }
+
+    @Test
+    public void testUser1Allowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role1");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password1", SC_OK);
+    }
+
+    @Test
+    public void testRoleRequired(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role2");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password1", SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testUser1NotAuthenticated(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role2");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "wrong_pass", SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testUser2NotAuthenticated(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role2");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user2", "wrong_pass", SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testRoleUser2Allowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role2");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user2", "password2", SC_OK);
+    }
+
+    @Test
+    public void testRoleUser2NotAllowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role1");
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED); // assert that auth is required
+        Utils.makeCallWithBasicAuthn(servletUrl, "user2", "password2", SC_FORBIDDEN);
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        if (System.getProperty("ts.layers") == null) {
+            CLIWrapper cli = new CLIWrapper(true);
+            cli.sendLine("/subsystem=undertow/application-security-domain=JAASSecurityDomain:remove");
+            cli.sendLine("/subsystem=elytron/http-authentication-factory=example-fs-http-auth:remove");
+            cli.sendLine("/subsystem=elytron/security-domain=JAASSecurityDomain:remove");
+            cli.sendLine("/subsystem=elytron/custom-realm=customJaasRealm:remove");
+            try {
+                cli.sendLine("module remove --name=" + "jaasLoginModule");
+            } catch (AssertionError e) {
+                // ignore failure on Windows, cannot remove module on running server due to file locks
+                if (!Util.isWindows())
+                    throw e;
+            }
+            cli.sendLine("reload");
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/TestCallbackHandler.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/TestCallbackHandler.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.realm;
+
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import java.security.Principal;
+
+/**
+ * A custom {@link CallbackHandler} used in the JAAS security realm tests. It implements the
+ * {@code setSecurityInfo} method that has been historically used to populate custom handlers. Also, its {@code handle}
+ * implementation will handle any kind of credential by calling {@code toString} and then {@code toCharArray} on the opaque
+ * object.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class TestCallbackHandler implements CallbackHandler {
+
+    private Principal principal;
+    private Evidence evidence;
+
+    public TestCallbackHandler() {
+    }
+
+    /**
+     * Sets this handler's state.
+     *
+     * @param principal the principal being authenticated.
+     * @param evidence the evidence being verified.
+     */
+    public void setSecurityInfo(final Principal principal, final Object evidence) {
+        this.principal = principal;
+        this.evidence = (Evidence) evidence;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        if (callbacks == null) {
+            throw new IllegalArgumentException("The callbacks argument cannot be null");
+        }
+
+        for (Callback callback : callbacks) {
+            if (callback instanceof NameCallback) {
+                NameCallback nameCallback = (NameCallback) callback;
+                if (principal != null)
+                    nameCallback.setName(this.principal.getName());
+            }
+            else if (callback instanceof PasswordCallback) {
+                PasswordCallback passwordCallback = (PasswordCallback) callback;
+                if (this.evidence instanceof PasswordGuessEvidence) {
+                    passwordCallback.setPassword(((PasswordGuessEvidence) this.evidence).getGuess());
+                }
+            }
+            else {
+                throw new UnsupportedCallbackException(callback, "Unsupported callback");
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/TestLoginModule.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/TestLoginModule.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.realm;
+
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link LoginModule} implementation used in the JAAS security realm via a custom realm tests.
+ * accepts only credentials user1 with password1 and this user has role Role1
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class TestLoginModule implements LoginModule {
+
+    private final Map<String, char[]> usersMap = new HashMap<>();
+    private Subject subject;
+    private CallbackHandler handler;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+        this.handler = callbackHandler;
+        this.usersMap.put("user1", "password1".toCharArray());
+        this.usersMap.put("user2", "password2".toCharArray());
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        // obtain the incoming username and password from the callback handler
+        NameCallback nameCallback = new NameCallback("Username");
+        PasswordCallback passwordCallback = new PasswordCallback("Password", false);
+        Callback[] callbacks = new Callback[]{nameCallback, passwordCallback};
+        try {
+            this.handler.handle(callbacks);
+        } catch (UnsupportedCallbackException | IOException e) {
+            throw new LoginException("Error handling callback: " + e.getMessage());
+        }
+
+        final String username = nameCallback.getName();
+        final char[] password = passwordCallback.getPassword();
+
+        char[] storedPassword = this.usersMap.get(username);
+        boolean success = password != null && username != null && Arrays.equals(storedPassword, password);
+        if (success) {
+            this.subject.getPrincipals().add(new NamePrincipal(username));
+            if (username.equals("user1")) {
+                this.subject.getPrincipals().add(new Roles("Role1"));
+            } else if (username.equals("user2")) {
+                this.subject.getPrincipals().add(new Roles("Role2"));
+            }
+        }
+        return success;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        this.subject.getPrincipals().clear();
+        return true;
+    }
+
+    private static class Roles implements Principal {
+
+        private final String name;
+
+        Roles(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/jaas-jboss-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/jaas-jboss-web.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2023 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jboss-web version="7.4" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/schema/jbossas/jboss-web_7_1.xsd">
+    <security-domain>JAASSecurityDomain</security-domain>
+</jboss-web>

--- a/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/realm/jaas-login.config
+++ b/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/realm/jaas-login.config
@@ -1,0 +1,4 @@
+Entry1 {
+    org.wildfly.test.integration.elytron.realm.TestLoginModule required;
+};
+

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -98,7 +98,6 @@ public abstract class LayersTestBase {
      * Packages that are always expected to be included in the return value of {@link #getExpectedUnreferenced()}.
      */
     public static final String[] NOT_REFERENCED_COMMON = {
-            "javax.xml.stream.api",
             // injected by ee
             "org.wildfly.naming",
             // Injected by jaxrs
@@ -251,6 +250,7 @@ public abstract class LayersTestBase {
             "ibm.jdk",
             "javax.api",
             "javax.sql.api",
+            "javax.xml.stream.api",
             // TODO see if org.apache.activemq.artemis.client can use specific JDK module(s)
             //"sun.jdk",
             //"sun.scripting",

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -98,6 +98,7 @@ public abstract class LayersTestBase {
      * Packages that are always expected to be included in the return value of {@link #getExpectedUnreferenced()}.
      */
     public static final String[] NOT_REFERENCED_COMMON = {
+            "javax.xml.stream.api",
             // injected by ee
             "org.wildfly.naming",
             // Injected by jaxrs
@@ -152,6 +153,7 @@ public abstract class LayersTestBase {
             "org.jboss.mod_cluster.container.spi",
             "org.jboss.mod_cluster.core",
             "org.jboss.mod_cluster.load.spi",
+            "org.wildfly.extension.elytron.jaas-realm",
             "org.wildfly.extension.mod_cluster",
             "org.wildfly.mod_cluster.undertow",
             // Brought by galleon ServerRootResourceDefinition
@@ -249,7 +251,6 @@ public abstract class LayersTestBase {
             "ibm.jdk",
             "javax.api",
             "javax.sql.api",
-            "javax.xml.stream.api",
             // TODO see if org.apache.activemq.artemis.client can use specific JDK module(s)
             //"sun.jdk",
             //"sun.scripting",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18163

Supersedes https://github.com/wildfly/wildfly/pull/17622

I have made the updates @yersan suggested in https://github.com/wildfly/wildfly/pull/17622 to add `javax.xml.stream.api` back to `LayersTestBase` and opened this new PR since @Skyllarr is now on PTO.