### PR TITLE
[WFLY-19267] Support running the bootable jar WildFly testsuite against bootable jars provisioned with the 'latest standard channels'

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -33,8 +33,6 @@
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <!-- properties to enable bootable phases -->
         <bootable-jar-maven-jar-plugin.create.modules.phase>none</bootable-jar-maven-jar-plugin.create.modules.phase>
-        <bootable-jar-jpa-packaging.phase>none</bootable-jar-jpa-packaging.phase>
-        <bootable-jar-cloud-profile-packaging.phase>none</bootable-jar-cloud-profile-packaging.phase>
         <bootable-jar-copy-module-files.phase>none</bootable-jar-copy-module-files.phase>
         <glow.cloud-profile.phase>none</glow.cloud-profile.phase>
         <glow.jdr.phase>none</glow.jdr.phase>
@@ -1430,28 +1428,15 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
-                    <!-- Package a cloud-profile server -->
+                    <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
                     <execution>
-                        <id>bootable-jar-cloud-profile-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${bootable-jar-cloud-profile-packaging.phase}</phase>
+                        <id>bootable-jar-packaging</id>
                         <configuration>
                             <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
                             <extra-server-content-dirs>
                                 <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                             </extra-server-content-dirs>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/microprofile.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -1462,20 +1447,12 @@
                         <goals>
                             <goal>package</goal>
                         </goals>
-                        <phase>${bootable-jar-jpa-packaging.phase}</phase>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <output-file-name>test-wildfly-jpa.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
                             <extra-server-content-dirs>
                                 <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                             </extra-server-content-dirs>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/jpa-layers.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -3292,8 +3269,7 @@
             <properties>
                 <bootable-jar-copy-module-files.phase>test-compile</bootable-jar-copy-module-files.phase>
                 <bootable-jar-maven-jar-plugin.create.modules.phase>test-compile</bootable-jar-maven-jar-plugin.create.modules.phase>
-                <bootable-jar-jpa-packaging.phase>test-compile</bootable-jar-jpa-packaging.phase>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.cloud-profile.phase>test-compile</glow.cloud-profile.phase>
                 <glow.jpa.phase>test-compile</glow.jpa.phase>
             </properties>
@@ -3453,8 +3429,7 @@
             <properties>
                 <bootable-jar-copy-module-files.phase>test-compile</bootable-jar-copy-module-files.phase>
                 <bootable-jar-maven-jar-plugin.create.modules.phase>test-compile</bootable-jar-maven-jar-plugin.create.modules.phase>
-                <bootable-jar-jpa-packaging.phase>test-compile</bootable-jar-jpa-packaging.phase>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.cloud-profile.phase>test-compile</glow.cloud-profile.phase>
                 <glow.jpa.phase>test-compile</glow.jpa.phase>
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -31,8 +31,6 @@
         <version.org.infinispan.server.driver>${version.org.infinispan}</version.org.infinispan.server.driver>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>
         <!-- properties to enable plugins shared by various bootable jar executions -->
-        <bootable-jar-cloud-profile-packaging.phase>none</bootable-jar-cloud-profile-packaging.phase>
-        <bootable-jar-load-balancer-packaging.phase>none</bootable-jar-load-balancer-packaging.phase>
         <glow.phase>none</glow.phase>
         <ts.config-as.configure-wildfly.phase>process-test-resources</ts.config-as.configure-wildfly.phase>
         <ts.config-as.configure-lb.phase>generate-test-resources</ts.config-as.configure-lb.phase>
@@ -510,27 +508,14 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
-                    <!-- Package a cloud-profile server -->
+                    <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
                     <execution>
-                        <id>bootable-jar-cloud-profile-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${bootable-jar-cloud-profile-packaging.phase}</phase>
+                        <id>bootable-jar-packaging</id>
                         <configuration>
                             <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
                             <!-- content that is installed in wildfly home -->
                             <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <cli-sessions>
                                 <cli-session>
                                     <script-files>
@@ -548,17 +533,9 @@
                         <goals>
                             <goal>package</goal>
                         </goals>
-                        <phase>${bootable-jar-jpa-distributed-packaging.phase}</phase>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <output-file-name>test-wildfly-jpa-distributed.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <cli-sessions>
                                 <cli-session>
                                     <script-files>
@@ -576,17 +553,9 @@
                         <goals>
                             <goal>package</goal>
                         </goals>
-                        <phase>${bootable-jar-load-balancer-packaging.phase}</phase>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <output-file-name>test-wildfly-cloud-profile-load-balancer.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <cli-sessions>
                                 <cli-session>
                                     <script-files>
@@ -2675,9 +2644,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
-                <bootable-jar-jpa-distributed-packaging.phase>test-compile</bootable-jar-jpa-distributed-packaging.phase>
-                <bootable-jar-load-balancer-packaging.phase>test-compile</bootable-jar-load-balancer-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
                 <glow.phase>test-compile</glow.phase>
                 <ts.config-as.configure-wildfly.phase>none</ts.config-as.configure-wildfly.phase>
@@ -2805,9 +2772,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
-                <bootable-jar-jpa-distributed-packaging.phase>test-compile</bootable-jar-jpa-distributed-packaging.phase>
-                <bootable-jar-load-balancer-packaging.phase>test-compile</bootable-jar-load-balancer-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.phase>test-compile</glow.phase>
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -29,8 +29,6 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
-        <!-- properties to enable plugins shared by various bootable jar executions -->
-        <bootable-jar-packaging.phase>none</bootable-jar-packaging.phase>
         <glow.phase>none</glow.phase>
     </properties>
 
@@ -180,7 +178,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
                     <!-- Provision a cloud server -->
                     <execution>
@@ -188,19 +185,11 @@
                         <goals>
                             <goal>package</goal>
                         </goals>
-                        <phase>${bootable-jar-packaging.phase}</phase>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <!-- content that is installed in wildfly home -->
                             <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
                             <output-file-name>test-wildfly.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -543,7 +532,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-packaging.phase>test-compile</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.phase>test-compile</glow.phase>
             </properties>
             <build>
@@ -629,7 +618,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-packaging.phase>test-compile</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.phase>test-compile</glow.phase>
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
             </properties>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -861,6 +861,9 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <properties>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
@@ -939,27 +942,14 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>
                                 <id>bootable-jar-packaging</id>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                                <phase>process-test-classes</phase>
                                 <configuration>
                                     <output-file-name>test-wildfly.jar</output-file-name>
-                                    <hollowJar>true</hollowJar>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>true</offline>
                                     <!-- content that is installed in wildfly home -->
                                     <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
                                     <cli-sessions>
                                         <cli-session>
                                             <script-files>

--- a/testsuite/integration/microprofile-tck/config/pom.xml
+++ b/testsuite/integration/microprofile-tck/config/pom.xml
@@ -163,7 +163,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
                 <!-- Disable 'configure-weld-subsystem' since that is for a standalone server -->
                 <config.configure-weld-subsystem.phase>none</config.configure-weld-subsystem.phase>
@@ -175,7 +175,7 @@
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>bootable-jar-microprofile-tck-packaging</id>
+                                <id>bootable-jar-packaging</id>
                                 <configuration>
                                     <cli-sessions>
                                         <cli-session>
@@ -202,7 +202,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
                 <!-- Disable 'configure-weld-subsystem' since that is for a standalone server -->
                 <config.configure-weld-subsystem.phase>none</config.configure-weld-subsystem.phase>
@@ -214,7 +214,7 @@
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>bootable-jar-microprofile-tck-packaging</id>
+                                <id>bootable-jar-packaging</id>
                                 <configuration>
                                     <cli-sessions>
                                         <cli-session>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -113,7 +113,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -128,7 +128,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/health/pom.xml
+++ b/testsuite/integration/microprofile-tck/health/pom.xml
@@ -125,7 +125,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -140,7 +140,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -224,7 +224,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -239,7 +239,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/lra/pom.xml
+++ b/testsuite/integration/microprofile-tck/lra/pom.xml
@@ -151,7 +151,7 @@
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -167,7 +167,7 @@
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -173,7 +173,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -189,7 +189,7 @@
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -35,7 +35,6 @@
              still being easily disabled in profiles where it is not wanted. -->
         <ts.copy-wildfly.phase>generate-test-resources</ts.copy-wildfly.phase>
         <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
-        <ts.bootable-jar-microprofile-tck-packaging.phase>none</ts.bootable-jar-microprofile-tck-packaging.phase>
         <ts.microprofile-tck-glow.phase>none</ts.microprofile-tck-glow.phase>
         <ts.microprofile-tck-glow.config.name>standalone-microprofile.xml</ts.microprofile-tck-glow.config.name>
         <ts.microprofile-tck-glow.expected-discovery>FIXME-must-override</ts.microprofile-tck-glow.expected-discovery>
@@ -175,24 +174,11 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
                     <execution>
-                        <id>bootable-jar-microprofile-tck-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${ts.bootable-jar-microprofile-tck-packaging.phase}</phase>
+                        <id>bootable-jar-packaging</id>
                         <configuration>
                             <output-file-name>test-wildfly-microprofile-tck.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/default-test/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -343,7 +329,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <execution>
                                 <id>bootable-jar-microprofile-tck-packaging</id>

--- a/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
+++ b/testsuite/integration/microprofile-tck/reactive-messaging/pom.xml
@@ -147,7 +147,7 @@
             <properties>
                 <!-- Turn off provisioning since it is enabled by default-->
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -164,7 +164,7 @@
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile-tck/reactive-streams-operators/pom.xml
+++ b/testsuite/integration/microprofile-tck/reactive-streams-operators/pom.xml
@@ -118,9 +118,8 @@
                 <!-- Turn off provisioning since it is enabled by default-->
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
-
             </properties>
         </profile>
 
@@ -136,9 +135,8 @@
                 <ts.microprofile-tck-provisioning.phase>none</ts.microprofile-tck-provisioning.phase>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
-
            </properties>
         </profile>
 

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -429,7 +429,7 @@
                 <executions>
                     <!-- Override the bootable jar packaging from the parent to add res-client tck specific settings -->
                     <execution>
-                        <id>bootable-jar-microprofile-tck-packaging</id>
+                        <id>bootable-jar-packaging</id>
                         <configuration>
                             <cli-sessions>
                                 <cli-session>
@@ -522,7 +522,7 @@
             </activation>
             <properties>
                 <!-- Enable bootable jar packaging -->
-                <ts.bootable-jar-microprofile-tck-packaging.phase>process-test-resources</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-resources</ts.bootable-jar-packaging.phase>
                 <bootable-jar-generate-properties-file.phase>compile</bootable-jar-generate-properties-file.phase>
             </properties>
             <build>
@@ -557,7 +557,7 @@
             </activation>
             <properties>
                 <!-- Enable bootable jar packaging -->
-                <ts.bootable-jar-microprofile-tck-packaging.phase>process-test-resources</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-resources</ts.bootable-jar-packaging.phase>
                 <bootable-jar-generate-properties-file.phase>compile</bootable-jar-generate-properties-file.phase>
             </properties>
             <build>

--- a/testsuite/integration/microprofile-tck/telemetry/pom.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/pom.xml
@@ -185,7 +185,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>
@@ -200,7 +200,7 @@
             <properties>
                 <!-- Enable bootable jar packaging -->
                 <ts.microprofile-tck-glow.phase>test-compile</ts.microprofile-tck-glow.phase>
-                <ts.bootable-jar-microprofile-tck-packaging.phase>test-compile</ts.bootable-jar-microprofile-tck-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <ts.microprofile-tck-glow.config.name>standalone.xml</ts.microprofile-tck-glow.config.name>
             </properties>
         </profile>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -30,8 +30,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
-        <!-- properties to enable plugins shared by various bootable jar executions -->
-        <bootable-jar-packaging.phase>none</bootable-jar-packaging.phase>
 
         <ts.glow.phase>none</ts.glow.phase>
         <ts.glow.config-name>standalone-microprofile.xml</ts.glow.config-name>
@@ -450,27 +448,14 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
                     <!-- Provision a cloud server including all the MicroProfile specs layers -->
                     <execution>
                         <id>bootable-jar-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <!-- content that is installed in wildfly home -->
                             <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
                             <output-file-name>test-wildfly.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -833,7 +818,7 @@
             <properties>
                 <ts.glow.phase>test-compile</ts.glow.phase>
                 <ts.glow.config-name>standalone.xml</ts.glow.config-name>
-                <bootable-jar-packaging.phase>test-compile</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
             </properties>
             <build>
                 <plugins>
@@ -920,7 +905,7 @@
             <properties>
                 <ts.glow.phase>test-compile</ts.glow.phase>
                 <ts.glow.config-name>standalone.xml</ts.glow.config-name>
-                <bootable-jar-packaging.phase>test-compile</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-resources</ts.bootable-jar-packaging.phase>
 
                 <!-- Use the WFP dependencyManagement set.
                      This is set in this profile in a parent module, but the explicit global override

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -32,7 +32,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <jboss.dist>${basedir}/target/wildfly</jboss.dist>
         <!-- properties to enable plugins shared by various bootable jar executions -->
-        <bootable-jar-cloud-profile-packaging.phase>none</bootable-jar-cloud-profile-packaging.phase>
         <glow.phase.observability>none</glow.phase.observability>
         <glow.phase.sar>none</glow.phase.sar>
     </properties>
@@ -586,25 +585,12 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
-                    <!-- Package a cloud-profile server -->
+                    <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
                     <execution>
-                        <id>bootable-jar-cloud-profile-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${bootable-jar-cloud-profile-packaging.phase}</phase>
+                        <id>bootable-jar-packaging</id>
                         <configuration>
                             <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <provisioning-file>target/glow-scan/microprofile.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -871,7 +857,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.phase.observability>test-compile</glow.phase.observability>
             </properties>
             <build>
@@ -958,7 +944,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <bootable-jar-cloud-profile-packaging.phase>test-compile</bootable-jar-cloud-profile-packaging.phase>
+                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
                 <glow.phase.observability>test-compile</glow.phase.observability>
             </properties>
             <build>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -38,7 +38,6 @@
         <bootable.ts.config-as.copy-users.phase>none</bootable.ts.config-as.copy-users.phase>
         <bootable.copy-external-taglib-module-xml.phase>none</bootable.copy-external-taglib-module-xml.phase>
         <bootable.create-external-taglib-module.phase>none</bootable.create-external-taglib-module.phase>
-        <bootable-jar-packaging.phase>none</bootable-jar-packaging.phase>
         <glow.phase>none</glow.phase>
     </properties>
 
@@ -326,25 +325,12 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>${version.org.wildfly.jar.plugin}</version>
                 <executions>
-                    <!-- Package a datasources-web-server -->
+                    <!-- Package a datasources-web-server with the default 'bootable-jar-packaging' execution -->
                     <execution>
                         <id>bootable-jar-packaging</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <phase>${bootable-jar-packaging.phase}</phase>
                         <configuration>
                             <output-file-name>test-wildfly-web-profile.jar</output-file-name>
-                            <hollowJar>true</hollowJar>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                             <extra-server-content-dirs>
                                 <extra-content>${basedir}/target/wildfly-users</extra-content>
                                 <extra-content>${basedir}/target/external-taglib-module</extra-content>
@@ -548,7 +534,7 @@
                 <bootable.ts.config-as.copy-users.phase>generate-test-resources</bootable.ts.config-as.copy-users.phase>
                 <bootable.copy-external-taglib-module-xml.phase>generate-test-resources</bootable.copy-external-taglib-module-xml.phase>
                 <bootable.create-external-taglib-module.phase>process-test-classes</bootable.create-external-taglib-module.phase>
-                <bootable-jar-packaging.phase>process-test-classes</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
                 <glow.phase>test-compile</glow.phase>
             </properties>
             <build>
@@ -648,7 +634,7 @@
                 <bootable.ts.config-as.copy-users.phase>generate-test-resources</bootable.ts.config-as.copy-users.phase>
                 <bootable.copy-external-taglib-module-xml.phase>generate-test-resources</bootable.copy-external-taglib-module-xml.phase>
                 <bootable.create-external-taglib-module.phase>process-test-classes</bootable.create-external-taglib-module.phase>
-                <bootable-jar-packaging.phase>process-test-classes</bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
                 <glow.phase>test-compile</glow.phase>
             </properties>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -519,6 +519,36 @@
         </profile>
 
         <profile>
+            <!-- Use the latest version of the standard channels when provisioning a bootable jar. -->
+            <id>latest.standard.channels.profile</id>
+            <activation><property><name>latest.standard.channels</name></property></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <configuration>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-ee</artifactId>
+                                    </manifest>
+                                </channel>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                    </manifest>
+                                </channel>
+                            </channels>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>preview.profile</id>
             <activation><property><name>ts.preview</name></property></activation>
             <properties>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -170,6 +170,10 @@
 
         <!-- Dynamic part of the name of ee-version-specific test source dir that may be added to the build -->
         <additional.ee.test.source>ee10</additional.ee.test.source>
+
+        <!-- properties to enable plugin executions -->
+        <ts.bootable-jar-packaging.phase>none</ts.bootable-jar-packaging.phase>
+
     </properties>
 
     <dependencyManagement>
@@ -278,6 +282,34 @@
                        </execution>
                    </executions>
                </plugin>
+
+                <!-- Basic configuration for bootable jar packaging, if enabled -->
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.jar.plugin}</version>
+                    <configuration>
+                        <hollowJar>true</hollowJar>
+                        <record-state>false</record-state>
+                        <log-time>${galleon.log.time}</log-time>
+                        <offline>true</offline>
+                        <plugin-options>
+                            <jboss-maven-dist/>
+                            <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                        </plugin-options>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>bootable-jar-packaging</id>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                            <!-- This execution's phase is controlled by a property that defaults to 'none'.
+                                 Profiles that want it to run set the property to a different phase-->
+                            <phase>${ts.bootable-jar-packaging.phase}</phase>
+                        </execution>
+                    </executions>
+                </plugin>
 
 
                <!-- WFLY-3361 - use external xalan for XML transformations to

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -542,7 +542,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Package a server with hibernate-search -->
                             <execution>
@@ -553,19 +552,11 @@
                                 <phase>process-test-classes</phase>
                                 <configuration>
                                     <output-file-name>test-wildfly-hibernate-search.jar</output-file-name>
-                                    <hollowJar>true</hollowJar>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
                                     <extra-server-content-dirs>
                                         <!-- Uncomment if we add extra content
                                         <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                                         -->
                                     </extra-server-content-dirs>
-                                    <offline>true</offline>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
                                     <provisioning-file>target/glow-scan/hibernate-search.layer.surefire/provisioning.xml</provisioning-file>
                                 </configuration>
                             </execution>
@@ -579,19 +570,11 @@
                                 <phase>process-test-classes</phase>
                                 <configuration>
                                     <output-file-name>test-wildfly-mvc.jar</output-file-name>
-                                    <hollowJar>true</hollowJar>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
                                     <extra-server-content-dirs>
                                         <!-- Uncomment if we add extra content
                                         <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                                         -->
                                     </extra-server-content-dirs>
-                                    <offline>true</offline>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
                                     <provisioning-file>target/glow-scan/mvc.layer.surefire/provisioning.xml</provisioning-file>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19267 -- part twp

This is adds bootable jar provisioning to the work in #17838.

This builds on #17853, which was inspired by the WFLY-19267 use case but has its own value.

This is upstream for https://github.com/jbossas/jboss-eap8/pull/367

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19295](https://issues.redhat.com/browse/WFLY-19295)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)