### PR TITLE
[WFLY-19076] Upgrade WildFly Core to 24.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>24.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>24.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.2.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19076

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/24.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/24.0.0.Beta1...24.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6685'>WFCORE-6685</a>] -         CLIEmbedServerTestCase.testStdOutEcho fails intermittently
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6697'>WFCORE-6697</a>] -         list-resource-loader-paths fails with MalformedURLException
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6699'>WFCORE-6699</a>] -         Add HostExcludeResourceDefinition.KnownRelease items for EAP 8.0
</li>
</ul>
                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6696'>WFCORE-6696</a>] -         Upgrade SLF4J from 2.0.11 to 2.0.12
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6698'>WFCORE-6698</a>] -         Upgrade SSHD from 2.12.0 to 2.12.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6701'>WFCORE-6701</a>] -         Upgrade JBoss VFS to 3.3.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6702'>WFCORE-6702</a>] -         Upgrade WildFly Elytron to 2.3.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6703'>WFCORE-6703</a>] -         Upgrade Elytron Web to 4.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6706'>WFCORE-6706</a>] -         Upgrade JBoss MSC to 1.5.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6707'>WFCORE-6707</a>] -         CVE-2024-1635 Upgrade XNIO to 3.8.13.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6708'>WFCORE-6708</a>] -         CVE-2024-1635 Upgrade JBoss Remoting to 5.0.28.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6709'>WFCORE-6709</a>] -         CVE-2023-5379 CVE-2024-1459 CVE-2024-1635 Upgrade Undertow to 2.3.12.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6710'>WFCORE-6710</a>] -         Upgrade jboss-modules to 2.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6714'>WFCORE-6714</a>] -         Upgrade JBoss Marshalling to 2.1.4.SP1
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6650'>WFCORE-6650</a>] -         Expose Stability level from DeploymentUnit
</li>
</ul>
</details>
