### PR TITLE
[WFLY-19346] Make 'org.wildfly.security.elytron-http-oidc' module public

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron-oidc-client/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron-oidc-client/main/module.xml
@@ -7,10 +7,6 @@
 
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.elytron-oidc-client">
 
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
     <resources>
         <artifact name="${org.wildfly:wildfly-elytron-oidc-client-subsystem}"/>
     </resources>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-http-oidc/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-http-oidc/main/module.xml
@@ -6,10 +6,6 @@
   -->
 <module xmlns="urn:jboss:module:1.9" name="org.wildfly.security.elytron-http-oidc">
 
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
     <resources>
         <artifact name="${org.wildfly.security:wildfly-elytron-http-oidc}"/>
     </resources>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19346

Make 'org.wildfly.security.elytron-http-oidc' module public

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)