### PR TITLE
[WFLY-19145] Ensure the test feature pack is built before testsuite t…

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -39,6 +39,34 @@
             </dependency>
 
             <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>wildfly-test-galleon-pack</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>zip</type>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>wildfly-test-feature-pack-preview</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>zip</type>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
                 <version>${version.com.beust}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1416,6 +1416,18 @@
         </profile>
 
         <profile>
+            <id>normal-build</id>
+            <activation>
+                <property>
+                    <name>!quickly</name>
+                </property>
+            </activation>
+            <modules>
+                <module>testsuite/test-feature-pack-preview</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>jdk18</id>
             <activation>
                 <jdk>[18,)</jdk>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -199,6 +199,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Ensure the relevant test feature pack is built -->
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
+            <artifactId>${testsuite.test.galleon.pack.artifactId}</artifactId>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -463,7 +470,6 @@
                 <dependency.management.import.artifact>wildfly-preview-expansion-bom</dependency.management.import.artifact>
             </properties>
             <modules>
-                <module>test-feature-pack-preview</module>
                 <module>domain</module>
                 <module>integration</module>
                 <module>layers</module>
@@ -480,7 +486,6 @@
                 </property>
             </activation>
             <modules>
-                <module>test-feature-pack-preview</module>
                 <module>integration</module>
                 <module>preview</module>
             </modules>
@@ -500,10 +505,6 @@
             <properties>
                 <testsuite.test.galleon.pack.artifactId>wildfly-test-feature-pack-preview</testsuite.test.galleon.pack.artifactId>
             </properties>
-            <modules>
-                <!-- Ensure the wildfly-test-feature-pack-preview artifact is built -->
-                <module>test-feature-pack-preview</module>
-            </modules>
         </profile>
 
         <!--


### PR DESCRIPTION
…ests begin

https://issues.redhat.com/browse/WFLY-19145

Follow up to the previous work to ensure wildfly-test-feature-pack-preview is built before ts modules that need it execute.

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)