### PR TITLE
[WFLY-19237] Add a suppression for CVE-2024-23080

### DIFF
--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -227,4 +227,13 @@
       <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
       <vulnerabilityName>CVE-2023-1973</vulnerabilityName>
    </suppress>
+   <suppress until="2025-04-12">
+      <notes><![CDATA[
+      file name: joda-time-2.12.6.jar
+
+      [WFLY-19237] This CVE is disputed as the only proposed reason for the CVE is a NullPointerException is possible.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/joda\-time/joda\-time@.*$</packageUrl>
+      <vulnerabilityName>CVE-2024-23080</vulnerabilityName>
+   </suppress>   
 </suppressions>


### PR DESCRIPTION
This CVE is disputed as the only proposed reason for the CVE is a NullPointerException is possible.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19237](https://issues.redhat.com/browse/WFLY-19237)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)