### PR TITLE
[WFLY-19366] Add io.smallrye.opentelemetry to the deployment classpath

### DIFF
--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemDefinition.java
@@ -55,7 +55,8 @@ class OpenTelemetrySubsystemDefinition extends PersistentResourceDefinition {
             "io.opentelemetry.api",
             "io.opentelemetry.context",
             "io.opentelemetry.exporter",
-            "io.opentelemetry.sdk"
+            "io.opentelemetry.sdk",
+            "io.smallrye.opentelemetry"
     };
 
     static final RuntimeCapability<Void> OPENTELEMETRY_CAPABILITY =


### PR DESCRIPTION
Otherwise it cannot find the Tracer bean for injection unless microprofile-telemetry is present (microprofile-telemetry adds this module so with it present, injection works)

https://issues.redhat.com/browse/WFLY-19366

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)