### PR TITLE
Ignore intermittently failing DistributedTimerServiceTestCase

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/DistributedTimerServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/DistributedTimerServiceTestCase.java
@@ -7,12 +7,18 @@ package org.jboss.as.test.clustering.cluster.ejb.timer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.shrinkwrap.api.Archive;
+import org.junit.BeforeClass;
 
 /**
  * @author Paul Ferraro
  */
 public class DistributedTimerServiceTestCase extends AbstractTimerServiceTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        IntermittentFailure.thisTestIsFailingIntermittently("WFLY-19139");
+    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)


### PR DESCRIPTION
Ignore until WFLY-19139 is resolved.