### PR TITLE
[WFLY-19058] Upgrade WildFly Core to 23.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.5</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>23.0.2.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>23.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.6.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.2.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19058

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/23.0.3.Final
Diff: https://github.com/wildfly/wildfly-core/compare/23.0.2.Final...23.0.3.Final

---

<details>
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6707'>WFCORE-6707</a>] -         CVE-2024-1635 Upgrade XNIO to 3.8.13.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6708'>WFCORE-6708</a>] -         CVE-2024-1635 Upgrade JBoss Remoting to 5.0.28.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6709'>WFCORE-6709</a>] -         CVE-2023-5379 CVE-2024-1459 CVE-2024-1635 Upgrade Undertow to 2.3.12.Final
</li>
</ul>
                       
</details>
