### PR TITLE
WFLY-19262 hibernate.type.json_format_mapper error

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -24,6 +24,7 @@
         <module name="com.fasterxml.jackson.core.jackson-databind" optional="true"/>
         <module name="jakarta.annotation.api"/>
         <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.json.bind.api"/>
         <module name="jakarta.persistence.api"/>
         <module name="jakarta.transaction.api"/>
         <module name="jakarta.validation.api"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/json/persistence.xml
@@ -11,7 +11,7 @@
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
-            <!-- property name="hibernate.type.json_format_mapper" value="MyJsonFormatMapper" / -->
+            <property name="hibernate.type.json_format_mapper" value="jsonb"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19262

Add `jakarta.json.bind.api` dependency to the Hibernate ORM module so applications can specify the `<property name="hibernate.type.json_format_mapper" value="jsonb"/>` setting.

Both of the following settings work now:

hibernate.type.json_format_mapper=jackson
hibernate.type.json_format_mapper=jsonb

A unit test has been updated to test the `hibernate.type.json_format_mapper=jsonb` setting.
____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)

____