### PR TITLE
[WFLY-19100] Fixes Datasource subsystem 5.0 and 6.0 parsing

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
@@ -2506,6 +2506,8 @@ public class DsParser extends AbstractParser {
                                 case DATASOURCES_4_0:
                                     parseDsSecurity(reader, operation);
                                     break;
+                                case DATASOURCES_5_0:
+                                case DATASOURCES_6_0:
                                 case DATASOURCES_7_0:
                                     parseDsSecurity_5_0(reader, operation);
                                     break;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19100

Notes:
* The issue seems to be affecting only the ds security parsing, thus the simple fix. 
* Tested with all default configs from all affected WFLY versions.