### PR TITLE
[WFLY-19236] Update the suppression of the CPE mapping for the org.wildfly.deployment:transformer component.

### DIFF
--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -69,8 +69,10 @@
    <suppress>
       <notes><![CDATA[
       file name: transformer-7.0.0.Beta2.jar
+
+      [WFLY-19236] This component is independent of WildFly so should not be matched against WildFly CVEs.
       ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.wildfly\.galleon\-plugins/transformer@.*$</packageUrl>
+      <packageUrl regex="true">^pkg:maven/org\.wildfly\.deployment/transformer@.*$</packageUrl>
       <cpe>cpe:/a:redhat:wildfly</cpe>
    </suppress>
    <suppress>


### PR DESCRIPTION
This component is being incorrectly matched against general WildFly CVEs.

https://issues.redhat.com/browse/WFLY-19236

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)