### PR TITLE
WFLY-19029 Hibernate ORM 6.4+ should export services to consumer clas…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
@@ -23,7 +23,7 @@
         <module name="jakarta.validation.api"/>
         <module name="jakarta.xml.bind.api"/>
 
-        <module name="org.hibernate"/>
+        <module name="org.hibernate" services="import"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.infinispan.core" services="import"/>
         <module name="org.infinispan.protostream"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -44,4 +44,11 @@
         <!-- If the PostgreSQL JDBC driver classes are accessible, Hibernate ORM will use them to tailor PostgresDialect and CockroachDialect behavior -->
         <module name="org.postgresql.jdbc" optional="true"/>
     </dependencies>
+
+    <provides>
+        <service name="org.hibernate.bytecode.spi.BytecodeProvider">
+            <with-class name="org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl"/>
+        </service>
+    </provides>
+
 </module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19029
Back port of https://github.com/wildfly/wildfly/pull/17591 for 31.0.1.Final