### PR TITLE
[WFLY-19272] Upgrade WildFly Core to 24.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>24.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>24.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19272

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/24.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/24.0.0.Beta3...24.0.0.Final

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6673'>WFCORE-6673</a>] -         Create SPI module for IO subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6691'>WFCORE-6691</a>] -         Add ServiceDescriptor variants of OperationContext.hasOptionalCapability(...) and CapabilityServiceSupport.hasCapability(...) 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6769'>WFCORE-6769</a>] -         Port NaryServiceNameFactory logic from wildfly-clustering-common to ServiceNameFactory
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6781'>WFCORE-6781</a>] -         Port composite ResourceOperationServiceHandler logic from wildfly-clustering-common
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6786'>WFCORE-6786</a>] -         Port CredentialSourceDependency from wildfly-clustering-common
</li>
</ul>
                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6347'>WFCORE-6347</a>] -         Port subsystem development enhancements from wildfly-clustering-common to wildfly-core
</li>
</ul>
            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5386'>WFCORE-5386</a>] -         RemotingLegacySubsystemTestCase#testSubsystemWithConnectorPropertyChange intermittently fails
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6490'>WFCORE-6490</a>] -         worker attribute of /subsystem=remoting should not have a default value
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6749'>WFCORE-6749</a>] -         Incorrect output from standalone.sh -v
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6756'>WFCORE-6756</a>] -         Subsystem model bump and transformer adjustments needed for the dynamic SSL context support
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6757'>WFCORE-6757</a>] -         Clean up ServiceBuilder references in AuthenticationClientDefinitions#performRuntime
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6765'>WFCORE-6765</a>] -         Schema version comparison should require compatible stability level
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6771'>WFCORE-6771</a>] -         Fixing several small issues with the YAML extension
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6772'>WFCORE-6772</a>] -         bin/installation-manager.sh: 5: [: x: unexpected operator
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6776'>WFCORE-6776</a>] -         Can&#39;t specify a stability level when starting a bootable JAR.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6789'>WFCORE-6789</a>] -         Bootable JAR cannot start when jboss.server.data.dir is specified
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6670'>WFCORE-6670</a>] -         Drop io subsystem parsers for 1.0 version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6671'>WFCORE-6671</a>] -         Drop obsolete subsystem transformations from IO subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6753'>WFCORE-6753</a>] -         Refactor so that ServerEnvironment.setStability() doesn&#39;t need to be public
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6754'>WFCORE-6754</a>] -         Chnage the visibility of ServerSenvironment stability mutator method to package protected
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6764'>WFCORE-6764</a>] -         Deprecate static builder methods of PersistentResourceXMLDescription
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6767'>WFCORE-6767</a>] -         ServiceDependency interface is missing QuaternaryServiceDescriptor factory method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6768'>WFCORE-6768</a>] -         Fix goofy WriteAttributeTranslationOperationStepHandler class name
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6773'>WFCORE-6773</a>] -         StabilityServerSetupSnapshotRestoreTasks should read the permitted stability levels
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6777'>WFCORE-6777</a>] -         Do not allow mixed domains for preview and experimental stability levels
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6787'>WFCORE-6787</a>] -         Add the ability to configure the allowed jku values for a token-realm using a new system property for CVE-2024-1233
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6791'>WFCORE-6791</a>] -         Tidy wildfly-discovery code to better use as a reference for wildfly-subsystem usage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6792'>WFCORE-6792</a>] -         Rename Installer.Builder.async() -&gt; Installer.Builder.blocking()
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6738'>WFCORE-6738</a>] -         CVE-2023-5685 Upgrade XNIO to 3.8.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6762'>WFCORE-6762</a>] -         Upgrade to Galleon 6.0.0.Beta5 and Galleon Plugins 7.0.0.Beta6
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6770'>WFCORE-6770</a>] -         Upgrade to Galleon 6.0.0.Beta6 and Galleon Plugins 7.0.0.Beta7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6774'>WFCORE-6774</a>] -         CVE-2024-29857, CVE-2024-29857 and CVE-2024-30172 Upgrade BouncyCastle from 1.77 to 1.78
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6780'>WFCORE-6780</a>] -         Upgrade WildFly Elytron to 2.4.0.Final for CVE-2024-1233 and CVE-2023-6236
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6782'>WFCORE-6782</a>] -         Upgrade to Galleon 6.0.0.Final and Galleon Plugins 7.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6783'>WFCORE-6783</a>] -         Upgrade JBoss VFS to 3.3.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6784'>WFCORE-6784</a>] -         Upgrade JBoss MSC to 1.5.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6785'>WFCORE-6785</a>] -         Upgrade JBoss Modules to 2.1.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6790'>WFCORE-6790</a>] -         Upgrade wildfly-maven-plugin to 5.0.0.Final and wildfly-jar-maven-plugin to 11.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6794'>WFCORE-6794</a>] -         CVE-2023-1973 Upgrade Undertow to 2.3.13.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6796'>WFCORE-6796</a>] -         Upgrade WildFly Elytron to 2.4.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6560'>WFCORE-6560</a>] -         Log installation provisioning information at boot
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6763'>WFCORE-6763</a>] -         PersistentResourceXMLDescription.Builder needs a stream variant for attributes using the same marshaller/parser
</li>
</ul>
</details>

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)