### PR TITLE
WFLY-19044: Fixing the User Forum link on the welcome page

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/content/welcome-content/index.html
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/welcome-content/index.html
@@ -30,7 +30,7 @@
             Console</a> </p>
 
         <p><a href="https://wildfly.org">WildFly Project</a> |
-            <a href="https://community.jboss.org/en/wildfly">User Forum</a> |
+            <a href="https://groups.google.com/g/wildfly">User Forum</a> |
             <a href="https://issues.jboss.org/browse/WFLY">Report an issue</a></p>
         <p class="logos"><a href="https://www.jboss.org"><img src="jbosscommunity_logo_hori_white.png" alt="JBoss and JBoss Community" width=
                 "195" height="37" border="0"></a></p>


### PR DESCRIPTION
This corrects the issue brought up in [WFLY-19044](https://issues.redhat.com/projects/WFLY/issues/WFLY-19044) where the User Forum link on the http://localhost:8080 welcome page is out of date.
This changes the URL from https://community.jboss.org/en/wildfly to https://groups.google.com/g/wildfly

____
<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19044](https://issues.redhat.com/browse/WFLY-19044)

<--- END OF WILDFLY GITHUB BOT REPORT --->