### PR TITLE
[WFLY-19145] When provisioning a wildfly-preview based server for tests, use wildfly-test-feature-pack-preview for test-specific content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,10 @@
         <testsuite.full.galleon.pack.groupId>${full.maven.groupId}</testsuite.full.galleon.pack.groupId>
         <testsuite.full.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.full.galleon.pack.artifactId>
         <testsuite.full.galleon.pack.version>${full.maven.version}</testsuite.full.galleon.pack.version>
+        <!-- Galleon feature pack to use in testsuite provisioning executions that install test-specific content.
+             Profiles can set this to wildfly-test-feature-pack-preview when testing wildfly-preview.
+        -->
+        <testsuite.test.galleon.pack.artifactId>wildfly-test-galleon-pack</testsuite.test.galleon.pack.artifactId>
 
         <!-- Properties that set the phase used for different plugin executions.
              Profiles can override the values here to enable/disable executions.
@@ -1432,6 +1436,7 @@
                 <wildfly.build.output.dir>preview/dist/target/${server.output.dir.prefix}-preview-${server.output.dir.version}</wildfly.build.output.dir>
                 <testsuite.ee.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.ee.galleon.pack.artifactId>
                 <testsuite.full.galleon.pack.artifactId>wildfly-preview-feature-pack</testsuite.full.galleon.pack.artifactId>
+                <testsuite.test.galleon.pack.artifactId>wildfly-test-feature-pack-preview</testsuite.test.galleon.pack.artifactId>
                 <!-- Disable the surefire tests (at least the default ones) for all modules except for
                      those where this profile turns them back on. -->
                 <surefire.default-test.phase>none</surefire.default-test.phase>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1142,7 +1142,7 @@
                         </feature-pack>
                         <feature-pack>
                             <groupId>${project.groupId}</groupId>
-                            <artifactId>wildfly-test-galleon-pack</artifactId>
+                            <artifactId>${testsuite.test.galleon.pack.artifactId}</artifactId>
                             <version>${project.version}</version>
                         </feature-pack>
                     </feature-packs>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -74,7 +74,7 @@
 
         <!-- Props to control what phase plugin executions run in.
              Default is none. Profiles set these to other values to enable executions.
-             Provisioning executions using the wildfly-test-galleon-pack are handled separately from others. -->
+             Provisioning executions using the wildfly-preview-galleon-pack are handled separately from others. -->
         <provisioning.phase>none</provisioning.phase>
         <provisioning.phase.preview.excluded>none</provisioning.phase.preview.excluded> <!-- Use for executions that won't work with WildFly Preview -->
         <provisioning.phase.preview.only>none</provisioning.phase.preview.only> <!-- Use for executions that will only work with WildFly Preview -->

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -83,7 +83,7 @@
 
         <!-- Props to control what phase plugin executions run in.
              Default is none. Profiles set these to other values to enable executions.
-             Provisioning executions using the wildfly-test-galleon-pack are handled separately from others. -->
+             Provisioning executions using the wildfly-preview-galleon-pack are handled separately from others. -->
         <provisioning.phase>none</provisioning.phase>
         <provisioning.phase.preview.excluded>none</provisioning.phase.preview.excluded> <!-- Use for executions that won't work with WildFly Preview -->
         <provisioning.phase.preview.only>none</provisioning.phase.preview.only> <!-- Use for executions that will only work with WildFly Preview -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -485,6 +485,26 @@
                 <module>preview</module>
             </modules>
         </profile>
+        <!-- Profile that can be activated in combination with -Dts.layers and -Dts.galleon
+             to execute the tests activated by those profiles, but using the wildfly-preview feature pack
+             based variant of wildfly-test-galleon-pack.
+        -->
+        <profile>
+            <id>test.feature.pack.preview.profile</id>
+            <activation>
+                <property>
+                    <name>testsuite.ee.galleon.pack.artifactId</name>
+                    <value>wildfly-preview-feature-pack</value>
+                </property>
+            </activation>
+            <properties>
+                <testsuite.test.galleon.pack.artifactId>wildfly-test-feature-pack-preview</testsuite.test.galleon.pack.artifactId>
+            </properties>
+            <modules>
+                <!-- Ensure the wildfly-test-feature-pack-preview artifact is built -->
+                <module>test-feature-pack-preview</module>
+            </modules>
+        </profile>
 
         <!--
           Debugging profiles.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19145

Builds on #17731 which has another fix related to getting tests of WildFly Preview working properly.

____
<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19140](https://issues.redhat.com/browse/WFLY-19140)

<--- END OF WILDFLY GITHUB BOT REPORT --->