### PR TITLE
WFLY-19131 Clustering TS: disable color output logging from nodes

### DIFF
--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -40,5 +40,6 @@
 /subsystem=jgroups/stack=udp:remove
 
 # Logging configuration
-# Prepend node name to console log messages
-/subsystem=logging/pattern-formatter=COLOR-PATTERN:write-attribute(name=pattern,value="${jboss.node.name} %K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -42,8 +42,9 @@ embed-server --server-config=standalone-ha.xml
 /subsystem=jgroups/stack=udp:remove
 
 # Logging configuration
-# Prepend node name to console log messages
-/subsystem=logging/pattern-formatter=COLOR-PATTERN:write-attribute(name=pattern,value="${jboss.node.name} %K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)
 
 stop-embedded-server
 
@@ -87,7 +88,8 @@ embed-server --server-config=standalone-full-ha.xml
 /subsystem=jgroups/stack=udp:remove
 
 # Logging configuration
-# Prepend node name to console log messages
-/subsystem=logging/pattern-formatter=COLOR-PATTERN:write-attribute(name=pattern,value="${jboss.node.name} %K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)
 
 stop-embedded-server

--- a/testsuite/integration/clustering/clustering-load-balancer-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-load-balancer-bootable-jar.cli
@@ -6,3 +6,8 @@
 /subsystem=undertow/configuration=filter/mod-cluster=load-balancer:undefine-attribute(name=advertise-socket-binding)
 
 /subsystem=undertow/configuration=filter/mod-cluster=load-balancer/affinity=ranked:add()
+
+# Logging configuration
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)

--- a/testsuite/integration/clustering/clustering-load-balancer.cli
+++ b/testsuite/integration/clustering/clustering-load-balancer.cli
@@ -9,4 +9,9 @@ embed-server --server-config=standalone-load-balancer.xml
 
 /subsystem=undertow/configuration=filter/mod-cluster=load-balancer/affinity=ranked:add()
 
+# Logging configuration
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)
+
 stop-embedded-server

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -42,7 +42,8 @@ embed-server --server-config=standalone-microprofile-ha.xml
 /subsystem=jgroups/stack=udp:remove
 
 # Logging configuration
-# Prepend node name to console log messages
-/subsystem=logging/pattern-formatter=COLOR-PATTERN:write-attribute(name=pattern,value="${jboss.node.name} %K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+# Prepend node name to console log messages and disable color output
+/subsystem=logging/pattern-formatter=TESTSUITE-PATTERN:add(pattern="${jboss.node.name} %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+/subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter, value=TESTSUITE-PATTERN)
 
 stop-embedded-server


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-19131