### PR TITLE
[WFLY-19150] Clean up server.jvm.args handling

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -341,8 +341,6 @@
                                     <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager ${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>
                                     
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
-                                        
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                         <jboss.home>${project.basedir}/target/wildfly</jboss.home>
                                         <module.path>${jboss.dist}/modules</module.path>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1493,6 +1493,7 @@
                         <!-- Narayana transaction data storage for transaction started at client side -->
                         <ObjectStoreEnvironmentBean.objectStoreDir>target/NarayanaObjectStore</ObjectStoreEnvironmentBean.objectStoreDir>
                         <ObjectStoreEnvironmentBean.communicationStore.objectStoreDir>target/NarayanaObjectStore</ObjectStoreEnvironmentBean.communicationStore.objectStoreDir>
+                        <!-- TODO remove this when https://issues.redhat.com/browse/WFLY-19156 is resolved. -->
                         <server.jvm.args>${server.jvm.args} -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</server.jvm.args>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -433,9 +433,6 @@
                             <systemPropertyVariables>
                                 <!-- Override the standard module path that points at the shared module set from the dist -->
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
-                                <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is
-                                        expected by microprofile-config tests -->
-                                <server.jvm.args>-Dnode0=${node0} -Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -45,7 +45,6 @@
         <version.javax.xml.bind.jaxb-api>2.4.0-b180830.0359</version.javax.xml.bind.jaxb-api>
         <version.org.glassfish.jaxb.jaxb-runtime>2.4.0-b180830.0438</version.org.glassfish.jaxb.jaxb-runtime>
         <version.org.apache.kerby>2.0.3</version.org.apache.kerby>
-        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.other} ${jvm.args.timeouts} ${extra.server.jvm.args}</server.jvm.args>
 
         <maven.local.repo>${settings.localRepository}</maven.local.repo>
         <modular.jdk.testsuite.args>${modular.jdk.args} --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED</modular.jdk.testsuite.args>
@@ -488,7 +487,6 @@
                         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
                         <jboss.inst>${wildfly.dir}</jboss.inst>
                         <module.path>${wildfly.dir}/modules</module.path>
-                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
                         <node0>${node0}</node0>
                     </systemPropertyVariables>
                     <argLine>${surefire.system.args} ${jvm.args.ip.client}</argLine>
@@ -1068,9 +1066,6 @@
                                 <id>default-test</id>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                             <execution>
@@ -1078,7 +1073,7 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} -Djava.security.properties=${security.properties}</server.jvm.args>
+                                        <server.jvm.args>-Djava.security.properties=${security.properties} ${server.jvm.args}</server.jvm.args>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -709,9 +709,6 @@
                             <systemPropertyVariables>
                                 <!-- Override the standard module path that points at the shared module set from the dist -->
                                 <module.path>${project.build.directory}/wildfly/modules</module.path>
-                                <!-- -Dnode0 is present in the parent definition of server.jvm.args, it is
-                                        expected by microprofile-config tests -->
-                                <server.jvm.args>${surefire.jpda.args} -Dnode0=${node0} -Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -151,9 +151,6 @@
                                 <id>default-test</id>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
-                                    </systemPropertyVariables>
                                     <environmentVariables>
                                         <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
                                     </environmentVariables>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -947,7 +947,6 @@
             <properties>
                 <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
                 <glow.phase.observability>test-compile</glow.phase.observability>
-                <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>
             <build>
                 <plugins>
@@ -1037,9 +1036,6 @@
                                 <id>default-test</id>
                                 <phase>test</phase>
                                 <configuration>
-                                     <systemPropertyVariables>
-                                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</server.jvm.args>
-                                    </systemPropertyVariables>
                                     <excludes>
                                         <!-- Requires messaging -->
                                         <exclude>org/jboss/as/test/smoke/jms/**/*TestCase.java</exclude>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -469,7 +469,6 @@
                                         <javax.net.ssl.keyStore>${project.build.testOutputDirectory}/org/jboss/as/test/integration/ws/wsse/trust/client.keystore</javax.net.ssl.keyStore>
                                         <javax.net.ssl.keyStorePassword>changeit</javax.net.ssl.keyStorePassword>
                                         <javax.net.ssl.keyStoreType>jks</javax.net.ssl.keyStoreType>
-                                        <server.jvm.args>${server.jvm.args} -Dorg.wildfly.unsupported.skip.jakarta.transformer=true</server.jvm.args>
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>


### PR DESCRIPTION
- Fix places that were not passing through the 'server.jvm.args' maven property value to surefire 

- Remove some (but not all) redundant -Dmaven.repo.local=${settings.localRepository} setting, as it's in server.jvm.args via surefire.system.args 

- Remove crufty -Dorg.wildfly.unsupported.skip.jakarta.transformer=true settings 

- Remove overridden setting of the surefire 'server.jvm.args' system property that just does the same as the global config setting in testsuite/integration/pom.xml

https://issues.redhat.com/browse/WFLY-19150