### PR TITLE
[WFLY-18585]:  SimpleTimerMDBTestCase.testTimedObjectTimeoutMethod in…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/TimedObjectTimerServiceMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/timerservice/TimedObjectTimerServiceMDB.java
@@ -31,10 +31,6 @@ public class TimedObjectTimerServiceMDB implements TimedObject , MessageListener
     @Resource
     private TimerService timerService;
 
-    public void createTimer() {
-        timerService.createTimer(100, null);
-    }
-
     public static boolean awaitTimerCall(int timeout) {
         try {
             latch.await(timeout, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
…termittently fails

Cleaning up the code, I couldn't reproduce after 500 iterations.

Jira: https://issues.redhat.com/browse/WFLY-18585

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)