### PR TITLE
[WFLY-19090][WFLY-19091][WFLY-19092][WFLY-19093][WFLY-19094] Upgrade Jakarta Activation, Jakarta Mail and Angus implementations

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -33,15 +33,6 @@
         <!-- Use only by RemoteNamingResourceDefinition resource -->
         <module name="org.jboss.remoting" optional="true"/>
         <module name="org.jboss.threads"/>
-        <!--
-        The Angus Mail services are required to be able to load the Jakarta Mail Session from this Module context classloader
-        when listing the Mail context stored in the JNDI tree.
-        -->
-        <module name="org.eclipse.angus.mail" services="import" optional="true">
-            <imports>
-                <include path="META-INF"/>
-            </imports>
-        </module>
     </dependencies>
 
 </module>

--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -18,7 +18,6 @@ import org.jboss.msc.service.StartException;
 import jakarta.mail.Authenticator;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -149,19 +148,7 @@ class SessionProviderFactory {
 
         @Override
         public Session getSession() {
-            final Session session;
-            final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-            if (current == null) {
-                try {
-                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(Session.class.getClassLoader());
-                    session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
-                } finally {
-                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
-                }
-            } else {
-                session = Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
-            }
-            return session;
+            return Session.getInstance(properties, new ManagedPasswordAuthenticator(sessionConfig));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
         <version.io.undertow.jastow>2.2.7.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.3</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.6</version.io.vertx.vertx-kafka-client>
-        <version.jakarta.activation.jakarta.activation-api>2.1.2</version.jakarta.activation.jakarta.activation-api>
+        <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>6.4.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
-        <version.org.eclipse.angus.angus-activation>2.0.1</version.org.eclipse.angus.angus-activation>
+        <version.org.eclipse.angus.angus-activation>2.0.2</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>2.0.2</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.32.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile>6.1</version.org.eclipse.microprofile>

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.json.bind.api>3.0.0</version.jakarta.json.bind.api>
-        <version.jakarta.mail-api>2.1.2</version.jakarta.mail-api>
+        <version.jakarta.mail-api>2.1.3</version.jakarta.mail-api>
         <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
         <version.jakarta.security.enterprise>3.0.0</version.jakarta.security.enterprise>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
         <version.org.codehaus.woodstox.woodstox-core>6.4.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.eclipse.angus.angus-activation>2.0.2</version.org.eclipse.angus.angus-activation>
-        <version.org.eclipse.angus.angus-mail>2.0.2</version.org.eclipse.angus.angus-mail>
+        <version.org.eclipse.angus.angus-mail>2.0.3</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.32.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile>6.1</version.org.eclipse.microprofile>
         <version.org.eclipse.microprofile.config.api>3.1</version.org.eclipse.microprofile.config.api>


### PR DESCRIPTION
Upgrade Jakarta Activation and Jakarta Mail together with their Angus implementations to the latest ones.
In addition, rollback changes we required to circumvent https://github.com/jakartaee/mail-api/issues/665

Jira issues:
https://issues.redhat.com/browse/WFLY-19090
https://issues.redhat.com/browse/WFLY-19091
https://issues.redhat.com/browse/WFLY-19092
https://issues.redhat.com/browse/WFLY-19093
https://issues.redhat.com/browse/WFLY-19094