### PR TITLE
[WFLY-19351] Add Micrometer test to verify that applications with shared metrics names are not merged when exported

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
@@ -26,18 +26,16 @@ import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deployment.FaultTolerantApplication;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deployment.TimeoutService;
-import org.wildfly.test.integration.observability.micrometer.MicrometerSetupTask;
+import org.wildfly.test.integration.observability.setuptask.MicrometerSetupTask;
 
 /**
  * Test case to verify basic SmallRye Fault Tolerance integration with Micrometer. The test first invokes a REST
@@ -68,14 +66,6 @@ public class FaultToleranceMicrometerIntegrationTestCase {
 
     @Inject
     private MeterRegistry meterRegistry;
-
-    // The @ServerSetup(MicrometerSetupTask.class) requires Docker to be available.
-    // Otherwise the org.wildfly.extension.micrometer.registry.NoOpRegistry is installed which will result in 0 counters,
-    // and cause the test fail seemingly intermittently on machines with broken Docker setup.
-    @BeforeClass
-    public static void checkForDocker() {
-        AssumeTestGroupUtil.assumeDockerAvailable();
-    }
 
     @Test
     @InSequence(1)

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/OpenTelemetryCollectorContainer.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/OpenTelemetryCollectorContainer.java
@@ -4,9 +4,17 @@
  */
 package org.wildfly.test.integration.observability.container;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import org.testcontainers.utility.MountableFile;
 import org.wildfly.test.integration.observability.opentelemetry.jaeger.JaegerTrace;
 
@@ -20,10 +28,6 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     public static final String OTEL_COLLECTOR_CONFIG_YAML = "/etc/otel-collector-config.yaml";
 
     private JaegerContainer jaegerContainer;
-
-    private String otlpGrpcEndpoint;
-    private String otlpHttpEndpoint;
-    private String prometheusUrl;
 
     public OpenTelemetryCollectorContainer() {
         super("OpenTelemetryCollector", IMAGE_NAME, IMAGE_VERSION,
@@ -40,10 +44,6 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
         super.start();
         jaegerContainer.start();
 
-        otlpGrpcEndpoint = "http://localhost:" + getMappedPort(OTLP_GRPC_PORT);
-        otlpHttpEndpoint = "http://localhost:" + getMappedPort(OTLP_HTTP_PORT);
-        prometheusUrl = "http://localhost:" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
-
         debugLog("OTLP gRPC port: " + getMappedPort(OTLP_GRPC_PORT));
         debugLog("OTLP HTTP port: " + getMappedPort(OTLP_HTTP_PORT));
         debugLog("Prometheus port: " + getMappedPort(PROMETHEUS_PORT));
@@ -52,26 +52,82 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
 
     @Override
     public synchronized void stop() {
-        if (jaegerContainer != null) {
-            jaegerContainer.stop();
-            jaegerContainer = null;
-        }
+        jaegerContainer.stop();
         super.stop();
     }
 
     public String getOtlpGrpcEndpoint() {
-        return otlpGrpcEndpoint;
+        return "http://localhost:" + getMappedPort(OTLP_GRPC_PORT);
     }
 
     public String getOtlpHttpEndpoint() {
-        return otlpHttpEndpoint;
+        return "http://localhost:" + getMappedPort(OTLP_HTTP_PORT);
     }
 
     public String getPrometheusUrl() {
-        return prometheusUrl;
+        return "http://localhost:" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
     }
 
     public List<JaegerTrace> getTraces(String serviceName) throws InterruptedException {
         return (jaegerContainer != null ? jaegerContainer.getTraces(serviceName) : Collections.emptyList());
+    }
+
+    public List<PrometheusMetric> fetchMetrics(String nameToMonitor) throws InterruptedException {
+        String body = "";
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(getPrometheusUrl());
+
+            int attemptCount = 0;
+            boolean found = false;
+
+            // Request counts can vary. Setting high to help ensure test stability
+            while (!found && attemptCount < 30) {
+                // Wait to give Micrometer time to export
+                Thread.sleep(1000);
+
+                body = target.request().get().readEntity(String.class);
+                found = body.contains(nameToMonitor);
+                attemptCount++;
+            }
+        }
+
+        return buildPrometheusMetrics(body);
+    }
+
+    private List<PrometheusMetric> buildPrometheusMetrics(String body) {
+        if (body.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] entries = body.split("\n");
+        Map<String, String> help = new HashMap<>();
+        Map<String, String> type = new HashMap<>();
+        List<PrometheusMetric> metrics = new LinkedList<>();
+        Arrays.stream(entries).forEach(e -> {
+            if (e.startsWith("# HELP")) {
+                extractMetadata(help, e);
+            } else if (e.startsWith("# TYPE")) {
+                extractMetadata(type, e);
+            } else {
+                String[] parts = e.split("[{}]");
+                String key = parts[0];
+                Map<String, String> tags = Arrays.stream(parts[1].split(","))
+                        .map(t -> t.split("="))
+                        .collect(Collectors.toMap(i -> i[0],
+                                i -> i[1]
+                                        .replaceAll("^\"", "")
+                                        .replaceAll("\"$", "")
+                        ));
+                metrics.add(new PrometheusMetric(key, tags, parts[2].trim(), type.get(key), help.get(key)));
+            }
+        });
+
+        return metrics;
+    }
+
+    private void extractMetadata(Map<String, String> target, String source) {
+        String[] parts = source.split(" ");
+        target.put(parts[2],
+                Arrays.stream(Arrays.copyOfRange(parts, 3, parts.length))
+                        .reduce("", (total, element) -> total + " " + element));
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/PrometheusMetric.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/PrometheusMetric.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.container;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class PrometheusMetric {
+    private final String key;
+    private final Map<String, String> tags;
+    private final String value;
+    private final String type;
+    private final String help;
+
+    public PrometheusMetric(String key,
+                            Map<String, String> tags,
+                            String value,
+                            String type,
+                            String help) {
+        this.key = key;
+        this.tags = Collections.unmodifiableMap(tags);
+        this.value = value;
+        this.type = type;
+        this.help = help;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getHelp() {
+        return help;
+    }
+
+    @Override
+    public String toString() {
+        return "PrometheusMetric{" +
+                "key='" + key + '\'' +
+                ", tags=" + tags +
+                ", value='" + value + '\'' +
+                ", type='" + type + '\'' +
+                ", help='" + help + '\'' +
+                '}';
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
@@ -19,6 +19,7 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.opentelemetry.application.JaxRsActivator;
+import org.wildfly.test.integration.observability.setuptask.MicrometerSetupTask;
 
 
 @RunWith(Arquillian.class)

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MetricResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MetricResource.java
@@ -36,7 +36,7 @@ public class MetricResource {
 
         timer.record(() -> {
             try {
-                Thread.sleep((long) (Math.random() * 1000L));
+                Thread.sleep((long) (Math.random() * 100L));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -22,9 +22,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.test.shared.CdiUtils;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,7 +33,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.container.OpenTelemetryCollectorContainer;
+import org.wildfly.test.integration.observability.container.PrometheusMetric;
 import org.wildfly.test.integration.observability.opentelemetry.application.JaxRsActivator;
+import org.wildfly.test.integration.observability.setuptask.MicrometerSetupTask;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
@@ -50,25 +50,10 @@ public class MicrometerOtelIntegrationTestCase {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;
 
-    static final String WEB_XML =
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                    + "<web-app xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n"
-                    + "           xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\"\n"
-                    + "         xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd\" \n"
-                    + "              version=\"4.0\">\n"
-                    + "    <servlet-mapping>\n"
-                    + "        <servlet-name>jakarta.ws.rs.core.Application</servlet-name>\n"
-                    + "        <url-pattern>/*</url-pattern>\n"
-                    + "    </servlet-mapping>"
-                    + "</web-app>\n";
-
     @Deployment
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "micrometer-test.war")
-                .addClasses(ServerSetupTask.class,
-                        JaxRsActivator.class,
-                        MetricResource.class,
-                        AssumeTestGroupUtil.class)
+                .addClasses(JaxRsActivator.class, MetricResource.class)
                 .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml");
     }
 
@@ -91,25 +76,14 @@ public class MicrometerOtelIntegrationTestCase {
         }
     }
 
-    @Test
-    @InSequence(3)
-    public void checkCounter() throws InterruptedException {
-        Thread.sleep(TimeoutUtil.adjust(1000)); // Allow time for metrics to be pushed
-        String meterName = "demo_counter";
-        Map<String, String> metrics = getMetricsMap(fetchMetrics(meterName));
-
-        String counter = metrics.get(meterName + "_total{job=\"wildfly\"}");
-        Assert.assertEquals("" + REQUEST_COUNT, counter);
-    }
-
     // Request the published metrics from the OpenTelemetry Collector via the configured Prometheus exporter and check
     // a few metrics to verify there existence
     @Test
-    @RunAsClient
     @InSequence(4)
     public void getMetrics() throws InterruptedException {
         List<String> metricsToTest = Arrays.asList(
                 "demo_counter",
+                "demo_timer",
                 "memory_used_heap",
                 "cpu_available_processors",
                 "classloader_loaded_classes_count",
@@ -119,12 +93,12 @@ public class MicrometerOtelIntegrationTestCase {
                 "undertow_bytes_received"
         );
 
-        final String response = fetchMetrics(metricsToTest.get(0));
-        metricsToTest.forEach(n -> Assert.assertTrue("Missing metric: " + n, response.contains(n)));
+        final List<PrometheusMetric> metrics = otelCollector.fetchMetrics(metricsToTest.get(0));
+        metricsToTest.forEach(n -> Assert.assertTrue("Missing metric: " + n,
+                metrics.stream().anyMatch(m -> m.getKey().startsWith(n))));
     }
 
     @Test
-    @RunAsClient
     @InSequence(5)
     public void testJmxMetrics() throws InterruptedException {
         List<String> metricsToTest = Arrays.asList(
@@ -132,16 +106,19 @@ public class MicrometerOtelIntegrationTestCase {
                 "classloader_loaded_classes",
                 "cpu_system_load_average",
                 "cpu_process_cpu_time",
-                "classloader_unloaded_classes",
                 "classloader_loaded_classes_count",
                 "thread_count",
                 "thread_daemon_count",
                 "cpu_available_processors"
         );
-        Map<String, String> metrics = getMetricsMap(fetchMetrics(metricsToTest.get(0)));
+        final List<PrometheusMetric> metrics = otelCollector.fetchMetrics(metricsToTest.get(0));
+
         metricsToTest.forEach(m -> {
             Assert.assertNotEquals("Metric value should be non-zero: " + m,
-                    "0", metrics.get(m + "{job=\"wildfly\"}")); // Add the metrics tags to complete the key
+                    "0", metrics.stream().filter(e -> e.getKey().startsWith(m))
+                            .findFirst()
+                            .orElseThrow()
+                            .getValue()); // Add the metrics tags to complete the key
         });
     }
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMultipleTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMultipleTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.multiple;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.observability.container.OpenTelemetryCollectorContainer;
+import org.wildfly.test.integration.observability.container.PrometheusMetric;
+import org.wildfly.test.integration.observability.setuptask.MicrometerSetupTask;
+
+@RunWith(Arquillian.class)
+@ServerSetup(MicrometerSetupTask.class)
+@DockerRequired(AssumptionViolatedException.class)
+@RunAsClient
+public abstract class BaseMultipleTestCase {
+    protected static final String SERVICE_ONE = "service-one";
+    protected static final String SERVICE_TWO = "service-two";
+    protected static final int REQUEST_COUNT = 5;
+
+    @Testcontainer
+    protected OpenTelemetryCollectorContainer otelCollector;
+
+    protected void makeRequests(URI service) throws URISyntaxException {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(service);
+            for (int i = 0; i < REQUEST_COUNT; i++) {
+                Assert.assertEquals(200, target.request().get().getStatus());
+            }
+        }
+    }
+
+    protected @NotNull List<PrometheusMetric> getMetricsByName(List<PrometheusMetric> metrics, String key) {
+        return metrics.stream()
+                .filter(m -> m.getKey().equals(key))
+                .collect(Collectors.toList());
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.multiple;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.test.integration.observability.container.PrometheusMetric;
+import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
+import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
+
+public class EarDeploymentTestCase extends BaseMultipleTestCase {
+    protected static final String ENTERPRISE_APP = "enterprise-app";
+
+    @Deployment(name = ENTERPRISE_APP)
+    public static EnterpriseArchive createDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, ENTERPRISE_APP + ".ear")
+                .addAsModule(MultipleWarTestCase.createDeployment1())
+                .addAsModule(MultipleWarTestCase.createDeployment2())
+                .setApplicationXML(new StringAsset("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<application xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" " +
+                        "       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                        "       xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd\" " +
+                        "       version=\"10\">\n"
+                        + "  <display-name>metrics</display-name>\n"
+                        + "  <module>\n"
+                        + "    <web>\n"
+                        + "      <web-uri>" + SERVICE_ONE + ".war</web-uri>\n"
+                        + "    </web>\n"
+                        + "  </module>\n"
+                        + "  <module>\n"
+                        + "    <web>\n"
+                        + "      <web-uri>" + SERVICE_TWO + ".war</web-uri>\n"
+                        + "    </web>\n"
+                        + "  </module>\n"
+                        + "</application>"));
+    }
+
+    @Test
+    public void dataTest(@ArquillianResource @OperateOnDeployment(ENTERPRISE_APP) URL earUrl)
+            throws URISyntaxException, InterruptedException {
+        makeRequests(new URI(String.format("%s/%s/%s/%s", earUrl, ENTERPRISE_APP, SERVICE_ONE, DuplicateMetricResource1.TAG)));
+        makeRequests(new URI(String.format("%s/%s/%s/%s", earUrl, ENTERPRISE_APP, SERVICE_TWO, DuplicateMetricResource2.TAG)));
+
+        List<PrometheusMetric> results = Collections.emptyList();
+
+        int attemptCount = 0;
+
+        while (attemptCount < 10) {
+            attemptCount++;
+
+            results = getMetricsByName(
+                    otelCollector.fetchMetrics(DuplicateMetricResource1.METER_NAME),
+                    DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
+            // On occasion, it seems that the test will grab the metrics between updates, so we get the metric for app 1,
+            // but app 2 has not been published yet. We loop here, then, for a short while to give the server time to
+            // publish the metrics it has. After that short while, we break out and fail.
+            if (results.size() == 2) {
+                break;
+            } else {
+                Thread.sleep(500);
+            }
+        }
+        Assert.assertEquals(2, results.size());
+        results.forEach(r -> Assert.assertEquals("" + REQUEST_COUNT, r.getValue()));
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.multiple;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.CdiUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.test.integration.observability.container.PrometheusMetric;
+import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
+import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
+import org.wildfly.test.integration.observability.micrometer.multiple.application.TestApplication;
+
+public class MultipleWarTestCase extends BaseMultipleTestCase {
+    @Deployment(name = SERVICE_ONE, order = 1, testable = false)
+    public static WebArchive createDeployment1() {
+        return ShrinkWrap.create(WebArchive.class, SERVICE_ONE + ".war")
+                .addClasses(TestApplication.class, DuplicateMetricResource1.class)
+                .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml");
+
+    }
+
+    @Deployment(name = SERVICE_TWO, order = 2, testable = false)
+    public static WebArchive createDeployment2() {
+        return ShrinkWrap.create(WebArchive.class, SERVICE_TWO + ".war")
+                .addClasses(TestApplication.class, DuplicateMetricResource2.class)
+                .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml");
+    }
+
+    @Test
+    @InSequence(1)
+    public void checkPingCount(@ArquillianResource @OperateOnDeployment(SERVICE_ONE) URL serviceOne,
+                               @ArquillianResource @OperateOnDeployment(SERVICE_TWO) URL serviceTwo)
+            throws URISyntaxException, InterruptedException {
+        makeRequests(new URI(String.format("%s/%s", serviceOne, DuplicateMetricResource1.TAG)));
+        makeRequests(new URI(String.format("%s/%s", serviceTwo, DuplicateMetricResource2.TAG)));
+
+        List<PrometheusMetric> results = getMetricsByName(
+                otelCollector.fetchMetrics(DuplicateMetricResource1.METER_NAME),
+                DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
+
+        Assert.assertEquals(2, results.size());
+        results.forEach(r -> Assert.assertEquals("" + REQUEST_COUNT, r.getValue()));
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/DuplicateMetricResource1.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/DuplicateMetricResource1.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.multiple.application;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@RequestScoped
+@Path("/" + DuplicateMetricResource1.TAG)
+public class DuplicateMetricResource1 {
+    public static final String TAG = "app1";
+    public static final String METER_NAME = "ping_count";
+    @SuppressWarnings("CdiInjectionPointsInspection")
+    @Inject
+    private MeterRegistry meterRegistry;
+    private Counter counter;
+
+    @PostConstruct
+    public void setupMeters() {
+        counter = meterRegistry.counter(METER_NAME, "app", TAG);
+    }
+
+    @GET
+    @Path("/")
+    public String ping() {
+        counter.increment();
+        return "ping";
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/DuplicateMetricResource2.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/DuplicateMetricResource2.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer.multiple.application;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@RequestScoped
+@Path("/" + DuplicateMetricResource2.TAG)
+public class DuplicateMetricResource2 {
+    public static final String TAG = "app2";
+    public static final String METER_NAME = "ping-count";
+
+    @SuppressWarnings("CdiInjectionPointsInspection")
+    @Inject
+    private MeterRegistry meterRegistry;
+    private Counter counter;
+
+    @PostConstruct
+    public void setupMeters() {
+        counter = meterRegistry.counter(METER_NAME, "app", TAG);
+    }
+
+    @GET
+    @Path("/")
+    public String ping() {
+        counter.increment();
+        return "ping";
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/TestApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/application/TestApplication.java
@@ -2,12 +2,11 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.wildfly.test.integration.observability.opentelemetry.application;
+package org.wildfly.test.integration.observability.micrometer.multiple.application;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/")
-public class JaxRsActivator extends Application {
-
+public class TestApplication extends Application {
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -78,10 +78,9 @@ public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
             String traceId = trace.getTraceID();
             List<JaegerSpan> spans = trace.getSpans();
 
-            spans.forEach(s -> {
-                Assert.assertEquals("The traceId of the span did not match the first span's. Context propagation failed.",
-                        traceId, s.getTraceID());
-            });
+            spans.forEach(s ->
+                    Assert.assertEquals("The traceId of the span did not match the first span's. Context propagation failed.",
+                            traceId, s.getTraceID()));
         }
     }
 

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
@@ -14,12 +14,9 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
-import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
@@ -31,15 +28,12 @@ import org.wildfly.test.integration.observability.setuptask.OpenTelemetrySetupTa
 import org.wildfly.test.integration.observability.setuptask.ServiceNameSetupTask;
 
 @RunWith(Arquillian.class)
-@ServerSetup({OpenTelemetrySetupTask.class})
+@ServerSetup({OpenTelemetrySetupTask.class, ServiceNameSetupTask.class})
 @RunAsClient
 @DockerRequired(AssumptionViolatedException.class)
 public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;
-
-    @ContainerResource
-    ManagementClient managementClient;
 
     @Deployment(testable = false)
     public static WebArchive getDeployment() {
@@ -47,13 +41,6 @@ public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
     }
 
     @Test
-    @InSequence(1)
-    public void setup() throws Exception {
-        new ServiceNameSetupTask().setup(managementClient, null);
-    }
-
-    @Test
-    @InSequence(2)
     public void testServiceNameOverride() throws Exception {
         try (Client client = ClientBuilder.newClient()) {
             Response response = client.target(getDeploymentUrl("otelinteg")).request().get();
@@ -62,11 +49,5 @@ public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
 
         List<JaegerTrace> traces = otelCollector.getTraces(SERVICE_NAME);
         Assert.assertFalse("Traces not found for service", traces.isEmpty());
-    }
-
-    @Test
-    @InSequence(3)
-    public void tearDown() throws Exception {
-        new ServiceNameSetupTask().tearDown(managementClient, null);
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/setuptask/MicrometerSetupTask.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/setuptask/MicrometerSetupTask.java
@@ -2,7 +2,7 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.wildfly.test.integration.observability.micrometer;
+package org.wildfly.test.integration.observability.setuptask;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATISTICS_ENABLED;
 
@@ -14,7 +14,6 @@ import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.AssumptionViolatedException;
 import org.wildfly.test.integration.observability.container.OpenTelemetryCollectorContainer;
-import org.wildfly.test.integration.observability.setuptask.AbstractSetupTask;
 
 /**
  * Sets up a functioning Micrometer subsystem configuration. Requires functioning Docker environment! Tests using this


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19351

Add test with multiple war deployments
Add test with ear with multiple war subdeployments 
Rework how Prometheus metrics are retrieved and handled 
Add test to verify that metrics with identical names are exported separately

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)