### PR TITLE
[WFLY-19290] Correct mistakes in the Jakarta EE spec listing tables

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -82,6 +82,8 @@ Profile |WildFly {wildflyVersion} Full Configuration |WildFly {wildflyVersion} D
 | Jakarta MVC 2.1
 (xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability])|--|--|--|--
 
+|Jakarta Pages 3.1 |X |X |X |X
+
 |Jakarta Persistence 3.1 |X |X |X |X
 
 |Jakarta RESTful Web Services 3.1 |X |X |X |X
@@ -90,11 +92,9 @@ Profile |WildFly {wildflyVersion} Full Configuration |WildFly {wildflyVersion} D
 
 |Jakarta Faces 4.0 |X |X |X |X
 
-|Jakarta Server Pages 3.1 |X |X |X |X
-
 |Jakarta Servlet 6.0 |X |X |X |X
 
-|Jakarta SOAP with Attachments 1.3 |Optional |-- |X |X
+|Jakarta SOAP with Attachments 3.0 |Optional |-- |X |X
 
 |Jakarta Standard Tag Library 3.0 |X |X |X |X
 

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -122,17 +122,17 @@ The following table lists the various Jakarta technologies offered by WildFly Pr
 | Jakarta MVC
 (_preview stability only_)| 2.1| N/A xref:note2[^2^]
 
+|Jakarta Pages| 3.1 |10
+
 |Jakarta Persistence| 3.2.0-M2 |11
 
 |Jakarta RESTful Web Services| 3.1 |10
 
 |Jakarta Security| 4.0.0-M2 |11
 
-|Jakarta Server Pages| 3.1 |10
-
 |Jakarta Servlet| 6.1.0-M2 |11
 
-|Jakarta SOAP with Attachments| 1.3 |10 xref:note1[^1^]
+|Jakarta SOAP with Attachments| 3.0 |10 xref:note1[^1^]
 
 |Jakarta Standard Tag Library| 3.0 |10 & 11
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19290

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)