### PR TITLE
[WFLY-19158][WFLY-19159] Upgrade to SR Config 3.7.1 and Reactive Messaging 4.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>3.8.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.0.0</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.6.0</version.io.smallrye.smallrye-opentelemetry>
-        <version.io.smallrye.smallrye-reactive-messaging>4.18.0</version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.smallrye.smallrye-reactive-messaging>4.19.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.7.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.3</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.8</version.io.vertx.vertx-kafka-client>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <version.io.smallrye.open-api>3.10.0</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.3.0</version.io.smallrye.smallrye-common>
-        <version.io.smallrye.smallrye-config>3.6.1</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>3.7.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.2.6</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.4</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19158
https://issues.redhat.com/browse/WFLY-19159

These are just routine updates to the latest version. Doing them together to avoid conflicts
