### PR TITLE
[WFLY-19187] Fix missed JMX bean name

### DIFF
--- a/observability/micrometer/src/main/resources/org/wildfly/extension/micrometer/jmx/jmx-metrics.properties
+++ b/observability/micrometer/src/main/resources/org/wildfly/extension/micrometer/jmx/jmx-metrics.properties
@@ -54,12 +54,12 @@ jvm_uptime.mbean: java.lang:type=Runtime/Uptime
 jvm_uptime.type: gauge
 jvm_uptime.unit: milliseconds
 memory_pool_usage.description: Current usage of the memory pool
-memory_pool_usage.mbean: java.lang:type=memory_pool,*/Usage#used
+memory_pool_usage.mbean: java.lang:type=MemoryPool,*/Usage#used
 memory_pool_usage.tagsToFill: name
 memory_pool_usage.type: gauge
 memory_pool_usage.unit: bytes
 memory_pool_usage_max.description=Peak usage of the memory pool
-memory_pool_usage_max.mbean=java.lang:type=memory_pool,*/PeakUsage#used
+memory_pool_usage_max.mbean=java.lang:type=MemoryPool,*/PeakUsage#used
 memory_pool_usage_max.tagsToFill=name
 memory_pool_usage_max.type=gauge
 memory_pool_usage_max.unit=bytes


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19187

Fix casing in mbean naming pattern

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)