### PR TITLE
[WFLY-19089]: Exception javax/management/openmbean/CompositeData usin…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
@@ -31,6 +31,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.management"/>
         <module name="java.security.jgss"/>
         <module name="java.security.sasl"/>
         <module name="jakarta.transaction.api"/>


### PR DESCRIPTION
…g AMQP-client in Wildfly built-in Artemis ActiveMQ server.

 * Adding missing depepdency on "java.management" in AMQP protocol.

Jira: https://issues.redhat.com/browse/WFLY-19089