### PR TITLE
WFLY-19071/WFLY-19072: Fixing AddressSettings default values and Artemis 2.32 dependencies

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1420,6 +1420,18 @@
             </dependency>
 
             <dependency>
+                <groupId>de.dentrassi.crypto</groupId>
+                <artifactId>pem-keystore</artifactId>
+                <version>${version.de.dentrassi.crypto}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>gnu.getopt</groupId>
                 <artifactId>java-getopt</artifactId>
                 <version>${version.gnu.getopt}</version>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -327,6 +327,17 @@
         </dependency>
 
         <dependency>
+            <groupId>de.dentrassi.crypto</groupId>
+            <artifactId>pem-keystore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>gnu.getopt</groupId>
             <artifactId>java-getopt</artifactId>
         </dependency>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/de/dentrassi/crypto/pem-keystore/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/de/dentrassi/crypto/pem-keystore/main/module.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="de.dentrassi.crypto.pem-keystore">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${de.dentrassi.crypto:pem-keystore}"/>
+    </resources>
+
+
+    <dependencies>
+        <module name="org.bouncycastle.bcpkix" export="true" services="export"/>
+        <module name="org.bouncycastle.bcprov" export="true" services="export"/>
+    </dependencies>
+
+    <provides>
+        <service name="java.security.Provider">
+            <with-class name="de.dentrassi.crypto.pem.PemKeyStoreProvider"/>
+        </service>
+    </provides>
+</module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
@@ -23,6 +23,7 @@
         <module name="org.apache.activemq.artemis" optional="true" export="true"/>
         <!-- Import is required to get  access to SSLContext Factory for Elytron -->
         <module name="org.wildfly.extension.messaging-activemq" services="import" export="true"/>
+        <module name="de.dentrassi.crypto.pem-keystore" services="import" export="true"/>
         <module name="com.google.guava"/>
         <module name="jakarta.json.api"/>
         <module name="io.netty.netty-buffer"/>
@@ -41,7 +42,7 @@
         <module name="jakarta.resource.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="jakarta.jms.api" />
-        <module name="sun.jdk"/>
+        <module name="java.base"/>
         <!-- supported protocols (in addition to the CORE protocol) -->
         <module name="org.apache.activemq.artemis.protocol.amqp" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.hornetq" services="import" optional="true"/>

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBroker.java
@@ -91,9 +91,16 @@ public interface ActiveMQBroker {
     Object[] getResources(Class<?> resourceType);
 
     /**
-     * Returns he {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl} to manage the
+     * Returns the {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl} to manage the
      * underlying {@link org.apache.activemq.artemis.core.server.ActiveMQServer}.
      * @return the {@link org.apache.activemq.artemis.api.core.management.ActiveMQServerControl}
      */
     ActiveMQServerControl getActiveMQServerControl();
+
+    /**
+     * Returns the JSON description of the address settings of the specified match address.
+     * @param addressMatch the address settings match address.
+     * @return the JSON description of the address settings of the specified match address
+     */
+    String getAddressSettingsAsJSON(String addressMatch);
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQBrokerImpl.java
@@ -11,6 +11,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.core.security.SecurityAuth;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
 /**
  * Implementation of the wrapper over {@link org.apache.activemq.artemis.core.server.ActiveMQServer} and
@@ -81,5 +82,13 @@ public class ActiveMQBrokerImpl implements ActiveMQBroker {
     public ActiveMQServerControl getActiveMQServerControl() {
         return delegate.getActiveMQServerControl();
     }
+
+    @Override
+    public String getAddressSettingsAsJSON(String addressMatch) {
+        AddressSettings settings = delegate.getAddressSettingsRepository().getMatch(addressMatch);
+        settings.merge(delegate.getAddressSettingsRepository().getDefault());
+        return ManagementUtil.convertAddressSettingInfosAsJSON(settings.toJSON());
+    }
+
 
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerControlHandler.java
@@ -113,7 +113,7 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
 
         final ServiceName serviceName = MessagingServices.getActiveMQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
 
-        if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+        if (READ_ATTRIBUTE_OPERATION.equals(operationName) || GET_ADDRESS_SETTINGS_AS_JSON.equals(operationName)) {
             ActiveMQBroker server = null;
             if (context.getRunningMode() == RunningMode.NORMAL) {
                 ServiceController<?> service = context.getServiceRegistry(false).getService(serviceName);
@@ -122,7 +122,12 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
                 }
                 server = ActiveMQBroker.class.cast(service.getValue());
             }
-            handleReadAttribute(context, operation, server);
+            if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+                handleReadAttribute(context, operation, server);
+                return;
+            }
+            String addressMatch = ADDRESS_MATCH.resolveModelAttribute(context, operation).asString();
+            context.getResult().set(server.getAddressSettingsAsJSON(addressMatch));
             return;
         }
 
@@ -202,7 +207,7 @@ public class ActiveMQServerControlHandler extends AbstractRuntimeOnlyHandler {
             } else if (GET_ADDRESS_SETTINGS_AS_JSON.equals(operationName)) {
                 String addressMatch = ADDRESS_MATCH.resolveModelAttribute(context, operation).asString();
                 String json = serverControl.getAddressSettingsAsJSON(addressMatch);
-                context.getResult().set(json);
+                context.getResult().set(ManagementUtil.convertAddressSettingInfosAsJSON(json));
             } else if (FORCE_FAILOVER.equals(operationName)) {
                 serverControl.forceFailover();
                 context.getResult();

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
@@ -52,10 +52,44 @@ class AddressSettingAdd extends AbstractAddStepHandler {
         final ActiveMQServer server = getActiveMQServer(context, operation);
         if (server != null) {
             final AddressSettings settings = createSettings(context, model);
+            if(server.getConfiguration().getWildcardConfiguration().equals(context.getCurrentAddressValue())) {
+                settings.merge(createDefaulAddressSettings());
+            }
             server.getAddressSettingsRepository().addMatch(context.getCurrentAddressValue(), settings);
         }
     }
 
+     static AddressSettings createDefaulAddressSettings() {
+            final AddressSettings settings = new AddressSettings();
+            settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.valueOf(AddressSettingDefinition.ADDRESS_FULL_MESSAGE_POLICY.getDefaultValue().asString()));
+            // always set the auto-create|delete-jms-queues attributes as their default attribute values differ from Artemis defaults.
+            settings.setAutoCreateJmsQueues(AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES.getDefaultValue().asBoolean());
+            settings.setAutoDeleteJmsQueues(AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES.getDefaultValue().asBoolean());
+            settings.setAutoCreateQueues(AddressSettingDefinition.AUTO_CREATE_QUEUES.getDefaultValue().asBoolean());
+            settings.setAutoDeleteQueues(AddressSettingDefinition.AUTO_DELETE_QUEUES.getDefaultValue().asBoolean());
+            settings.setAutoCreateAddresses(AddressSettingDefinition.AUTO_CREATE_ADDRESSES.getDefaultValue().asBoolean());
+            settings.setAutoDeleteAddresses(AddressSettingDefinition.AUTO_DELETE_ADDRESSES.getDefaultValue().asBoolean());
+            settings.setAutoDeleteCreatedQueues(AddressSettingDefinition.AUTO_DELETE_CREATED_QUEUES.getDefaultValue().asBoolean());
+            settings.setMaxReadPageBytes(AddressSettingDefinition.MAX_READ_PAGE_BYTES.getDefaultValue().asInt());
+            settings.setDeadLetterAddress(asSimpleString(DEAD_LETTER_ADDRESS.getDefaultValue(), null));
+            settings.setExpiryAddress(asSimpleString(EXPIRY_ADDRESS.getDefaultValue(), null));
+            settings.setExpiryDelay(AddressSettingDefinition.EXPIRY_DELAY.getDefaultValue().asLong());
+            settings.setDefaultLastValueQueue(AddressSettingDefinition.LAST_VALUE_QUEUE.getDefaultValue().asBoolean());
+            settings.setMaxDeliveryAttempts(AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS.getDefaultValue().asInt());
+            settings.setMaxRedeliveryDelay(AddressSettingDefinition.MAX_REDELIVERY_DELAY.getDefaultValue().asLong());
+            settings.setMaxSizeBytes(AddressSettingDefinition.MAX_SIZE_BYTES.getDefaultValue().asLong());
+            settings.setMessageCounterHistoryDayLimit(AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT.getDefaultValue().asInt());
+            settings.setPageCacheMaxSize(AddressSettingDefinition.PAGE_MAX_CACHE_SIZE.getDefaultValue().asInt());
+            settings.setPageSizeBytes(AddressSettingDefinition.PAGE_SIZE_BYTES.getDefaultValue().asInt());
+            settings.setRedeliveryDelay(AddressSettingDefinition.REDELIVERY_DELAY.getDefaultValue().asLong());
+            settings.setRedeliveryMultiplier(AddressSettingDefinition.REDELIVERY_MULTIPLIER.getDefaultValue().asDouble());
+            settings.setRedistributionDelay(AddressSettingDefinition.REDISTRIBUTION_DELAY.getDefaultValue().asLong());
+            settings.setSendToDLAOnNoRoute(AddressSettingDefinition.SEND_TO_DLA_ON_NO_ROUTE.getDefaultValue().asBoolean());
+            settings.setSlowConsumerCheckPeriod(AddressSettingDefinition.SLOW_CONSUMER_CHECK_PERIOD.getDefaultValue().asLong());
+            settings.setSlowConsumerPolicy(SlowConsumerPolicy.valueOf(AddressSettingDefinition.SLOW_CONSUMER_POLICY.getDefaultValue().asString()));
+            settings.setSlowConsumerThreshold(AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD.getDefaultValue().asLong());
+            return settings;
+        }
     /**
      * Create a setting.
      *
@@ -79,7 +113,9 @@ class AddressSettingAdd extends AbstractAddStepHandler {
         settings.setAutoCreateAddresses(AddressSettingDefinition.AUTO_CREATE_ADDRESSES.resolveModelAttribute(context, config).asBoolean());
         settings.setAutoDeleteAddresses(AddressSettingDefinition.AUTO_DELETE_ADDRESSES.resolveModelAttribute(context, config).asBoolean());
         settings.setAutoDeleteCreatedQueues(AddressSettingDefinition.AUTO_DELETE_CREATED_QUEUES.resolveModelAttribute(context, config).asBoolean());
-        settings.setMaxReadPageBytes(AddressSettingDefinition.MAX_READ_PAGE_BYTES.resolveModelAttribute(context, config).asInt());
+        if (config.hasDefined(AddressSettingDefinition.MAX_READ_PAGE_BYTES.getName())) {
+            settings.setMaxReadPageBytes(AddressSettingDefinition.MAX_READ_PAGE_BYTES.resolveModelAttribute(context, config).asInt());
+        }
         if (config.hasDefined(DEAD_LETTER_ADDRESS.getName())) {
             settings.setDeadLetterAddress(asSimpleString(DEAD_LETTER_ADDRESS.resolveModelAttribute(context, config), null));
         }
@@ -136,7 +172,7 @@ class AddressSettingAdd extends AbstractAddStepHandler {
     }
 
     static SimpleString asSimpleString(final ModelNode node, final String defVal) {
-        return SimpleString.toSimpleString(node.getType() != ModelType.UNDEFINED ? node.asString() : defVal);
+        return SimpleString.toSimpleString(node != null && node.getType() != ModelType.UNDEFINED ? node.asString() : defVal);
     }
 
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ManagementUtil.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ManagementUtil.java
@@ -2,7 +2,6 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.client.helpers.ClientConstants.NAME;
@@ -17,6 +16,7 @@ import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.DE
 import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.MANAGE;
 import static org.wildfly.extension.messaging.activemq.SecurityRoleDefinition.SEND;
 
+import java.util.Locale;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -27,6 +27,9 @@ import org.jboss.dmr.Property;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class ManagementUtil {
+
+    private static final String SNAKE_REPLACEMENT = "$1-$2";
+    private static final String CAMEL_REGEXP = "([a-z])([A-Z]+)";
 
     public static void reportRolesAsJSON(OperationContext context, String rolesAsJSON) {
         ModelNode camelCase = ModelNode.fromJSONString(rolesAsJSON);
@@ -44,19 +47,19 @@ public class ManagementUtil {
         result.setEmptyList();
         if (roles != null && roles.length > 0) {
             for (Object objRole : roles) {
-                Object[] role = (Object[])objRole;
+                Object[] role = (Object[]) objRole;
                 final ModelNode roleNode = result.add();
                 roleNode.get(NAME).set(role[0].toString());
-                roleNode.get(SEND.getName()).set((Boolean)role[1]);
-                roleNode.get(CONSUME.getName()).set((Boolean)role[2]);
-                roleNode.get(CREATE_DURABLE_QUEUE.getName()).set((Boolean)role[3]);
-                roleNode.get(DELETE_DURABLE_QUEUE.getName()).set((Boolean)role[4]);
-                roleNode.get(CREATE_NON_DURABLE_QUEUE.getName()).set((Boolean)role[5]);
-                roleNode.get(DELETE_NON_DURABLE_QUEUE.getName()).set((Boolean)role[6]);
-                roleNode.get(MANAGE.getName()).set((Boolean)role[7]);
-                roleNode.get(BROWSE.getName()).set((Boolean)role[8]);
-                roleNode.get(CREATE_ADDRESS.getName()).set((Boolean)role[9]);
-                roleNode.get(DELETE_ADDRESS.getName()).set((Boolean)role[10]);
+                roleNode.get(SEND.getName()).set((Boolean) role[1]);
+                roleNode.get(CONSUME.getName()).set((Boolean) role[2]);
+                roleNode.get(CREATE_DURABLE_QUEUE.getName()).set((Boolean) role[3]);
+                roleNode.get(DELETE_DURABLE_QUEUE.getName()).set((Boolean) role[4]);
+                roleNode.get(CREATE_NON_DURABLE_QUEUE.getName()).set((Boolean) role[5]);
+                roleNode.get(DELETE_NON_DURABLE_QUEUE.getName()).set((Boolean) role[6]);
+                roleNode.get(MANAGE.getName()).set((Boolean) role[7]);
+                roleNode.get(BROWSE.getName()).set((Boolean) role[8]);
+                roleNode.get(CREATE_ADDRESS.getName()).set((Boolean) role[9]);
+                roleNode.get(DELETE_ADDRESS.getName()).set((Boolean) role[10]);
             }
         }
         return result;
@@ -74,7 +77,7 @@ public class ManagementUtil {
     }
 
     /**
-     *  Utility for converting camel case based ActiveMQ formats to WildFly standards.
+     * Utility for converting camel case based ActiveMQ formats to WildFly standards.
      */
     static ModelNode convertSecurityRole(final ModelNode camelCase) {
         final ModelNode result = new ModelNode();
@@ -84,33 +87,48 @@ public class ManagementUtil {
                 final ModelNode roleNode = result.add();
                 for (Property prop : role.asPropertyList()) {
                     String key = prop.getName();
-                    if (null != key) switch (key) {
-                        case "createDurableQueue":
-                            key = SecurityRoleDefinition.CREATE_DURABLE_QUEUE.getName();
-                            break;
-                        case "deleteDurableQueue":
-                            key = SecurityRoleDefinition.DELETE_DURABLE_QUEUE.getName();
-                            break;
-                        case "createNonDurableQueue":
-                            key = SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE.getName();
-                            break;
-                        case "deleteNonDurableQueue":
-                            key = SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE.getName();
-                            break;
-                        case "createAddress":
-                            key = "create-address";
-                            break;
-                        case "deleteAddress":
-                            key = "delete-address";
-                            break;
-                        default:
-                            break;
+                    if (null != key) {
+                        key = camelToSnake(key);
+                        roleNode.get(key).set(prop.getValue());
                     }
-                    roleNode.get(key).set(prop.getValue());
                 }
             }
         }
 
         return result;
+    }
+
+    static String camelToSnake(String str) {
+        return str.replaceAll(CAMEL_REGEXP, SNAKE_REPLACEMENT).toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Utility for converting new address settings infos to the old format.
+     */
+    static String convertAddressSettingInfosAsJSON(final String infosAsJSON) {
+        ModelNode camelCase = ModelNode.fromJSONString(infosAsJSON);
+        final ModelNode result = new ModelNode();
+        result.setEmptyObject();
+        if (camelCase.isDefined()) {
+            for (ModelNode role : camelCase.asList()) {
+                for (Property prop : role.asPropertyList()) {
+                    String key = prop.getName();
+                    if (null != key) {
+                        switch (key) {
+                            case "deadLetterAddress":
+                                key = "DLA";
+                                break;
+                            case "defaultLastValueQueue":
+                                key = "lastValueQueue";
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    result.get(key).set(prop.getValue());
+                }
+            }
+        }
+        return result.toJSONString(false);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,7 @@
         <version.commons-codec>1.15</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-io>2.11.0</version.commons-io>
+        <version.de.dentrassi.crypto>2.2.2</version.de.dentrassi.crypto>
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.io.agroal>2.0</version.io.agroal>
         <version.io.grpc>1.58.0</version.io.grpc>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -251,9 +251,8 @@ public abstract class LayersTestBase {
             "javax.api",
             "javax.sql.api",
             "javax.xml.stream.api",
-            // TODO see if org.apache.activemq.artemis.client can use specific JDK module(s)
-            //"sun.jdk",
-            //"sun.scripting",
+            "sun.jdk",
+            "sun.scripting",
             // Special support status -- wildfly-elytron-http-stateful-basic
             "org.wildfly.security.http.sfbasic",
             // test-all-layers installation is non-ha and does not include layers that provide jgroups


### PR DESCRIPTION
  * Setting the default values on the root of AddressSettings so that
    they are used by all child AddressSettings.
  * Fixing the JSON produced to be retro compatible.
  * Adding module de.dentrassi.crypto.pem-keystore
  * Moving from sunb.jdk to java.base   

Jira: https://issues.redhat.com/browse/WFLY-19072
      https://issues.redhat.com/browse/WFLY-19071