### PR TITLE
[WFLY-19331] Correct the product.docs.server.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <ee.maven.groupId>${project.groupId}</ee.maven.groupId>
         <ee.maven.version>${project.version}</ee.maven.version>
         <channels.maven.groupId>${project.groupId}.channels</channels.maven.groupId>
-        <product.docs.server.version>31</product.docs.server.version>
+        <product.docs.server.version>32</product.docs.server.version>
         <!-- A short variant of product.release.version used in 'startsWith' tests done by dist verification logic -->
         <verifier.product.release.version>${product.docs.server.version}.0</verifier.product.release.version>
         <!-- The Galleon channel for the minor version with which this branch is associated.  -->

--- a/testsuite/galleon/update/pom.xml
+++ b/testsuite/galleon/update/pom.xml
@@ -23,6 +23,15 @@
     <packaging>pom</packaging>
     <name>WildFly Test Suite: Galleon update tests</name>
     <description>Install a base version and check that wildfly producers can get updated to the SNAPSHOT version.</description>
+
+    <properties>
+        <!-- We use maven properties to control which phase the xxx-update maven-antrun-plugin executions run in.
+             Use 'none' to disable the execution. Different maven profiles can change the property values. -->
+        <wildfly-ee.update.phase>compile</wildfly-ee.update.phase>
+        <wildfly.update.phase>compile</wildfly.update.phase>
+        <wildfly-preview.update.phase>none</wildfly-preview.update.phase>
+    </properties>
+
     <profiles>
         <profile>
             <id>galleon.profile</id>
@@ -62,7 +71,11 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <phase>compile</phase>
+                                <id>wildfly-ee-update</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>${wildfly-ee.update.phase}</phase>
                                 <configuration>
                                     <tasks>
                                         <exec executable="./run-test.sh" failonerror="true">
@@ -74,6 +87,17 @@
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="jaxrs-server"/>
                                         </exec>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>wildfly-update</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>${wildfly.update.phase}</phase>
+                                <configuration>
+                                    <tasks>
                                         <exec executable="./run-test.sh" failonerror="true">
                                             <env key="GALLEON_VERSION" value="${version.org.jboss.galleon}"/>
                                             <env key="BASE_DIR" value="${project.basedir}"/>
@@ -82,7 +106,18 @@
                                             <env key="WILDFLY_PRODUCER" value="wildfly"/>
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server"/>
-                                        </exec>
+                                        </exec>\
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>wildfly-preview-update</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>${wildfly-preview.update.phase}</phase>
+                                <configuration>
+                                    <tasks>
                                         <exec executable="./run-test.sh" failonerror="true">
                                             <env key="GALLEON_VERSION" value="${version.org.jboss.galleon}"/>
                                             <env key="BASE_DIR" value="${project.basedir}"/>
@@ -94,14 +129,37 @@
                                         </exec>
                                     </tasks>
                                 </configuration>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>preview.profile</id>
+            <activation><property><name>ts.preview</name></property></activation>
+            <properties>
+                <!-- Enable WFP tests and disable std WF -->
+                <wildfly-ee.update.phase>none</wildfly-ee.update.phase>
+                <wildfly.update.phase>none</wildfly.update.phase>
+                <wildfly-preview.update.phase>compile</wildfly-preview.update.phase>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>ee-galleon-pack.profile</id>
+            <activation>
+                <property>
+                    <name>testsuite.ee.galleon.pack.artifactId</name>
+                    <value>wildfly-ee-galleon-pack</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Skip the WF feature pack test -->
+                <wildfly.update.phase>none</wildfly.update.phase>
+            </properties>
+        </profile>
     </profiles>
+
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -496,6 +496,7 @@
             </properties>
             <modules>
                 <module>domain</module>
+                <module>galleon</module>
                 <module>integration</module>
                 <module>layers</module>
                 <module>layers-expansion</module>


### PR DESCRIPTION
Roughly related to https://issues.redhat.com/browse/WFLY-19331, which was actually fixed via https://github.com/wildfly/wildfly.github.io/pull/76.

We don't regenerate docs for micros, so the change here shouldn't matter, but it's better to have this correct.

Also includes the fix for https://issues.redhat.com/browse/WFLY-19341, which is required for CI to pass with this change.

Upstream: #17886

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)