### PR TITLE
[WFLY-19305]: ClassCastException when running live-only HA policy.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicyConfigurationBuilder.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicyConfigurationBuilder.java
@@ -42,7 +42,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ScaleDownConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ColocatedPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.PrimaryOnlyPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.SharedStorePrimaryPolicyConfiguration;
@@ -119,7 +119,7 @@ public class HAPolicyConfigurationBuilder {
 
     private HAPolicyConfiguration buildLiveOnlyConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
         ScaleDownConfiguration scaleDownConfiguration = ScaleDownAttributes.addScaleDownConfiguration(context, model);
-        return new LiveOnlyPolicyConfiguration(scaleDownConfiguration);
+        return new PrimaryOnlyPolicyConfiguration(scaleDownConfiguration);
     }
 
     private HAPolicyConfiguration buildReplicationPrimaryConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {


### PR DESCRIPTION
* Replacing the use of LiveOnlyPolicyConfiguration by PrimaryOnlyPolicyConfiguration.

Jira: https://issues.redhat.com/browse/WFLY-19305

Upstream PR: https://github.com/wildfly/wildfly/pull/17867

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)