### PR TITLE
[WFLY-19221] Use the wildfly-maven-plugin for dist, ee-dist and preview/dist

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -43,28 +43,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -73,10 +72,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -93,10 +93,10 @@
                                     <version>${full.maven.version}</version>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -62,6 +62,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -93,22 +105,8 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -117,13 +115,23 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${basedir}/target/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -280,6 +288,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!-- For the dist zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly:${full.maven.version}</wildfly.channels>
+            </properties>
         </profile>
     </profiles>
 

--- a/ee-build/pom.xml
+++ b/ee-build/pom.xml
@@ -43,28 +43,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -73,10 +72,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -87,10 +87,10 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -62,6 +62,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -77,9 +88,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-testsuite-shared</artifactId>
-            <scope>test</scope>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -93,22 +105,8 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -117,13 +115,23 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${basedir}/target/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-ee</artifactId>
+                                        <version>${ee.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -274,6 +282,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!-- For the dist zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-ee:${full.maven.version}</wildfly.channels>
+            </properties>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1503,6 +1503,35 @@
         </profile>
 
         <profile>
+            <!-- Use the channels specified by the user-provided external.wildfly.channels property
+                 when provisioning. -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
+                     if a wildfly.channels pom property is set.
+
+                     Note the user could just directly do -Dwildfly-channels=xxx and get
+                     the same effect, but we use this indirection to leave open the possibility
+                     to have other ways of setting the property, without having to deal with
+                     users having learned to directly use -Dwildfly.channels.
+                 -->
+                <wildfly.channels>${external.wildfly.channels}</wildfly.channels>
+            </properties>
+        </profile>
+
+        <profile>
+            <!-- Use the internally-created channel when provisioning -->
+            <id>internal.channel.profile</id>
+            <activation><property><name>internal.wildfly.channels</name></property></activation>
+            <properties>
+                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
+                     if a wildfly.channels pom property is set. -->
+                <wildfly.channels>${channels.maven.groupId}:wildfly:${full.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+
+        <profile>
             <id>preview.test.profile</id>
             <activation>
                 <property>

--- a/preview/build/pom.xml
+++ b/preview/build/pom.xml
@@ -42,28 +42,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-preview</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -72,10 +71,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -86,10 +86,10 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -52,6 +52,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-preview</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -83,22 +95,8 @@
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -107,13 +105,23 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
+                            <provisioning-dir>${basedir}/target/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-preview</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -264,6 +272,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!-- For the dist zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-preview:${full.maven.version}</wildfly.channels>
+            </properties>
         </profile>
     </profiles>
 

--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -337,6 +337,69 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- galleon-maven-plugin installation provisioning is vulnerable to leftover files in the target
+                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-wildffy-without-channel</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/wildfly-without-channel</directory>
+                                    <follow-symlinks>false</follow-symlinks>
+                                    <use-default-excludes>false</use-default-excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>channel-provisioning-comparison</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>${channel.provisioning.phase}</phase>
+                        <configuration>
+                            <install-dir>${project.build.directory}/wildfly-without-channel</install-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>${ee.maven.groupId}</groupId>
+                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                    <version>${ee.maven.version}</version>
+                                    <included-packages>
+                                        <name>docs.examples.configs</name>
+                                    </included-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <groupId>${full.maven.groupId}</groupId>
+                                    <artifactId>wildfly-galleon-pack</artifactId>
+                                    <version>${full.maven.version}</version>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Surefire. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -463,6 +463,40 @@
                         </feature-packs>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!-- galleon-maven-plugin installation provisioning is vulnerable to leftover files in the target
+                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-wildffy-without-channel</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/wildfly-without-channel</directory>
+                                    <follow-symlinks>false</follow-symlinks>
+                                    <use-default-excludes>false</use-default-excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-maven-plugin</artifactId>
+                <executions>
+                    <!-- Provision an installation not using a channel to check that
+                         channel-based provisioning provides the same results as provisioning
+                         from the version included in the feature pack. -->
                     <execution>
                         <id>channel-provisioning-comparison</id>
                         <goals>
@@ -470,23 +504,13 @@
                         </goals>
                         <phase>${channel.provisioning.phase}</phase>
                         <configuration>
-                            <provisioning-dir>${project.build.directory}/wildfly-from-channel</provisioning-dir>
-                            <record-provisioning-state>true</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>true</offline-provisioning>
-                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
-                            <galleon-options>
+                            <install-dir>${project.build.directory}/wildfly-without-channel</install-dir>
+                            <record-state>true</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </galleon-options>
-                            <channels>
-                                <channel>
-                                    <manifest>
-                                        <groupId>${channels.maven.groupId}</groupId>
-                                        <artifactId>wildfly-ee</artifactId>
-                                        <version>${ee.maven.version}</version>
-                                    </manifest>
-                                </channel>
-                            </channels>
+                            </plugin-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${ee.maven.groupId}</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1243,7 +1243,7 @@
             <properties>
                 <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
                      if a wildfly.channels pom property is set. -->
-                <wildfly.channels>${project.groupId}:wildfly-manifest:${project.version}</wildfly.channels>
+                <wildfly.channels>org.wildfly.channels:wildfly:${full.maven.version}</wildfly.channels>
             </properties>
         </profile>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1218,34 +1218,5 @@
             </build>
         </profile>
 
-        <profile>
-            <!-- Use the channels specified by the user-provided external.wildfly.channels property
-                 when provisioning. -->
-            <id>external.channel.profile</id>
-            <activation><property><name>external.wildfly.channels</name></property></activation>
-            <properties>
-                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
-                     if a wildfly.channels pom property is set.
-
-                     Note the user could just directly do -Dwildfly-channels=xxx and get
-                     the same effect, but we use this indirection to leave open the possibility
-                     to have other ways of setting the property, without having to deal with
-                     users having learned to directly use -Dwildfly.channels.
-                 -->
-                <wildfly.channels>${external.wildfly.channels}</wildfly.channels>
-            </properties>
-        </profile>
-
-        <profile>
-            <!-- Use the internally-created channel when provisioning -->
-            <id>internal.channel.profile</id>
-            <activation><property><name>internal.wildfly.channels</name></property></activation>
-            <properties>
-                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
-                     if a wildfly.channels pom property is set. -->
-                <wildfly.channels>org.wildfly.channels:wildfly:${full.maven.version}</wildfly.channels>
-            </properties>
-        </profile>
-
     </profiles>
 </project>

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
@@ -43,11 +43,11 @@ public abstract class ProvisioningConsistencyBaseTest {
     private static final String INSTALLATION = ".installation";
     private static final String PROVISIONING = ".wildfly-maven-plugin-provisioning.xml";
     private static final Path JBOSS_HOME = resolveJBossHome();
-    private static final Path CHANNEL_INSTALLATION = JBOSS_HOME.getParent().resolve("wildfly-from-channel");
-    private static final Path INSTALLATION_METADATA = CHANNEL_INSTALLATION.resolve(INSTALLATION);
-    private static final Path PROVISIONING_XML = CHANNEL_INSTALLATION.resolve(PROVISIONING);
-    private static final Path SOURCE_HOME = JBOSS_HOME.getParent().getParent().getParent().getParent().getParent();
-    private final Path DIST_INSTALLATION;
+    private final Path CHANNEL_INSTALLATION;
+    private final Path INSTALLATION_METADATA;
+    private final Path PROVISIONING_XML;
+    private final Path SOURCE_HOME = JBOSS_HOME.getParent().getParent().getParent().getParent().getParent();
+    private static final Path DIST_INSTALLATION = JBOSS_HOME.getParent().resolve("wildfly-without-channel");
 
     private static Path resolveJBossHome() {
         try {
@@ -63,7 +63,9 @@ public abstract class ProvisioningConsistencyBaseTest {
 
 
     protected ProvisioningConsistencyBaseTest(String targetDist) {
-        DIST_INSTALLATION = SOURCE_HOME.resolve(targetDist).resolve("target").resolve(getDistDir());
+        CHANNEL_INSTALLATION = SOURCE_HOME.resolve(targetDist).resolve("target").resolve(getDistDir());
+        INSTALLATION_METADATA = CHANNEL_INSTALLATION.resolve(INSTALLATION);
+        PROVISIONING_XML = CHANNEL_INSTALLATION.resolve(PROVISIONING);
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19221

Put .installation metadata in our download zips.

This swaps the two ProvisioningConsistencyTestCases to use the official dist as the 'with channel' one and then doesn't use the channels in the locally provisioned comparison dist.

Builds on #17799

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19214](https://issues.redhat.com/browse/WFLY-19214)
> * [WFLY-19222](https://issues.redhat.com/browse/WFLY-19222)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)