### PR TITLE
[WFLY-19101] Add test checking for X-Content-Type-Options header in management console

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/console/ManagementConsoleHttpHeaderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/console/ManagementConsoleHttpHeaderTestCase.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class XFrameOptionsHeaderTestCase {
+public class ManagementConsoleHttpHeaderTestCase {
 
     private static final int MGMT_PORT = 9990;
 
@@ -53,6 +53,12 @@ public class XFrameOptionsHeaderTestCase {
     public void checkManagementConsoleForXFrameOptionsHeader() throws IOException, URISyntaxException {
         URL url = new URL("http", managementClient.getMgmtAddress(), MGMT_PORT, "/console/index.html");
         checkURLForHeader(url, "X-Frame-Options", "SAMEORIGIN");
+    }
+
+    @Test
+    public void checkManagementConsoleForXContentTypeOptionsHeader() throws IOException, URISyntaxException {
+        URL url = new URL("http", managementClient.getMgmtAddress(), MGMT_PORT, "/console/index.html");
+        checkURLForHeader(url, "X-Content-Type-Options", "nosniff");
     }
 
     private void checkURLForHeader(URL url, String headerName, String expectedHeaderValue) throws URISyntaxException, IOException {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19101

Add test checking for X-Content-Type-Options header in management console

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)