### PR TITLE
[WFLY-19062] Add preview stability support for Jakarta MVC to standard WildFly

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -1402,6 +1402,26 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>mvc-krazo-galleon-shared</artifactId>
+                <version>${version.org.wildfly.mvc.krazo}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>mvc-krazo-galleon-shared</artifactId>
+                <version>${version.org.wildfly.mvc.krazo}</version>
+                <type>zip</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.wildfly.security.mp</groupId>
                 <artifactId>wildfly-elytron-jwt</artifactId>
                 <version>${version.org.wildfly.security.elytron-mp}</version>

--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -70,39 +70,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- Import the MVC runtime deps -->
-            <dependency>
-                <groupId>org.wildfly</groupId>
-                <artifactId>mvc-krazo-galleon-shared</artifactId>
-                <version>${preview.version.org.wildfly.mvc.krazo}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly</groupId>
-                <artifactId>mvc-krazo-galleon-shared</artifactId>
-                <version>${preview.version.org.wildfly.mvc.krazo}</version>
-                <type>zip</type>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly</groupId>
-                <artifactId>mvc-krazo-subsystem</artifactId>
-                <version>${preview.version.org.wildfly.mvc.krazo}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>org.wildfly.deployment</groupId>
                 <artifactId>wildfly-ee-9-deployment-transformer</artifactId>

--- a/boms/standard-test-expansion/pom.xml
+++ b/boms/standard-test-expansion/pom.xml
@@ -187,6 +187,14 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Tests need to compile against MVC -->
+            <dependency>
+                <groupId>jakarta.mvc</groupId>
+                <artifactId>jakarta.mvc-api</artifactId>
+                <version>${version.jakarta.mvc.jakarta-mvc-api}</version>
+                <scope>test</scope>
+            </dependency>
+
             <!--
                 Needed by io.smallrye.reactive:smallrye-reactive-messaging-kafka-test-companion which doesn't pull
                 this in automatically

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -80,7 +80,7 @@ Profile |WildFly {wildflyVersion} Full Configuration |WildFly {wildflyVersion} D
 |Jakarta Messaging 3.1 |X |-- |X |--
 
 | Jakarta MVC 2.1
-(_WildFly Preview only_)|--|--|--|--
+(xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability])|--|--|--|--
 
 |Jakarta Persistence 3.1 |X |X |X |X
 

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -117,7 +117,6 @@ configuration to act as a primary or backup. An embedded messaging broker also h
 requirements than a server primarily dedicated to handling HTTP requests would have. Note however that running an
 embedded broker is still supported. We've added to the $WILDFLY_HOME/docs/examples/configs folder an example
 ``standalone-activemq-embedded.xml`` configuration showing its use.
-* WildFly Preview provides out of the box support for link:https://jakarta.ee/specifications/mvc[Jakarta MVC]. However, tech-preview support for Jakarta MVC can also be added to standard WildFly by including the link:https://github.com/wildfly-extras/mvc-krazo-feature-pack/blob/main/README.md[`wildfly-mvc-krazo-feature-pack`] Galleon feature pack in your server provisioning configuration.
 * The Hibernate ORM integration used by the link:Developer_Guide{outfilesuffix}#JPA_Reference_Guide[JPA subsystem's] Hibernate Search feature supports using outbox polling as coordination strategy for automatic indexing.
 * The extensions providing the legacy subsystems 'cmp', 'config-admin', 'jacorb', 'jaxr', 'jsr-77', 'messaging' (HornetQ based),
 'security' (not 'elytron'), and 'web' (not 'undertow') are removed. These were only used for domain mode to allow a Domain Controller to control

--- a/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
@@ -80,6 +80,8 @@ include::subsystem-configuration/Jakarta_Batch.adoc[]
 
 include::subsystem-configuration/Jakarta_Faces.adoc[]
 
+include::subsystem-configuration/Jakarta_MVC.adoc[]
+
 include::subsystem-configuration/JMX.adoc[]
 
 include::subsystem-configuration/Deployment_Scanner.adoc[]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_MVC.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_MVC.adoc
@@ -1,0 +1,50 @@
+[[Jakarta_MVC]]
+= Jakarta MVC Subsystem Configuration
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+[abstract]
+
+The `mvc-krazo` subsystem provides support for the use of Jakarta MVC in deployments.
+
+[WARNING]
+
+The `mvc-krazo` subsystem is currently provided at xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability]. This means use of the subsystem requires running xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview] or using the `--stability=preview` parameter when starting standard WildFly.
+
+[[mvc-krazo-subsystem-provision]]
+== Provisioning the subsystem
+
+When provisioning a WildFly instance, you can include Jakarta MVC support in your server configuration by specifying the `mvc-krazo` Galleon layer.
+
+////
+TODO add discussion of the need to specify config-stability-level when provisioning. But this should point to general content available via WFLY-19021 and WFLY-19172
+////
+
+[[mvc-krazo-subsystem-enable]]
+== Enabling the subsystem
+
+If the WildFly configuration does not have the `mvc-krazo` subsystem enabled, it can be enabled using the CLI:
+
+[source,options="nowrap"]
+----
+[standalone@localhost:9990  /] org.wildfly.extension.mvc-krazo:add
+{"outcome" => "success"}
+[standalone@localhost:9990  /] /subsystem=mvc-krazo:add
+{
+    "outcome" => "success",
+    "response-headers" => {
+        "operation-requires-reload" => true,
+        "process-state" => "reload-required"
+    }
+}
+----
+
+== Configuration
+
+The `mvc-krazo` subsystem doesn't offer any configuration options beyond its presence in the overall configuration.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Simple_configuration_subsystems.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Simple_configuration_subsystems.adoc
@@ -32,7 +32,7 @@ and could be useful to anyone, it is primarily useful for JBoss EAP
 subscribers who would provide the data to Red Hat when requesting
 support.
 
-|mvc-krazo| Provides support for use of Jakarta MVC in deployments. Currently only provided in WildFly Preview, although `preview` stability level support can be added to standard WildFly by including the link:https://github.com/wildfly-extras/mvc-krazo-feature-pack/blob/main/README.md[`wildfly-mvc-krazo-feature-pack`] Galleon feature pack in your server provisioning configuration.
+|mvc-krazo| Provides support for use of Jakarta MVC in deployments. Currently provided at xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability].
 
 |pojo |Enables the deployment of applications containing JBoss
 Microcontainer services, as supported by previous versions of JBoss

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -463,7 +463,7 @@ link:#gal.opentelemetry[opentelemetry]
 link:#gal.web-server[web-server] +
 
 |[[gal.mvc-krazo]]mvc-krazo
-|Support for Jakarta MVC (_WildFly Preview only unless the  link:https://github.com/wildfly-extras/mvc-krazo-feature-pack/blob/main/README.md[`wildfly-mvc-krazo-feature-pack`] is used_)
+|Support for Jakarta MVC (xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability])
 |
 link:#gal.bean-validation[bean-validation] +
 link:#gal.cdi[cdi] +

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <ee.galleon.shared.resources.directory>${basedir}/../../ee-feature-pack/galleon-shared/src/main/resources</ee.galleon.shared.resources.directory>
         <license.directory>${project.build.directory}/resources/content/docs/licenses</license.directory>
+        <galleon.unpacked.resources.directory>${project.build.directory}/unpacked-dependency-galleon-resources</galleon.unpacked.resources.directory>
         <galleon.shared.resources.directory>${basedir}/../galleon-shared/src/main/resources</galleon.shared.resources.directory>
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
     </properties>
@@ -47,6 +48,32 @@
                         <goals>
                             <goal>clean</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-galleon-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>mvc-krazo-galleon-shared</artifactId>
+                                    <type>zip</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <!-- The feature pack build seems to ignore such things anyway, but to be
+                                 robust exclude artifact metadata content -->
+                            <excludes>**/pom.xml,META-INF,META-INF/**</excludes>
+                            <outputDirectory>${galleon.unpacked.resources.directory}</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -108,6 +135,23 @@
                             <overwrite>true</overwrite>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-unpacked-galleon-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <escapeString>\</escapeString>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target/unpacked-dependency-galleon-resources</directory>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -125,6 +169,7 @@
                             <generateVersionProperty>true</generateVersionProperty>
                             <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                             <licensesConfigFiles>
+                                <licensesConfigFile>${galleon.unpacked.resources.directory}/license/wildfly-mvc-krazo-licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${galleon.shared.resources.directory}/license/licenses.xml</licensesConfigFile>
                             </licensesConfigFiles>
                             <licensesOutputFile>${license.directory}/wildfly-feature-pack-licenses.xml</licensesOutputFile>
@@ -197,6 +242,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>mvc-krazo-galleon-shared</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>
@@ -259,6 +311,7 @@
                                                      transitives. Those poms ban transitives at their level -->
                                                 <exclude>${full.maven.groupId}:wildfly-feature-pack-galleon-shared</exclude>
                                                 <exclude>${full.maven.groupId}:wildfly-feature-pack-galleon-local</exclude>
+                                                <exclude>org.wildfly:mvc-krazo-galleon-shared</exclude>
                                             </excludes>
                                         </banTransitiveDependencies>
                                     </rules>

--- a/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -82,6 +82,7 @@
                 <extension>org.wildfly.extension.microprofile.opentracing-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.reactive-messaging-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.reactive-streams-operators-smallrye</extension>
+                <extension>org.wildfly.extension.mvc-krazo</extension>
                 <extension>org.wildfly.extension.opentelemetry</extension>
             </standalone>
             <domain>
@@ -95,6 +96,7 @@
                 <extension>org.wildfly.extension.microprofile.opentracing-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.reactive-messaging-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.reactive-streams-operators-smallrye</extension>
+                <extension>org.wildfly.extension.mvc-krazo</extension>
                 <extension>org.wildfly.extension.opentelemetry</extension>
             </domain>
         </extensions>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -10,50 +10,50 @@
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly28.0"/>
         <param name="host-release" value="WildFly28.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly29.0"/>
         <param name="host-release" value="WildFly29.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly30.0"/>
         <param name="host-release" value="WildFly30.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly31.0"/>
         <param name="host-release" value="WildFly31.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.elytron.jaas-realm&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,7 @@
         <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.json.bind.api>3.0.0</version.jakarta.json.bind.api>
         <version.jakarta.mail-api>2.1.3</version.jakarta.mail-api>
+        <version.jakarta.mvc.jakarta-mvc-api>2.1.0</version.jakarta.mvc.jakarta-mvc-api>
         <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
         <version.jakarta.security.enterprise>3.0.0</version.jakarta.security.enterprise>
@@ -563,7 +564,7 @@
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.core>24.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
-        <preview.version.org.wildfly.mvc.krazo>0.8.2.Final</preview.version.org.wildfly.mvc.krazo>
+        <version.org.wildfly.mvc.krazo>1.0.0.CR2</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-mp>2.0.0.Final</version.org.wildfly.security.elytron-mp>
         <version.org.wildfly.transaction.client>3.0.5.Final</version.org.wildfly.transaction.client>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -100,7 +100,7 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-unpacked-wildfly-core-galleon-resources</id>
+                        <id>copy-unpacked-galleon-resources</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
@@ -111,28 +111,6 @@
                             <resources>
                                 <resource>
                                     <directory>${basedir}/target/unpacked-dependency-galleon-resources</directory>
-                                    <excludes>
-                                        <!-- We handle system/add-ons separately -->
-                                        <exclude>modules/system/add-ons/mvc-krazo/**</exclude>
-                                    </excludes>
-                                </resource>
-                            </resources>
-                            <overwrite>true</overwrite>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- The mvc-krazo FP puts things in system/add-ons but for us they are in system/layers/base -->
-                        <id>copy-unpacked-module-addons-resources</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/resources/modules/system/layers/base</outputDirectory>
-                            <escapeString>\</escapeString>
-                            <resources>
-                                <resource>
-                                    <directory>${basedir}/target/unpacked-dependency-galleon-resources/modules/system/add-ons/mvc-krazo</directory>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>
@@ -210,6 +188,7 @@
                             <licensesConfigFiles>
                                 <licensesConfigFile>${basedir}/target/resources/license/core-feature-pack-common-licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${basedir}/target/resources/license/core-feature-pack-ee-10-api-licenses.xml</licensesConfigFile>
+                                <licensesConfigFile>${basedir}/target/resources/license/wildfly-mvc-krazo-licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${ee.galleon.shared.resources.directory}/license/licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${full.galleon.shared.resources.directory}/license/licenses.xml</licensesConfigFile>
                                 <licensesConfigFile>${galleon.local.resources.directory}/license/licenses.xml</licensesConfigFile>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -206,7 +206,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
             // to the internal mpExtensions Set defined on this class.
             // Don't add here extensions supplied only by the wildfly-preview-feature-pack because we are not tracking different releases
             // of wildfly preview. In such a case, add them to previewExtensions set defined below.
-            return List.of("org.wildfly.extension.elytron.jaas-realm");
+            return List.of("org.wildfly.extension.elytron.jaas-realm", "org.wildfly.extension.mvc-krazo");
         }
         private static List<String> getCurrentRemovedExtensions() {
             // TODO If we decide to remove these modules from WFP, uncomment this.
@@ -253,7 +253,6 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
         // to compute on which WildFly Preview was added such a new extension and track the Host Exclusions between
         // different WildFly Preview releases.
         private final Set<String> previewExtensions = new HashSet<>(Arrays.asList(
-                "org.wildfly.extension.mvc-krazo"
         ));
 
         ExtensionConf(String name, ExtensionConf parent, boolean supported) {

--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -64,6 +64,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.mvc</groupId>
+            <artifactId>jakarta.mvc-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
@@ -85,6 +95,11 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/CdiBean.java
+++ b/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/CdiBean.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.mvc;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
+
+@Named
+@RequestScoped
+public class CdiBean {
+    private String name;
+
+    public String getFirstName() {
+        return name;
+    }
+
+    public void setFirstName(String name) {
+        this.name = name;
+    }
+}

--- a/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoApplication.java
+++ b/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.mvc;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("mvc-smoke")
+public class MVCKrazoApplication extends Application {
+}

--- a/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoSmokeController.java
+++ b/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoSmokeController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.mvc;
+
+import jakarta.inject.Inject;
+import jakarta.mvc.Controller;
+import jakarta.mvc.Models;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Controller
+@Path("test")
+public class MVCKrazoSmokeController {
+
+    @Inject
+    private Models models;
+
+    @Inject
+    private CdiBean cdiBean;
+
+    @GET
+    public String render() {
+
+        cdiBean.setFirstName("Joan");
+        models.put("lastName", "Jett");
+        return "view.jsp";
+    }
+}

--- a/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoSmokeTestCase.java
+++ b/testsuite/integration/manualmode-expansion/src/test/java/org/wildfly/test/manual/mvc/MVCKrazoSmokeTestCase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.mvc;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp25.WebAppDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+//@ServerSetup(MVCKrazoSmokeTestCase.Setup.class) TODO migrate this to testsuite/integration/basic and let WFARQ call the ServerSetupTask
+public class MVCKrazoSmokeTestCase {
+
+    private static final Logger log = Logger.getLogger(MVCKrazoSmokeTestCase.class.getName());
+
+    // TODO migrate this to testsuite/integration/basic and drop the ContainerController aspect used in manualmode
+    private static final String CONTAINER = "stability-preview";
+    // TODO migrate this to testsuite/integration/basic and let WFARQ call the ServerSetupTask via @ServerSetup
+    private static final ServerSetupTask SETUP_TASK = new MVCKrazoSmokeTestCase.Setup();
+
+    private static final String DEPLOYMENT_NAME = "MVCKrazoSmokeTestCase";
+
+    private static final String MVC_EXTENSION = "org.wildfly.extension.mvc-krazo";
+    private static final String MVC_SUBSYSTEM = "mvc-krazo";
+
+    @Deployment(name = DEPLOYMENT_NAME, testable = false, managed = false) // TODO migrate this to testsuite/integration/basic and change to managed = true
+    @TargetsContainer(CONTAINER)
+    public static WebArchive createDeployment() {
+        Descriptors.create(WebAppDescriptor.class);
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war")
+                .addClass(MVCKrazoApplication.class)
+                .addClass(MVCKrazoSmokeController.class)
+                .addClass(CdiBean.class)
+                .addAsWebInfResource(new StringAsset("<html>" +
+                                "<p>First Name = [${cdiBean.firstName}]</p>\n" +
+                                "<p>Last Name = [${lastName}]</p>\n" +
+                                "</html>"),
+                        "views/view.jsp");
+    }
+    // TODO migrate this to testsuite/integration/basic and drop the ContainerController aspect used in manualmode
+    @ArquillianResource
+    private static ContainerController containerController;
+
+    // TODO migrate this to testsuite/integration/basic and drop the manual deployment aspect used in manualmode
+    @ArquillianResource
+    private static Deployer deployer;
+
+    // TODO migrate this to testsuite/integration/basic and inject the http listener URL
+//    @ArquillianResource
+//    private URL url;
+
+
+    // TODO migrate this to testsuite/integration/basic and drop this
+    @Test
+    @InSequence(-1)
+    public void startAndSetupContainer() throws Exception {
+
+        log.trace("*** starting server");
+        containerController.start(CONTAINER);
+        ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
+        ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
+                TestSuiteEnvironment.getServerPort(), "remote+http");
+
+        log.trace("*** will configure server now");
+        SETUP_TASK.setup(managementClient, CONTAINER);
+
+        deployer.deploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    @InSequence(1)
+    public void test() throws Exception {
+        // TODO migrate this to testsuite/integration/basic and inject the http listener URL
+        //URL url = new URL(this.url.toExternalForm() + "mvc-smoke/test");
+        URL url = new URL("http", TestSuiteEnvironment.getServerAddress(), 8080, "/" + DEPLOYMENT_NAME + "/mvc-smoke/test");
+        String s = HttpRequest.get(url.toExternalForm(), 10, TimeUnit.SECONDS);
+        assertTrue(s, s.contains("Joan"));
+        assertTrue(s, s.contains("Jett"));
+    }
+
+    // TODO migrate this to testsuite/integration/basic and drop this
+    @Test
+    @InSequence(10)
+    public void stopContainer() throws Exception {
+        deployer.undeploy(DEPLOYMENT_NAME);
+        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
+        final ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
+                TestSuiteEnvironment.getServerPort(), "remote+http");
+        log.trace("*** resetting test configuration");
+        SETUP_TASK.tearDown(managementClient, CONTAINER);
+
+        log.trace("*** stopping container");
+        containerController.stop(CONTAINER);
+    }
+
+    public static class Setup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String s) {
+
+            if (!Boolean.getBoolean("ts.layers") && !Boolean.getBoolean("ts.bootable.preview")) {
+                ModelNode op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+                ModelNode steps = op.get(STEPS);
+                steps.add(Util.createAddOperation(PathAddress.pathAddress(EXTENSION, MVC_EXTENSION)));
+                steps.add(Util.createAddOperation(PathAddress.pathAddress(SUBSYSTEM, MVC_SUBSYSTEM)));
+                try {
+                    ModelNode response = managementClient.getControllerClient().execute(op);
+                    if (!SUCCESS.equals(response.get(OUTCOME).asString())) {
+                        throw new RuntimeException(String.format("%s response -- %s", op, response));
+                    }
+                    ServerReload.executeReloadAndWaitForCompletion(managementClient);
+
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+            if (!Boolean.getBoolean("ts.layers")) {
+                ModelNode op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+                ModelNode steps = op.get(STEPS);
+                steps.add(Util.createRemoveOperation(PathAddress.pathAddress(SUBSYSTEM, MVC_SUBSYSTEM)));
+                steps.add(Util.createRemoveOperation(PathAddress.pathAddress(EXTENSION, MVC_EXTENSION)));
+                managementClient.getControllerClient().execute(op);
+
+                ServerReload.executeReloadAndWaitForCompletion(managementClient);
+            }
+
+        }
+    }
+}

--- a/testsuite/integration/manualmode-expansion/src/test/resources/arquillian.xml
+++ b/testsuite/integration/manualmode-expansion/src/test/resources/arquillian.xml
@@ -47,6 +47,25 @@
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
+
+        <!-- A container we launch with the 'stability=preview' setting -->
+        <container qualifier="stability-preview" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args} --stability=preview</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+                <property name="javaHome">${container.java.home}</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/integration/manualmode-expansion/src/test/resources/logging.properties
+++ b/testsuite/integration/manualmode-expansion/src/test/resources/logging.properties
@@ -1,0 +1,29 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
+logger.org.jboss.shrinkwrap.level=INFO
+logger.org.jboss.as.test.level=${test.log.level:INFO}
+logger.org.apache.directory.level=WARNING
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=WARN
+
+# Root logger handlers
+logger.handlers=FILE
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -665,7 +665,7 @@
                                 <goals>
                                     <goal>provision</goal>
                                 </goals>
-                                <phase>${provisioning.phase.preview.only}</phase>
+                                <phase>${provisioning.phase}</phase>
                                 <configuration>
                                     <install-dir>${layers.install.dir}/mvc-krazo</install-dir>
                                     <feature-packs>
@@ -795,6 +795,11 @@
                                                 <layer>microprofile-rest-client</layer>
                                                 <layer>microprofile-telemetry</layer>
                                                 <layer>microprofile-platform</layer>
+                                                <!-- TODO WFLY-19175 uncomment when promoted to community stability.
+                                                     This execution runs a standard WF server, so at the OOTB community
+                                                     stability. So, provisioning this layer has no effect.
+                                                <layer>mvc-krazo</layer>
+                                                -->
                                             </layers>
                                         </config>
                                     </configurations>
@@ -904,6 +909,11 @@
                                                 <layer>microprofile-reactive-messaging-kafka</layer>
                                                 <layer>microprofile-telemetry</layer>
                                                 <layer>microprofile-platform</layer>
+                                                <!-- TODO WFLY-19175 uncomment when promoted to community stability.
+                                                     This execution runs a standard WF server, so at the OOTB community
+                                                     stability. So, provisioning this layer has no effect.
+                                                <layer>mvc-krazo</layer>
+                                                -->
                                             </layers>
                                             <excluded-layers>
                                                 <layer>jpa</layer>
@@ -983,7 +993,6 @@
                                                 <layer>messaging-activemq</layer>
                                                 <layer>micrometer</layer>
                                                 <layer>mod_cluster</layer>
-                                                <layer>mvc-krazo</layer>
                                                 <layer>naming</layer>
                                                 <layer>pojo</layer>
                                                 <layer>remoting</layer>
@@ -1017,6 +1026,7 @@
                                                 <layer>microprofile-rest-client</layer>
                                                 <layer>microprofile-telemetry</layer>
                                                 <layer>microprofile-platform</layer>
+                                                <layer>mvc-krazo</layer>
                                             </layers>
                                         </config>
                                     </configurations>
@@ -1089,7 +1099,6 @@
                                                 <layer>messaging-activemq</layer>
                                                 <layer>micrometer</layer>
                                                 <layer>mod_cluster</layer>
-                                                <layer>mvc-krazo</layer>
                                                 <layer>naming</layer>
                                                 <layer>pojo</layer>
                                                 <layer>remote-activemq</layer>
@@ -1115,6 +1124,7 @@
                                                 <layer>microprofile-jwt</layer>
                                                 <layer>microprofile-openapi</layer>
                                                 <layer>microprofile-telemetry</layer>
+                                                <layer>mvc-krazo</layer>
                                             </layers>
                                             <excluded-layers>
                                                 <layer>jpa</layer>

--- a/testsuite/preview/manualmode/pom.xml
+++ b/testsuite/preview/manualmode/pom.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ts-preview</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>32.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ******************************** Basic Integration ******************************* -->
+    <!-- ********************************************************************************** -->
+    <artifactId>wildfly-ts-preview-manualmode</artifactId>
+
+    <name>WildFly Test Suite: Preview - Manual Mode</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
+        <!-- Disable the default surefire test execution. -->
+        <surefire.default-test.phase>none</surefire.default-test.phase>
+        <glow.mvc.phase>none</glow.mvc.phase>
+        <glow.hibernate-search.phase>none</glow.hibernate-search.phase>
+        <ts.copy-wildfly-standalone-embedded-broker.phase>process-test-resources</ts.copy-wildfly-standalone-embedded-broker.phase>
+        <cloud-profile-provisioning.phase>none</cloud-profile-provisioning.phase>
+        <full-provisioning.phase>generate-test-resources</full-provisioning.phase>
+        <hibernate-search-provisioning.phase>none</hibernate-search-provisioning.phase>
+        <mvc-provisioning.phase>none</mvc-provisioning.phase>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.mvc</groupId>
+            <artifactId>jakarta.mvc-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Disable the standard copy-based provisioning -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions combine.children="append">
+                    <execution>
+                        <id>ts.copy-wildfly</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                    <systemPropertyVariables combine.children="append">
+                        <arquillian.launch>manual-mode</arquillian.launch>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <configuration>
+                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                </configuration>
+                <executions>
+                    <!-- Provision a non-slimmed server -->
+                    <execution>
+                        <id>full-server-provisioning</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>${full-provisioning.phase}</phase>
+                        <configuration>
+                            <provisioning-dir>${project.build.directory}/wildfly</provisioning-dir>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>${full.maven.groupId}</groupId>
+                                    <artifactId>wildfly-preview-feature-pack</artifactId>
+                                    <version>${full.maven.version}</version>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>basic.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!no.basic.integration.tests</name>
+                </property>
+            </activation>
+
+           <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions combine.children="append">
+                            <!-- Copy the docs/example configs into the regulard configuration dir so
+                                 they are available for use by surefire executions that need them. -->
+                            <execution>
+                                <id>ts.copy-wildfly-standalone-embedded-broker</id>
+                                <inherited>true</inherited>
+                                <phase>${ts.copy-wildfly-standalone-embedded-broker.phase}</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly/standalone/configuration/</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>${jbossas.project.dir}/${wildfly.build.output.dir}/docs/examples/configs/</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <!-- General configuration is inherited from the surefire plugin declaration outside this profile-->
+                        <!-- Here we just have executions -->
+                        <executions combine.children="append">
+
+                            <execution>
+                                <id>basic-preview-default-full.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Tests to execute. Overridden in webProfileExclusion.profile . -->
+                                    <includes>
+                                        <include>**/*TestCase*.java</include>
+                                    </includes>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
+                                    </environmentVariables>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables combine.children="append">
+                                        <jboss.server.config.file.name>standalone-activemq-embedded.xml</jboss.server.config.file.name>
+                                        <jboss.inst>${basedir}/target/wildfly</jboss.inst>
+                                        <!-- Needed for the IIOP tests-->
+                                        <com.sun.CORBA.ORBUseDynamicStub>true</com.sun.CORBA.ORBUseDynamicStub>
+                                        <!-- EJB client library hack, see WFLY-4973-->
+                                        <org.jboss.ejb.client.wildfly-testsuite-hack>true</org.jboss.ejb.client.wildfly-testsuite-hack>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
+                                    </additionalClasspathElements>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>basic-preview-default-web.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Tests to execute. Overriden in webProfileExclusion.profile . -->
+                                    <excludes>
+                                        <!-- Tests which need FULL config. -->
+                                        <exclude>**/*TestCase*.java</exclude>
+                                    </excludes>
+
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
+                                    </environmentVariables>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables combine.children="append">
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                        <jboss.inst>${basedir}/target/wildfly</jboss.inst>
+                                        <!-- EJB client library hack, see WFLY-4973-->
+                                        <org.jboss.ejb.client.wildfly-testsuite-hack>true</org.jboss.ejb.client.wildfly-testsuite-hack>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
+                                    </additionalClasspathElements>
+                                    <reportNameSuffix>basic-preview-default-web.surefire</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+</project>

--- a/testsuite/preview/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/preview/manualmode/src/test/resources/arquillian.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <group qualifier="manual-mode">
+        <container qualifier="default-jbossas" default="true" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+                <property name="javaHome">${container.java.home}</property>
+            </configuration>
+        </container>
+    </group>
+
+</arquillian>

--- a/testsuite/preview/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/preview/manualmode/src/test/resources/arquillian.xml
@@ -27,6 +27,25 @@
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
+
+        <!-- A container we launch with the 'stability=preview' setting -->
+        <container qualifier="stability-preview" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args} --stability=preview</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+                <property name="javaHome">${container.java.home}</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/preview/manualmode/src/test/resources/logging.properties
+++ b/testsuite/preview/manualmode/src/test/resources/logging.properties
@@ -1,0 +1,29 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
+logger.org.jboss.shrinkwrap.level=INFO
+logger.org.jboss.as.test.level=${test.log.level:INFO}
+logger.org.apache.directory.level=WARNING
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=WARN
+
+# Root logger handlers
+logger.handlers=FILE
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/testsuite/preview/pom.xml
+++ b/testsuite/preview/pom.xml
@@ -60,6 +60,18 @@
         <ts.config-as.copy-mgmt-users.phase>generate-test-resources</ts.config-as.copy-mgmt-users.phase>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-test-expansion-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Common ARQ related dependencies. -->

--- a/testsuite/preview/pom.xml
+++ b/testsuite/preview/pom.xml
@@ -120,11 +120,22 @@
                 <module>rbac</module>
                 <module>clustering</module>
                 <module>multinode</module>
-                <module>manualmode</module>
                 <module>secman</module>
                 <module>legacy</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>-->
+            </modules>
+        </profile>
+
+        <profile>
+            <id>preview.profile</id>
+            <activation><property><name>ts.preview</name></property></activation>
+            <properties>
+                <dependency.management.import.artifact>wildfly-preview-expansion-bom</dependency.management.import.artifact>
+            </properties>
+            <modules>
+                <module>basic</module>
+                <module>manualmode</module>
             </modules>
         </profile>
 
@@ -165,9 +176,9 @@
                 <module>rts</module>
                 <module>rbac</module>
                 <module>clustering</module>
-                <module>multinode</module>
+                <module>multinode</module>-->
                 <module>manualmode</module>
-                <module>secman</module>
+                <!--<module>secman</module>
                 <module>legacy</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>-->
@@ -179,7 +190,7 @@
             <activation><property><name>ts.integration</name></property></activation>
             <modules>
                 <module>basic</module>
-                <!--><module>ws</module>
+                <!--<module>ws</module>
                 <module>web</module>
                 <module>smoke</module>
                 <module>microprofile</module>
@@ -189,9 +200,9 @@
                 <module>iiop</module>
                 <module>xts</module>
                 <module>rts</module>
-                <module>rbac</module>
-                <module>multinode</module>
+                <module>rbac</module>-->
                 <module>manualmode</module>
+                <!--<module>multinode</module>
                 <module>secman</module>
                 <module>legacy</module>
                 <module>elytron</module>
@@ -270,7 +281,7 @@
         </profile>
         -->
 
-        <!-- -Dts.manualmode
+        <!-- -Dts.manualmode. -->
         <profile>
             <id>ts.integ.group.manualmode</id>
             <activation><property><name>ts.manualmode</name></property></activation>
@@ -278,7 +289,6 @@
                 <module>manualmode</module>
             </modules>
         </profile>
-        -->
 
         <!-- -Dts.rbac
         <profile>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -83,7 +83,13 @@ public abstract class LayersTestBase {
      * Included in the return value of {@link #getExpectedUnusedInAllLayers()}
      * only when testing provisioning from the wildfly feature pack.
      */
-    public static final String[] NO_LAYER_WILDFLY = {};
+    public static final String[] NO_LAYER_WILDFLY = {
+            // Preview stability 'mvc-krazo' layer cannot be provisioned in OOTB standard wildfly
+            "org.wildfly.extension.mvc-krazo",
+            "jakarta.mvc.api",
+            "org.eclipse.krazo.core",
+            "org.eclipse.krazo.resteasy"
+    };
 
     /**
      * Included in the return value of {@link #getExpectedUnusedInAllLayers()}
@@ -209,6 +215,11 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.microprofile.metrics-smallrye",
             // Extension not included in the default config
             "org.wildfly.extension.microprofile.opentracing-smallrye",
+            // Extension not included in the default config
+            "org.wildfly.extension.mvc-krazo",
+            "jakarta.mvc.api",
+            "org.eclipse.krazo.core",
+            "org.eclipse.krazo.resteasy",
             // Injected by jaxrs subsystem
             "org.jboss.resteasy.microprofile.config",
             "org.jboss.resteasy.resteasy-client-microprofile",
@@ -216,7 +227,7 @@ public abstract class LayersTestBase {
 
     /**
      * Included in the return value of {@link #getExpectedUnreferenced()}
-     * only when testing provisioning from the wildfly-preview feature pack.
+     * only when testing provisioning from the wildfly feature pack.
      */
     public static final String[] NOT_REFERENCED_WILDFLY = {
             // Extension not included in the default config
@@ -225,6 +236,11 @@ public abstract class LayersTestBase {
             "io.micrometer",
             "com.google.protobuf",
             "io.opentelemetry.proto",
+            // Extension not included in the default config
+            "org.wildfly.extension.mvc-krazo",
+            "jakarta.mvc.api",
+            "org.eclipse.krazo.core",
+            "org.eclipse.krazo.resteasy",
     };
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19062

This also incorporates fixes for:

https://issues.redhat.com/browse/WFLY-19170 (see also #17764)
https://issues.redhat.com/browse/WFLY-19163 (see also #17753)

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)