### PR TITLE
[WFLY-19152] Add indices of APIs annotated with annotations indicating unstable API

### DIFF
--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -34,6 +34,14 @@
       <exists>true</exists>
     </file>
     <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.zip</location>
+      <exists>true</exists>
+    </file>
+    <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>
       <exists>true</exists>
     </file>

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Core_Management.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Core_Management.adoc
@@ -132,3 +132,37 @@ Now we can list the last configuration changes :
     }]
 }
 ----
+
+[[unstable-api-annotation]]
+== [Preview Feature] Reporting of API elements annotated with annotations indicating unstable API
+
+Note: This feature only exists at the `preview` stability level or lower.
+
+Some libraries use annotations on classes/interfaces/members to indicate that the API is considered to be unstable, and likely to change or go away in a future release. For example Hibernate uses the `org.hibernate.Incubating` annotation to mark such API elements.
+
+WildFly can scan for usage of such API when your applications are deployed into WildFly, but it needs to be enabled via addition of the `/subsystem=core-management/service=unstable-api-annotations` resource. Once enabled, you can choose whether usage of these API elements should result in a warning in the logs, or a failed deployment. The next two child sections show examples of how to configure the scanner.
+
+=== Log a warning
+To enable the scanner and log a warning if annotated API elements are used in your code, execute the following CLI command:
+
+[source,options="nowrap"]
+----
+/subsystem=core-management/service=unstable-api-annotations:add(level=log)
+----
+
+The warning message in the log will contain information about which API elements were called, from where, and which annotations they contain that indicate unstable API.
+
+=== Throw an error
+To enable the scanner and throw an error if annotated API elements are used in your code, execute the following CLI command:
+
+[source,options="nowrap"]
+----
+/subsystem=core-management/service=unstable-api-annotations:add(level=error)
+----
+
+If you use annotated API elements in your code, the deployment will fail, and the error message will contain  information about which API elements were called, from where, and which annotations they contain that indicate unstable API.
+
+
+
+
+

--- a/ee-dist/src/verifier/verifications.xml
+++ b/ee-dist/src/verifier/verifications.xml
@@ -86,6 +86,10 @@
       <exists>false</exists>
     </file>
     <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip</location>
+      <exists>true</exists>
+    </file>
+    <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-txn_5_0.xsd</location>
       <exists>true</exists>
     </file>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <galleon.shared.resources.directory>${basedir}/../galleon-shared/src/main/resources</galleon.shared.resources.directory>
+        <galleon.shared.generated.resources.directory>${basedir}/../galleon-shared/target/index</galleon.shared.generated.resources.directory>
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
         <license.directory>${project.build.directory}/resources/content/docs/licenses</license.directory>
         <pruned.resources.directory>${basedir}/../pruned/src/main/resources</pruned.resources.directory>
@@ -118,6 +119,23 @@
                             <resources>
                                 <resource>
                                     <directory>${galleon.shared.resources.directory}</directory>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-galleon-shared-feature-pack-generated-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Just copy here rather than trying to get from the shared zip, since nothing else is using the zip -->
+                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/content</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${galleon.shared.generated.resources.directory}</directory>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -25,5 +25,7 @@
         <package name="cleanup.domain.servers.dir" optional="true"/>
         <package name="cleanup.domain.log.dir" optional="true"/>
         <package name="cleanup.domain.data.dir" optional="true"/>
+        <!-- Unstable API Annotation Index -->
+        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack"/>
     </packages>
 </config>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -35,5 +35,7 @@
         <package name="org.jboss.common-beans" optional="true"/>
         <package name="docs.licenses" optional="true"/>
         <package name="docs.licenses.merge" optional="true"/>
+        <!-- Unstable API Annotation Index -->
+        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack"/>
     </packages>
 </config>

--- a/ee-feature-pack/galleon-shared/assembly.xml
+++ b/ee-feature-pack/galleon-shared/assembly.xml
@@ -16,6 +16,10 @@
             <directory>src/main/resources</directory>
             <outputDirectory/>
         </fileSet>
+        <fileSet>
+            <directory>target/index</directory>
+            <outputDirectory>packages/unstable-api-annotation-index.wildfly-ee-feature-pack/content/</outputDirectory>
+        </fileSet>
     </fileSets>
     <files>
         <file>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -4119,7 +4119,7 @@
                 <groupId>org.wildfly.unstable.api.annotation</groupId>
                 <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
                 <configuration>
-                    <outputFile>${project.build.directory}/index/wildfly-ee-feature-pack.txt</outputFile>
+                    <outputFile>${project.build.directory}/index/wildfly-ee-feature-pack.zip</outputFile>
                     <filters>
                         <filter>
                             <annotation>org.hibernate.Incubating</annotation>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -4115,6 +4115,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.wildfly.unstable.api.annotation</groupId>
+                <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
+                <configuration>
+                    <outputFile>${project.build.directory}/index/wildfly-ee-feature-pack.txt</outputFile>
+                    <filters>
+                        <filter>
+                            <annotation>org.hibernate.Incubating</annotation>
+                            <groupIds>
+                                <groupId>org.hibernate</groupId>
+                                <groupId>org.hibernate.*</groupId>
+                            </groupIds>
+                        </filter>
+                        <filter>
+                            <annotation>org.hibernate.validator.Incubating</annotation>
+                            <groupIds>
+                                <groupId>org.hibernate</groupId>
+                                <groupId>org.hibernate.*</groupId>
+                            </groupIds>
+                        </filter>
+                    </filters>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/package.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="unstable-api-annotation-index.wildfly-ee-feature-pack">
+</package-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
+    <append-file
+            target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
+            ignore="true">
+        <line>wildfly-ee-feature-pack.txt</line>
+    </append-file>
+    <copy-path src="wildfly-ee-feature-pack.txt" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.txt"/>
+
+</tasks>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
@@ -8,8 +8,8 @@
     <append-file
             target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
             ignore="true">
-        <line>wildfly-ee-feature-pack.txt</line>
+        <line>wildfly-ee-feature-pack.zip</line>
     </append-file>
-    <copy-path src="wildfly-ee-feature-pack.txt" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.txt"/>
+    <copy-path src="wildfly-ee-feature-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip"/>
 
 </tasks>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
@@ -5,11 +5,6 @@
   -->
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
-    <append-file
-            target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
-            ignore="true">
-        <line>wildfly-ee-feature-pack.zip</line>
-    </append-file>
-    <copy-path src="wildfly-ee-feature-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip"/>
+        <copy-path src="wildfly-ee-feature-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip"/>
 
 </tasks>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -31,6 +31,7 @@
         <license.directory>${project.build.directory}/resources/content/docs/licenses</license.directory>
         <galleon.unpacked.resources.directory>${project.build.directory}/unpacked-dependency-galleon-resources</galleon.unpacked.resources.directory>
         <galleon.shared.resources.directory>${basedir}/../galleon-shared/src/main/resources</galleon.shared.resources.directory>
+        <galleon.shared.generated.resources.directory>${basedir}/../galleon-shared/target/index</galleon.shared.generated.resources.directory>
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
     </properties>
 
@@ -114,6 +115,23 @@
                             <resources>
                                 <resource>
                                     <directory>${galleon.shared.resources.directory}</directory>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-galleon-shared-feature-pack-generated-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Just copy here rather than trying to get from the shared zip, since nothing else is using the zip -->
+                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/content</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${galleon.shared.generated.resources.directory}</directory>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/galleon-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -9,5 +9,7 @@
     <packages>
         <package name="product.conf" optional="true"/>
         <package name="misc.domain"/>
+        <!-- Unstable API Annotation Index -->
+        <package name="unstable-api-annotation-index.wildfly-galleon-pack"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -12,5 +12,7 @@
         <package name="misc.standalone"/>
         <package name="docs.licenses" optional="true"/>
         <package name="docs.licenses.merge" optional="true"/>
+        <!-- Unstable API Annotation Index -->
+        <package name="unstable-api-annotation-index.wildfly-galleon-pack"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-shared/assembly.xml
+++ b/galleon-pack/galleon-shared/assembly.xml
@@ -16,6 +16,10 @@
             <directory>src/main/resources</directory>
             <outputDirectory/>
         </fileSet>
+        <fileSet>
+            <directory>target/index</directory>
+            <outputDirectory>packages/unstable-api-annotation-index.wildfly-galleon-pack/content/</outputDirectory>
+        </fileSet>
     </fileSets>
     <files>
         <file>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -653,7 +653,7 @@
                 <groupId>org.wildfly.unstable.api.annotation</groupId>
                 <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
                 <configuration>
-                    <outputFile>${project.build.directory}/index/wildfly-galleon-pack.txt</outputFile>
+                    <outputFile>${project.build.directory}/index/wildfly-galleon-pack.zip</outputFile>
                     <filters>
                         <filter>
                             <annotation>io.smallrye.common.annotation.Experimental</annotation>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -649,6 +649,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.wildfly.unstable.api.annotation</groupId>
+                <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
+                <configuration>
+                    <outputFile>${project.build.directory}/index/wildfly-galleon-pack.txt</outputFile>
+                    <filters>
+                        <filter>
+                            <annotation>io.smallrye.common.annotation.Experimental</annotation>
+                            <groupIds>
+                                <groupId>io.smallrye</groupId>
+                                <groupId>io.smallrye.*</groupId>
+                            </groupIds>
+                            <excludedClasses>
+                                <excludedClass>org.eclipse.microprofile.reactive.messaging.Channel</excludedClass>
+                                <excludedClass>org.eclipse.microprofile.reactive.messaging.Incoming</excludedClass>
+                            </excludedClasses>
+                        </filter>
+                    </filters>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/package.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="unstable-api-annotation-index.wildfly-galleon-pack">
+</package-spec>

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
+    <append-file
+            target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
+            ignore="true">
+        <line>wildfly-galleon-pack.txt</line>
+    </append-file>
+    <copy-path src="wildfly-galleon-pack.txt" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.txt"/>
+</tasks>

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
@@ -5,10 +5,5 @@
   -->
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
-    <append-file
-            target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
-            ignore="true">
-        <line>wildfly-galleon-pack.zip</line>
-    </append-file>
     <copy-path src="wildfly-galleon-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.zip"/>
 </tasks>

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
@@ -8,7 +8,7 @@
     <append-file
             target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/index.txt"
             ignore="true">
-        <line>wildfly-galleon-pack.txt</line>
+        <line>wildfly-galleon-pack.zip</line>
     </append-file>
-    <copy-path src="wildfly-galleon-pack.txt" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.txt"/>
+    <copy-path src="wildfly-galleon-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.zip"/>
 </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
+        <version.org.wildfly.unstable.annotation.api>1.0.0.Alpha3</version.org.wildfly.unstable.annotation.api>
         <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
@@ -1321,6 +1322,20 @@
                             <version>${version.org.wildfly.common}</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.wildfly.unstable.api.annotation</groupId>
+                    <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
+                    <version>${version.org.wildfly.unstable.annotation.api}</version>
+                    <executions>
+                        <execution>
+                            <id>scan-experimental-annotations</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>index-unstable-api-annotations</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.unstable.annotation.api>1.0.0.Alpha3</version.org.wildfly.unstable.annotation.api>
+        <version.org.wildfly.unstable.annotation.api>1.0.0.Beta1</version.org.wildfly.unstable.annotation.api>
         <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1741,6 +1741,7 @@
                                         <include>org/jboss/as/test/integration/ee/naming/defaultbindings/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java</include>
                                         <include>org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java</include>
+                                        <include>org/wildfly/test/integration/unstable_api_annotation/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java</include>
                                     </includes>
 
@@ -1800,6 +1801,7 @@
                                         <exclude>org/jboss/as/test/integration/jca/moduledeployment/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java</exclude>
+                                        <include>org/wildfly/test/integration/unstable_api_annotation/*TestCase.java</include>
                                         <exclude>org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/jaxrs/cfg/**/ResteasyAttributeTestCase.java</exclude>
                                     </excludes>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -778,6 +778,11 @@
             <artifactId>jboss-saaj-api_3.0_spec</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-management-subsystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.discovery</groupId>
             <artifactId>wildfly-discovery-client</artifactId>
         </dependency>
@@ -1516,6 +1521,7 @@
                                 <include>org/jboss/as/test/integration/weld/**/*Test.java</include>
                                 <include>org/wildfly/test/integration/microprofile/**/*TestCase.java</include>
                                 <include>org/wildfly/test/integration/microprofile/**/*Test.java</include>
+                                <include>org/wildfly/test/integration/unstable_api_annotation/*TestCase.java</include>
                             </includes>
                             <excludes>
                                 <!-- ee-security subsystem missing, javax.enterprise.security.api not injected -->

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
@@ -5,6 +5,21 @@
 
 package org.wildfly.test.integration.unstable_api_annotation;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -37,21 +52,6 @@ import org.wildfly.test.integration.unstable_api_annotation.jar2.Jar2ClassA;
 import org.wildfly.test.integration.unstable_api_annotation.war.Servlet;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
-
 /**
  * The full test for testing the reporting of usage of unstable API annotation annotated constructs lives
  * in WildFly Core. This test is just to verify that the annotation index from the feature packs is present in the server.
@@ -67,7 +67,7 @@ public class UnstableApiAnnotationIndexTestCase {
             "system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main";
 
     private static final String CONTENT = "content";
-    private static final String INDEX_INDEX_FILE = "index.txt";
+    private static final String README_TXT = "README.txt";
 
     private static final String WILDFLY_EE_FEATURE_PACK_INDEX = "wildfly-ee-feature-pack.zip";
     private static final String WILDFLY_GALLEON_PACK_INDEX = "wildfly-galleon-pack.zip";
@@ -103,21 +103,14 @@ public class UnstableApiAnnotationIndexTestCase {
                 Path indexContentDir = indexModulePath.resolve(CONTENT);
                 Assert.assertTrue(Files.exists(indexContentDir));
 
-                Path mainIndexFile = indexContentDir.resolve(INDEX_INDEX_FILE);
-                Assert.assertTrue(Files.exists(mainIndexFile));
-
                 Set<String> indices = Files.list(indexContentDir)
-                        .filter(p -> !p.getFileName().toString().equals(INDEX_INDEX_FILE))
+                        .filter(p -> !p.getFileName().toString().equals(README_TXT))
                         .map(p -> p.getFileName().toString())
                         .collect(Collectors.toSet());
                 // We are always running in an execution that has both feature packs provisioned
                 Assert.assertEquals(2, indices.size());
                 Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_EE_FEATURE_PACK_INDEX));
                 Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_GALLEON_PACK_INDEX));
-
-                List<String> mainIndexEntries = Files.readAllLines(mainIndexFile).stream().filter(l -> !l.isEmpty() && !l.startsWith("#")).collect(Collectors.toList());
-                Assert.assertEquals(mainIndexEntries + " : " + indices, mainIndexEntries.size(), indices.size());
-                Assert.assertTrue(mainIndexEntries + " : " + indices, indices.containsAll(mainIndexEntries));
 
                 break;
             }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.unstable_api_annotation.dummy.Dummy;
+import org.wildfly.test.integration.unstable_api_annotation.jar.JarClassA;
+import org.wildfly.test.integration.unstable_api_annotation.jar2.Jar2ClassA;
+import org.wildfly.test.integration.unstable_api_annotation.war.Servlet;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+
+/**
+ * The full test for testing the reporting of usage of unstable API annotation annotated constructs lives
+ * in WildFly Core. This test is just to verify that the annotation index from the feature packs is present in the server.
+ *
+ * Also, there is some verification that in various types of archives, the classes are only scanned once.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({UnstableApiAnnotationIndexTestCase.AddUnstableApiAnnotationResourceSetupTask.class, UnstableApiAnnotationIndexTestCase.SystemPropertyServerSetupTask.class})
+public class UnstableApiAnnotationIndexTestCase {
+
+    private static final String INDEX_MODULE_DIR =
+            "system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main";
+
+    private static final String CONTENT = "content";
+    private static final String INDEX_INDEX_FILE = "index.txt";
+
+    private static final String WILDFLY_EE_FEATURE_PACK_INDEX = "wildfly-ee-feature-pack.txt";
+    private static final String WILDFLY_GALLEON_PACK_INDEX = "wildfly-galleon-pack.txt";
+
+    @ArquillianResource
+    public ManagementClient managementClient;
+
+    @Deployment(testable = false)
+    public static Archive<?> getDummyDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, "dummy.jar")
+                .addClass(Dummy.class);
+    }
+
+    @Test
+    public void testIndexExists() throws Exception {
+        String[] modulePathStrings = System.getProperty("module.path", null).split(File.pathSeparator);
+        List<Path> modulePaths = new ArrayList<>();
+        for (String mp : modulePathStrings) {
+            Path p = Paths.get(mp);
+            if (Files.exists(p)) {
+                modulePaths.add(p);
+            }
+        }
+
+        Assert.assertTrue(modulePaths.size() > 0);
+
+        boolean found = false;
+        for (Path modulesPath : modulePaths) {
+            Path indexModulePath = modulesPath.resolve(INDEX_MODULE_DIR);
+            if (Files.exists(indexModulePath)) {
+                found = true;
+
+                Path indexContentDir = indexModulePath.resolve(CONTENT);
+                Assert.assertTrue(Files.exists(indexContentDir));
+
+                Path mainIndexFile = indexContentDir.resolve(INDEX_INDEX_FILE);
+                Assert.assertTrue(Files.exists(mainIndexFile));
+
+                Set<String> indices = Files.list(indexContentDir)
+                        .filter(p -> !p.getFileName().toString().equals(INDEX_INDEX_FILE))
+                        .map(p -> p.getFileName().toString())
+                        .collect(Collectors.toSet());
+                // We are always running in an execution that has both feature packs provisioned
+                Assert.assertEquals(2, indices.size());
+                Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_EE_FEATURE_PACK_INDEX));
+                Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_GALLEON_PACK_INDEX));
+
+                List<String> mainIndexEntries = Files.readAllLines(mainIndexFile).stream().filter(l -> !l.isEmpty() && !l.startsWith("#")).collect(Collectors.toList());
+                Assert.assertEquals(mainIndexEntries + " : " + indices, mainIndexEntries.size(), indices.size());
+                Assert.assertTrue(mainIndexEntries + " : " + indices, indices.containsAll(mainIndexEntries));
+
+                break;
+            }
+        }
+
+        Assert.assertTrue("Could not find annotation index module", found);
+    }
+
+    @Test
+    public void testJavaArchive() throws Exception {
+        JavaArchive jar = createJavaArchive();
+        testArchiveDeployment(jar, 2);
+    }
+
+    @Test
+    public void testJavaArchive2() throws Exception {
+        // Temporary check
+        JavaArchive jar = createJavaArchive();
+        testArchiveDeployment(jar, 2);
+    }
+
+    @Test
+    public void testEmptyWebArchive() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                        .add(new StringAsset("test"), "test.txt");
+
+        testArchiveDeployment(war, 0);
+    }
+
+    @Test
+    public void testWebArchiveWithClassesInWrongLocation() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                        .add(new ClassAsset(Servlet.class), "org/jboss/as/test/integration/unstable_api_annotation/war/WarClassA.class");
+
+        testArchiveDeployment(war, 0);
+    }
+
+    @Test
+    public void testWebArchiveWithWebInfClasses() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                        .addPackage(Servlet.class.getPackage());
+        testArchiveDeployment(war, 4);
+    }
+
+    @Test
+    public void testWebArchiveWithLibJar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                        .addAsLibraries(createJavaArchive());
+
+        testArchiveDeployment(war, 2);
+    }
+
+
+    @Test
+    public void testWebArchiveWithWebInfClassesAndLibJar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage())
+                .addAsLibraries(createJavaArchive());
+
+        testArchiveDeployment(war, 6);
+    }
+
+    @Test
+    public void testWebArchiveWithWebInfClassesAndTwoLibJar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage())
+                .addAsLibraries(createJavaArchive(), createJavaArchive2());
+
+        testArchiveDeployment(war, 14);
+    }
+
+    @Test
+    public void testEarWithOneModuleJar() throws Exception {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsModule(createJavaArchive());
+        testArchiveDeployment(ear, 2);
+    }
+
+    @Test
+    public void testEarWithOneModuleJarAndClassInWrongPlace() throws Exception {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsModule(createJavaArchive());
+        ear.add(new ClassAsset(Dummy.class), "org/jboss/as/test/integration/unstable_api_annotation/dummy/Dummy.class");
+
+        testArchiveDeployment(ear, 2);
+    }
+
+    @Test
+    public void testEarWithNoModuleJarAndEmptyWar() throws Exception {
+
+        WebArchive emptyWar = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .add(new ClassAsset(Servlet.class), "org/jboss/as/test/integration/unstable_api_annotation/war/WarClassA.class");
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsModule(emptyWar);
+
+        testArchiveDeployment(ear, 0);
+    }
+
+    @Test
+    public void testEarWithModuleJarAndWarWithClasses() throws Exception {
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage());
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsModule(createJavaArchive());
+        ear.addAsModule(war);
+
+        testArchiveDeployment(ear, 6);
+    }
+
+    @Test
+    public void testEarWithModuleJarAndWarWithClassesAndLibJar() throws Exception {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsModule(createJavaArchive());
+        ear.addAsModule(ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage())
+                .addAsLibraries(createJavaArchive2()));
+
+        testArchiveDeployment(ear, 14);
+    }
+
+    @Test
+    public void testEarWithLibJarAndWarWithClasses() throws Exception {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsLibrary(createJavaArchive());
+        ear.addAsModule(ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage()));
+
+        testArchiveDeployment(ear, 6);
+    }
+
+    @Test
+    public void testEarWithModuleJarLibJarAndWarWithClasses() throws Exception {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test-unstable-api-annotation-empty.ear");
+        ear.addAsLibrary(createJavaArchive());
+        ear.addAsModule(createJavaArchive2());
+        ear.addAsModule(ShrinkWrap.create(WebArchive.class, "test-unstable-api-annotation-empty.war")
+                .addPackage(Servlet.class.getPackage()));
+
+        testArchiveDeployment(ear, 14);
+    }
+
+    private void testArchiveDeployment(Archive<?> archive, int expectedClassesCount) throws Exception {
+        LogDiffer logDiffer = new LogDiffer();
+        logDiffer.takeSnapshot();
+
+        ModelControllerClient mcc = managementClient.getControllerClient();
+
+        Operation deploymentOp = createDeploymentOp(archive);
+        ManagementOperations.executeOperation(mcc, deploymentOp);
+        try {
+            List<String> list = logDiffer.getNewLogEntries();
+            checkExpectedNumberClasses(list, expectedClassesCount);
+        } finally {
+            ManagementOperations.executeOperation(mcc, Util.createRemoveOperation(PathAddress.pathAddress("deployment", archive.getName())));
+        }
+    }
+
+    private Operation createDeploymentOp(Archive<?> deployment) {
+        final List<InputStream> streams = new ArrayList<>();
+        streams.add(deployment.as(ZipExporter.class).exportAsInputStream());
+        final ModelNode addOperation = Util.createAddOperation(PathAddress.pathAddress("deployment", deployment.getName()));
+        addOperation.get("enabled").set(true);
+        addOperation.get("content").add().get("input-stream-index").set(0);
+        return Operation.Factory.create(addOperation, streams, true);
+    }
+
+
+    private JavaArchive createJavaArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "test-unstable-api-annotation.jar")
+                .addPackage(JarClassA.class.getPackage());
+    }
+
+    private JavaArchive createJavaArchive2() {
+        return ShrinkWrap.create(JavaArchive.class, "test-unstable-api-annotation2.jar")
+                .addPackage(Jar2ClassA.class.getPackage());
+    }
+
+    private void checkExpectedNumberClasses(List<String> newLogEntries, int numberClasses) {
+        int classCount = 0;
+        for (String logEntry : newLogEntries.stream().filter(s -> s.contains("WFLYCM0016")).collect(Collectors.toList())) {
+            int index = logEntry.lastIndexOf(":");
+            String count = logEntry.substring(index + 1).trim();
+            classCount += Integer.parseInt(count);
+        }
+        Assert.assertFalse(newLogEntries.isEmpty());
+        Assert.assertEquals(numberClasses, classCount);
+    }
+
+    private static class LogDiffer {
+        Path logFile;
+
+        private List<String> lastLogSnapshot = Collections.emptyList();
+
+
+        public LogDiffer() {
+            String jbossHomeProp = System.getProperty("jboss.home");
+            Path jbossHome = Paths.get(jbossHomeProp);
+            Assert.assertTrue(Files.exists(jbossHome));
+            this.logFile = jbossHome.resolve("standalone/log/server.log");
+            Assert.assertTrue(Files.exists(logFile));
+        }
+
+        public void takeSnapshot() {
+            try {
+                lastLogSnapshot = Files.readAllLines(logFile);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public List<String> getNewLogEntries() {
+            try {
+                List<String> currentLog = Files.readAllLines(logFile);
+                return currentLog.stream()
+                        .filter(s -> !lastLogSnapshot.contains(s))
+                        .filter(s -> s.contains("WFLYCM"))
+                        .collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+
+    public static class AddUnstableApiAnnotationResourceSetupTask extends StabilityServerSetupSnapshotRestoreTasks.Preview {
+        @Override
+        public void doSetup(ManagementClient managementClient) throws Exception {
+            PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "core-management"))
+                    .append(PathElement.pathElement(SERVICE, "unstable-api-annotations"));
+            ModelNode addOp = Util.createAddOperation(address);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), addOp);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        }
+    }
+
+
+    public static class SystemPropertyServerSetupTask extends SnapshotRestoreSetupTask {
+        @Override
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            super.doSetup(client, containerId);
+            ModelNode op = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "org.wildfly.test.unstable-api-annotation.extra-output"));
+            op.get("value").set("true");
+            ManagementOperations.executeOperation(client.getControllerClient(), op);
+            // Reload so the system property is picked up by the deployer in order to print extra information
+            // about class count
+            ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient());
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
@@ -9,7 +9,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 
-import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,7 +16,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -62,16 +60,6 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 @RunAsClient
 @ServerSetup({UnstableApiAnnotationIndexTestCase.AddUnstableApiAnnotationResourceSetupTask.class, UnstableApiAnnotationIndexTestCase.SystemPropertyServerSetupTask.class})
 public class UnstableApiAnnotationIndexTestCase {
-
-    private static final String INDEX_MODULE_DIR =
-            "system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main";
-
-    private static final String CONTENT = "content";
-    private static final String README_TXT = "README.txt";
-
-    private static final String WILDFLY_EE_FEATURE_PACK_INDEX = "wildfly-ee-feature-pack.zip";
-    private static final String WILDFLY_GALLEON_PACK_INDEX = "wildfly-galleon-pack.zip";
-
     @ArquillianResource
     public ManagementClient managementClient;
 
@@ -79,44 +67,6 @@ public class UnstableApiAnnotationIndexTestCase {
     public static Archive<?> getDummyDeployment() {
         return ShrinkWrap.create(JavaArchive.class, "dummy.jar")
                 .addClass(Dummy.class);
-    }
-
-    @Test
-    public void testIndexExists() throws Exception {
-        String[] modulePathStrings = System.getProperty("module.path", null).split(File.pathSeparator);
-        List<Path> modulePaths = new ArrayList<>();
-        for (String mp : modulePathStrings) {
-            Path p = Paths.get(mp);
-            if (Files.exists(p)) {
-                modulePaths.add(p);
-            }
-        }
-
-        Assert.assertTrue(modulePaths.size() > 0);
-
-        boolean found = false;
-        for (Path modulesPath : modulePaths) {
-            Path indexModulePath = modulesPath.resolve(INDEX_MODULE_DIR);
-            if (Files.exists(indexModulePath)) {
-                found = true;
-
-                Path indexContentDir = indexModulePath.resolve(CONTENT);
-                Assert.assertTrue(Files.exists(indexContentDir));
-
-                Set<String> indices = Files.list(indexContentDir)
-                        .filter(p -> !p.getFileName().toString().equals(README_TXT))
-                        .map(p -> p.getFileName().toString())
-                        .collect(Collectors.toSet());
-                // We are always running in an execution that has both feature packs provisioned
-                Assert.assertEquals(2, indices.size());
-                Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_EE_FEATURE_PACK_INDEX));
-                Assert.assertTrue(indices.toString(), indices.contains(WILDFLY_GALLEON_PACK_INDEX));
-
-                break;
-            }
-        }
-
-        Assert.assertTrue("Could not find annotation index module", found);
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/UnstableApiAnnotationIndexTestCase.java
@@ -69,8 +69,8 @@ public class UnstableApiAnnotationIndexTestCase {
     private static final String CONTENT = "content";
     private static final String INDEX_INDEX_FILE = "index.txt";
 
-    private static final String WILDFLY_EE_FEATURE_PACK_INDEX = "wildfly-ee-feature-pack.txt";
-    private static final String WILDFLY_GALLEON_PACK_INDEX = "wildfly-galleon-pack.txt";
+    private static final String WILDFLY_EE_FEATURE_PACK_INDEX = "wildfly-ee-feature-pack.zip";
+    private static final String WILDFLY_GALLEON_PACK_INDEX = "wildfly-galleon-pack.zip";
 
     @ArquillianResource
     public ManagementClient managementClient;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/dummy/Dummy.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/dummy/Dummy.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.dummy;
+
+public class Dummy {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar/JarClassA.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar/JarClassA.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar;
+
+public class JarClassA {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar/JarClassB.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar/JarClassB.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar;
+
+public class JarClassB {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassA.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassA.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassA {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassB.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassB.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassB {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassC.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassC.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassC {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassD.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassD.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassD {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassE.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassE.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassE {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassF.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassF.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassF {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassG.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassG.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassG {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassH.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/jar2/Jar2ClassH.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.jar2;
+
+public class Jar2ClassH {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/Servlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/Servlet.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.war;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+
+@WebServlet(name = "WarClassA", urlPatterns = { "/WarClassA" })
+public class Servlet extends HttpServlet {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassA.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassA.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.war;
+
+public class WarClassA {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassB.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassB.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.war;
+
+public class WarClassB {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassC.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/unstable_api_annotation/war/WarClassC.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.unstable_api_annotation.war;
+
+public class WarClassC {
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19152

Needs https://github.com/wildfly/wildfly-core/pull/5913 (this also contains the link to the analysis document)

Also requires https://github.com/wildfly/wildfly/pull/17849 for the reload to a lower stability level

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-13682](https://issues.redhat.com/browse/WFLY-13682)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)