### PR TITLE
[WFLY-19224] Suppress CVE-2023-1973 as WildFly no longer uses Undertow's authentication mechanisms.

### DIFF
--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -216,5 +216,15 @@
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.spring/resteasy\-spring@.*$</packageUrl>
       <cve>CVE-2018-1051</cve>
-   </suppress>   
+   </suppress>
+   <suppress until="2025-04-10">
+      <notes><![CDATA[
+      file name: undertow-core-2.3.12.Final.jar
+
+      [WFLY-19224] Since WildFly moved to using WildFly Elytron exclusively for security the
+      authentication mechanism from undertow-core is not used. This is a false positive.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
+      <vulnerabilityName>CVE-2023-1973</vulnerabilityName>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19224

@bstansberry this is a little easier to see what is needed to suppress a CVE.

Firstly it is not required that we have an until (and if we are scanning older branches this could be an issue) but I was adding these as a mechanism to ensure we at least triage again in the future.

On the original PR you mentioned also adding comments to record in the file why the suppression was added, here I have added it in the notes section which means it will also be included in the resulting HTML report of suppressed CVEs so we can quickly check why it was suppressed there.

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)