### PR TITLE
[WFLY-14825] Removing unnecessary permissions in DatabaseTimerServiceMultiNodeTestCase

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FilePermission;
 import java.net.SocketPermission;
-import java.security.SecurityPermission;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -175,7 +174,6 @@ public class DatabaseTimerServiceMultiNodeTestCase {
             war.addAsManifestResource(
                     createPermissionsXmlAsset(
                             new SocketPermission("*:9092", "connect,resolve"),
-                            new SecurityPermission("putProviderProperty.WildFlyElytron"),
                             new FilePermission(System.getProperty("jboss.home") + File.separatorChar + "standalone" + File.separatorChar + "tmp" + File.separatorChar + "auth" + File.separatorChar + "-", "read")),
                     "permissions.xml");
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14825

____

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)