### PR TITLE
Fix for WFLY-19270, Shared CI to build and test WildFly issue with Windows and JDK11

### DIFF
--- a/.github/workflows/shared-wildfly-build-and-test.yml
+++ b/.github/workflows/shared-wildfly-build-and-test.yml
@@ -113,32 +113,37 @@ jobs:
          tar -xzf ${{ inputs.maven-repo-path }} -C ~
         # Do not compile with JDK 11. If 11 is specified, we will build with 17 and test with 11
         # So, setup 17
-      - name: Set up JDK 17 for JDK 11 tests
+      - name: Set up JDK 17 and JDK 11 for JDK11 execution
         if: matrix.java == 11
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: |
+            17
+            11
           distribution: 'temurin'
+          # Cache must be computed prior to build WildFly. On Windows we run into https://github.com/actions/upload-artifact/issues/240
+          # when computing cache hash (**/pom.xml) due to galleon generated feature long file names.
           cache: 'maven'
-        # For JDK 11 tests, build with 17, skipping tests
-      - name: Build WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }} with JDK 17 for JDK 11 tests
-        if: matrix.java == 11
-        run: mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -DskipTests
-        shell: bash
       - name: Set up JDK ${{ matrix.java }}
+        if: matrix.java != 11
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
+        # For JDK 11 tests, build with 17, skipping tests
+      - name: Build WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }} with JDK 17 for JDK 11 tests
+        if: matrix.java == 11
+        run: JAVA_HOME=$JAVA_HOME_17_${{ runner.arch }} mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -DskipTests
+        shell: bash
         # For JDK 11 tests, we already built, so just run the 'test' goal with the -DnoCompile setting to disable recompile
       - name: Test WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }} with -DnoCompile for JDK 11 tests
         if: matrix.java == 11
-        run: mvn -U -B -ntp test -DnoCompile ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -rf testsuite
+        run: JAVA_HOME=$JAVA_HOME_${{ matrix.java }}_${{ runner.arch }} mvn -U -B -ntp test -DnoCompile ${{ inputs.build-arguments }} ${{ inputs.test-arguments }} -rf testsuite
         shell: bash
       - name: Build and Test WildFly SNAPSHOT ${{ inputs.build-arguments }}  ${{ inputs.test-arguments }}
         if: matrix.java != 11
-        run: mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }}
+        run: JAVA_HOME=$JAVA_HOME_${{ matrix.java }}_${{ runner.arch }} mvn -U -B -ntp clean install ${{ inputs.build-arguments }} ${{ inputs.test-arguments }}
         shell: bash
         # We need this due to long file names on Windows: https://github.com/actions/upload-artifact/issues/240
       - name: Find reports


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19270

A running job that used these changes: https://github.com/jfdenise/galleon-plugins/actions/runs/8797644577

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)