### PR TITLE
[WFLY-19242 - WFLY-19246] Galleon based component upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.11</version.org.jacoco>
         <version.org.jboss.galleon>6.0.0.Final</version.org.jboss.galleon>
-        <version.org.wildfly.glow>1.0.0.Beta13</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.0.0.Beta7</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Final</version.org.wildfly.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         <version.ant.junit>1.10.14</version.ant.junit>
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.11</version.org.jacoco>
-        <version.org.jboss.galleon>6.0.0.Beta6</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.0.Final</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Beta13</version.org.wildfly.glow>
         <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>11.0.0.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.wildfly-channel-plugin>1.0.9</version.org.wildfly.wildfly-channel-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <version.org.wildfly.galleon-plugins>7.0.0.Beta7</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
-        <version.org.wildfly.plugin>5.0.0.Beta4</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin>5.0.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.wildfly-channel-plugin>1.0.9</version.org.wildfly.wildfly-channel-plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
         <version.xml.plugin>1.0.2</version.xml.plugin>


### PR DESCRIPTION
This includes #17815

These are various Galleon based, mostly maven plugins, based upgrades. They are grouped together as they should likely all be tested together as well as save CI cycles.

Issues:
- https://issues.redhat.com/browse/WFLY-19242
- https://issues.redhat.com/browse/WFLY-19243
- https://issues.redhat.com/browse/WFLY-19244
- https://issues.redhat.com/browse/WFLY-19245
- https://issues.redhat.com/browse/WFLY-19246

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)