### PR TITLE
[WFLY-19338] Upgrade WildFly Core to 25.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19338

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Beta1...25.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6816'>WFCORE-6816</a>] -         A resource with a deployment chain contributor should require restarting all services on removal
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6817'>WFCORE-6817</a>] -         Operation parameters and reply attributes not enabled by the current stability level still appear in the resource description
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6824'>WFCORE-6824</a>] -         ServiceNameFactory.resolveServiceName(UnaryServiceDescriptor) throws ISE if resolved to NullaryServiceDescriptor
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5753'>WFCORE-5753</a>] -         Update ModelTestControllerVersion.EAP_XP_4 to use proper EAP XP4 artifacts
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6700'>WFCORE-6700</a>] -         Replace temporal ModelTestControllerVersion based on WF29 by real 8.0.0.GA
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6488'>WFCORE-6488</a>] -         Upgrade WildFly Legacy Tests to 8.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6820'>WFCORE-6820</a>] -         Upgrade io.smallrye:jandex from 3.1.7 to 3.1.8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6826'>WFCORE-6826</a>] -         Upgrade wildfly-jar-maven-plugin to 11.0.2.Final
</li>
</ul>
</details>

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)