### PR TITLE
WFLY-19105 Upgrade to Hibernate Search 7.1 (WFLY-19107 Upgrade to Elasticsearch client 8.12/ WFLY-19106 Upgrade to Lucene 9.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.4.4.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.0.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.1.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.24.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.10</version.org.apache.james.apache-mime4j>
         <version.org.apache.kafka>3.6.1</version.org.apache.kafka>
-        <version.org.apache.lucene>9.8.0</version.org.apache.lucene>
+        <version.org.apache.lucene>9.9.2</version.org.apache.lucene>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.3</version.org.apache.santuario>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
         <version.org.eclipse.microprofile.telemetry>1.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.0</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>8.11.1</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.12.2</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.4</version.org.glassfish.jaxb>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19105
https://issues.redhat.com/browse/WFLY-19106
https://issues.redhat.com/browse/WFLY-19107

And for what's new in Hibernate Search 7.1: https://hibernate.org/search/releases/7.1/