### PR TITLE
[WFLY-19380] Admin Guide's Logging doc improvements

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
@@ -9,11 +9,19 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-The overall server logging configuration is represented by the logging
+[abstract]
+--
+The overall server logging configuration is represented by the `logging`
 subsystem. It consists of four notable parts: `handler` configurations,
 `logger` and the `root logger` declarations (aka log categories) and
 logging profiles. Each logger references a handler (or set of
-handlers). Each handler declares the log format and output:
+handlers). Each handler declares the log format and output.
+--
+
+[TIP]
+The WildFly Model Reference provides a complete description of the link:./wildscribe/subsystem/logging/index.html[management API for the `logging` subsystem].
+
+Here is an example of the `logging` subsystem XML configuration:
 
 [source,xml,options="nowrap"]
 ----
@@ -170,7 +178,7 @@ operations are valid in both standalone and domain modes.
 [[list-log-files]]
 === List Log Files
 
-The logging subsystem has a `log-file` resource off the subsystem root
+The `logging` subsystem has a `log-file` resource off the subsystem root
 resource and off each `logging-profile` resource to list each log file.
 
 .CLI command and output
@@ -239,14 +247,14 @@ down.
 
 You may have noticed that there is a `logging.properties` file in the
 configuration directory. This is logging configuration is used when the
-server boots up until the logging subsystem kicks in. If the logging
+server boots up until the `logging` subsystem kicks in. If the `logging`
 subsystem is not included in your configuration, then this would act as
 the logging configuration for the entire server.
 
 [TIP]
 
 The `logging.properties` file is overwritten at boot and with each
-change to the logging subsystem. Any changes made to the file are not
+change to the `logging` subsystem. Any changes made to the file are not
 persisted. Any changes made to the XML configuration or via management
 operations will be persisted to the `logging.properties` file and used
 on the next boot.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Handlers.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Handlers.adoc
@@ -85,7 +85,7 @@ A `socket-handler` is a handler which sends messages over a socket. This can be 
 defined in a <<socket-binding-groups,socket binding group>> under the `local-destination-outbound-socket-binding` or
 `remote-destination-outbound-socket-binding` resource.
 
-During the boot logging messages will be queued until the socket binding is configured and the logging subsystem is
+During the boot logging messages will be queued until the socket binding is configured and the `logging` subsystem is
 added. This is important to note because setting the level of the handler to `DEBUG` or `TRACE` could result in
 large memory consumption during boot.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_How_To.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_How_To.adoc
@@ -63,5 +63,5 @@ If you want to use your own log4j2 implementation, such as log4j-core, then you 
 in a link:Developer_Guide.html#jboss-deployment-structure-file[jboss-deployment-structure.xml].
 2. Then you would need to include the log4j-api and a log4j2 implementation library in your deployment.
 
-IMPORTANT: This only works for logging in your deployment. Server logs will continue to use the logging subsystem
+IMPORTANT: This only works for logging in your deployment. Server logs will continue to use the `logging` subsystem
            configuration.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Loggers.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Loggers.adoc
@@ -9,10 +9,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-WIP
-
 [IMPORTANT]
-
 This is still a work in progress. Please feel free to edit any mistakes
 you find icon:smile-o[role="yellow"]
 

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -72,6 +72,9 @@ you how to create a cluster, how to configure the web container and Jakarta Ente
 container for clustering and how to configure load balancing
 and failover.
 
+* The link:wildscribe[WildFly model reference] provides information about all standalone server and managed domain
+configuration options, using information generated directly from the WildFly management model.
+
 [[developer-guides]]
 == Developer Guides
 
@@ -103,11 +106,6 @@ into WildFly.
 * The link:Migration_Guide{outfilesuffix}[Migration Guide] describes alternative options for
 features which have been removed from WildFly.
 
-== Model Reference
-
-* The link:wildscribe[WildFly model reference^] provides information about all standalone server and managed domain
-configuration options, using information generated directly from the WildFly management model.
-
 == Security Guide
 
 * The link:WildFly_Elytron_Security{outfilesuffix}[WildFly Elytron Security] guide walks you through WildFly's new security layer.
@@ -125,8 +123,7 @@ configuration options, using information generated directly from the WildFly man
 == More Resources
 
 * link:Glossary.html[Glossary]
-* https://www.wildfly.org[WildFly project page]
-* https://issues.redhat.com/browse/WFLY[WildFly issue tracker]
-* https://groups.google.com/g/wildfly[WildFly user forum]
-* https://developer.jboss.org/en/wildfly/dev[WildFly wiki]
-* https://github.com/wildfly/wildfly/[WildFly source]
+* https://wildfly.org[project page]
+* https://issues.redhat.com/browse/WFLY[issue tracker]
+* https://groups.google.com/g/wildfly[user forum]
+* https://github.com/wildfly/wildfly/[Source code at GitHub]


### PR DESCRIPTION
@jamezp @bstansberry As I've been playing with wildscribe, I think we should make it easier to find in our docs and a simple action is to link to the corresponding page from each of our subsystem guides.

I did it just for the `logging` subsystem. But if you agree with that PR, I can definitely do it for all our documented subsystems in the Admin Guide.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19380](https://issues.redhat.com/browse/WFLY-19380)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)