### PR TITLE
WFLY-19304: update model definition and bump schema

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -24,8 +24,10 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.security.CredentialReference;
@@ -39,6 +41,7 @@ import org.jboss.jca.common.api.metadata.ds.Driver;
 import org.jboss.jca.common.api.metadata.ds.DsPool;
 import org.jboss.jca.common.api.metadata.ds.Statement;
 import org.jboss.jca.common.api.metadata.ds.TimeOut;
+import org.jboss.jca.common.api.metadata.ds.TransactionIsolation;
 import org.jboss.jca.common.api.metadata.ds.Validation;
 import org.jboss.jca.common.api.metadata.ds.XaDataSource;
 
@@ -431,7 +434,8 @@ public class Constants {
     static SimpleAttributeDefinition TRACK_STATEMENTS = new SimpleAttributeDefinitionBuilder(TRACKSTATEMENTS_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
             .setXmlName(Statement.Tag.TRACK_STATEMENTS.getLocalName())
-            .setDefaultValue(new ModelNode(Defaults.TRACK_STATEMENTS.name()))
+            .setDefaultValue(new ModelNode(Defaults.TRACK_STATEMENTS.toString()))
+            .setValidator(EnumValidator.create(Statement.TrackStatementsEnum.class))
             .setRestartAllServices()
             .build();
 
@@ -444,6 +448,7 @@ public class Constants {
 
     static SimpleAttributeDefinition ALLOCATION_RETRY_WAIT_MILLIS = new SimpleAttributeDefinitionBuilder(ALLOCATION_RETRY_WAIT_MILLIS_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.ALLOCATION_RETRY_WAIT_MILLIS.getLocalName())
+            .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -472,6 +477,7 @@ public class Constants {
 
     static SimpleAttributeDefinition QUERY_TIMEOUT = new SimpleAttributeDefinitionBuilder(QUERYTIMEOUT_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.QUERY_TIMEOUT.getLocalName())
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -492,6 +498,9 @@ public class Constants {
     static SimpleAttributeDefinition TRANSACTION_ISOLATION = new SimpleAttributeDefinitionBuilder(TRANSACTION_ISOLATION_NAME, ModelType.STRING, true)
             .setXmlName(DataSource.Tag.TRANSACTION_ISOLATION.getLocalName())
             .setAllowExpression(true)
+            .setAllowedValues(TransactionIsolation.TRANSACTION_NONE.name(), TransactionIsolation.TRANSACTION_READ_COMMITTED.name(),
+                    TransactionIsolation.TRANSACTION_READ_UNCOMMITTED.name(), TransactionIsolation.TRANSACTION_REPEATABLE_READ.name(),
+                    TransactionIsolation.TRANSACTION_SERIALIZABLE.name())
             .setRestartAllServices()
             .build();
 
@@ -623,6 +632,7 @@ public class Constants {
 
     static SimpleAttributeDefinition XA_RESOURCE_TIMEOUT = new SimpleAttributeDefinitionBuilder(XA_RESOURCE_TIMEOUT_NAME, ModelType.INT, true)
             .setXmlName(TimeOut.Tag.XA_RESOURCE_TIMEOUT.getLocalName())
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
@@ -105,11 +105,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 
+import java.util.Arrays;
 import java.util.List;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
@@ -194,6 +196,35 @@ public class DataSourcesExtension implements Extension {
             XMLElementWriter<SubsystemMarshallingContext> {
 
 
+        private static final SimpleAttributeDefinition[] COMMON_SIMPLE_DS_ATTRIBUTES = {
+                DATASOURCE_DRIVER, URL_DELIMITER, URL_SELECTOR_STRATEGY_CLASS_NAME, NEW_CONNECTION_SQL, TRANSACTION_ISOLATION
+        };
+
+        private static final SimpleAttributeDefinition[] POOL_ATTRIBUTES = {
+                MIN_POOL_SIZE, INITIAL_POOL_SIZE, MAX_POOL_SIZE, POOL_PREFILL, POOL_FAIR, POOL_USE_STRICT_MIN, POOL_FLUSH_STRATEGY, ALLOW_MULTIPLE_USERS
+        };
+
+        private static final SimpleAttributeDefinition[] XA_POOL_ATTRIBUTES = {
+                SAME_RM_OVERRIDE, INTERLEAVING, NO_TX_SEPARATE_POOL, PAD_XID, WRAP_XA_RESOURCE
+        };
+
+        private static final SimpleAttributeDefinition[] TIMEOUT_ATTRIBUTES = {
+                SET_TX_QUERY_TIMEOUT, BLOCKING_TIMEOUT_WAIT_MILLIS, IDLETIMEOUTMINUTES, QUERY_TIMEOUT, USE_TRY_LOCK,
+                ALLOCATION_RETRY, ALLOCATION_RETRY_WAIT_MILLIS, XA_RESOURCE_TIMEOUT
+        };
+
+        private static final SimpleAttributeDefinition[] RECOVERY_ATTRIBUTES = {
+                RECOVERY_SECURITY_DOMAIN, RECOVERY_AUTHENTICATION_CONTEXT, RECOVERY_CREDENTIAL_REFERENCE, RECOVERY_ELYTRON_ENABLED
+        };
+
+        private static final SimpleAttributeDefinition[] SECURITY_ATTRIBUTES = {
+                SECURITY_DOMAIN, AUTHENTICATION_CONTEXT, CREDENTIAL_REFERENCE, ELYTRON_ENABLED
+        };
+
+        private static final SimpleAttributeDefinition[] STATEMENT_ATTRIBUTES = {
+                TRACK_STATEMENTS, PREPARED_STATEMENTS_CACHE_SIZE, SHARE_PREPARED_STATEMENTS
+        };
+
         /**
          * {@inheritDoc}
          */
@@ -264,9 +295,7 @@ public class DataSourcesExtension implements Extension {
                 STATISTICS_ENABLED.marshallAsAttribute(dataSourceNode, writer);
 
                 if (!isXADataSource) {
-                    CONNECTION_URL.marshallAsElement(dataSourceNode, writer);
-                    DRIVER_CLASS.marshallAsElement(dataSourceNode, writer);
-                    DATASOURCE_CLASS.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, CONNECTION_URL, DRIVER_CLASS, DATASOURCE_CLASS);
                     if (dataSourceNode.hasDefined(CONNECTION_PROPERTIES.getName())) {
                         for (Property connectionProperty : dataSourceNode.get(CONNECTION_PROPERTIES.getName()).asPropertyList()) {
                             writeProperty(writer, dataSourceNode, connectionProperty.getName(), connectionProperty
@@ -282,49 +311,24 @@ public class DataSourcesExtension implements Extension {
                         }
 
                     }
-                    XA_DATASOURCE_CLASS.marshallAsElement(dataSourceNode, writer);
-                    URL_PROPERTY.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, XA_DATASOURCE_CLASS, URL_PROPERTY);
                 }
-                DATASOURCE_DRIVER.marshallAsElement(dataSourceNode, writer);
-                URL_DELIMITER.marshallAsElement(dataSourceNode, writer);
-                URL_SELECTOR_STRATEGY_CLASS_NAME.marshallAsElement(dataSourceNode, writer);
-                NEW_CONNECTION_SQL.marshallAsElement(dataSourceNode, writer);
-                TRANSACTION_ISOLATION.marshallAsElement(dataSourceNode, writer);
+                marshallAsElements(dataSourceNode, writer, COMMON_SIMPLE_DS_ATTRIBUTES);
 
-                boolean poolRequired = INITIAL_POOL_SIZE.isMarshallable(dataSourceNode) ||
-                        MIN_POOL_SIZE.isMarshallable(dataSourceNode) ||
-                        MAX_POOL_SIZE.isMarshallable(dataSourceNode) ||
-                        POOL_PREFILL.isMarshallable(dataSourceNode) ||
-                        POOL_FAIR.isMarshallable(dataSourceNode) ||
-                        POOL_USE_STRICT_MIN.isMarshallable(dataSourceNode) ||
-                        POOL_FLUSH_STRATEGY.isMarshallable(dataSourceNode) ||
-                        ALLOW_MULTIPLE_USERS.isMarshallable(dataSourceNode) ||
+                boolean poolRequired = isAnyRequired(dataSourceNode, POOL_ATTRIBUTES) ||
                         CONNECTION_LISTENER_CLASS.isMarshallable(dataSourceNode) ||
                         CONNECTION_LISTENER_PROPERTIES.isMarshallable(dataSourceNode);
                 if (isXADataSource) {
-                    poolRequired = poolRequired
-                            || SAME_RM_OVERRIDE.isMarshallable(dataSourceNode) ||
-                            INTERLEAVING.isMarshallable(dataSourceNode) ||
-                            NO_TX_SEPARATE_POOL.isMarshallable(dataSourceNode) ||
-                            PAD_XID.isMarshallable(dataSourceNode) ||
-                            WRAP_XA_RESOURCE.isMarshallable(dataSourceNode);
+                    poolRequired = poolRequired || isAnyRequired(dataSourceNode, XA_POOL_ATTRIBUTES);
                 }
-                final boolean capacityRequired = CAPACITY_INCREMENTER_CLASS.isMarshallable(dataSourceNode) ||
-                        CAPACITY_INCREMENTER_PROPERTIES.isMarshallable(dataSourceNode) ||
-                        CAPACITY_DECREMENTER_CLASS.isMarshallable(dataSourceNode) ||
-                        CAPACITY_DECREMENTER_PROPERTIES.isMarshallable(dataSourceNode);
+
+                final boolean capacityRequired = isAnyRequired(dataSourceNode, CAPACITY_INCREMENTER_CLASS,
+                        CAPACITY_INCREMENTER_PROPERTIES, CAPACITY_DECREMENTER_CLASS, CAPACITY_DECREMENTER_PROPERTIES);
                 poolRequired = poolRequired || capacityRequired;
                 if (poolRequired) {
                     writer.writeStartElement(isXADataSource ? XaDataSource.Tag.XA_POOL.getLocalName() : DataSource.Tag.POOL
                             .getLocalName());
-                    MIN_POOL_SIZE.marshallAsElement(dataSourceNode, writer);
-                    INITIAL_POOL_SIZE.marshallAsElement(dataSourceNode, writer);
-                    MAX_POOL_SIZE.marshallAsElement(dataSourceNode, writer);
-                    POOL_PREFILL.marshallAsElement(dataSourceNode, writer);
-                    POOL_FAIR.marshallAsElement(dataSourceNode, writer);
-                    POOL_USE_STRICT_MIN.marshallAsElement(dataSourceNode, writer);
-                    POOL_FLUSH_STRATEGY.marshallAsElement(dataSourceNode, writer);
-                    ALLOW_MULTIPLE_USERS.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, POOL_ATTRIBUTES);
 
                     if (dataSourceNode.hasDefined(CONNECTION_LISTENER_CLASS.getName())) {
                         writer.writeStartElement(DsPool.Tag.CONNECTION_LISTENER.getLocalName());
@@ -344,43 +348,30 @@ public class DataSourcesExtension implements Extension {
                         writer.writeEndElement();
                     }
 
-
                     if (capacityRequired) {
                         writer.writeStartElement(DsPool.Tag.CAPACITY.getLocalName());
                         if (dataSourceNode.hasDefined(CAPACITY_INCREMENTER_CLASS.getName())) {
                             writer.writeStartElement(Capacity.Tag.INCREMENTER.getLocalName());
                             CAPACITY_INCREMENTER_CLASS.marshallAsAttribute(dataSourceNode, writer);
                             CAPACITY_INCREMENTER_PROPERTIES.marshallAsElement(dataSourceNode, writer);
-
                             writer.writeEndElement();
                         }
                         if (dataSourceNode.hasDefined(CAPACITY_DECREMENTER_CLASS.getName())) {
                             writer.writeStartElement(Capacity.Tag.DECREMENTER.getLocalName());
                             CAPACITY_DECREMENTER_CLASS.marshallAsAttribute(dataSourceNode, writer);
                             CAPACITY_DECREMENTER_PROPERTIES.marshallAsElement(dataSourceNode, writer);
-
                             writer.writeEndElement();
                         }
                         writer.writeEndElement();
                     }
                     if (isXADataSource) {
-                        SAME_RM_OVERRIDE.marshallAsElement(dataSourceNode, writer);
-                        INTERLEAVING.marshallAsElement(dataSourceNode, writer);
-                        NO_TX_SEPARATE_POOL.marshallAsElement(dataSourceNode, writer);
-                        PAD_XID.marshallAsElement(dataSourceNode, writer);
-                        WRAP_XA_RESOURCE.marshallAsElement(dataSourceNode, writer);
+                        marshallAsElements(dataSourceNode, writer, XA_POOL_ATTRIBUTES);
                     }
                     writer.writeEndElement();
                 }
-
-                boolean recoveryRequired = RECOVERY_USERNAME.isMarshallable(dataSourceNode) ||
-                        RECOVERY_PASSWORD.isMarshallable(dataSourceNode) ||
-                        RECOVERY_SECURITY_DOMAIN.isMarshallable(dataSourceNode) ||
-                        RECOVERY_ELYTRON_ENABLED.isMarshallable(dataSourceNode) ||
-                        RECOVER_PLUGIN_CLASSNAME.isMarshallable(dataSourceNode) ||
-                        RECOVERY_CREDENTIAL_REFERENCE.isMarshallable(dataSourceNode) ||
-                        NO_RECOVERY.isMarshallable(dataSourceNode) ||
-                        RECOVER_PLUGIN_PROPERTIES.isMarshallable(dataSourceNode);
+                boolean recoveryRequired = isAnyRequired(dataSourceNode, RECOVERY_USERNAME, RECOVERY_PASSWORD,
+                        RECOVERY_SECURITY_DOMAIN, RECOVERY_ELYTRON_ENABLED, RECOVER_PLUGIN_CLASSNAME,
+                        RECOVERY_CREDENTIAL_REFERENCE, NO_RECOVERY, RECOVER_PLUGIN_PROPERTIES);
                 if (recoveryRequired && isXADataSource) {
                     writer.writeStartElement(XaDataSource.Tag.RECOVERY.getLocalName());
                     NO_RECOVERY.marshallAsAttribute(dataSourceNode, writer);
@@ -388,10 +379,7 @@ public class DataSourcesExtension implements Extension {
                         writer.writeStartElement(Recovery.Tag.RECOVER_CREDENTIAL.getLocalName());
                         RECOVERY_USERNAME.marshallAsAttribute(dataSourceNode, writer);
                         RECOVERY_PASSWORD.marshallAsAttribute(dataSourceNode, writer);
-                        RECOVERY_AUTHENTICATION_CONTEXT.marshallAsElement(dataSourceNode, writer);
-                        RECOVERY_SECURITY_DOMAIN.marshallAsElement(dataSourceNode, writer);
-                        RECOVERY_CREDENTIAL_REFERENCE.marshallAsElement(dataSourceNode, writer);
-                        RECOVERY_ELYTRON_ENABLED.marshallAsElement(dataSourceNode, writer);
+                        marshallAsElements(dataSourceNode, writer, RECOVERY_ATTRIBUTES);
                         writer.writeEndElement();
                     }
                     if (hasAnyOf(dataSourceNode, RECOVER_PLUGIN_CLASSNAME)) {
@@ -412,22 +400,13 @@ public class DataSourcesExtension implements Extension {
                     }
                     writer.writeEndElement();
                 }
-
-                boolean securityRequired = USERNAME.isMarshallable(dataSourceNode) ||
-                        PASSWORD.isMarshallable(dataSourceNode) ||
-                        CREDENTIAL_REFERENCE.isMarshallable(dataSourceNode) ||
-                        SECURITY_DOMAIN.isMarshallable(dataSourceNode) ||
-                        ELYTRON_ENABLED.isMarshallable(dataSourceNode) ||
-                        REAUTH_PLUGIN_CLASSNAME.isMarshallable(dataSourceNode) ||
-                        REAUTHPLUGIN_PROPERTIES.isMarshallable(dataSourceNode);
+                boolean securityRequired = isAnyRequired(dataSourceNode, USERNAME, PASSWORD, CREDENTIAL_REFERENCE,
+                        SECURITY_DOMAIN, ELYTRON_ENABLED, REAUTH_PLUGIN_CLASSNAME, REAUTHPLUGIN_PROPERTIES);
                 if (securityRequired) {
                     writer.writeStartElement(DataSource.Tag.SECURITY.getLocalName());
                     USERNAME.marshallAsAttribute(dataSourceNode, writer);
                     PASSWORD.marshallAsAttribute(dataSourceNode, writer);
-                    SECURITY_DOMAIN.marshallAsElement(dataSourceNode, writer);
-                    AUTHENTICATION_CONTEXT.marshallAsElement(dataSourceNode, writer);
-                    CREDENTIAL_REFERENCE.marshallAsElement(dataSourceNode, writer);
-                    ELYTRON_ENABLED.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, SECURITY_ATTRIBUTES);
 
                     if (dataSourceNode.hasDefined(REAUTH_PLUGIN_CLASSNAME.getName())) {
                         writer.writeStartElement(DsSecurity.Tag.REAUTH_PLUGIN.getLocalName());
@@ -448,20 +427,11 @@ public class DataSourcesExtension implements Extension {
                     writer.writeEndElement();
                 }
 
-                boolean validationRequired = VALID_CONNECTION_CHECKER_CLASSNAME.isMarshallable(dataSourceNode) ||
-                        VALID_CONNECTION_CHECKER_MODULE.isMarshallable(dataSourceNode) ||
-                        VALID_CONNECTION_CHECKER_PROPERTIES.isMarshallable(dataSourceNode) ||
-                        CHECK_VALID_CONNECTION_SQL.isMarshallable(dataSourceNode) ||
-                        VALIDATE_ON_MATCH.isMarshallable(dataSourceNode) ||
-                        BACKGROUNDVALIDATION.isMarshallable(dataSourceNode) ||
-                        BACKGROUNDVALIDATIONMILLIS.isMarshallable(dataSourceNode) ||
-                        USE_FAST_FAIL.isMarshallable(dataSourceNode) ||
-                        STALE_CONNECTION_CHECKER_CLASSNAME.isMarshallable(dataSourceNode) ||
-                        STALE_CONNECTION_CHECKER_MODULE.isMarshallable(dataSourceNode) ||
-                        STALE_CONNECTION_CHECKER_PROPERTIES.isMarshallable(dataSourceNode) ||
-                        EXCEPTION_SORTER_CLASSNAME.isMarshallable(dataSourceNode) ||
-                        EXCEPTION_SORTER_MODULE.isMarshallable(dataSourceNode) ||
-                        EXCEPTION_SORTER_PROPERTIES.isMarshallable(dataSourceNode);
+                boolean validationRequired = isAnyRequired(dataSourceNode, VALID_CONNECTION_CHECKER_CLASSNAME,
+                        VALID_CONNECTION_CHECKER_MODULE, CHECK_VALID_CONNECTION_SQL,
+                        VALIDATE_ON_MATCH, BACKGROUNDVALIDATION, BACKGROUNDVALIDATIONMILLIS, USE_FAST_FAIL,
+                        STALE_CONNECTION_CHECKER_CLASSNAME, STALE_CONNECTION_CHECKER_MODULE, STALE_CONNECTION_CHECKER_PROPERTIES,
+                        EXCEPTION_SORTER_CLASSNAME, EXCEPTION_SORTER_MODULE, EXCEPTION_SORTER_PROPERTIES);
                 if (validationRequired) {
                     writer.writeStartElement(DataSource.Tag.VALIDATION.getLocalName());
                     if (dataSourceNode.hasDefined(VALID_CONNECTION_CHECKER_CLASSNAME.getName())) {
@@ -485,11 +455,8 @@ public class DataSourcesExtension implements Extension {
                         }
                         writer.writeEndElement();
                     }
-                    CHECK_VALID_CONNECTION_SQL.marshallAsElement(dataSourceNode, writer);
-                    VALIDATE_ON_MATCH.marshallAsElement(dataSourceNode, writer);
-                    BACKGROUNDVALIDATION.marshallAsElement(dataSourceNode, writer);
-                    BACKGROUNDVALIDATIONMILLIS.marshallAsElement(dataSourceNode, writer);
-                    USE_FAST_FAIL.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, CHECK_VALID_CONNECTION_SQL, VALIDATE_ON_MATCH,
+                            BACKGROUNDVALIDATION, BACKGROUNDVALIDATIONMILLIS, USE_FAST_FAIL);
                     if (dataSourceNode.hasDefined(STALE_CONNECTION_CHECKER_CLASSNAME.getName())) {
                         writer.writeStartElement(Validation.Tag.STALE_CONNECTION_CHECKER.getLocalName());
                         writer.writeAttribute(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName(),
@@ -534,33 +501,16 @@ public class DataSourcesExtension implements Extension {
                     }
                     writer.writeEndElement();
                 }
-                boolean timeoutRequired = BLOCKING_TIMEOUT_WAIT_MILLIS.isMarshallable(dataSourceNode) ||
-                        IDLETIMEOUTMINUTES.isMarshallable(dataSourceNode) ||
-                        SET_TX_QUERY_TIMEOUT.isMarshallable(dataSourceNode) ||
-                        QUERY_TIMEOUT.isMarshallable(dataSourceNode) ||
-                        USE_TRY_LOCK.isMarshallable(dataSourceNode) ||
-                        ALLOCATION_RETRY.isMarshallable(dataSourceNode) ||
-                        ALLOCATION_RETRY_WAIT_MILLIS.isMarshallable(dataSourceNode) ||
-                        XA_RESOURCE_TIMEOUT.isMarshallable(dataSourceNode);
+                boolean timeoutRequired = isAnyRequired(dataSourceNode, TIMEOUT_ATTRIBUTES);
                 if (timeoutRequired) {
                     writer.writeStartElement(DataSource.Tag.TIMEOUT.getLocalName());
-                    SET_TX_QUERY_TIMEOUT.marshallAsElement(dataSourceNode, writer);
-                    BLOCKING_TIMEOUT_WAIT_MILLIS.marshallAsElement(dataSourceNode, writer);
-                    IDLETIMEOUTMINUTES.marshallAsElement(dataSourceNode, writer);
-                    QUERY_TIMEOUT.marshallAsElement(dataSourceNode, writer);
-                    USE_TRY_LOCK.marshallAsElement(dataSourceNode, writer);
-                    ALLOCATION_RETRY.marshallAsElement(dataSourceNode, writer);
-                    ALLOCATION_RETRY_WAIT_MILLIS.marshallAsElement(dataSourceNode, writer);
-                    XA_RESOURCE_TIMEOUT.marshallAsElement(dataSourceNode, writer);
+                    marshallAsElements(dataSourceNode, writer, TIMEOUT_ATTRIBUTES);
                     writer.writeEndElement();
                 }
-                boolean statementRequired = hasAnyOf(dataSourceNode, TRACK_STATEMENTS, PREPARED_STATEMENTS_CACHE_SIZE, SHARE_PREPARED_STATEMENTS);
+                boolean statementRequired = hasAnyOf(dataSourceNode, STATEMENT_ATTRIBUTES);
                 if (statementRequired) {
                     writer.writeStartElement(DataSource.Tag.STATEMENT.getLocalName());
-                    TRACK_STATEMENTS.marshallAsElement(dataSourceNode, writer);
-                    PREPARED_STATEMENTS_CACHE_SIZE.marshallAsElement(dataSourceNode, writer);
-                    SHARE_PREPARED_STATEMENTS.marshallAsElement(dataSourceNode, writer);
-
+                    marshallAsElements(dataSourceNode, writer, STATEMENT_ATTRIBUTES);
                     writer.writeEndElement();
                 }
 
@@ -601,6 +551,11 @@ public class DataSourcesExtension implements Extension {
             }
         }
 
+        private void marshallAsElements(ModelNode node, XMLExtendedStreamWriter writer, SimpleAttributeDefinition... names) throws XMLStreamException {
+            for (SimpleAttributeDefinition attr : names) {
+                attr.marshallAsElement(node, writer);
+            }
+        }
 
         private boolean hasAnyOf(ModelNode node, SimpleAttributeDefinition... names) {
             for (SimpleAttributeDefinition current : names) {
@@ -614,6 +569,10 @@ public class DataSourcesExtension implements Extension {
         private boolean has(ModelNode node, String name) {
             return node.has(name) && node.get(name).isDefined();
         }
+
+        private boolean isAnyRequired(ModelNode node, AttributeDefinition... names) {
+            return Arrays.stream(names).anyMatch(name -> name.isMarshallable(node));
+        };
 
         @Override
         public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> list) throws XMLStreamException {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Namespace.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Namespace.java
@@ -32,12 +32,14 @@ public enum Namespace {
 
     DATASOURCES_7_0("urn:jboss:domain:datasources:7.0"),
 
-    DATASOURCES_7_1("urn:jboss:domain:datasources:7.1");
+    DATASOURCES_7_1("urn:jboss:domain:datasources:7.1"),
+
+    DATASOURCES_7_2("urn:jboss:domain:datasources:7.2");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DATASOURCES_7_1;
+    public static final Namespace CURRENT = DATASOURCES_7_2;
 
     private final String name;
 

--- a/connector/src/main/resources/schema/wildfly-datasources_7_2.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_7_2.xsd
@@ -1,0 +1,1119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:datasources:7.2" xmlns="urn:jboss:domain:datasources:7.2"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+
+  <xs:element name="subsystem" type="subsystemType"/>
+
+  <xs:complexType name="subsystemType">
+    <xs:all>
+      <xs:element name="datasources" type="datasourcesType" minOccurs="1" maxOccurs="1"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="datasourcesType">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="datasource" type="datasourceType">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies a non-XA datasource, using local transactions
+               ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="xa-datasource" type="xa-datasourceType">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies a XA datasource
+                ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:element name="drivers" type="driversType" maxOccurs="1" minOccurs="0"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datasourceType" mixed="false">
+    <xs:sequence>
+      <xs:element name="connection-url" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The JDBC driver connection URL Ex: <connection-url>jdbc:hsqldb:hsql://localhost:1701</connection-url>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC driver class Ex: <driver-class>org.hsqldb.jdbcDriver</driver-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC datasource class Ex: <datasource-class>org.h2.jdbcx.JdbcDataSource</datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="connection-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The connection-property element allows you to pass in arbitrary connection
+              properties to the Driver.connect(url, props) method. Each connection-property
+              specifies a string name/value pair with the property name coming from the
+              name attribute and the value coming from the element content. Ex:
+              <connection-property name="char.encoding">UTF-8</connection-property>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                An unique reference to the classloader module which contains the JDBC driver
+                The accepted format is driverName#majorVersion.minorVersion
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the delimeter for URLs in connection-url for HA datasources
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to execute whenever a connection is added
+              to the connection pool.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Set java.sql.Connection transaction isolation level to use. The constants
+              defined by transaction-isolation-values are the possible transaction isolation
+              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
+              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="pool" type="poolType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the pooling settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="security" type="dsSecurityType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the time out settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="statement" type="statementType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the statement settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="jta" type="xs:boolean" default="true" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable JTA integration
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attributeGroup ref="common-datasourceAttributes" />
+  </xs:complexType>
+  <xs:complexType name="xa-datasourceType">
+    <xs:sequence>
+      <xs:element name="xa-datasource-property" type="xa-datasource-propertyType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies a property to assign to the XADataSource implementation class.
+              Each property is identified by the name attribute and the property value
+              is given by the xa-datasource-property element content. The property is mapped
+              onto the XADataSource implementation by looking for a JavaBeans style getter
+              method for the property name. If found, the value of the property is set
+              using the JavaBeans setter with the element text translated to the true property
+              type using the java.beans.PropertyEditor for the type. Ex:
+              <xa-datasource-property name="IfxWAITTIME">10</xa-datasource-property>
+              <xa-datasource-property name="IfxIFXHOST">myhost.mydomain.com</xa-datasource-property>
+              <xa-datasource-property name="PortNumber">1557</xa-datasource-property>
+              <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>
+              <xa-datasource-property name="ServerName">myserver</xa-datasource-property>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the javax.sql.XADataSource implementation
+              class. Ex: <xa-datasource-class>oracle.jdbc.xa.client.OracleXADataSource</xa-datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-property" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                     Specifies the property for the URL property in the xa-datasource-property values
+                    ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                An unique reference to the classloader module which contains the JDBC driver
+                The accepted format is driverName#majorVersion.minorVersion
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the delimeter for URLs in connection-url for HA datasources
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to execute whenever a connection is added
+              to the connection pool.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Set java.sql.Connection transaction isolation level to use. The constants
+              defined by transaction-isolation-values are the possible transaction isolation
+              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
+              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-pool" type="xa-poolType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the pooling settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
+      <xs:element name="security" type="dsSecurityType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the time out settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="statement" type="statementType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the statement settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attributeGroup ref="common-datasourceAttributes" />
+  </xs:complexType>
+  <xs:complexType name="boolean-presenceType" />
+  <xs:attributeGroup name="common-datasourceAttributes">
+    <xs:attribute name="jndi-name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the JNDI name for the datasource
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="pool-name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the pool name for the datasource used for management
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enabled" type="xs:boolean" default="true" form="unqualified" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies if the datasource should be enabled
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="true" name="use-java-context" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Setting this to false will bind the DataSource into global JNDI
+            Ex: use-java-context="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="spy" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable spy functionality on the JDBC layer - e.g. log all JDBC traffic to the datasource.
+            Remember to enable the logging category (org.jboss.jdbc) too.
+            Ex: spy="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="true" name="use-ccm" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable the use of a cached connection manager
+            Ex: use-ccm="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="connectable" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                  Enable cmr functionality on this datsource's connections
+                 ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="tracking" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if IronJacamar should track connection handles across transaction boundaries
+          ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="statistics-enabled" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                  Enable statistics for this datasource
+                 ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="mcp" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines the ManagedConnectionPool implementation, f.ex. org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreArrayListManagedConnectionPool
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if WildFly/IronJacamar should record enlistment traces
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:simpleType name="transaction-isolationType">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Define constants used as the possible transaction isolation levels in transaction-isolation
+          type. Include: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ,
+          TRANSACTION_SERIALIZABLE, TRANSACTION_NONE
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="TRANSACTION_READ_UNCOMMITTED" />
+      <xs:enumeration value="TRANSACTION_READ_COMMITTED" />
+      <xs:enumeration value="TRANSACTION_REPEATABLE_READ" />
+      <xs:enumeration value="TRANSACTION_SERIALIZABLE" />
+      <xs:enumeration value="TRANSACTION_NONE" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="xa-datasource-propertyType" mixed="true">
+    <xs:attribute name="name" use="required" type="xs:token" />
+  </xs:complexType>
+  <xs:complexType name="connection-propertyType" mixed="true">
+    <xs:attribute name="name" use="required" type="xs:token" />
+  </xs:complexType>
+  <xs:complexType name="validationType">
+    <xs:sequence>
+      <xs:element name="valid-connection-checker" type="moduleExtensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.ValidConnectionChecker that provides
+              a SQLException isValidConnection(Connection e) method to validate is a connection
+              is valid. An exception means the connection is destroyed. This overrides
+              the check-valid-connection-sql when present. Ex:
+              <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.vendor.OracleValidConnectionChecker"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="check-valid-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to check validity of a pool connection. This
+              may be called when managed connection is taken from pool for use.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validate-on-match" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The validate-on-match element indicates whether or not connection
+              level validation should be done when a connection factory attempts to match
+              a managed connection for a given set. This is typically exclusive to the
+              use of background validation
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An element to specify that connections should be validated on a background
+              thread versus being validated prior to use
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The background-validation-millis element specifies the amount of
+              time, in millis, that background validation will run.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-fast-fail" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether fail a connection allocation on the first connection if it
+              is invalid (true) or keep trying until the pool is exhausted of all potential
+              connections (false) default false. e.g. <use-fast-fail>true</use-fast-fail>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="stale-connection-checker" type="moduleExtensionType">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.StaleConnectionChecker that provides
+              a boolean isStaleConnection(SQLException e) method which if it it returns
+              true will wrap the exception in an org.jboss.jca.adapters.jdbc.StaleConnectionException
+              which is a subclass of SQLException. Ex:
+              <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.vendor.OracleStaleConnectionChecker"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="exception-sorter" type="moduleExtensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.ExceptionSorter that provides a
+              boolean isExceptionFatal(SQLException e) method to validate is an exception
+              should be broadcast to all javax.resource.spi.ConnectionEventListener as
+              a connectionErrorOccurred message. Ex:
+              <exception-sorter class-name="org.jboss.jca.adapters.jdbc.vendor.OracleExceptionSorter"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="timeoutType">
+    <xs:sequence>
+      <xs:element name="set-tx-query-timeout" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to set the query timeout based on the time remaining until
+              transaction timeout, any configured query timeout will be used if there is
+              no transaction. The default is false. e.g. <set-tx-query-timeout/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="blocking-timeout-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The blocking-timeout-millis element indicates the maximum time in
+              milliseconds to block while waiting for a connection before throwing an exception.
+              Note that this blocks only while waiting for a permit for a connection, and
+              will never throw an exception if creating a new connection takes an inordinately
+              long time. The default is 30000 (30 seconds).
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="idle-timeout-minutes" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The idle-timeout-minutes elements indicates the maximum time in minutes
+              a connection may be idle before being closed. The actual maximum time depends
+              also on the IdleRemover scan time, which is 1/2 the smallest idle-timeout-minutes
+              of any pool.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="query-timeout" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Any configured query timeout in seconds The default is no timeout
+              e.g. 5 minutes <query-timeout>300</query-timeout>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-try-lock" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Any configured timeout for internal locks on the resource adapter
+              objects in seconds The default is a 60 second timeout e.g. 5 minutes <use-try-lock>300</use-try-lock>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry element indicates the number of times that allocating
+              a connection should be tried before throwing an exception. The default is 0.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry-wait-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry wait millis element indicates the time in milliseconds
+              to wait between retrying to allocate a connection. The default is 5000 (5 seconds).
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-resource-timeout" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Passed to XAResource.setTransactionTimeout() Default is zero which
+              does not invoke the setter. In seconds e.g. 5 minutes <xa-resource-timeout>300</xa-resource-timeout>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="track-statementsType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="true" />
+      <xs:enumeration value="false" />
+      <xs:enumeration value="nowarn" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="statementType">
+    <xs:sequence>
+      <xs:element name="track-statements" type="track-statementsType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to check for unclosed statements when a connection is returned
+              to the pool and result sets are closed when a statement is closed/return
+              to the prepared statement cache. valid values are: false - do not track statements
+              and results true - track statements and result sets and warn when they are
+              not closed nowarn - track statements but do no warn about them being unclosed
+              (the default) e.g. <track-statements>nowarn</track-statements>
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="prepared-statement-cache-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The number of prepared statements per connection in an LRU cache
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="share-prepared-statements" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to share prepare statements, i.e. whether asking for same
+              statement twice without closing uses the same underlying prepared statement.
+              The default is false. e.g. <share-prepared-statements/>
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="poolType">
+    <xs:sequence>
+      <xs:element name="min-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The min-pool-size element indicates the minimum number of connections
+              a pool should hold. These are not created until a Subject is known from a
+              request for a connection. This default to 0. Ex: <min-pool-size>1</min-pool-size>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="initial-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    The initial-pool-size element indicates the initial number of connections
+                    a pool should hold. This default to 0. Ex: <initial-pool-size>1</initial-pool-size>
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="max-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The max-pool-size element indicates the maximum number of connections
+              for a pool. No more connections will be created in each sub-pool.
+              This defaults to 20.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="prefill" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to attempt to prefill the connection pool. Empty element denotes
+              a true value. e.g. <prefill>true</prefill>.
+              Default is false
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="fair" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Defines if pool use should be fair
+              Default true
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-strict-min" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Define if the min-pool-size should be considered a strictly.
+              Default false
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="flush-strategy" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies how the pool should be flush in case of an error.
+              Valid values are: FailingConnectionOnly (default), InvalidIdleConnections, IdleConnections, Gracefully, EntirePool,
+              AllInvalidIdleConnections, AllIdleConnections, AllGracefully, AllConnections
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allow-multiple-users" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies if multiple users will access the datasource through the getConnection(user, password)
+              method and hence if the internal pool type should account for that
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="connection-listener" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    An org.jboss.jca.adapters.jdbc.spi.listener.ConnectionListener that provides
+                    a possible to listen for connection activation and passivation in order to
+                    perform actions before the connection is returned to the application or returned
+                    to the pool. Ex:
+                    <connection-listener class-name="com.acme.jdbc.OracleConnectionListener"/>
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="capacity" type="capacityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    Specifies the capacity policies for the pool
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="xa-poolType">
+    <xs:complexContent>
+      <xs:extension base="poolType">
+        <xs:sequence>
+          <xs:element name="is-same-rm-override" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  The is-same-rm-override element allows one to unconditionally
+                  set whether the javax.transaction.xa.XAResource.isSameRM(XAResource) returns
+                  true or false. Ex: <is-same-rm-override>true</is-same-rm-override>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="interleaving" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  An element to enable interleaving for XA connection factories
+                  Ex: <interleaving/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="no-tx-separate-pools" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  Oracle does not like XA connections getting used both inside and outside a JTA transaction.
+                  To workaround the problem you can create separate sub-pools for the different contexts
+                  using <no-tx-separate-pools/>
+                  Ex: <no-tx-separate-pools/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="pad-xid" type="xs:boolean" default="false" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the Xid be padded
+                   Ex: <pad-xid>true</pad-xid>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="wrap-xa-resource" type="xs:boolean" default="true" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
+                   instance
+                   Ex: <wrap-xa-resource>true</wrap-xa-resource>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="dsSecurityType">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="security-domain" type="xs:token" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Indicates Subject (from security domain) are used to distinguish connections in the pool.
+                The content of the security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+                Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="authentication-context" type="xs:token" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates the Elytron context that will be used for authenticating connections during
+                container-managed sign-on.
+                The resulting Subject will be used to distinguish connections in the pool.
+                The authentication-context name correlates to the authentication context defined in
+                the Elytron subsystem.
+                Ex:
+                  <elytron-enabled/>
+                  <authentication-context>HsqlDbContext</authentication-context>
+                ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      </xs:choice>
+      <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Credential to be used by the configuration.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="elytron-enabled" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via authentication-context), Elytron will use the specified context
+                for authenticating. Else, Elytron will use the current authentication context of the caller that
+                is retrieving the connection.
+                Ex:
+                  <elytron-enabled/>
+                ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="reauth-plugin" type="extensionType" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="user-name" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Specify the username used when creating a new connection.
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="password" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Specify the password used when creating a new connection.
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="extensionType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="moduleExtensionType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+    <xs:attribute name="module" type="xs:token" use="optional"></xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="config-propertyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Specifies a Java bean property value
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attribute use="required" name="name" type="xs:token">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies the name of the config-property
+               ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="recoverType">
+    <xs:sequence>
+      <xs:element name="recover-credential" type="dsSecurityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security options used when creating a connection during recovery.
+              Note: if this credential are not specified the security credential are used for recover too
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recover-plugin" type="extensionType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the extension plugin used in spi (core.spi.xa)
+              which can be implemented by various plugins to provide better feedback to the XA recovery system.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="no-recovery" type="xs:boolean" default="false" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specify if the xa-datasource should be excluded from recovery.
+            Default false.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="driverType">
+    <xs:sequence>
+      <xs:element name="driver-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC driver class Ex: <driver-class>org.hsqldb.jdbcDriver</driver-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the javax.sql.XADataSource implementation
+              class. Ex: <xa-datasource-class>oracle.jdbc.xa.client.OracleXADataSource</xa-datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the javax.sql.DataSource implementation
+              class.
+             ]]>
+          </xs:documentation>
+        </xs:annotation></xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the symbolic name of this driver used to reference this driver
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="module" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the name of AS7 module providing this driver.
+            This tag is not used in IronJacamar standalone container.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="major-version" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the major version of this driver. If the major and minor versions are omitted the first available
+            Driver in module will be used.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="minor-version" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the minor version of this driver. If the major and minor versions are omitted the first available
+            Driver in module will be used.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="driversType">
+    <xs:sequence>
+      <xs:element name="driver" type="driverType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="capacityType">
+    <xs:sequence>
+      <xs:element name="incrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Defines the policy for incrementing connections in the pool
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="decrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Defines the policy for decrementing connections in the pool
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/connector/src/main/resources/schema/wildfly-datasources_7_2.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_7_2.xsd
@@ -41,10 +41,10 @@
           </xs:annotation>
         </xs:element>
       </xs:choice>
-      <xs:element name="drivers" type="driversType" maxOccurs="1" minOccurs="0"></xs:element>
+      <xs:element name="drivers" type="driversType" maxOccurs="1" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:complexType name="datasourceType" mixed="false">
+  <xs:complexType name="datasourceType">
     <xs:sequence>
       <xs:element name="connection-url" type="xs:token">
         <xs:annotation>
@@ -86,56 +86,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="driver" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-                An unique reference to the classloader module which contains the JDBC driver
-                The accepted format is driverName#majorVersion.minorVersion
-               ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the delimeter for URLs in connection-url for HA datasources
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specify an SQL statement to execute whenever a connection is added
-              to the connection pool.
-              ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Set java.sql.Connection transaction isolation level to use. The constants
-              defined by transaction-isolation-values are the possible transaction isolation
-              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
-              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:group ref="common-simpleDatasourceElements"/>
       <xs:element name="pool" type="poolType" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>
@@ -145,42 +96,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="security" type="dsSecurityType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the security settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="validation" type="validationType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the validation settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="timeout" type="timeoutType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the time out settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="statement" type="statementType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the statement settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:group ref="common-complexDatasourceElements"/>
     </xs:sequence>
     <xs:attribute name="jta" type="xs:boolean" default="true" use="optional">
       <xs:annotation>
@@ -191,11 +107,11 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attributeGroup ref="common-datasourceAttributes" />
+    <xs:attributeGroup ref="common-datasourceAttributes"/>
   </xs:complexType>
   <xs:complexType name="xa-datasourceType">
     <xs:sequence>
-      <xs:element name="xa-datasource-property" type="xa-datasource-propertyType" minOccurs="1" maxOccurs="unbounded">
+      <xs:element name="xa-datasource-property" type="config-propertyType" minOccurs="1" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>
             <![CDATA[[
@@ -234,56 +150,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="driver" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-                An unique reference to the classloader module which contains the JDBC driver
-                The accepted format is driverName#majorVersion.minorVersion
-               ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the delimeter for URLs in connection-url for HA datasources
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specify an SQL statement to execute whenever a connection is added
-              to the connection pool.
-              ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Set java.sql.Connection transaction isolation level to use. The constants
-              defined by transaction-isolation-values are the possible transaction isolation
-              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
-              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:group ref="common-simpleDatasourceElements"/>
       <xs:element name="xa-pool" type="xa-poolType" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>
@@ -293,47 +160,11 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
-      <xs:element name="security" type="dsSecurityType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the security settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="validation" type="validationType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the validation settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="timeout" type="timeoutType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the time out settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="statement" type="statementType" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[[
-              Specifies the statement settings
-             ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"/>
+      <xs:group ref="common-complexDatasourceElements"/>
     </xs:sequence>
-    <xs:attributeGroup ref="common-datasourceAttributes" />
+    <xs:attributeGroup ref="common-datasourceAttributes"/>
   </xs:complexType>
-  <xs:complexType name="boolean-presenceType" />
   <xs:attributeGroup name="common-datasourceAttributes">
     <xs:attribute name="jndi-name" type="xs:token" use="required">
       <xs:annotation>
@@ -439,6 +270,103 @@
       </xs:annotation>
     </xs:attribute>
   </xs:attributeGroup>
+
+  <xs:group name="common-simpleDatasourceElements">
+    <xs:sequence>
+      <xs:element name="driver" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                An unique reference to the classloader module which contains the JDBC driver
+                The accepted format is driverName#majorVersion.minorVersion
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the delimeter for URLs in connection-url for HA datasources
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to execute whenever a connection is added
+              to the connection pool.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Set java.sql.Connection transaction isolation level to use. The constants
+              defined by transaction-isolation-values are the possible transaction isolation
+              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
+              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="common-complexDatasourceElements">
+    <xs:sequence>
+      <xs:element name="security" type="dsSecurityType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the time out settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="statement" type="statementType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the statement settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+
   <xs:simpleType name="transaction-isolationType">
     <xs:annotation>
       <xs:documentation>
@@ -450,19 +378,13 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:token">
-      <xs:enumeration value="TRANSACTION_READ_UNCOMMITTED" />
-      <xs:enumeration value="TRANSACTION_READ_COMMITTED" />
-      <xs:enumeration value="TRANSACTION_REPEATABLE_READ" />
-      <xs:enumeration value="TRANSACTION_SERIALIZABLE" />
-      <xs:enumeration value="TRANSACTION_NONE" />
+      <xs:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xs:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xs:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xs:enumeration value="TRANSACTION_SERIALIZABLE"/>
+      <xs:enumeration value="TRANSACTION_NONE"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:complexType name="xa-datasource-propertyType" mixed="true">
-    <xs:attribute name="name" use="required" type="xs:token" />
-  </xs:complexType>
-  <xs:complexType name="connection-propertyType" mixed="true">
-    <xs:attribute name="name" use="required" type="xs:token" />
-  </xs:complexType>
   <xs:complexType name="validationType">
     <xs:sequence>
       <xs:element name="valid-connection-checker" type="moduleExtensionType" minOccurs="0">
@@ -652,9 +574,9 @@
   </xs:complexType>
   <xs:simpleType name="track-statementsType">
     <xs:restriction base="xs:token">
-      <xs:enumeration value="true" />
-      <xs:enumeration value="false" />
-      <xs:enumeration value="nowarn" />
+      <xs:enumeration value="true"/>
+      <xs:enumeration value="false"/>
+      <xs:enumeration value="nowarn"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="statementType">
@@ -885,9 +807,9 @@
           </xs:annotation>
         </xs:element>
         <xs:element name="authentication-context" type="xs:token" minOccurs="0">
-            <xs:annotation>
-              <xs:documentation>
-                <![CDATA[[
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
                 Indicates the Elytron context that will be used for authenticating connections during
                 container-managed sign-on.
                 The resulting Subject will be used to distinguish connections in the pool.
@@ -897,9 +819,9 @@
                   <elytron-enabled/>
                   <authentication-context>HsqlDbContext</authentication-context>
                 ]]>
-              </xs:documentation>
-            </xs:annotation>
-          </xs:element>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
       </xs:choice>
       <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
         <xs:annotation>
@@ -922,7 +844,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="reauth-plugin" type="extensionType" minOccurs="0" maxOccurs="1" />
+      <xs:element name="reauth-plugin" type="extensionType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="user-name" type="xs:token" use="optional">
       <xs:annotation>
@@ -946,38 +868,23 @@
 
   <xs:complexType name="extensionType">
     <xs:sequence>
-      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+    <xs:attribute name="class-name" type="xs:token" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="moduleExtensionType">
-    <xs:sequence>
-      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"></xs:element>
-    </xs:sequence>
-    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
-    <xs:attribute name="module" type="xs:token" use="optional"></xs:attribute>
+    <xs:complexContent>
+      <xs:extension base="extensionType">
+        <xs:attribute name="module" type="xs:token" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="config-propertyType" mixed="true">
-    <xs:annotation>
-      <xs:documentation>
-        <![CDATA[[
-          Specifies a Java bean property value
-         ]]>
-      </xs:documentation>
-    </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:token">
-        <xs:attribute use="required" name="name" type="xs:token">
-          <xs:annotation>
-            <xs:documentation>
-              <![CDATA[[
-                Specifies the name of the config-property
-               ]]>
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
+        <xs:attribute use="required" name="name" type="xs:token"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -1090,7 +997,7 @@
 
   <xs:complexType name="driversType">
     <xs:sequence>
-      <xs:element name="driver" type="driverType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+      <xs:element name="driver" type="driverType" maxOccurs="unbounded" minOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="capacityType">

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -45,12 +45,12 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
     @Override
     protected String getSubsystemXml() throws IOException {
         //test configuration put in standalone.xml
-        return readResource("datasources-minimal.xml");
+        return readResource("datasources-full.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-datasources_7_1.xsd";
+        return "schema/wildfly-datasources_7_2.xsd";
     }
 
     @Test

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasource.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasource.xml
@@ -3,257 +3,238 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:4.0">
-            <datasources>
-                <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool" jta="false" use-java-context="true" spy="false" use-ccm="true" statistics-enabled="true" tracking="true">
-                    <connection-url>
-                        jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-                    </connection-url>
-                    <driver-class>
-                        org.hsqldb.jdbcDriver
-                    </driver-class>
-                    <datasource-class>
-                        org.jboss.as.connector.subsystems.datasources.ModifiableDataSource
-                    </datasource-class>
-                    <connection-property name="char.encoding">
-                        UTF-8
-                    </connection-property>
-                    <driver>
-                        h2
-                    </driver>
-                    <new-connection-sql>
-                        select 1
-                    </new-connection-sql>
-                    <transaction-isolation>
-                        TRANSACTION_READ_COMMITTED
-                    </transaction-isolation>
-                    <url-delimiter>
-                        :
-                    </url-delimiter>
-                    <url-selector-strategy-class-name>
-                        someClass
-                    </url-selector-strategy-class-name>
-                    <pool>
-                        <min-pool-size>
-                            1
-                        </min-pool-size>
-                        <max-pool-size>
-                            5
-                        </max-pool-size>
-                        <prefill>
-                            true
-                        </prefill>
-                        <fair>
-                            true
-                        </fair>
-                        <use-strict-min>
-                            true
-                        </use-strict-min>
-                        <flush-strategy>
-                            EntirePool
-                        </flush-strategy>
-                        <allow-multiple-users/>
-                    </pool>
-                    <security>
-                        <user-name>
-                            sa
-                        </user-name>
-                        <password>
-                            sa
-                        </password>
-                        <reauth-plugin class-name="someClass1">
-                        <config-property name="name">Property1</config-property>
-            </reauth-plugin>
-                    </security>
-                    <validation>
-                        <valid-connection-checker class-name="someClass2">
-                        <config-property name="name">Property2</config-property>
-            </valid-connection-checker>
-                        <check-valid-connection-sql>
-                            select 1
-                        </check-valid-connection-sql>
-                        <validate-on-match>
-                            true
-                        </validate-on-match>
-                        <background-validation>
-                            true
-                        </background-validation>
-                        <background-validation-millis>
-                            2000
-                        </background-validation-millis>
-                        <use-fast-fail>
-                            true
-                        </use-fast-fail>
-                        <stale-connection-checker class-name="someClass3">
-                        <config-property name="name">Property3</config-property>
-            </stale-connection-checker>
-                        <exception-sorter class-name="someClass4">
-                        <config-property name="name">Property4</config-property>
-            </exception-sorter>
-                    </validation>
-                    <timeout>
-            <blocking-timeout-millis>20000</blocking-timeout-millis>
-            <idle-timeout-minutes>4</idle-timeout-minutes>
-            <set-tx-query-timeout/>
-                        <query-timeout>
-                            120
-                        </query-timeout>
-                        <use-try-lock>
-                            100
-                        </use-try-lock>
-                        <allocation-retry>
-                            2
-                        </allocation-retry>
-                        <allocation-retry-wait-millis>
-                            3000
-                        </allocation-retry-wait-millis>
-                    </timeout>
-                    <statement>
-                        <prepared-statement-cache-size>
-                            30
-                        </prepared-statement-cache-size>
-            <share-prepared-statements/>
-                        <track-statements>nowarn</track-statements>
-                    </statement>
-                </datasource>
-                <xa-datasource jndi-name="java:jboss/xa-datasources/complexXaDs" pool-name="complexXaDs_Pool" use-java-context="true" spy="false" use-ccm="true">
-                    <xa-datasource-property name="URL">
-                        jdbc:h2:mem:test
-                    </xa-datasource-property>
-                    <xa-datasource-class>
-                        org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource
-                    </xa-datasource-class>
-                    <driver>
-                        h2
-                    </driver>
-                    <url-delimiter>
-                        :
-                    </url-delimiter>
-                    <url-selector-strategy-class-name>
-                        someClass
-                    </url-selector-strategy-class-name>
-                    <new-connection-sql>
-                        select 1
-                    </new-connection-sql>
-                    <transaction-isolation>
-                        TRANSACTION_READ_COMMITTED
-                    </transaction-isolation>
-                    <xa-pool>
-                        <min-pool-size>
-                            1
-                        </min-pool-size>
-                        <max-pool-size>
-                            5
-                        </max-pool-size>
-                        <prefill>
-                            true
-                        </prefill>
-                        <fair>
-                            true
-                        </fair>
-                        <use-strict-min>
-                            true
-                        </use-strict-min>
-                        <flush-strategy>
-                            EntirePool
-                        </flush-strategy>
-                        <is-same-rm-override>
-                            true
-                        </is-same-rm-override>
-            <interleaving/>
-            <no-tx-separate-pools/>
-                        <pad-xid>
-                            true
-                        </pad-xid>
-                        <wrap-xa-resource>
-                            true
-                        </wrap-xa-resource>
-                    </xa-pool>
-                    <security>
-                        <user-name>
-                            sa
-                        </user-name>
-                        <password>
-                            sa
-                        </password>
-                        <reauth-plugin class-name="someClass1">
-                        <config-property name="name">Property1</config-property>
-            </reauth-plugin>
-                    </security>
-                    <recovery no-recovery="false">
-                        <recover-credential>
-                            <user-name>
-                                sa
-                            </user-name>
-                            <password>
-                                sa
-                            </password>
-                        </recover-credential>
-                        <recover-plugin class-name="someClass5">
-                        <config-property name="name">Property5</config-property>
-                        <config-property name="name1">Property6</config-property>
-            </recover-plugin>
-                    </recovery>
-                    <validation>
-                        <valid-connection-checker class-name="someClass2">
-                        <config-property name="name">Property2</config-property>
-            </valid-connection-checker>
-                        <check-valid-connection-sql>
-                            select 1
-                        </check-valid-connection-sql>
-                        <validate-on-match>
-                            true
-                        </validate-on-match>
-                        <background-validation>
-                            true
-                        </background-validation>
-                        <background-validation-millis>
-                            2000
-                        </background-validation-millis>
-                        <use-fast-fail>
-                            true
-                        </use-fast-fail>
-                        <stale-connection-checker class-name="someClass3">
-                        <config-property name="name">Property3</config-property>
-            </stale-connection-checker>
-                        <exception-sorter class-name="someClass4">
-                        <config-property name="name">Property4</config-property>
-            </exception-sorter>
-                    </validation>
-                    <timeout>
-            <blocking-timeout-millis>20000</blocking-timeout-millis>
-            <idle-timeout-minutes>4</idle-timeout-minutes>
-            <set-tx-query-timeout/>
-                        <query-timeout>
-                            120
-                        </query-timeout>
-                        <use-try-lock>
-                            100
-                        </use-try-lock>
-                        <allocation-retry>
-                            2
-                        </allocation-retry>
-                        <allocation-retry-wait-millis>
-                            3000
-                        </allocation-retry-wait-millis>
-                        <xa-resource-timeout>
-                            120
-                        </xa-resource-timeout>
-                    </timeout>
-                    <statement>
-                        <prepared-statement-cache-size>
-                            30
-                        </prepared-statement-cache-size>
-            <share-prepared-statements/>
-            <track-statements>nowarn</track-statements>
-                    </statement>
-          </xa-datasource>
-                <drivers>
-                    <driver name="h2" module="com.h2database.h2">
-                        <xa-datasource-class>
-                            org.h2.jdbcx.JdbcDataSource
-                        </xa-datasource-class>
-                    </driver>
-                </drivers>
-            </datasources>
-        </subsystem>
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
+    <datasources>
+        <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool" jta="false" use-java-context="true" spy="false" use-ccm="true" statistics-enabled="true" tracking="true">
+            <connection-url>
+                jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+            </connection-url>
+            <driver-class>
+                org.hsqldb.jdbcDriver
+            </driver-class>
+            <datasource-class>
+                org.jboss.as.connector.subsystems.datasources.ModifiableDataSource
+            </datasource-class>
+            <connection-property name="char.encoding">
+                UTF-8
+            </connection-property>
+            <driver>
+                h2
+            </driver>
+            <url-delimiter>
+                :
+            </url-delimiter>
+            <url-selector-strategy-class-name>
+                someClass
+            </url-selector-strategy-class-name>
+            <new-connection-sql>
+                select 1
+            </new-connection-sql>
+            <transaction-isolation>
+                TRANSACTION_READ_COMMITTED
+            </transaction-isolation>
+            <pool>
+                <min-pool-size>
+                    1
+                </min-pool-size>
+                <max-pool-size>
+                    5
+                </max-pool-size>
+                <prefill>
+                    true
+                </prefill>
+                <fair>
+                    true
+                </fair>
+                <use-strict-min>
+                    true
+                </use-strict-min>
+                <flush-strategy>
+                    EntirePool
+                </flush-strategy>
+                <allow-multiple-users>true</allow-multiple-users>
+            </pool>
+            <security user-name="sa" password="sa">
+                <reauth-plugin class-name="someClass1">
+                    <config-property name="name">Property1</config-property>
+                </reauth-plugin>
+            </security>
+            <validation>
+                <valid-connection-checker class-name="someClass2">
+                    <config-property name="name">Property2</config-property>
+                </valid-connection-checker>
+                <check-valid-connection-sql>
+                    select 1
+                </check-valid-connection-sql>
+                <validate-on-match>
+                    true
+                </validate-on-match>
+                <background-validation>
+                    true
+                </background-validation>
+                <background-validation-millis>
+                    2000
+                </background-validation-millis>
+                <use-fast-fail>
+                    true
+                </use-fast-fail>
+                <stale-connection-checker class-name="someClass3">
+                    <config-property name="name">Property3</config-property>
+                </stale-connection-checker>
+                <exception-sorter class-name="someClass4">
+                    <config-property name="name">Property4</config-property>
+                </exception-sorter>
+            </validation>
+            <timeout>
+                <set-tx-query-timeout>true</set-tx-query-timeout>
+                <blocking-timeout-millis>20000</blocking-timeout-millis>
+                <idle-timeout-minutes>4</idle-timeout-minutes>
+                <query-timeout>
+                    120
+                </query-timeout>
+                <use-try-lock>
+                    100
+                </use-try-lock>
+                <allocation-retry>
+                    2
+                </allocation-retry>
+                <allocation-retry-wait-millis>
+                    3000
+                </allocation-retry-wait-millis>
+            </timeout>
+            <statement>
+                <track-statements>nowarn</track-statements>
+                <prepared-statement-cache-size>
+                    30
+                </prepared-statement-cache-size>
+                <share-prepared-statements>true</share-prepared-statements>
+            </statement>
+        </datasource>
+        <xa-datasource jndi-name="java:jboss/xa-datasources/complexXaDs" pool-name="complexXaDs_Pool" use-java-context="true" spy="false" use-ccm="true">
+            <xa-datasource-property name="URL">
+                jdbc:h2:mem:test
+            </xa-datasource-property>
+            <xa-datasource-class>
+                org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource
+            </xa-datasource-class>
+            <driver>
+                h2
+            </driver>
+            <url-delimiter>
+                :
+            </url-delimiter>
+            <url-selector-strategy-class-name>
+                someClass
+            </url-selector-strategy-class-name>
+            <new-connection-sql>
+                select 1
+            </new-connection-sql>
+            <transaction-isolation>
+                TRANSACTION_READ_COMMITTED
+            </transaction-isolation>
+            <xa-pool>
+                <min-pool-size>
+                    1
+                </min-pool-size>
+                <max-pool-size>
+                    5
+                </max-pool-size>
+                <prefill>
+                    true
+                </prefill>
+                <fair>
+                    true
+                </fair>
+                <use-strict-min>
+                    true
+                </use-strict-min>
+                <flush-strategy>
+                    EntirePool
+                </flush-strategy>
+                <is-same-rm-override>
+                    true
+                </is-same-rm-override>
+                <interleaving>true</interleaving>
+                <no-tx-separate-pools>true</no-tx-separate-pools>
+                <pad-xid>
+                    true
+                </pad-xid>
+                <wrap-xa-resource>
+                    true
+                </wrap-xa-resource>
+            </xa-pool>
+            <recovery no-recovery="false">
+                <recover-credential user-name="sa" password="sa" />
+                <recover-plugin class-name="someClass5">
+                    <config-property name="name">Property5</config-property>
+                    <config-property name="name1">Property6</config-property>
+                </recover-plugin>
+            </recovery>
+            <security user-name="sa" password="sa">
+                <reauth-plugin class-name="someClass1">
+                    <config-property name="name">Property1</config-property>
+                </reauth-plugin>
+            </security>
+            <validation>
+                <valid-connection-checker class-name="someClass2">
+                    <config-property name="name">Property2</config-property>
+                </valid-connection-checker>
+                <check-valid-connection-sql>
+                    select 1
+                </check-valid-connection-sql>
+                <validate-on-match>
+                    true
+                </validate-on-match>
+                <background-validation>
+                    true
+                </background-validation>
+                <background-validation-millis>
+                    2000
+                </background-validation-millis>
+                <use-fast-fail>
+                    true
+                </use-fast-fail>
+                <stale-connection-checker class-name="someClass3">
+                    <config-property name="name">Property3</config-property>
+                </stale-connection-checker>
+                <exception-sorter class-name="someClass4">
+                    <config-property name="name">Property4</config-property>
+                </exception-sorter>
+            </validation>
+            <timeout>
+                <set-tx-query-timeout>true</set-tx-query-timeout>
+                <blocking-timeout-millis>20000</blocking-timeout-millis>
+                <idle-timeout-minutes>4</idle-timeout-minutes>
+                <query-timeout>
+                    120
+                </query-timeout>
+                <use-try-lock>
+                    100
+                </use-try-lock>
+                <allocation-retry>
+                    2
+                </allocation-retry>
+                <allocation-retry-wait-millis>
+                    3000
+                </allocation-retry-wait-millis>
+                <xa-resource-timeout>
+                    120
+                </xa-resource-timeout>
+            </timeout>
+            <statement>
+                <track-statements>nowarn</track-statements>
+                <prepared-statement-cache-size>
+                    30
+                </prepared-statement-cache-size>
+                <share-prepared-statements>true</share-prepared-statements>
+            </statement>
+        </xa-datasource>
+        <drivers>
+            <driver name="h2" module="com.h2database.h2">
+                <xa-datasource-class>
+                    org.h2.jdbcx.JdbcDataSource
+                </xa-datasource-class>
+            </driver>
+        </drivers>
+    </datasources>
+</subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled-expression.xml
@@ -3,276 +3,276 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
-  <datasources>
-    <!--You have a CHOICE of the next 2 items at this level-->
-    <datasource jta="${test.expr:true}" jndi-name="${test.expr:java:/token}" pool-name="token" enabled="${test.expr:true}" use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" connectable="${test.expr:true}" statistics-enabled="${test.expr:true}" tracking="${test.expr:true}">
-      <connection-url>${test.expr:token}</connection-url>
-      <driver-class>${test.expr:token}</driver-class>
-      <!--Optional:-->
-      <datasource-class>${test.expr:token}</datasource-class>
-      <!--Zero or more repetitions:-->
-      <connection-property name="token">${test.expr:e gero}</connection-property>
-      <!--Optional:-->
-      <driver>${test.expr:token}</driver>
-      <!--Optional:-->
-      <new-connection-sql>${test.expr:string}</new-connection-sql>
-      <!--Optional:-->
-      <transaction-isolation>${test.expr:TRANSACTION_REPEATABLE_READ}</transaction-isolation>
-      <!--Optional:-->
-      <url-delimiter>${test.expr:token}</url-delimiter>
-      <!--Optional:-->
-      <url-selector-strategy-class-name>${test.expr:token}</url-selector-strategy-class-name>
-      <!--Optional:-->
-      <pool>
-        <!--Optional:-->
-        <min-pool-size>${test.expr:200}</min-pool-size>
-        <!--Optional:-->
-        <initial-pool-size>${test.expr:200}</initial-pool-size>
-        <!--Optional:-->
-        <max-pool-size>${test.expr:200}</max-pool-size>
-        <!--Optional:-->
-        <prefill>${test.expr:true}</prefill>
-        <!--Optional:-->
-        <use-strict-min>${test.expr:true}</use-strict-min>
-        <!--Optional:-->
-        <flush-strategy>${test.expr:EntirePool}</flush-strategy>
-        <!--Optional:-->
-        <allow-multiple-users>${test.expr:true}</allow-multiple-users>
-        <!--Optional:-->
-        <connection-listener class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </connection-listener>
-        <!--Optional:-->
-        <capacity>
-          <!--Optional:-->
-          <incrementer class-name="${test.expr:token}">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">${test.expr:token}</config-property>
-          </incrementer>
-          <!--Optional:-->
-          <decrementer class-name="${test.expr:token}">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">${test.expr:token}</config-property>
-          </decrementer>
-        </capacity>
-      </pool>
-      <!--Optional:-->
-      <security>
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
+    <datasources>
         <!--You have a CHOICE of the next 2 items at this level-->
-        <!--Optional:-->
-        <security-domain>${test.expr:token}</security-domain>
-        <!--Optional:-->
-        <credential-reference store="test-store" alias="${test.expr:test-alias}" type="${test.expr:org.wildfly.Foo}"/>
-        <elytron-enabled>${test.expr:true}</elytron-enabled>
-      </security>
-      <!--Optional:-->
-      <validation>
-        <!--Optional:-->
-        <valid-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </valid-connection-checker>
-        <!--Optional:-->
-        <check-valid-connection-sql>${test.expr:string}</check-valid-connection-sql>
-        <!--Optional:-->
-        <validate-on-match>${test.expr:true}</validate-on-match>
-        <!--Optional:-->
-        <background-validation>${test.expr:true}</background-validation>
-        <!--Optional:-->
-        <background-validation-millis>${test.expr:200}</background-validation-millis>
-        <!--Optional:-->
-        <use-fast-fail>${test.expr:false}</use-fast-fail>
-        <!--Optional:-->
-        <stale-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </stale-connection-checker>
-        <!--Optional:-->
-        <exception-sorter class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </exception-sorter>
-      </validation>
-      <!--Optional:-->
-      <timeout>
-        <!--Optional:-->
-        <set-tx-query-timeout>${test.expr:true}</set-tx-query-timeout>
-        <!--Optional:-->
-        <blocking-timeout-millis>${test.expr:200}</blocking-timeout-millis>
-        <!--Optional:-->
-        <idle-timeout-minutes>${test.expr:200}</idle-timeout-minutes>
-        <!--Optional:-->
-        <query-timeout>${test.expr:200}</query-timeout>
-        <!--Optional:-->
-        <use-try-lock>${test.expr:200}</use-try-lock>
-        <!--Optional:-->
-        <allocation-retry>${test.expr:200}</allocation-retry>
-        <!--Optional:-->
-        <allocation-retry-wait-millis>${test.expr:200}</allocation-retry-wait-millis>
-      </timeout>
-      <!--Optional:-->
-      <statement>
-        <!--Optional:-->
-        <track-statements>${test.expr:false}</track-statements>
-        <!--Optional:-->
-        <prepared-statement-cache-size>${test.expr:200}</prepared-statement-cache-size>
-        <!--Optional:-->
-        <share-prepared-statements>${test.expr:true}</share-prepared-statements>
-      </statement>
-    </datasource>
-    <xa-datasource jndi-name="${test.expr:java:/token}" pool-name="xa-token" enabled="${test.expr:true}" use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" connectable="${test.expr:true}"  statistics-enabled="${test.expr:true}" tracking="${test.expr:true}">
-      <!--1 or more repetitions:-->
-      <xa-datasource-property name="token">${test.expr:per turbine}</xa-datasource-property>
-      <!--Optional:-->
-      <xa-datasource-class>${test.expr:token}</xa-datasource-class>
-      <!--Optional:-->
-      <driver>${test.expr:token}</driver>
-      <!--Optional:-->
-      <url-delimiter>${test.expr:token}</url-delimiter>
-      <!--Optional:-->
-      <url-selector-strategy-class-name>${test.expr:token}</url-selector-strategy-class-name>
-      <!--Optional:-->
-      <new-connection-sql>${test.expr:string}</new-connection-sql>
-      <!--Optional:-->
-      <transaction-isolation>${test.expr:TRANSACTION_SERIALIZABLE}</transaction-isolation>
-      <!--Optional:-->
-      <xa-pool>
-        <!--Optional:-->
-        <min-pool-size>${test.expr:200}</min-pool-size>
-        <!--Optional:-->
-        <initial-pool-size>${test.expr:200}</initial-pool-size>
-        <!--Optional:-->
-        <max-pool-size>${test.expr:200}</max-pool-size>
-        <!--Optional:-->
-        <prefill>${test.expr:false}</prefill>
-        <!--Optional:-->
-        <use-strict-min>${test.expr:true}</use-strict-min>
-        <!--Optional:-->
-        <flush-strategy>${test.expr:EntirePool}</flush-strategy>
-        <!--Optional:-->
-        <allow-multiple-users>${test.expr:true}</allow-multiple-users>
-        <!--Optional:-->
-        <connection-listener class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </connection-listener>
-        <!--Optional:-->
-        <capacity>
-          <!--Optional:-->
-          <incrementer class-name="${test.expr:token}">
+        <datasource jta="${test.expr:true}" jndi-name="${test.expr:java:/token}" pool-name="token" enabled="${test.expr:true}" use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" connectable="${test.expr:true}" statistics-enabled="${test.expr:true}" tracking="${test.expr:true}">
+            <connection-url>${test.expr:token}</connection-url>
+            <driver-class>${test.expr:token}</driver-class>
+            <!--Optional:-->
+            <datasource-class>${test.expr:token}</datasource-class>
             <!--Zero or more repetitions:-->
-            <config-property name="token">${test.expr:token}</config-property>
-          </incrementer>
-          <!--Optional:-->
-          <decrementer class-name="${test.expr:token}">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">${test.expr:token}</config-property>
-          </decrementer>
-        </capacity>
+            <connection-property name="token">${test.expr:e gero}</connection-property>
+            <!--Optional:-->
+            <driver>${test.expr:token}</driver>
+            <!--Optional:-->
+            <url-delimiter>${test.expr:token}</url-delimiter>
+            <!--Optional:-->
+            <url-selector-strategy-class-name>${test.expr:token}</url-selector-strategy-class-name>
+            <!--Optional:-->
+            <new-connection-sql>${test.expr:string}</new-connection-sql>
+            <!--Optional:-->
+            <transaction-isolation>${test.expr:TRANSACTION_REPEATABLE_READ}</transaction-isolation>
+            <!--Optional:-->
+            <pool>
+                <!--Optional:-->
+                <min-pool-size>${test.expr:200}</min-pool-size>
+                <!--Optional:-->
+                <initial-pool-size>${test.expr:200}</initial-pool-size>
+                <!--Optional:-->
+                <max-pool-size>${test.expr:200}</max-pool-size>
+                <!--Optional:-->
+                <prefill>${test.expr:true}</prefill>
+                <!--Optional:-->
+                <use-strict-min>${test.expr:true}</use-strict-min>
+                <!--Optional:-->
+                <flush-strategy>${test.expr:EntirePool}</flush-strategy>
+                <!--Optional:-->
+                <allow-multiple-users>${test.expr:true}</allow-multiple-users>
+                <!--Optional:-->
+                <connection-listener class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </connection-listener>
+                <!--Optional:-->
+                <capacity>
+                    <!--Optional:-->
+                    <incrementer class-name="${test.expr:token}">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">${test.expr:token}</config-property>
+                    </incrementer>
+                    <!--Optional:-->
+                    <decrementer class-name="${test.expr:token}">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">${test.expr:token}</config-property>
+                    </decrementer>
+                </capacity>
+            </pool>
+            <!--Optional:-->
+            <security>
+                <!--You have a CHOICE of the next 2 items at this level-->
+                <!--Optional:-->
+                <security-domain>${test.expr:token}</security-domain>
+                <!--Optional:-->
+                <credential-reference store="test-store" alias="${test.expr:test-alias}" type="${test.expr:org.wildfly.Foo}"/>
+                <elytron-enabled>${test.expr:true}</elytron-enabled>
+            </security>
+            <!--Optional:-->
+            <validation>
+                <!--Optional:-->
+                <valid-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </valid-connection-checker>
+                <!--Optional:-->
+                <check-valid-connection-sql>${test.expr:string}</check-valid-connection-sql>
+                <!--Optional:-->
+                <validate-on-match>${test.expr:true}</validate-on-match>
+                <!--Optional:-->
+                <background-validation>${test.expr:true}</background-validation>
+                <!--Optional:-->
+                <background-validation-millis>${test.expr:200}</background-validation-millis>
+                <!--Optional:-->
+                <use-fast-fail>${test.expr:false}</use-fast-fail>
+                <!--Optional:-->
+                <stale-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </stale-connection-checker>
+                <!--Optional:-->
+                <exception-sorter class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </exception-sorter>
+            </validation>
+            <!--Optional:-->
+            <timeout>
+                <!--Optional:-->
+                <set-tx-query-timeout>${test.expr:true}</set-tx-query-timeout>
+                <!--Optional:-->
+                <blocking-timeout-millis>${test.expr:200}</blocking-timeout-millis>
+                <!--Optional:-->
+                <idle-timeout-minutes>${test.expr:200}</idle-timeout-minutes>
+                <!--Optional:-->
+                <query-timeout>${test.expr:200}</query-timeout>
+                <!--Optional:-->
+                <use-try-lock>${test.expr:200}</use-try-lock>
+                <!--Optional:-->
+                <allocation-retry>${test.expr:200}</allocation-retry>
+                <!--Optional:-->
+                <allocation-retry-wait-millis>${test.expr:200}</allocation-retry-wait-millis>
+            </timeout>
+            <!--Optional:-->
+            <statement>
+                <!--Optional:-->
+                <track-statements>${test.expr:false}</track-statements>
+                <!--Optional:-->
+                <prepared-statement-cache-size>${test.expr:200}</prepared-statement-cache-size>
+                <!--Optional:-->
+                <share-prepared-statements>${test.expr:true}</share-prepared-statements>
+            </statement>
+        </datasource>
+        <xa-datasource jndi-name="${test.expr:java:/token}" pool-name="xa-token" enabled="${test.expr:true}" use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" connectable="${test.expr:true}"    statistics-enabled="${test.expr:true}" tracking="${test.expr:true}">
+            <!--1 or more repetitions:-->
+            <xa-datasource-property name="token">${test.expr:per turbine}</xa-datasource-property>
+            <!--Optional:-->
+            <xa-datasource-class>${test.expr:token}</xa-datasource-class>
+            <!--Optional:-->
+            <driver>${test.expr:token}</driver>
+            <!--Optional:-->
+            <url-delimiter>${test.expr:token}</url-delimiter>
+            <!--Optional:-->
+            <url-selector-strategy-class-name>${test.expr:token}</url-selector-strategy-class-name>
+            <!--Optional:-->
+            <new-connection-sql>${test.expr:string}</new-connection-sql>
+            <!--Optional:-->
+            <transaction-isolation>${test.expr:TRANSACTION_SERIALIZABLE}</transaction-isolation>
+            <!--Optional:-->
+            <xa-pool>
+                <!--Optional:-->
+                <min-pool-size>${test.expr:200}</min-pool-size>
+                <!--Optional:-->
+                <initial-pool-size>${test.expr:200}</initial-pool-size>
+                <!--Optional:-->
+                <max-pool-size>${test.expr:200}</max-pool-size>
+                <!--Optional:-->
+                <prefill>${test.expr:false}</prefill>
+                <!--Optional:-->
+                <use-strict-min>${test.expr:true}</use-strict-min>
+                <!--Optional:-->
+                <flush-strategy>${test.expr:EntirePool}</flush-strategy>
+                <!--Optional:-->
+                <allow-multiple-users>${test.expr:true}</allow-multiple-users>
+                <!--Optional:-->
+                <connection-listener class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </connection-listener>
+                <!--Optional:-->
+                <capacity>
+                    <!--Optional:-->
+                    <incrementer class-name="${test.expr:token}">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">${test.expr:token}</config-property>
+                    </incrementer>
+                    <!--Optional:-->
+                    <decrementer class-name="${test.expr:token}">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">${test.expr:token}</config-property>
+                    </decrementer>
+                </capacity>
+                <!--Optional:-->
+                <is-same-rm-override>${test.expr:false}</is-same-rm-override>
+                <!--Optional:-->
+                <interleaving>${test.expr:true}</interleaving>
+                <!--Optional:-->
+                <no-tx-separate-pools>${test.expr:true}</no-tx-separate-pools>
+                <!--Optional:-->
+                <pad-xid>${test.expr:false}</pad-xid>
+                <!--Optional:-->
+                <wrap-xa-resource>${test.expr:false}</wrap-xa-resource>
+            </xa-pool>
+            <!--Optional:-->
+            <recovery no-recovery="${test.expr:false}">
+                <!--Optional:-->
+                <recover-credential>
+                    <authentication-context>CredentialAuthCtxt</authentication-context>
+                    <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
+                    <elytron-enabled>${test.expr:true}</elytron-enabled>
+                </recover-credential>
+                <!--Optional:-->
+                <recover-plugin class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </recover-plugin>
+            </recovery>
+            <!--Optional:-->
+            <security user-name="${test.expr:token}" password="${test.expr:token}">
+                <elytron-enabled>${test.expr:true}</elytron-enabled>
+                <!--Optional:-->
+                <reauth-plugin class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </reauth-plugin>
+            </security>
+            <!--Optional:-->
+            <validation>
+                <!--Optional:-->
+                <valid-connection-checker class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </valid-connection-checker>
+                <!--Optional:-->
+                <check-valid-connection-sql>${test.expr:string}</check-valid-connection-sql>
+                <!--Optional:-->
+                <validate-on-match>${test.expr:false}</validate-on-match>
+                <!--Optional:-->
+                <background-validation>${test.expr:false}</background-validation>
+                <!--Optional:-->
+                <background-validation-millis>${test.expr:200}</background-validation-millis>
+                <!--Optional:-->
+                <use-fast-fail>${test.expr:true}</use-fast-fail>
+                <!--Optional:-->
+                <stale-connection-checker class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </stale-connection-checker>
+                <!--Optional:-->
+                <exception-sorter class-name="${test.expr:token}">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">${test.expr:token}</config-property>
+                </exception-sorter>
+            </validation>
+            <!--Optional:-->
+            <timeout>
+                <!--Optional:-->
+                <set-tx-query-timeout>${test.expr:true}</set-tx-query-timeout>
+                <!--Optional:-->
+                <blocking-timeout-millis>${test.expr:200}</blocking-timeout-millis>
+                <!--Optional:-->
+                <idle-timeout-minutes>${test.expr:200}</idle-timeout-minutes>
+                <!--Optional:-->
+                <query-timeout>${test.expr:200}</query-timeout>
+                <!--Optional:-->
+                <use-try-lock>${test.expr:200}</use-try-lock>
+                <!--Optional:-->
+                <allocation-retry>${test.expr:200}</allocation-retry>
+                <!--Optional:-->
+                <allocation-retry-wait-millis>${test.expr:200}</allocation-retry-wait-millis>
+                <!--Optional:-->
+                <xa-resource-timeout>${test.expr:200}</xa-resource-timeout>
+            </timeout>
+            <!--Optional:-->
+            <statement>
+                <!--Optional:-->
+                <track-statements>${test.expr:nowarn}</track-statements>
+                <!--Optional:-->
+                <prepared-statement-cache-size>${test.expr:200}</prepared-statement-cache-size>
+                <!--Optional:-->
+                <share-prepared-statements>${test.expr:true}</share-prepared-statements>
+            </statement>
+        </xa-datasource>
         <!--Optional:-->
-        <is-same-rm-override>${test.expr:false}</is-same-rm-override>
-        <!--Optional:-->
-        <interleaving>${test.expr:true}</interleaving>
-        <!--Optional:-->
-        <no-tx-separate-pools>${test.expr:true}</no-tx-separate-pools>
-        <!--Optional:-->
-        <pad-xid>${test.expr:false}</pad-xid>
-        <!--Optional:-->
-        <wrap-xa-resource>${test.expr:false}</wrap-xa-resource>
-      </xa-pool>
-      <!--Optional:-->
-      <security user-name="${test.expr:token}" password="${test.expr:token}">
-        <elytron-enabled>${test.expr:true}</elytron-enabled>
-        <!--Optional:-->
-        <reauth-plugin class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </reauth-plugin>
-      </security>
-      <!--Optional:-->
-      <recovery no-recovery="${test.expr:false}">
-        <!--Optional:-->
-        <recover-credential>
-          <elytron-enabled>${test.expr:true}</elytron-enabled>
-          <authentication-context>CredentialAuthCtxt</authentication-context>
-          <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
-        </recover-credential>
-        <!--Optional:-->
-        <recover-plugin class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </recover-plugin>
-      </recovery>
-      <!--Optional:-->
-      <validation>
-        <!--Optional:-->
-        <valid-connection-checker class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </valid-connection-checker>
-        <!--Optional:-->
-        <check-valid-connection-sql>${test.expr:string}</check-valid-connection-sql>
-        <!--Optional:-->
-        <validate-on-match>${test.expr:false}</validate-on-match>
-        <!--Optional:-->
-        <background-validation>${test.expr:false}</background-validation>
-        <!--Optional:-->
-        <background-validation-millis>${test.expr:200}</background-validation-millis>
-        <!--Optional:-->
-        <use-fast-fail>${test.expr:true}</use-fast-fail>
-        <!--Optional:-->
-        <stale-connection-checker class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </stale-connection-checker>
-        <!--Optional:-->
-        <exception-sorter class-name="${test.expr:token}">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">${test.expr:token}</config-property>
-        </exception-sorter>
-      </validation>
-      <!--Optional:-->
-      <timeout>
-        <!--Optional:-->
-        <set-tx-query-timeout>${test.expr:true}</set-tx-query-timeout>
-        <!--Optional:-->
-        <blocking-timeout-millis>${test.expr:200}</blocking-timeout-millis>
-        <!--Optional:-->
-        <idle-timeout-minutes>${test.expr:200}</idle-timeout-minutes>
-        <!--Optional:-->
-        <query-timeout>${test.expr:200}</query-timeout>
-        <!--Optional:-->
-        <use-try-lock>${test.expr:200}</use-try-lock>
-        <!--Optional:-->
-        <allocation-retry>${test.expr:200}</allocation-retry>
-        <!--Optional:-->
-        <allocation-retry-wait-millis>${test.expr:200}</allocation-retry-wait-millis>
-        <!--Optional:-->
-        <xa-resource-timeout>${test.expr:200}</xa-resource-timeout>
-      </timeout>
-      <!--Optional:-->
-      <statement>
-        <!--Optional:-->
-        <track-statements>${test.expr:nowarn}</track-statements>
-        <!--Optional:-->
-        <prepared-statement-cache-size>${test.expr:200}</prepared-statement-cache-size>
-        <!--Optional:-->
-        <share-prepared-statements>${test.expr:true}</share-prepared-statements>
-      </statement>
-    </xa-datasource>
-    <!--Optional:-->
-    <drivers>
-      <!--1 or more repetitions:-->
-      <driver name="token" module="token" major-version="${test.expr:3}" minor-version="${test.expr:3}">
-        <!--Optional:-->
-        <driver-class>${test.expr:token}</driver-class>
-        <!--Optional:-->
-        <xa-datasource-class>${test.expr:token}</xa-datasource-class>
-        <!--Optional:-->
-        <datasource-class>${test.expr:token}</datasource-class>
-      </driver>
-    </drivers>
-  </datasources>
+        <drivers>
+            <!--1 or more repetitions:-->
+            <driver name="token" module="token" major-version="${test.expr:3}" minor-version="${test.expr:3}">
+                <!--Optional:-->
+                <driver-class>${test.expr:token}</driver-class>
+                <!--Optional:-->
+                <xa-datasource-class>${test.expr:token}</xa-datasource-class>
+                <!--Optional:-->
+                <datasource-class>${test.expr:token}</datasource-class>
+            </driver>
+        </drivers>
+    </datasources>
 </subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled.xml
@@ -3,277 +3,277 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
-  <datasources>
-    <!--You have a CHOICE of the next 2 items at this level-->
-    <datasource jta="true" jndi-name="java:/token" pool-name="token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="${test.expr:true}" statistics-enabled="true" tracking="true">
-      <connection-url>token</connection-url>
-      <!--Optional:-->
-      <driver-class>token</driver-class>
-      <!--Optional:-->
-      <datasource-class>token</datasource-class>
-      <!--Zero or more repetitions:-->
-      <connection-property name="token">e gero</connection-property>
-      <!--Optional:-->
-      <driver>token</driver>
-      <!--Optional:-->
-      <new-connection-sql>string</new-connection-sql>
-      <!--Optional:-->
-      <transaction-isolation>TRANSACTION_REPEATABLE_READ</transaction-isolation>
-      <!--Optional:-->
-      <url-delimiter>token</url-delimiter>
-      <!--Optional:-->
-      <url-selector-strategy-class-name>token</url-selector-strategy-class-name>
-      <!--Optional:-->
-      <pool>
-        <!--Optional:-->
-        <min-pool-size>200</min-pool-size>
-        <!--Optional:-->
-        <initial-pool-size>200</initial-pool-size>
-        <!--Optional:-->
-        <max-pool-size>200</max-pool-size>
-        <!--Optional:-->
-        <prefill>true</prefill>
-        <!--Optional:-->
-        <use-strict-min>true</use-strict-min>
-        <!--Optional:-->
-        <flush-strategy>EntirePool</flush-strategy>
-        <!--Optional:-->
-        <allow-multiple-users>true</allow-multiple-users>
-        <!--Optional:-->
-        <connection-listener class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </connection-listener>
-        <!--Optional:-->
-        <capacity>
-          <!--Optional:-->
-          <incrementer class-name="token">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">token</config-property>
-          </incrementer>
-          <!--Optional:-->
-          <decrementer class-name="token">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">token</config-property>
-          </decrementer>
-        </capacity>
-      </pool>
-      <!--Optional:-->
-      <security>
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
+    <datasources>
         <!--You have a CHOICE of the next 2 items at this level-->
-        <!--Optional:-->
-        <security-domain>token</security-domain>
-        <!--Optional:-->
-        <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
-        <elytron-enabled>true</elytron-enabled>
-      </security>
-      <!--Optional:-->
-      <validation>
-        <!--Optional:-->
-        <valid-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </valid-connection-checker>
-        <!--Optional:-->
-        <check-valid-connection-sql>string</check-valid-connection-sql>
-        <!--Optional:-->
-        <validate-on-match>true</validate-on-match>
-        <!--Optional:-->
-        <background-validation>true</background-validation>
-        <!--Optional:-->
-        <background-validation-millis>200</background-validation-millis>
-        <!--Optional:-->
-        <use-fast-fail>false</use-fast-fail>
-        <!--Optional:-->
-        <stale-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </stale-connection-checker>
-        <!--Optional:-->
-        <exception-sorter class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </exception-sorter>
-      </validation>
-      <!--Optional:-->
-      <timeout>
-        <!--Optional:-->
-        <set-tx-query-timeout>true</set-tx-query-timeout>
-        <!--Optional:-->
-        <blocking-timeout-millis>200</blocking-timeout-millis>
-        <!--Optional:-->
-        <idle-timeout-minutes>200</idle-timeout-minutes>
-        <!--Optional:-->
-        <query-timeout>200</query-timeout>
-        <!--Optional:-->
-        <use-try-lock>200</use-try-lock>
-        <!--Optional:-->
-        <allocation-retry>200</allocation-retry>
-        <!--Optional:-->
-        <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
-      </timeout>
-      <!--Optional:-->
-      <statement>
-        <!--Optional:-->
-        <track-statements>false</track-statements>
-        <!--Optional:-->
-        <prepared-statement-cache-size>200</prepared-statement-cache-size>
-        <!--Optional:-->
-        <share-prepared-statements>true</share-prepared-statements>
-      </statement>
-    </datasource>
-    <xa-datasource jndi-name="java:/token" pool-name="xa-token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="${test.expr:true}"  statistics-enabled="true" tracking="true">
-      <!--1 or more repetitions:-->
-      <xa-datasource-property name="token">per turbine</xa-datasource-property>
-      <!--Optional:-->
-      <xa-datasource-class>token</xa-datasource-class>
-      <!--Optional:-->
-      <driver>token</driver>
-      <!--Optional:-->
-      <url-delimiter>token</url-delimiter>
-      <!--Optional:-->
-      <url-selector-strategy-class-name>token</url-selector-strategy-class-name>
-      <!--Optional:-->
-      <new-connection-sql>string</new-connection-sql>
-      <!--Optional:-->
-      <transaction-isolation>TRANSACTION_SERIALIZABLE</transaction-isolation>
-      <!--Optional:-->
-      <xa-pool>
-        <!--Optional:-->
-        <min-pool-size>200</min-pool-size>
-        <!--Optional:-->
-        <initial-pool-size>200</initial-pool-size>
-        <!--Optional:-->
-        <max-pool-size>200</max-pool-size>
-        <!--Optional:-->
-        <prefill>false</prefill>
-        <!--Optional:-->
-        <use-strict-min>true</use-strict-min>
-        <!--Optional:-->
-        <flush-strategy>EntirePool</flush-strategy>
-        <!--Optional:-->
-        <allow-multiple-users>true</allow-multiple-users>
-        <!--Optional:-->
-        <connection-listener class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </connection-listener>
-        <!--Optional:-->
-        <capacity>
-          <!--Optional:-->
-          <incrementer class-name="token">
+        <datasource jta="true" jndi-name="java:/token" pool-name="token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="true" statistics-enabled="true" tracking="true">
+            <connection-url>token</connection-url>
+            <!--Optional:-->
+            <driver-class>token</driver-class>
+            <!--Optional:-->
+            <datasource-class>token</datasource-class>
             <!--Zero or more repetitions:-->
-            <config-property name="token">token</config-property>
-          </incrementer>
-          <!--Optional:-->
-          <decrementer class-name="token">
-            <!--Zero or more repetitions:-->
-            <config-property name="token">token</config-property>
-          </decrementer>
-        </capacity>
+            <connection-property name="token">e gero</connection-property>
+            <!--Optional:-->
+            <driver>token</driver>
+            <!--Optional:-->
+            <url-delimiter>token</url-delimiter>
+            <!--Optional:-->
+            <url-selector-strategy-class-name>token</url-selector-strategy-class-name>
+            <!--Optional:-->
+            <new-connection-sql>string</new-connection-sql>
+            <!--Optional:-->
+            <transaction-isolation>TRANSACTION_REPEATABLE_READ</transaction-isolation>
+            <!--Optional:-->
+            <pool>
+                <!--Optional:-->
+                <min-pool-size>200</min-pool-size>
+                <!--Optional:-->
+                <initial-pool-size>200</initial-pool-size>
+                <!--Optional:-->
+                <max-pool-size>200</max-pool-size>
+                <!--Optional:-->
+                <prefill>true</prefill>
+                <!--Optional:-->
+                <use-strict-min>true</use-strict-min>
+                <!--Optional:-->
+                <flush-strategy>EntirePool</flush-strategy>
+                <!--Optional:-->
+                <allow-multiple-users>true</allow-multiple-users>
+                <!--Optional:-->
+                <connection-listener class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </connection-listener>
+                <!--Optional:-->
+                <capacity>
+                    <!--Optional:-->
+                    <incrementer class-name="token">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">token</config-property>
+                    </incrementer>
+                    <!--Optional:-->
+                    <decrementer class-name="token">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">token</config-property>
+                    </decrementer>
+                </capacity>
+            </pool>
+            <!--Optional:-->
+            <security>
+                <!--You have a CHOICE of the next 2 items at this level-->
+                <!--Optional:-->
+                <security-domain>token</security-domain>
+                <!--Optional:-->
+                <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
+                <elytron-enabled>true</elytron-enabled>
+            </security>
+            <!--Optional:-->
+            <validation>
+                <!--Optional:-->
+                <valid-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </valid-connection-checker>
+                <!--Optional:-->
+                <check-valid-connection-sql>string</check-valid-connection-sql>
+                <!--Optional:-->
+                <validate-on-match>true</validate-on-match>
+                <!--Optional:-->
+                <background-validation>true</background-validation>
+                <!--Optional:-->
+                <background-validation-millis>200</background-validation-millis>
+                <!--Optional:-->
+                <use-fast-fail>false</use-fast-fail>
+                <!--Optional:-->
+                <stale-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </stale-connection-checker>
+                <!--Optional:-->
+                <exception-sorter class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </exception-sorter>
+            </validation>
+            <!--Optional:-->
+            <timeout>
+                <!--Optional:-->
+                <set-tx-query-timeout>true</set-tx-query-timeout>
+                <!--Optional:-->
+                <blocking-timeout-millis>200</blocking-timeout-millis>
+                <!--Optional:-->
+                <idle-timeout-minutes>200</idle-timeout-minutes>
+                <!--Optional:-->
+                <query-timeout>200</query-timeout>
+                <!--Optional:-->
+                <use-try-lock>200</use-try-lock>
+                <!--Optional:-->
+                <allocation-retry>200</allocation-retry>
+                <!--Optional:-->
+                <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
+            </timeout>
+            <!--Optional:-->
+            <statement>
+                <!--Optional:-->
+                <track-statements>false</track-statements>
+                <!--Optional:-->
+                <prepared-statement-cache-size>200</prepared-statement-cache-size>
+                <!--Optional:-->
+                <share-prepared-statements>true</share-prepared-statements>
+            </statement>
+        </datasource>
+        <xa-datasource jndi-name="java:/token" pool-name="xa-token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="true" statistics-enabled="true" tracking="true">
+            <!--1 or more repetitions:-->
+            <xa-datasource-property name="token">per turbine</xa-datasource-property>
+            <!--Optional:-->
+            <xa-datasource-class>token</xa-datasource-class>
+            <!--Optional:-->
+            <driver>token</driver>
+            <!--Optional:-->
+            <url-delimiter>token</url-delimiter>
+            <!--Optional:-->
+            <url-selector-strategy-class-name>token</url-selector-strategy-class-name>
+            <!--Optional:-->
+            <new-connection-sql>string</new-connection-sql>
+            <!--Optional:-->
+            <transaction-isolation>TRANSACTION_SERIALIZABLE</transaction-isolation>
+            <!--Optional:-->
+            <xa-pool>
+                <!--Optional:-->
+                <min-pool-size>200</min-pool-size>
+                <!--Optional:-->
+                <initial-pool-size>200</initial-pool-size>
+                <!--Optional:-->
+                <max-pool-size>200</max-pool-size>
+                <!--Optional:-->
+                <prefill>false</prefill>
+                <!--Optional:-->
+                <use-strict-min>true</use-strict-min>
+                <!--Optional:-->
+                <flush-strategy>EntirePool</flush-strategy>
+                <!--Optional:-->
+                <allow-multiple-users>true</allow-multiple-users>
+                <!--Optional:-->
+                <connection-listener class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </connection-listener>
+                <!--Optional:-->
+                <capacity>
+                    <!--Optional:-->
+                    <incrementer class-name="token">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">token</config-property>
+                    </incrementer>
+                    <!--Optional:-->
+                    <decrementer class-name="token">
+                        <!--Zero or more repetitions:-->
+                        <config-property name="token">token</config-property>
+                    </decrementer>
+                </capacity>
+                <!--Optional:-->
+                <is-same-rm-override>false</is-same-rm-override>
+                <!--Optional:-->
+                <interleaving>true</interleaving>
+                <!--Optional:-->
+                <no-tx-separate-pools>true</no-tx-separate-pools>
+                <!--Optional:-->
+                <pad-xid>false</pad-xid>
+                <!--Optional:-->
+                <wrap-xa-resource>false</wrap-xa-resource>
+            </xa-pool>
+            <!--Optional:-->
+            <recovery no-recovery="false">
+                <!--Optional:-->
+                <recover-credential>
+                    <authentication-context>CredentialAuthCtxt</authentication-context>
+                    <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
+                    <elytron-enabled>true</elytron-enabled>
+                </recover-credential>
+                <!--Optional:-->
+                <recover-plugin class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </recover-plugin>
+            </recovery>
+            <!--Optional:-->
+            <security user-name="token" password="token">
+                <elytron-enabled>true</elytron-enabled>
+                <!--Optional:-->
+                <reauth-plugin class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </reauth-plugin>
+            </security>
+            <!--Optional:-->
+            <validation>
+                <!--Optional:-->
+                <valid-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </valid-connection-checker>
+                <!--Optional:-->
+                <check-valid-connection-sql>string</check-valid-connection-sql>
+                <!--Optional:-->
+                <validate-on-match>false</validate-on-match>
+                <!--Optional:-->
+                <background-validation>false</background-validation>
+                <!--Optional:-->
+                <background-validation-millis>200</background-validation-millis>
+                <!--Optional:-->
+                <use-fast-fail>true</use-fast-fail>
+                <!--Optional:-->
+                <stale-connection-checker class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </stale-connection-checker>
+                <!--Optional:-->
+                <exception-sorter class-name="token">
+                    <!--Zero or more repetitions:-->
+                    <config-property name="token">token</config-property>
+                </exception-sorter>
+            </validation>
+            <!--Optional:-->
+            <timeout>
+                <!--Optional:-->
+                <set-tx-query-timeout>true</set-tx-query-timeout>
+                <!--Optional:-->
+                <blocking-timeout-millis>200</blocking-timeout-millis>
+                <!--Optional:-->
+                <idle-timeout-minutes>200</idle-timeout-minutes>
+                <!--Optional:-->
+                <query-timeout>200</query-timeout>
+                <!--Optional:-->
+                <use-try-lock>200</use-try-lock>
+                <!--Optional:-->
+                <allocation-retry>200</allocation-retry>
+                <!--Optional:-->
+                <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
+                <!--Optional:-->
+                <xa-resource-timeout>200</xa-resource-timeout>
+            </timeout>
+            <!--Optional:-->
+            <statement>
+                <!--Optional:-->
+                <track-statements>nowarn</track-statements>
+                <!--Optional:-->
+                <prepared-statement-cache-size>200</prepared-statement-cache-size>
+                <!--Optional:-->
+                <share-prepared-statements>true</share-prepared-statements>
+            </statement>
+        </xa-datasource>
         <!--Optional:-->
-        <is-same-rm-override>false</is-same-rm-override>
-        <!--Optional:-->
-        <interleaving>true</interleaving>
-        <!--Optional:-->
-        <no-tx-separate-pools>true</no-tx-separate-pools>
-        <!--Optional:-->
-        <pad-xid>false</pad-xid>
-        <!--Optional:-->
-        <wrap-xa-resource>false</wrap-xa-resource>
-      </xa-pool>
-      <!--Optional:-->
-      <security user-name="token" password="token">
-        <elytron-enabled>true</elytron-enabled>
-        <!--Optional:-->
-        <reauth-plugin class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </reauth-plugin>
-      </security>
-      <!--Optional:-->
-      <recovery no-recovery="false">
-        <!--Optional:-->
-        <recover-credential>
-          <elytron-enabled>true</elytron-enabled>
-          <authentication-context>CredentialAuthCtxt</authentication-context>
-          <credential-reference store="test-store" alias="test-alias" type="org.wildfly.Foo" />
-        </recover-credential>
-        <!--Optional:-->
-        <recover-plugin class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </recover-plugin>
-      </recovery>
-      <!--Optional:-->
-      <validation>
-        <!--Optional:-->
-        <valid-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </valid-connection-checker>
-        <!--Optional:-->
-        <check-valid-connection-sql>string</check-valid-connection-sql>
-        <!--Optional:-->
-        <validate-on-match>false</validate-on-match>
-        <!--Optional:-->
-        <background-validation>false</background-validation>
-        <!--Optional:-->
-        <background-validation-millis>200</background-validation-millis>
-        <!--Optional:-->
-        <use-fast-fail>true</use-fast-fail>
-        <!--Optional:-->
-        <stale-connection-checker class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </stale-connection-checker>
-        <!--Optional:-->
-        <exception-sorter class-name="token">
-          <!--Zero or more repetitions:-->
-          <config-property name="token">token</config-property>
-        </exception-sorter>
-      </validation>
-      <!--Optional:-->
-      <timeout>
-        <!--Optional:-->
-        <set-tx-query-timeout>true</set-tx-query-timeout>
-        <!--Optional:-->
-        <blocking-timeout-millis>200</blocking-timeout-millis>
-        <!--Optional:-->
-        <idle-timeout-minutes>200</idle-timeout-minutes>
-        <!--Optional:-->
-        <query-timeout>200</query-timeout>
-        <!--Optional:-->
-        <use-try-lock>200</use-try-lock>
-        <!--Optional:-->
-        <allocation-retry>200</allocation-retry>
-        <!--Optional:-->
-        <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
-        <!--Optional:-->
-        <xa-resource-timeout>200</xa-resource-timeout>
-      </timeout>
-      <!--Optional:-->
-      <statement>
-        <!--Optional:-->
-        <track-statements>nowarn</track-statements>
-        <!--Optional:-->
-        <prepared-statement-cache-size>200</prepared-statement-cache-size>
-        <!--Optional:-->
-        <share-prepared-statements>true</share-prepared-statements>
-      </statement>
-    </xa-datasource>
-    <!--Optional:-->
-    <drivers>
-      <!--1 or more repetitions:-->
-      <driver name="token" module="token" major-version="3" minor-version="3">
-        <!--Optional:-->
-        <driver-class>token</driver-class>
-        <!--Optional:-->
-        <xa-datasource-class>token</xa-datasource-class>
-        <!--Optional:-->
-        <datasource-class>token</datasource-class>
-      </driver>
-    </drivers>
-  </datasources>
+        <drivers>
+            <!--1 or more repetitions:-->
+            <driver name="token" module="token" major-version="3" minor-version="3">
+                <!--Optional:-->
+                <driver-class>token</driver-class>
+                <!--Optional:-->
+                <xa-datasource-class>token</xa-datasource-class>
+                <!--Optional:-->
+                <datasource-class>token</datasource-class>
+            </driver>
+        </drivers>
+    </datasources>
 </subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full-expression.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool"
                     use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" jta="${test.expr:false}"
@@ -23,18 +23,18 @@
             <driver>
                 ${test.expr:h2}
             </driver>
-            <new-connection-sql>
-                ${test.expr:select 1}
-            </new-connection-sql>
-            <transaction-isolation>
-                ${test.expr:TRANSACTION_READ_COMMITTED}
-            </transaction-isolation>
             <url-delimiter>
                 ${test.expr::}
             </url-delimiter>
             <url-selector-strategy-class-name>
                 ${test.expr:someClass}
             </url-selector-strategy-class-name>
+            <new-connection-sql>
+                ${test.expr:select 1}
+            </new-connection-sql>
+            <transaction-isolation>
+                ${test.expr:TRANSACTION_READ_COMMITTED}
+            </transaction-isolation>
             <pool>
                 <min-pool-size>${test.expr:1}</min-pool-size>
                 <max-pool-size>${test.expr:5}</max-pool-size>
@@ -161,11 +161,6 @@
                 </wrap-xa-resource>
 
             </xa-pool>
-            <security user-name="${test.expr:sa}" password="${test.expr:sa}">
-                <reauth-plugin class-name="${test.expr:someClass1}">
-                    <config-property name="name">${test.expr:Property1}</config-property>
-                </reauth-plugin>
-            </security>
             <recovery no-recovery="${test.expr:false}">
                 <recover-credential user-name="${test.expr:sa}" password="${test.expr:sa}"/>
                 <recover-plugin class-name="${test.expr:someClass5}">
@@ -173,6 +168,11 @@
                     <config-property name="name1">${test.expr:Property6}</config-property>
                 </recover-plugin>
             </recovery>
+            <security user-name="${test.expr:sa}" password="${test.expr:sa}">
+                <reauth-plugin class-name="${test.expr:someClass1}">
+                    <config-property name="name">${test.expr:Property1}</config-property>
+                </reauth-plugin>
+            </security>
             <validation>
                 <valid-connection-checker class-name="${test.expr:someClass2}" module="${test.expr:someModule2}">
                     <config-property name="name">${test.expr:Property2}</config-property>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool" jta="false"
                     use-java-context="true" spy="false" use-ccm="true" connectable="false" statistics-enabled="true" tracking="true">
@@ -22,18 +22,18 @@
             <driver>
                 h2
             </driver>
-            <new-connection-sql>
-                select 1
-            </new-connection-sql>
-            <transaction-isolation>
-                TRANSACTION_READ_COMMITTED
-            </transaction-isolation>
             <url-delimiter>
                 :
             </url-delimiter>
             <url-selector-strategy-class-name>
                 someClass
             </url-selector-strategy-class-name>
+            <new-connection-sql>
+                select 1
+            </new-connection-sql>
+            <transaction-isolation>
+                TRANSACTION_READ_COMMITTED
+            </transaction-isolation>
             <pool>
                 <min-pool-size>1</min-pool-size>
                 <max-pool-size>5</max-pool-size>
@@ -103,7 +103,6 @@
                 <track-statements>nowarn</track-statements>
                 <prepared-statement-cache-size>30</prepared-statement-cache-size>
                 <share-prepared-statements>true</share-prepared-statements>
-
             </statement>
         </datasource>
         <xa-datasource jndi-name="java:jboss/xa-datasources/complexXaDs" pool-name="complexXaDs_Pool"
@@ -157,13 +156,7 @@
                 <wrap-xa-resource>
                     true
                 </wrap-xa-resource>
-
             </xa-pool>
-            <security user-name="sa" password="sa">
-                <reauth-plugin class-name="someClass1">
-                    <config-property name="name">Property1</config-property>
-                </reauth-plugin>
-            </security>
             <recovery no-recovery="false">
                 <recover-credential user-name="sa" password="sa"/>
                 <recover-plugin class-name="someClass5">
@@ -171,6 +164,11 @@
                     <config-property name="name1">Property6</config-property>
                 </recover-plugin>
             </recovery>
+            <security user-name="sa" password="sa">
+                <reauth-plugin class-name="someClass1">
+                    <config-property name="name">Property1</config-property>
+                </reauth-plugin>
+            </security>
             <validation>
                 <valid-connection-checker class-name="someClass2" module="someModule2">
                     <config-property name="name">Property2</config-property>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-minimal.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-minimal.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS"
                     use-java-context="true">

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-validation-custom-modules-reject.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-validation-custom-modules-reject.xml
@@ -3,16 +3,13 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS"
                     use-java-context="true">
             <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
             <driver>h2</driver>
-            <security>
-                <user-name>sa</user-name>
-                <password>sa</password>
-            </security>
+            <security user-name="sa" password="sa"/>
             <validation>
                 <valid-connection-checker class-name="someClass2" module="someModule2"/>
                 <stale-connection-checker class-name="someClass3" module="someModule3"/>
@@ -28,10 +25,7 @@
                 org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource
             </xa-datasource-class>
             <driver>h2</driver>
-            <security>
-                <user-name>sa</user-name>
-                <password>sa</password>
-            </security>
+            <security user-name="sa" password="sa"/>
             <validation>
                 <valid-connection-checker class-name="someClass2" module="someModule2"/>
                 <stale-connection-checker class-name="someClass3" module="someModule3"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/DataSourceCfgMetricUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/DataSourceCfgMetricUnitTestCase.java
@@ -91,7 +91,7 @@ public class DataSourceCfgMetricUnitTestCase extends JCAMetrictsTestBase {
     @Test
     public void testStatementDefaultProperties() throws Exception {
         setModel("statement-properties.xml");
-        assertEquals("NOWARN", readAttribute(baseAddress, "track-statements").asString());
+        assertEquals("nowarn", readAttribute(baseAddress, "track-statements").asString());
         assertFalse(readAttribute(baseAddress, "share-prepared-statements").asBoolean());
         removeDs();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/basic-attributes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/basic-attributes.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS" enabled="true" statistics-enabled="true">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2" major-version="2" minor-version="2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/empty-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/empty-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/pool-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/pool-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/statement-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/statement-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/timeout-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/timeout-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/validation-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/validation-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.1">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-driver-classes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-driver-classes.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-ds-classes-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-ds-classes-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-xa-ds-classes-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-xa-ds-classes-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-wait-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-wait-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-blckg-timeout-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-blckg-timeout-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver name="" module="com.h2database.h2" major-version="2" minor-version="1">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-flush-strategy-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-flush-strategy-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-idle-mins-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-idle-mins-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-less-min-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-less-min-pool-size-propertiy.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-pool-size-propertiy.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-min-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-min-pool-size-propertiy.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-xa-ds-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-xa-ds-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <!-- there is no xa-datasource-property -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-stmt-cache-size-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-stmt-cache-size-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-transaction-isolation-type.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-transaction-isolation-type.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-trck-stmt-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-trck-stmt-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-validation-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-validation-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <drivers>
             <driver module="com.h2database.h2" major-version="2" minor-version="1">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-2-security-domains.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-2-security-domains.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-bogus-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-bogus-driver.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-res-timeout-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-res-timeout-property.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-basic-attributes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-basic-attributes.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS" enabled="true">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-bool-pres-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-default-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-default-properties.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-false-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-false-bool-pres-properties.xml
@@ -3,21 +3,21 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>
             <driver>h2</driver>
             <xa-pool>
-                <no-tx-separate-pools>false</no-tx-separate-pools>
                 <interleaving>false</interleaving>
+                <no-tx-separate-pools>false</no-tx-separate-pools>
             </xa-pool>
-            <statement>
-                <share-prepared-statements>false</share-prepared-statements>
-            </statement>
             <timeout>
                 <set-tx-query-timeout>false</set-tx-query-timeout>
             </timeout>
+            <statement>
+                <share-prepared-statements>false</share-prepared-statements>
+            </statement>
         </xa-datasource>
     </datasources>
 </subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-true-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-true-bool-pres-properties.xml
@@ -3,21 +3,21 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:datasources:7.0">
+<subsystem xmlns="urn:jboss:domain:datasources:7.2">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>
             <driver>h2</driver>
             <xa-pool>
-                <no-tx-separate-pools>true</no-tx-separate-pools>
                 <interleaving>true</interleaving>
+                <no-tx-separate-pools>true</no-tx-separate-pools>
             </xa-pool>
-            <statement>
-                <share-prepared-statements>true</share-prepared-statements>
-            </statement>
             <timeout>
                 <set-tx-query-timeout>true</set-tx-query-timeout>
             </timeout>
+            <statement>
+                <share-prepared-statements>true</share-prepared-statements>
+            </statement>
         </xa-datasource>
     </datasources>
 </subsystem>


### PR DESCRIPTION
Issue: [WFLY-19304](https://issues.redhat.com/browse/WFLY-19304)

Updated the schema to reflect what's actually produced by the XmlWriter. The bigger part is keeping the elements in the correct order, though I did change the order in the writer as well to keep it the same between `datasource` and `xa-datasource`. Since the parser doesn't care about the order this should not affect backwards compatibility.

Second part is changing some elements from "boolean presence" - `<element />` to simple boolean - `<element>true</element>`. The elements declared as "boolean presence" were neither written nor parsed as such, `<elem />` and `<elem>true</elem>` should be equivalent but `<elem />` is actually considered "false", this is potentially breaking backwards compatibility but if so it was broken already.

Thirdly two attributes had allowed values added since that's what's expected.

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)