### PR TITLE
[31.x] [WFLY-18073] Add the OWASP dependency-check plugin to the WildFly build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1402,6 +1402,34 @@
                 <module>docs</module>
             </modules>
         </profile>
+        <profile>
+            <id>dependency-check</id>
+            <activation>
+                <property>
+                    <name>dependency-check</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                      <groupId>org.owasp</groupId>
+                      <artifactId>dependency-check-maven</artifactId>
+                      <version>9.0.9</version>
+                      <configuration>
+                          <nvdApiServerId>nvd</nvdApiServerId>
+                          <suppressionFile>./sca-overrides/owasp-suppressions.xml</suppressionFile>
+                      </configuration>
+                      <executions>
+                          <execution>
+                              <goals>
+                                  <goal>aggregate</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <!--
           Name: jpda

--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -211,4 +211,21 @@
       <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-tracing\-api@.*$</packageUrl>
       <cve>CVE-2021-20293</cve>
    </suppress>
+   <suppress until="2025-03-15">
+      <notes><![CDATA[
+      file name: resteasy-spring-3.1.2.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.spring/resteasy\-spring@.*$</packageUrl>
+      <cve>CVE-2018-1051</cve>
+   </suppress>
+   <suppress until="2025-04-10">
+      <notes><![CDATA[
+      file name: undertow-core-2.3.12.Final.jar
+
+      [WFLY-19224] Since WildFly moved to using WildFly Elytron exclusively for security the
+      authentication mechanism from undertow-core is not used. This is a false positive.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
+      <vulnerabilityName>CVE-2023-1973</vulnerabilityName>
+   </suppress>
 </suppressions>

--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -197,4 +197,18 @@
       <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
       <vulnerabilityName>CVE-2016-6311</vulnerabilityName>
    </suppress>
+   <suppress until="2025-03-08">
+      <notes><![CDATA[
+      file name: resteasy-spring-3.0.4.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.spring/resteasy\-spring@.*$</packageUrl>
+      <cve>CVE-2021-20293</cve>
+   </suppress>
+   <suppress until="2025-03-08">
+      <notes><![CDATA[
+      file name: resteasy-tracing-api-2.0.1.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-tracing\-api@.*$</packageUrl>
+      <cve>CVE-2021-20293</cve>
+   </suppress>
 </suppressions>

--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <!-- CPE Supressions -->
+   <!-- Sometimes the mapping from GAV to CPE creates a bad match, this section supresses those matches. -->
+   <suppress>
+      <notes><![CDATA[
+      file name: expressly-5.0.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.glassfish\.expressly/expressly@.*$</packageUrl>
+      <cpe>cpe:/a:eclipse:glassfish</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: jakarta-client-resteasy-3.0.3.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.jakarta/jakarta\-client\-resteasy@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:resteasy</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: jboss-iiop-client-2.0.1.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss/jboss\-iiop\-client@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:jboss-ejb-client</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: mvc-krazo-subsystem-0.8.2.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly/mvc\-krazo\-subsystem@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: mvc-krazo-galleon-shared-0.8.2.Final.pom
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly/mvc\-krazo\-galleon\-shared@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: transformer-7.0.0.Beta2.jar (shaded: org.wildfly.extras.batavia:transformer-api:1.0.12.Final)
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.extras\.batavia/transformer\-api@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-elytron-audit-2.3.1.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.security/wildfly\-elytron\-audit@.*$</packageUrl>
+      <cpe>cpe:/a:linux_audit_project:linux_audit</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      Match all components from WildFly Core, these should use CPE redhat:wildfly-core
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.core/wildfly\-.*@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-plugin-core-4.1.1.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.plugins/wildfly\-plugin\-core@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+      <cpe>cpe:/a:redhat:wildfly_core</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: transformer-7.0.0.Beta2.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.galleon\-plugins/transformer@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-ee-9-deployment-transformer-1.0.0.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.deployment/wildfly\-ee\-9\-deployment\-transformer@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-galleon-plugins-7.0.0.Beta2.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.galleon\-plugins/wildfly\-galleon\-plugins@.*$</packageUrl>
+      <cpe>cpe:/a:redhat:wildfly</cpe>
+   </suppress>
+
+   <!-- CVE Expressions -->
+
+   <!-- In this section specific CVEs are supressed where we have triaged we are not interested in them being reported. -->
+
+   <!-- If we specify an until in 12 months time, it will give us an opportunity to check again,
+        also if it no longer triggers after this date we can remove the supression. -->
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: apacheds-interceptors-admin-2.0.0.AM26.jar
+      ]]></notes>
+      <!-- The regex was adjusted to match all apacheds artefacts, in most other cases we would use the rule as-proposed. -->
+      <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-.*@.*$</packageUrl>
+      <cve>CVE-2010-1151</cve>
+   </suppress>
+   <suppress until="2025-02-14">
+      <notes><![CDATA[
+      file name: mina-core-2.1.3.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.mina/mina\-core@.*$</packageUrl>
+      <cve>CVE-2021-41973</cve>
+   </suppress>
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: grpc-api-1.58.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-api@.*$</packageUrl>
+      <cve>CVE-2023-44487</cve> <!-- This CVE specifically affects grpc-go not grpc-api -->
+   </suppress>
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: h2-2.2.224.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+      <!-- Disputed by h2database https://github.com/h2database/h2database/issues/1294 -->
+      <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+   </suppress>
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: jackson-databind-2.15.3.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+      <!-- Disputed by FasterXML that this is a vulnerability https://github.com/FasterXML/jackson-databind/issues/3972 -->
+      <cve>CVE-2023-35116</cve>
+   </suppress>
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: jakarta.security.enterprise-3.0.3.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.glassfish\.soteria/jakarta\.security\.enterprise@.*$</packageUrl>
+      <vulnerabilityName>CVE-2020-1732</vulnerabilityName>
+   </suppress>
+   <suppress until="2025-02-09">
+      <notes><![CDATA[
+      file name: jgroups-aws-3.0.0.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jgroups\.aws/jgroups\-aws@.*$</packageUrl>
+      <cve>CVE-2016-2141</cve>
+   </suppress>
+   <suppress until="2025-03-04">
+      <notes><![CDATA[
+      file name: commons-compress-1.24.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+      <cve>CVE-2024-25710</cve>
+      <cve>CVE-2024-26308</cve>
+      <cve>CVE-2023-42503</cve>
+   </suppress>
+   <suppress until="2025-03-04">
+      <notes><![CDATA[
+      file name: opentelemetry-proto-0.20.0-alpha.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry\-proto@.*$</packageUrl>
+      <cve>CVE-2023-43810</cve> <!-- CVE within the Python library. -->
+      <cve>CVE-2023-45142</cve> <!-- CVE within the Go library. -->
+      <cve>CVE-2023-47108</cve> <!-- CVE within the Go library. -->
+   </suppress>
+   <suppress until="2025-03-04">
+      <notes><![CDATA[
+      file name: resteasy-spring-3.0.4.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.spring/resteasy\-spring@.*$</packageUrl>
+      <cve>CVE-2016-9606</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2014-3490</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2020-1695</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2020-10688</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2023-0482</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2020-25633</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+      <cve>CVE-2021-20289</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: resteasy-tracing-api-2.0.1.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-tracing\-api@.*$</packageUrl>
+      <cve>CVE-2016-9606</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2020-10688</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2023-0482</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2020-25633</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2021-20289</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2011-5245</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+      <cve>CVE-2012-0818</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
+   </suppress>
+   <suppress until="2025-03-04">
+      <notes><![CDATA[
+      file name: undertow-core-2.3.12.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
+      <vulnerabilityName>CVE-2016-6311</vulnerabilityName>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
Although we have no releases planned from the 31.x branch I am proposing we add the plugin there now as well so we can see how 31.x compares to ongoing development in main, on main we also have dependabot so many components get updated quickly before any CVE is identified.

See https://github.com/wildfly/wildfly/pull/17686 for more information about the plugin and how to use it.

https://issues.redhat.com/browse/WFLY-18073

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19224](https://issues.redhat.com/browse/WFLY-19224)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)