### PR TITLE
[WFLY-15366] Revert "Temporarily ignore DataSourceMultipleConnStatsTe…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceMultipleConnStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceMultipleConnStatsTestCase.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -127,10 +126,6 @@ public class DataSourceMultipleConnStatsTestCase {
     @InSequence(2)
     @Test
     public void testClearedDataSourceStatistics() throws Exception {
-
-        // Disable for now on Windows until WFLY-15336 is sorted
-        Assume.assumeTrue("WFLY-15336", System.getProperty("os.name").equalsIgnoreCase("Linux"));
-
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
         this.setConnectionPool();


### PR DESCRIPTION
…stCase.testClearedDataSourceStatistics() in non-Linux environments"

This reverts commit 1282d204ef6b89302c79e4c92b13ff4f765f84ad.

https://issues.redhat.com/browse/WFLY-15366

I'm trying to unignore this test on non-linux systems, at least to get stacktrace and logs from TC. I couldn't reproduce WFLY-15366 on our Windows CI systems and couldn't find a failing run in TeamCity history. It has been ignored for ~3 years.

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)