### PR TITLE
[WFLY-19221] Incorporate channel metadata in the download zips

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -61,6 +61,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Depends on the org.wildfly.channels:wildfly artifact to ensure
+             that this channel is built first before the distribution is created -->
+        <dependency>
+            <groupId>org.wildfly.channels</groupId>
+            <artifactId>wildfly</artifactId>
+            <version>${full.maven.version}</version>
+            <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -93,22 +109,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -117,13 +120,23 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioningDir>${project.build.directory}/${project.build.finalName}</provisioningDir>
+                            <recordProvisioningState>true</recordProvisioningState>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>
@@ -283,6 +296,14 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- For the dist zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly:${full.maven.version}</wildfly.channels>
+            </properties>
         </profile>
     </profiles>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -130,6 +130,7 @@
                             </galleon-options>
                             <channels>
                                 <channel>
+                                    <name>wildfly</name>
                                     <manifest>
                                         <groupId>${channels.maven.groupId}</groupId>
                                         <artifactId>wildfly</artifactId>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -19,6 +19,7 @@
     9) Schemas coming from a module formerly distributed by the transitive core-galleon-pack are copied to docs/schema
    10) the .galleon dir exists
    11) no .galleon/history dir exists
+   12) the .installation dir exists and contains channel metadata
 -->
   <files>
     <file>
@@ -81,5 +82,23 @@
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.galleon/history</location>
       <exists>false</exists>
     </file>
+    <!-- start of (#12) -->
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/installer-channels.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest_version.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/provisioning_record.xml</location>
+      <exists>true</exists>
+    </file>
+    <!-- end of (#12) -->
   </files>
 </verifications>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -76,8 +76,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -86,9 +87,17 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
-                            <install-dir>${jboss.home}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
+                            <provisioningDir>${jboss.home}</provisioningDir>
+                            <recordProvisioningState>false</recordProvisioningState>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>org.wildfly.channels</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -107,9 +116,6 @@
                                     </included-configs>
                                 </feature-pack>
                             </feature-packs>
-                            <plugin-options>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -127,6 +127,7 @@
                             </galleon-options>
                             <channels>
                                 <channel>
+                                    <name>wildfly-ee</name>
                                     <manifest>
                                         <groupId>${channels.maven.groupId}</groupId>
                                         <artifactId>wildfly-ee</artifactId>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -62,6 +62,19 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>${channels.maven.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -93,22 +106,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -117,13 +117,23 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioning-dir>${project.build.directory}/${project.build.finalName}</provisioning-dir>
+                            <record-provisioning-state>true</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly-ee</artifactId>
+                                        <version>${ee.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
@@ -274,6 +284,14 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- For the dist zip, ignore any external channel setting -->
+            <id>external.channel.profile</id>
+            <activation><property><name>external.wildfly.channels</name></property></activation>
+            <properties>
+                <wildfly.channels>${channels.maven.groupId}:wildfly-ee:${full.maven.version}</wildfly.channels>
+            </properties>
         </profile>
     </profiles>
 

--- a/ee-dist/src/verifier/verifications.xml
+++ b/ee-dist/src/verifier/verifications.xml
@@ -19,6 +19,8 @@
     9) Schemas coming from a module formerly distributed by the transitive core-galleon-pack are copied to docs/schema
    10) the .galleon dir exists
    11) no .galleon/history dir exists
+   12) the .installation dir exists and contains channel metadata
+
 -->
   <files>
     <file>
@@ -113,5 +115,23 @@
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.galleon/history</location>
       <exists>false</exists>
     </file>
+    <!-- start of (#12) -->
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/installer-channels.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest_version.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/provisioning_record.xml</location>
+      <exists>true</exists>
+    </file>
+    <!-- end of (#12) -->
   </files>
 </verifications>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -257,6 +257,19 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Galleon universe dependencies (so that they are present in the channel manifest) -->
+
+        <dependency>
+            <groupId>org.jboss.universe</groupId>
+            <artifactId>community-universe</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.universe.producer</groupId>
+            <artifactId>wildfly-producers</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- module and copy artifact dependencies -->
 
         <dependency>

--- a/galleon-pack/channel/pom.xml
+++ b/galleon-pack/channel/pom.xml
@@ -41,6 +41,17 @@
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
+        <!-- Depends on the org.wildfly.channels:wildfly-ee artifact to ensure
+             that this channel is built first as it is required by the org.wildfly.channels:wildfly channel
+             built by this module -->
+        <dependency>
+            <groupId>org.wildfly.channels</groupId>
+            <artifactId>wildfly-ee</artifactId>
+            <version>${ee.maven.version}</version>
+            <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -246,6 +246,19 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Galleon universe dependencies (so that they are present in the channel manifest) -->
+
+        <dependency>
+            <groupId>org.jboss.universe</groupId>
+            <artifactId>community-universe</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.universe.producer</groupId>
+            <artifactId>wildfly-producers</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- module and copy artifact dependencies -->
 
         <dependency>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -246,19 +246,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Galleon universe dependencies (so that they are present in the channel manifest) -->
-
-        <dependency>
-            <groupId>org.jboss.universe</groupId>
-            <artifactId>community-universe</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.universe.producer</groupId>
-            <artifactId>wildfly-producers</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- module and copy artifact dependencies -->
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,8 @@
         <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.1.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
         <version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>
         <version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.ws.api_4.0_spec>
+        <version.org.jboss.universe.community>1.2.0.Final</version.org.jboss.universe.community>
+        <version.org.jboss.universe.producer.wildfly>1.3.11.Final</version.org.jboss.universe.producer.wildfly>
         <version.org.jboss.weld.weld>5.1.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>5.0.SP3</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>3.0.0.Final</version.org.jboss.ws.api>
@@ -884,6 +886,16 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.jboss.universe</groupId>
+                <artifactId>community-universe</artifactId>
+                <version>${version.org.jboss.universe.community}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.universe.producer</groupId>
+                <artifactId>wildfly-producers</artifactId>
+                <version>${version.org.jboss.universe.producer.wildfly}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -51,6 +51,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Depends on the org.wildfly.channels:wildfly-preview artifact to ensure
+             that this channel is built first before the distribution is created -->
+        <dependency>
+            <groupId>org.wildfly.channels</groupId>
+            <artifactId>wildfly-preview</artifactId>
+            <version>${project.version}</version>
+            <classifier>manifest</classifier>
+            <type>yaml</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -83,22 +100,9 @@
         <finalName>${server.output.dir.prefix}-preview-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <!-- Installation provisioning is vulnerable to leftover files in the target
-                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -107,13 +111,22 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <plugin-options>
+                            <provisioningDir>${project.build.directory}/${project.build.finalName}</provisioningDir>
+                            <recordProvisioningState>true</recordProvisioningState>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>true</offline-provisioning>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <manifest>
+                                        <groupId>org.wildfly.channels</groupId>
+                                        <artifactId>wildfly-preview</artifactId>
+                                        <version>${project.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/preview/dist/pom.xml
+++ b/preview/dist/pom.xml
@@ -120,6 +120,7 @@
                             </galleon-options>
                             <channels>
                                 <channel>
+                                    <name>wildfly-preview</name>
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-preview</artifactId>

--- a/preview/dist/src/verifier/verifications.xml
+++ b/preview/dist/src/verifier/verifications.xml
@@ -19,6 +19,7 @@
     9) Schemas coming from a module formerly distributed by the transitive core-galleon-pack are copied to docs/schema
    10) the .galleon dir exists
    11) no .galleon/history dir exists
+   12) the .installation dir exists and contains channel metadata
 -->
   <files>
     <file>
@@ -113,5 +114,24 @@
       <location>target/${server.output.dir.prefix}-preview-${server.output.dir.version}/.galleon/history</location>
       <exists>false</exists>
     </file>
+    <!-- start of (#12) -->
+    <file>
+      <location>target/${server.output.dir.prefix}-preview-${server.output.dir.version}/.installation/installer-channels.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-preview-${server.output.dir.version}/.installation/manifest.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-preview-${server.output.dir.version}/.installation/manifest_version.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-preview-${server.output.dir.version}/.installation/provisioning_record.xml</location>
+      <exists>true</exists>
+    </file>
+    <!-- end of (#12) -->
+
   </files>
 </verifications>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -269,6 +269,19 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Galleon universe dependencies (so that they are present in the channel manifest) -->
+
+        <dependency>
+            <groupId>org.jboss.universe</groupId>
+            <artifactId>community-universe</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.universe.producer</groupId>
+            <artifactId>wildfly-producers</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- module and copy artifact dependencies -->
 
         <!-- Deps from the source modules we copy in -->

--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -306,18 +306,76 @@
                                 <channel>
                                     <manifest>
                                         <groupId>${channels.maven.groupId}</groupId>
-                                        <artifactId>wildfly-ee</artifactId>
-                                        <version>${ee.maven.version}</version>
-                                    </manifest>
-                                </channel>
-                                <channel>
-                                    <manifest>
-                                        <groupId>${channels.maven.groupId}</groupId>
                                         <artifactId>wildfly</artifactId>
                                         <version>${full.maven.version}</version>
                                     </manifest>
                                 </channel>
                             </channels>
+                            <feature-packs>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>${ee.maven.groupId}</groupId>
+                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                    <version>${ee.maven.version}</version>
+                                    <included-packages>
+                                        <name>docs.examples.configs</name>
+                                    </included-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <groupId>${full.maven.groupId}</groupId>
+                                    <artifactId>wildfly-galleon-pack</artifactId>
+                                    <version>${full.maven.version}</version>
+                                    <included-packages>
+                                        <name>docs.examples.configs</name>
+                                    </included-packages>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- galleon-maven-plugin installation provisioning is vulnerable to leftover files in the target
+                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-wildfly-without-channel</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/wildfly-without-channel</directory>
+                                    <follow-symlinks>false</follow-symlinks>
+                                    <use-default-excludes>false</use-default-excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>channel-provisioning-comparison</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>${channel.provisioning.phase}</phase>
+                        <configuration>
+                            <install-dir>${project.build.directory}/wildfly-without-channel</install-dir>
+                            <record-state>true</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </plugin-options>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -422,44 +422,6 @@
                                 <!-- TODO needing to add this seems not user-friendly -->
                                 <ignore-not-excluded-layers>true</ignore-not-excluded-layers>
                             </galleon-options>
-                        <channels>
-                        <channel>
-                            <manifest>
-                                <groupId>${channels.maven.groupId}</groupId>
-                                <artifactId>wildfly-ee</artifactId>
-                                <version>${ee.maven.version}</version>
-                            </manifest>
-                        </channel>
-                        <channel>
-                            <manifest>
-                                 <url>${project.baseUri}/target/test-classes/product-conf-override-manifest.yaml</url>
-                            </manifest>
-                        </channel>
-                        </channels>
-                        <feature-packs>
-                            <feature-pack>
-                                <groupId>${ee.maven.groupId}</groupId>
-                                <artifactId>wildfly-ee-galleon-pack</artifactId>
-                                <version>${ee.maven.version}</version>
-                            </feature-pack>
-                        </feature-packs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>channel-provisioning-comparison</id>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                        <phase>${channel.provisioning.phase}</phase>
-                        <configuration>
-                            <provisioning-dir>${project.build.directory}/wildfly-from-channel</provisioning-dir>
-                            <record-provisioning-state>true</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>true</offline-provisioning>
-                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
-                            <galleon-options>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </galleon-options>
                             <channels>
                                 <channel>
                                     <manifest>
@@ -468,7 +430,69 @@
                                         <version>${ee.maven.version}</version>
                                     </manifest>
                                 </channel>
+                                <channel>
+                                    <manifest>
+                                        <url>${project.baseUri}/target/test-classes/product-conf-override-manifest.yaml</url>
+                                    </manifest>
+                                </channel>
                             </channels>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>${ee.maven.groupId}</groupId>
+                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                    <version>${ee.maven.version}</version>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!-- galleon-maven-plugin installation provisioning is vulnerable to leftover files in the target
+                     folder from previous builds, so always clean even if the clean lifecycle is not invoked -->
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-wildfly-without-channel</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/wildfly-without-channel</directory>
+                                    <follow-symlinks>false</follow-symlinks>
+                                    <use-default-excludes>false</use-default-excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-maven-plugin</artifactId>
+                <executions>
+                    <!-- Provision an installation not using a channel to check that
+                         channel-based provisioning provides the same results as provisioning
+                         from the version included in the feature pack. -->
+                    <execution>
+                        <id>channel-provisioning-comparison</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>${channel.provisioning.phase}</phase>
+                        <configuration>
+                            <install-dir>${project.build.directory}/wildfly-without-channel</install-dir>
+                            <record-state>true</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                            </plugin-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${ee.maven.groupId}</groupId>

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
@@ -45,11 +45,11 @@ public abstract class ProvisioningConsistencyBaseTest {
     private static final String INSTALLATION = ".installation";
     private static final String PROVISIONING = ".wildfly-maven-plugin-provisioning.xml";
     private static final Path JBOSS_HOME = resolveJBossHome();
-    private static final Path CHANNEL_INSTALLATION = JBOSS_HOME.getParent().resolve("wildfly-from-channel");
-    private static final Path INSTALLATION_METADATA = CHANNEL_INSTALLATION.resolve(INSTALLATION);
-    private static final Path PROVISIONING_XML = CHANNEL_INSTALLATION.resolve(PROVISIONING);
+    private final Path CHANNEL_INSTALLATION;
+    private final Path INSTALLATION_METADATA;
+    private final Path PROVISIONING_XML;
     private static final Path SOURCE_HOME = JBOSS_HOME.getParent().getParent().getParent().getParent().getParent();
-    private final Path DIST_INSTALLATION;
+    private static final Path DIST_INSTALLATION = JBOSS_HOME.getParent().resolve("wildfly-without-channel");
 
     private static Path resolveJBossHome() {
         try {
@@ -60,7 +60,9 @@ public abstract class ProvisioningConsistencyBaseTest {
     }
 
     protected ProvisioningConsistencyBaseTest(String targetDist) {
-        DIST_INSTALLATION = SOURCE_HOME.resolve(targetDist);
+        CHANNEL_INSTALLATION = SOURCE_HOME.resolve(targetDist);
+        INSTALLATION_METADATA = CHANNEL_INSTALLATION.resolve(INSTALLATION);
+        PROVISIONING_XML = CHANNEL_INSTALLATION.resolve(PROVISIONING);
     }
 
     /**


### PR DESCRIPTION
* WildFly full distribution is built using the wildfly-maven-plugin based on the org.wildfly.channels:wildfly channel.
* WildFly ee distribution is built using the wildfly-maven-plugin based on the org.wildfly.channels:wildfly-ee channel.
* WildFly Preview distribution is built based on the org.wildfly.channels:wildfly-preview channel

preview/dist and dist poms depends on the channels artifacts to ensure that they are build first so that the distributions can use them during provisioning.

This is required for https://github.com/wildfly/wildfly-proposals/pull/577

JIRA: https://issues.redhat.com/browse/WFLY-19221
