### PR TITLE
[32.x][WFLY-12329] managed executor service's execute(), submit() and schedule*() should use RequestController#forceBeginRequest() only when starting

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -5,6 +5,7 @@
 package org.jboss.as.ee.concurrent;
 
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.jboss.as.controller.ProcessStateNotifier;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 
 import jakarta.enterprise.concurrent.LastExecution;
@@ -28,66 +29,68 @@ import static org.jboss.as.ee.concurrent.SecurityIdentityUtils.doIdentityWrap;
 public class ManagedScheduledExecutorServiceImpl extends org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl implements ManagedExecutorWithHungThreads {
 
     private final ControlPoint controlPoint;
+    private final ProcessStateNotifier processStateNotifier;
     private final ManagedExecutorRuntimeStats runtimeStats;
 
-    public ManagedScheduledExecutorServiceImpl(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, ContextServiceImpl contextService, RejectPolicy rejectPolicy, ControlPoint controlPoint) {
+    public ManagedScheduledExecutorServiceImpl(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, ContextServiceImpl contextService, RejectPolicy rejectPolicy, ControlPoint controlPoint, ProcessStateNotifier processStateNotifier) {
         super(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, contextService, rejectPolicy);
         this.controlPoint = controlPoint;
+        this.processStateNotifier = processStateNotifier;
         this.runtimeStats = new ManagedExecutorRuntimeStatsImpl(this);
     }
 
     @Override
     public void execute(Runnable command) {
-        super.execute(doIdentityWrap(doWrap(command, controlPoint)));
+        super.execute(doIdentityWrap(doWrap(command, controlPoint, processStateNotifier)));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return super.submit(doIdentityWrap(doWrap(task, controlPoint)));
+        return super.submit(doIdentityWrap(doWrap(task, controlPoint, processStateNotifier)));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return super.submit(doIdentityWrap(doWrap(task, controlPoint)), result);
+        return super.submit(doIdentityWrap(doWrap(task, controlPoint, processStateNotifier)), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return super.submit(doIdentityWrap(doWrap(task, controlPoint)));
+        return super.submit(doIdentityWrap(doWrap(task, controlPoint, processStateNotifier)));
     }
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, Trigger trigger) {
         final CancellableTrigger ctrigger = new CancellableTrigger(trigger);
-        ctrigger.future = super.schedule(doIdentityWrap(doScheduledWrap(command, controlPoint)), ctrigger);
+        ctrigger.future = super.schedule(doIdentityWrap(doScheduledWrap(command, controlPoint, processStateNotifier)), ctrigger);
         return ctrigger.future;
     }
 
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, Trigger trigger) {
         final CancellableTrigger ctrigger = new CancellableTrigger(trigger);
-        ctrigger.future = super.schedule(doIdentityWrap(doScheduledWrap(callable, controlPoint)), ctrigger);
+        ctrigger.future = super.schedule(doIdentityWrap(doScheduledWrap(callable, controlPoint, processStateNotifier)), ctrigger);
         return ctrigger.future;
     }
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        return super.schedule(doIdentityWrap(doScheduledWrap(command, controlPoint)), delay, unit);
+        return super.schedule(doIdentityWrap(doScheduledWrap(command, controlPoint, processStateNotifier)), delay, unit);
     }
 
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        return super.schedule(doIdentityWrap(doScheduledWrap(callable, controlPoint)), delay, unit);
+        return super.schedule(doIdentityWrap(doScheduledWrap(callable, controlPoint, processStateNotifier)), delay, unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return super.scheduleAtFixedRate(doIdentityWrap(doScheduledWrap(command, controlPoint)), initialDelay, period, unit);
+        return super.scheduleAtFixedRate(doIdentityWrap(doScheduledWrap(command, controlPoint, processStateNotifier)), initialDelay, period, unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        return super.scheduleWithFixedDelay(doIdentityWrap(doScheduledWrap(command, controlPoint)), initialDelay, delay, unit);
+        return super.scheduleWithFixedDelay(doIdentityWrap(doScheduledWrap(command, controlPoint, processStateNotifier)), initialDelay, delay, unit);
     }
 
     @Override

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/resource/definition/ManagedExecutorDefinitionInjectionSource.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/resource/definition/ManagedExecutorDefinitionInjectionSource.java
@@ -6,6 +6,7 @@ package org.jboss.as.ee.concurrent.resource.definition;
 
 import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ManagedExecutorServiceAdapter;
+import org.jboss.as.controller.ProcessStateNotifier;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.concurrent.ContextServiceImpl;
 import org.jboss.as.ee.concurrent.deployers.EEConcurrentDefaultBindingProcessor;
@@ -41,6 +42,7 @@ public class ManagedExecutorDefinitionInjectionSource extends ResourceDefinition
     public static final String HUNG_TASK_THRESHOLD_PROP = "hungTaskThreshold";
     public static final String MAX_ASYNC_PROP = "maxAsync";
 
+    private static final String PROCESS_STATE_NOTIFIER_CAPABILITY_NAME = "org.wildfly.management.process-state-notifier";
     private static final String REQUEST_CONTROLLER_CAPABILITY_NAME = "org.wildfly.request-controller";
 
     private String contextServiceRef;
@@ -70,11 +72,12 @@ public class ManagedExecutorDefinitionInjectionSource extends ResourceDefinition
             final ServiceBuilder resourceServiceBuilder = phaseContext.getServiceTarget().addService(resourceServiceName);
             final Consumer<ManagedExecutorServiceAdapter> consumer = resourceServiceBuilder.provides(resourceServiceName);
             final Supplier<ManagedExecutorHungTasksPeriodicTerminationService> hungTasksPeriodicTerminationService = resourceServiceBuilder.requires(ConcurrentServiceNames.HUNG_TASK_PERIODIC_TERMINATION_SERVICE_NAME);
+            final Supplier<ProcessStateNotifier> processStateNotifierSupplier = resourceServiceBuilder.requires(capabilityServiceSupport.getCapabilityServiceName(PROCESS_STATE_NOTIFIER_CAPABILITY_NAME));
             Supplier<RequestController> requestControllerSupplier = null;
             if (capabilityServiceSupport.hasCapability(REQUEST_CONTROLLER_CAPABILITY_NAME)) {
                 requestControllerSupplier = resourceServiceBuilder.requires(capabilityServiceSupport.getCapabilityServiceName(REQUEST_CONTROLLER_CAPABILITY_NAME));
             }
-            final ManagedExecutorServiceService resourceService = new ManagedExecutorServiceService(consumer, null, null, requestControllerSupplier, resourceName, resourceJndiName, hungTaskThreshold, hungTaskTerminationPeriod, longRunningTasks, maxAsync, maxAsync, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueLength, rejectPolicy, threadPriority, hungTasksPeriodicTerminationService);
+            final ManagedExecutorServiceService resourceService = new ManagedExecutorServiceService(consumer, null, null, processStateNotifierSupplier, requestControllerSupplier, resourceName, resourceJndiName, hungTaskThreshold, hungTaskTerminationPeriod, longRunningTasks, maxAsync, maxAsync, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueLength, rejectPolicy, threadPriority, hungTasksPeriodicTerminationService);
             resourceServiceBuilder.setInstance(resourceService);
             final Injector<ManagedReferenceFactory> contextServiceLookupInjector = new Injector<>() {
                 @Override

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
@@ -15,6 +15,7 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ProcessStateNotifier;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.ee.concurrent.service.ConcurrentServiceNames;
@@ -32,6 +33,7 @@ import org.wildfly.extension.requestcontroller.RequestController;
  */
 public class ManagedExecutorServiceAdd extends AbstractAddStepHandler {
 
+    private static final String PROCESS_STATE_NOTIFIER_CAPABILITY_NAME = "org.wildfly.management.process-state-notifier";
     private static final String REQUEST_CONTROLLER_CAPABILITY_NAME = "org.wildfly.request-controller";
 
     static final ManagedExecutorServiceAdd INSTANCE = new ManagedExecutorServiceAdd();
@@ -109,11 +111,13 @@ public class ManagedExecutorServiceAdd extends AbstractAddStepHandler {
             threadFactory = ManagedExecutorServiceResourceDefinition.THREAD_FACTORY_AD.resolveModelAttribute(context, model).asString();
         }
         final Supplier<ManagedThreadFactoryImpl> threadFactorySupplier = threadFactory != null ? serviceBuilder.requiresCapability(ManagedThreadFactoryResourceDefinition.CAPABILITY.getName(), ManagedThreadFactoryImpl.class, threadFactory) : null;
+
+        final Supplier<ProcessStateNotifier> processStateNotifierSupplier = serviceBuilder.requiresCapability(PROCESS_STATE_NOTIFIER_CAPABILITY_NAME, ProcessStateNotifier.class);
         Supplier<RequestController> requestControllerSupplier = null;
         if (context.hasOptionalCapability(REQUEST_CONTROLLER_CAPABILITY_NAME, ManagedExecutorServiceResourceDefinition.CAPABILITY.getDynamicName(context.getCurrentAddress()), null)) {
             requestControllerSupplier = serviceBuilder.requiresCapability(REQUEST_CONTROLLER_CAPABILITY_NAME, RequestController.class);
         }
-        final ManagedExecutorServiceService service = new ManagedExecutorServiceService(consumer, contextServiceSupplier, threadFactorySupplier, requestControllerSupplier, name, jndiName, hungTaskThreshold, hungTaskTerminationPeriod, longRunningTasks, coreThreads, maxThreads, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueLength, rejectPolicy, threadPriority, hungTasksPeriodicTerminationService);
+        final ManagedExecutorServiceService service = new ManagedExecutorServiceService(consumer, contextServiceSupplier, threadFactorySupplier, processStateNotifierSupplier, requestControllerSupplier, name, jndiName, hungTaskThreshold, hungTaskTerminationPeriod, longRunningTasks, coreThreads, maxThreads, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueLength, rejectPolicy, threadPriority, hungTasksPeriodicTerminationService);
         serviceBuilder.setInstance(service);
         serviceBuilder.install();
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12329
Main branch PR: https://github.com/wildfly/wildfly/pull/17881

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)