### PR TITLE
[WFLY-19267] Support running the standard WildFly testsuite against installations provisioned with the 'latest standard channels'

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -43,28 +43,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -73,10 +72,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -93,10 +93,10 @@
                                     <version>${full.maven.version}</version>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-build/pom.xml
+++ b/ee-build/pom.xml
@@ -43,28 +43,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -73,10 +72,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -87,10 +87,10 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1503,6 +1503,41 @@
         </profile>
 
         <profile>
+            <!-- Use the latest version of the standard channels when provisioning. -->
+            <id>latest.standard.channels.profile</id>
+            <activation><property><name>latest.standard.channels</name></property></activation>
+            <properties>
+                <!-- Allow online provisioning so wildfly-maven-plugin can resolve the latest manifests -->
+                <galleon.offline>false</galleon.offline>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <configuration>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-ee</artifactId>
+                                    </manifest>
+                                </channel>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                    </manifest>
+                                </channel>
+                            </channels>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <!-- Use the channels specified by the user-provided external.wildfly.channels property
                  when provisioning. -->
             <id>external.channel.profile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1503,6 +1503,35 @@
         </profile>
 
         <profile>
+            <!-- Use the channels specified by the user-provided external.wildfly.channels property
+                 when provisioning. -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
+                     if a wildfly.channels pom property is set.
+
+                     Note the user could just directly do -Dwildfly-channels=xxx and get
+                     the same effect, but we use this indirection to leave open the possibility
+                     to have other ways of setting the property, without having to deal with
+                     users having learned to directly use -Dwildfly.channels.
+                 -->
+                <wildfly.channels>${external.wildfly.channels}</wildfly.channels>
+            </properties>
+        </profile>
+
+        <profile>
+            <!-- Use the internally-created channel when provisioning -->
+            <id>internal.channel.profile</id>
+            <activation><property><name>internal.wildfly.channels</name></property></activation>
+            <properties>
+                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
+                     if a wildfly.channels pom property is set. -->
+                <wildfly.channels>${channels.maven.groupId}:wildfly:${full.maven.version}</wildfly.channels>
+            </properties>
+        </profile>
+
+        <profile>
             <id>preview.test.profile</id>
             <activation>
                 <property>

--- a/preview/build/pom.xml
+++ b/preview/build/pom.xml
@@ -42,28 +42,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-preview</artifactId>
+            <type>yaml</type>
+            <classifier>manifest</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -72,10 +71,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -86,10 +86,10 @@
                                     </included-packages>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
+                            <galleon-options>
                                 <jboss-maven-dist/>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1218,34 +1218,5 @@
             </build>
         </profile>
 
-        <profile>
-            <!-- Use the channels specified by the user-provided external.wildfly.channels property
-                 when provisioning. -->
-            <id>external.channel.profile</id>
-            <activation><property><name>external.wildfly.channels</name></property></activation>
-            <properties>
-                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
-                     if a wildfly.channels pom property is set.
-
-                     Note the user could just directly do -Dwildfly-channels=xxx and get
-                     the same effect, but we use this indirection to leave open the possibility
-                     to have other ways of setting the property, without having to deal with
-                     users having learned to directly use -Dwildfly.channels.
-                 -->
-                <wildfly.channels>${external.wildfly.channels}</wildfly.channels>
-            </properties>
-        </profile>
-
-        <profile>
-            <!-- Use the internally-created channel when provisioning -->
-            <id>internal.channel.profile</id>
-            <activation><property><name>internal.wildfly.channels</name></property></activation>
-            <properties>
-                <!-- The wildfly-maven-plugin 'provision' mojo will provision using a channel
-                     if a wildfly.channels pom property is set. -->
-                <wildfly.channels>org.wildfly.channels:wildfly:${full.maven.version}</wildfly.channels>
-            </properties>
-        </profile>
-
     </profiles>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19267

This builds on #17799, which deals with a similar use case. The WFLY-19214 approach there is more flexible but more verbose in cases where the latest version of standard channels manifests are wanted.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19214](https://issues.redhat.com/browse/WFLY-19214)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)