### PR TITLE
Fix GH nick typo in wildfly-bot.yml

### DIFF
--- a/.github/wildfly-bot.yml
+++ b/.github/wildfly-bot.yml
@@ -108,7 +108,7 @@ wildfly:
 
     - id: rts
       directories: [ rts ]
-      notify: [ mmusgrove ]
+      notify: [ mmusgrov ]
 
     - id: sar
       directories: [ sar ]


### PR DESCRIPTION
@wildfly-bot[bot] skip format
