### PR TITLE
WFLY-19234 Upgrade to Hibernate Search 7.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.4.4.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.1.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.1.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.27.Final</version.org.infinispan>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -14,7 +14,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.11.1";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.13.2";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19234

Hibernate Search 7.1.1 clarifies some error messages and checks compatibility with the latest Elasticsearch 8.13 and OpenSearch 2.13.

This patch also includes an update to run Hibernate Search tests against the latest Elasticsearch version.

There are no updates to the Elasticsearch client or Lucene as 7.1.1 stays on the same versions as 7.1.0.

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)