### PR TITLE
[WFLY-19353] Upgrade RESTEasy to 6.2.9.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
         <version.org.jboss.mod_cluster>2.0.4.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.8.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.9.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.5.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.1.2.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19353

Upstream: #17901

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)