### PR TITLE
[WFLY-19141] Switch to using SE 17 for GH workflow builds

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -54,11 +54,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up JDK ${{ inputs.jdk-distribution }} 17 to build for JDK 11 test
+        if: inputs.jdk-version == 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ inputs.jdk-distribution }}
+          java-version: 17
+          cache: 'maven'
+      - name: Build with Maven and JDK 17 for JDK 11 Tests
+        if: inputs.jdk-version == 11
+        run: mvn -U -B -ntp clean install ${{ inputs.args }} -DskipTests
       - name: Set up JDK ${{ inputs.jdk-distribution }} ${{ inputs.jdk-version }}
         uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.jdk-distribution }}
           java-version: ${{ inputs.jdk-version }}
           cache: 'maven'
+      - name: Test with Maven and JDK 11 with -DnoCompile
+        if: inputs.jdk-version == 11
+        run: mvn -U -B -ntp test -DnoCompile ${{ inputs.args }} -rf testsuite
       - name: Build and test with Maven
+        if: inputs.jdk-version != 11
         run: mvn -U -B -ntp clean install ${{ inputs.args }}

--- a/.github/workflows/shared-wildfly-build-and-test.yml
+++ b/.github/workflows/shared-wildfly-build-and-test.yml
@@ -23,7 +23,7 @@
 #      - name: Set up JDK
 #        uses: actions/setup-java@v4
 #        with:
-#          java-version: '11'
+#          java-version: '17'
 #          distribution: 'temurin'
 #          cache: 'maven'
 #      - name: Build and Test my-dependency
@@ -103,12 +103,6 @@ jobs:
         with:
           repository: wildfly/wildfly
           ref: '${{ inputs.ref }}'
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: 'maven'
       - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.maven-repo-name }}
@@ -117,7 +111,33 @@ jobs:
         shell: bash
         run: |
          tar -xzf ${{ inputs.maven-repo-path }} -C ~
+        # Do not compile with JDK 11. If 11 is specified, we will build with 17 and test with 11
+        # So, setup 17
+      - name: Set up JDK 17 for JDK 11 tests
+        if: matrix.java == 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+        # For JDK 11 tests, build with 17, skipping tests
+      - name: Build WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }} with JDK 17 for JDK 11 tests
+        if: matrix.java == 11
+        run: mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -DskipTests
+        shell: bash
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+        # For JDK 11 tests, we already built, so just run the 'test' goal with the -DnoCompile setting to disable recompile
+      - name: Test WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }} with -DnoCompile for JDK 11 tests
+        if: matrix.java == 11
+        run: mvn -U -B -ntp test -DnoCompile ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -rf testsuite
+        shell: bash
       - name: Build and Test WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }}
+        if: matrix.java != 11
         run: mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }}
         shell: bash
         # We need this due to long file names on Windows: https://github.com/actions/upload-artifact/issues/240


### PR DESCRIPTION
For jobs that support testing with SE 11, build with 17 and -DskipTests and then test with 11 and -DnoCompile

https://issues.redhat.com/browse/WFLY-19141

This builds on #17757

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)