### PR TITLE
WFLY-18977 Upgrade jgroups-kubernetes to 2.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
         <version.org.jgroups>5.2.22.Final</version.org.jgroups>
         <version.org.jgroups.aws>3.0.0.Final</version.org.jgroups.aws>
         <version.org.jgroups.azure>2.0.2.Final</version.org.jgroups.azure>
-        <version.org.jgroups.kubernetes>2.0.1.Final</version.org.jgroups.kubernetes>
+        <version.org.jgroups.kubernetes>2.0.2.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.jvnet.staxex>2.1.0</version.org.jvnet.staxex>
         <version.org.keycloak.keycloak-saml-wildfly-subsystem>18.0.2</version.org.keycloak.keycloak-saml-wildfly-subsystem>


### PR DESCRIPTION
Upstream PR: https://github.com/wildfly/wildfly/pull/17633

@rhusar FIY, I back ported this component upgrade to 31.x