### PR TITLE
[WFLY-19326] LinkageError: loader constraint violation for class io.netty.*

### DIFF
--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
@@ -55,11 +55,7 @@ class OpenTelemetrySubsystemDefinition extends PersistentResourceDefinition {
             "io.opentelemetry.api",
             "io.opentelemetry.context",
             "io.opentelemetry.exporter",
-            "io.opentelemetry.sdk",
-            "io.smallrye.opentelemetry",
-            "io.vertx.core",
-            "io.vertx.grpc-client",
-            "io.netty.netty-buffer"
+            "io.opentelemetry.sdk"
     };
 
     static final RuntimeCapability<Void> OPENTELEMETRY_CAPABILITY =


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19326

Tighten up the modules exported by the subsystem

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)