### PR TITLE
[WFLY-19388] Upgrade WildFly Core to 25.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19388

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Beta2...25.0.0.Beta3

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3502'>WFCORE-3502</a>] -         Fix debug options in test-runner
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6069'>WFCORE-6069</a>] -         PermissionsDeploymentTestCase fails intermittently on Windows - Bootable JAR Job
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6732'>WFCORE-6732</a>] -         WildFlyRunner doesn&#39;t call tearDown and completed ServerSetupTasks if a later one fails in setup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6823'>WFCORE-6823</a>] -         We should not register the jaspi-factory in the host controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6825'>WFCORE-6825</a>] -         [CVE-2024-4029] wildfly-domain-http: wildfly: No timeout for EAP management interface may lead to Denial of Service (DoS)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6832'>WFCORE-6832</a>] -         Wrong arguments to standalone.sh may lead to server content removal
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6840'>WFCORE-6840</a>] -         Restart parent/ancestor ResourceOperationRuntimeHandler throws NoSuchResourceException if ancestor resource was created in same batch
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6842'>WFCORE-6842</a>] -         The Launcher API should not attempt to pass null environment variables
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6848'>WFCORE-6848</a>] -         In Domain mode applications are distributed twice to the domain&#39;s servers
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6836'>WFCORE-6836</a>] -         Port ResourceModelResolver&lt;T&gt; from wildfly-clustering-common to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6841'>WFCORE-6841</a>] -         Create ServiceDescriptors for capabilities defined in AbstractControllerService
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6844'>WFCORE-6844</a>] -         DeploymentPhaseContext is missing wildfly-service integration
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6831'>WFCORE-6831</a>] -         Upgrade WildFly Elytron to 2.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6833'>WFCORE-6833</a>] -         Upgrade XNIO to 3.8.15.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6835'>WFCORE-6835</a>] -         Upgrade JBoss MSC to 1.5.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6839'>WFCORE-6839</a>] -         Upgrade Byteman to 4.0.23
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6845'>WFCORE-6845</a>] -         Upgrade Apache Commons CLI from 1.6.0 to 1.8.0
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6821'>WFCORE-6821</a>] -         Use a builder to construct the different attributes for the  domain mode reload test suite operation
</li>
</ul>
</details>