### PR TITLE
[WFLY-19168] Upgrade WildFly core to 24.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>24.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>24.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <preview.version.org.wildfly.mvc.krazo>0.8.2.Final</preview.version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19168
https://github.com/wildfly/wildfly-core/compare/24.0.0.Beta2...24.0.0.Beta3

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)