### PR TITLE
Fix for WFLY-19021, WildFly provisioning to support WildFly stability

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -182,6 +182,7 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
+                            <minimum-stability>experimental</minimum-stability>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -19,51 +19,15 @@
         <group name="org.wildfly.core"/>
     </package-schemas>
 
-    <config name="standalone.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-full.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-full-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-load-balancer.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="domain.xml" model="domain">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host-primary.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host-secondary.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
+    <config name="standalone.xml" model="standalone"/>
+    <config name="standalone-ha.xml" model="standalone"/>
+    <config name="standalone-full.xml" model="standalone"/>
+    <config name="standalone-full-ha.xml" model="standalone"/>
+    <config name="standalone-load-balancer.xml" model="standalone"/>
+    <config name="domain.xml" model="domain"/>
+    <config name="host.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -149,6 +149,7 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
+                            <minimum-stability>experimental</minimum-stability>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -38,61 +38,17 @@
         <group name="org.wildfly"/>
     </package-schemas>
 
-    <config name="standalone.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-full.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-full-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-load-balancer.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-microprofile.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="standalone-microprofile-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="domain.xml" model="domain">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host-primary.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
-    <config name="host-secondary.xml" model="host">
-        <props>
-            <prop name="--stability" value="community"/>
-        </props>
-    </config>
+    <config name="standalone.xml" model="standalone"/>
+    <config name="standalone-ha.xml" model="standalone"/>
+    <config name="standalone-full.xml" model="standalone"/>
+    <config name="standalone-full-ha.xml" model="standalone"/>
+    <config name="standalone-load-balancer.xml" model="standalone"/>
+    <config name="standalone-microprofile.xml" model="standalone"/>
+    <config name="standalone-microprofile-ha.xml" model="standalone"/>
+    <config name="domain.xml" model="domain"/>
+    <config name="host.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>

--- a/pom.xml
+++ b/pom.xml
@@ -296,13 +296,13 @@
         <version.ant.junit>1.10.14</version.ant.junit>
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.11</version.org.jacoco>
-        <version.org.jboss.galleon>6.0.0.Beta2</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.0.Beta3</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Beta9</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.0.0.Beta2</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.0.0.Beta3</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Beta3</version.org.wildfly.plugin>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -234,6 +234,7 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
+                            <minimum-stability>experimental</minimum-stability>
                         </configuration>
                     </execution>
                 </executions>

--- a/preview/feature-pack/wildfly-feature-pack-build.xml
+++ b/preview/feature-pack/wildfly-feature-pack-build.xml
@@ -19,61 +19,17 @@
         <group name="org.wildfly.core"/>
     </package-schemas>
 
-    <config name="standalone.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-full.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-full-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-load-balancer.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-microprofile.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="standalone-microprofile-ha.xml" model="standalone">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="domain.xml" model="domain">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="host.xml" model="host">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="host-primary.xml" model="host">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
-    <config name="host-secondary.xml" model="host">
-        <props>
-            <prop name="--stability" value="preview"/>
-        </props>
-    </config>
+    <config name="standalone.xml" model="standalone"/>
+    <config name="standalone-ha.xml" model="standalone"/>
+    <config name="standalone-full.xml" model="standalone"/>
+    <config name="standalone-full-ha.xml" model="standalone"/>
+    <config name="standalone-load-balancer.xml" model="standalone"/>
+    <config name="standalone-microprofile.xml" model="standalone"/>
+    <config name="standalone-microprofile-ha.xml" model="standalone"/>
+    <config name="domain.xml" model="domain"/>
+    <config name="host.xml" model="host"/>
+    <config name="host-primary.xml" model="host"/>
+    <config name="host-secondary.xml" model="host"/>
 
     <plugins>
         <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19021

Also bumping Galleon and WildFly Galleon plugins to latest beta.

NOTE: The minimum stability of all built feature-pack has been set to `experimental`.

