### PR TITLE
[WFLY-19051] Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in messaging subsystem

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
@@ -86,7 +86,7 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 // keep the statements ordered by phase + priority
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_JMS_CONNECTION_FACTORY_RESOURCE_INJECTION, new DefaultJMSConnectionFactoryResourceReferenceProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RESOURCE_DEF_ANNOTATION_JMS_DESTINATION, new JMSDestinationDefinitionAnnotationProcessor());
-                processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RESOURCE_DEF_ANNOTATION_JMS_CONNECTION_FACTORY, new JMSConnectionFactoryDefinitionAnnotationProcessor(MessagingServices.capabilityServiceSupport.hasCapability("org.wildfly.legacy-security")));
+                processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RESOURCE_DEF_ANNOTATION_JMS_CONNECTION_FACTORY, new JMSConnectionFactoryDefinitionAnnotationProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_MESSAGING_XML_RESOURCES, new MessagingXmlParsingDeploymentUnitProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JMS, new MessagingDependencyProcessor());
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionAnnotationProcessor.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionAnnotationProcessor.java
@@ -29,12 +29,6 @@ public class JMSConnectionFactoryDefinitionAnnotationProcessor extends ResourceD
     private static final DotName JMS_CONNECTION_FACTORY_DEFINITION = DotName.createSimple(JMSConnectionFactoryDefinition.class.getName());
     private static final DotName JMS_CONNECTION_FACTORY_DEFINITIONS = DotName.createSimple(JMSConnectionFactoryDefinitions.class.getName());
 
-    private final boolean legacySecurityAvailable;
-
-    public JMSConnectionFactoryDefinitionAnnotationProcessor(boolean legacySecurityAvailable) {
-        this.legacySecurityAvailable = legacySecurityAvailable;
-    }
-
     @Override
     protected DotName getAnnotationDotName() {
         return JMS_CONNECTION_FACTORY_DEFINITION;
@@ -56,7 +50,6 @@ public class JMSConnectionFactoryDefinitionAnnotationProcessor extends ResourceD
         directJMSConnectionFactoryInjectionSource.setTransactional(AnnotationElement.asOptionalBoolean(annotationInstance, "transactional"));
         directJMSConnectionFactoryInjectionSource.setMaxPoolSize(AnnotationElement.asOptionalInt(annotationInstance, "maxPoolSize", MAX_POOL_SIZE.getDefaultValue().asInt()));
         directJMSConnectionFactoryInjectionSource.setMinPoolSize(AnnotationElement.asOptionalInt(annotationInstance, "minPoolSize", MIN_POOL_SIZE.getDefaultValue().asInt()));
-        directJMSConnectionFactoryInjectionSource.setLegacySecurityAvailable(legacySecurityAvailable);
         directJMSConnectionFactoryInjectionSource.addProperties(AnnotationElement.asOptionalStringArray(annotationInstance, AnnotationElement.PROPERTIES), propertyReplacer);
         return directJMSConnectionFactoryInjectionSource;
     }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -109,7 +109,6 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
     private boolean transactional;
     private int maxPoolSize;
     private int minPoolSize;
-    private boolean legacySecurityAvailable;
 
     public JMSConnectionFactoryDefinitionInjectionSource(String jndiName) {
         super(jndiName);
@@ -149,10 +148,6 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
 
     void setMinPoolSize(int minPoolSize) {
         this.minPoolSize = minPoolSize;
-    }
-
-    public void setLegacySecurityAvailable(boolean legacySecurityAvailable) {
-        this.legacySecurityAvailable = legacySecurityAvailable;
     }
 
     @Override


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19051

[WFLY-19051] Remove Stage.RUNTIME uses of capability 'org.wildfly.legacy-security' in messaging subsystem