### PR TITLE
Fix for WFLY-19181, Upgrade to Galleon 6.0.0.Beta5 and Galleon Plugins 7.0.0.Beta6

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -182,9 +182,9 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability>experimental</minimum-stability>
-                            <config-stability>community</config-stability>
-                            <package-stability>experimental</package-stability>
+                            <minimum-stability-level>experimental</minimum-stability-level>
+                            <config-stability-level>community</config-stability-level>
+                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -149,9 +149,9 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability>experimental</minimum-stability>
-                            <config-stability>community</config-stability>
-                            <package-stability>experimental</package-stability>
+                            <minimum-stability-level>experimental</minimum-stability-level>
+                            <config-stability-level>community</config-stability-level>
+                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -300,13 +300,13 @@
         <version.ant.junit>1.10.14</version.ant.junit>
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.11</version.org.jacoco>
-        <version.org.jboss.galleon>6.0.0.Beta4</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.0.Beta5</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Beta11</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.0.0.Beta5</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.0.0.Beta6</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Beta4</version.org.wildfly.plugin>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -234,9 +234,9 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability>experimental</minimum-stability>
-                            <config-stability>preview</config-stability>
-                            <package-stability>experimental</package-stability>
+                            <minimum-stability-level>experimental</minimum-stability-level>
+                            <config-stability-level>preview</config-stability-level>
+                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19181
The reason of this upgrade is the rename of galleon plugins Maven plugin stability options (suffixed with '-level').

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)