### PR TITLE
[WFLY-19364] Upgrade WildFly Core to 24.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>24.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>24.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19364

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/24.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/24.0.0.Final...24.0.1.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6825'>WFCORE-6825</a>] -         [CVE-2024-4029] wildfly-domain-http: wildfly: No timeout for EAP management interface may lead to Denial of Service (DoS)
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6792'>WFCORE-6792</a>] -         Rename Installer.Builder.async() -&gt; Installer.Builder.blocking()
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6797'>WFCORE-6797</a>] -         Upgrade BouncyCastle from 1.78 to 1.78.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6831'>WFCORE-6831</a>] -         Upgrade WildFly Elytron to 2.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6833'>WFCORE-6833</a>] -         Upgrade XNIO to 3.8.15.Final
</li>
</ul>
</details>

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)