### PR TITLE
[WFLY-19353 & WFLY-19354] Upgrade RESTEasy in WildFly and WIldFly Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -51,7 +51,7 @@
         <version.jakarta.websocket.jakarta-websocket-api>2.2.0-M1</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.org.glassfish.jakarta.faces>4.1.0-M1</version.org.glassfish.jakarta.faces>
-        <version.org.jboss.resteasy>7.0.0.Alpha1</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>7.0.0.Alpha2</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Beta1</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Beta4</version.org.jboss.weld.weld-api>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
         <version.org.jboss.mod_cluster>2.0.4.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.8.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.9.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.5.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.1.2.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
- https://issues.redhat.com/browse/WFLY-19353: RESTEasy 6.2.9.Final upgrade
- https://issues.redhat.com/browse/WFLY-19354: RESTEasy 7.0.0.Alpha2 upgrade

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)