### PR TITLE
WFLY-19392: jboss.as.jpa.classtransformer should be considered to be set if any hibernate.enhancer.* persistence unit properties are set to true

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -7,6 +7,7 @@ package org.jboss.as.jpa.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -227,6 +228,7 @@ public class Configuration {
     // key = provider class name, value = module name
     private static final Map<String, String> providerClassToModuleName = new HashMap<String, String>();
     private static final String HIBERNATE = "Hibernate";
+    private static final String HIBERNATE_ENHANCER = "hibernate.enhancer";
 
     static {
         // always choose the default hibernate version for the Hibernate provider class mapping
@@ -271,10 +273,30 @@ public class Configuration {
             return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
         }
         if (isHibernateProvider(pu.getPersistenceProviderClassName())) {
-            return false;
+
+            return isAnyHibernateEnhancerPropertySpecified(pu);
         }
         return true;
     }
+
+    /**
+     * Consider jboss.as.jpa.classtransformer to be set to true if any hibernate.enhancer properties are set to true.
+     *
+     * @param pu
+     * @return true if any hibernate.enhancer property is detected otherwise return false
+     */
+    private static boolean isAnyHibernateEnhancerPropertySpecified(PersistenceUnitMetadata pu) {
+
+        Set<String> set = pu.getProperties().stringPropertyNames();
+        for (String key : set) {
+            if (key.startsWith(HIBERNATE_ENHANCER) &&
+                    (true == Boolean.parseBoolean(pu.getProperties().getProperty(key)))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean isHibernateProvider(String provider) {
         // If the persistence provider is not specified (null case), Hibernate ORM will be used as the persistence provider.
         return provider == null || provider.contains(HIBERNATE);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/SFSB1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/SFSB1.java
@@ -57,7 +57,7 @@ public class SFSB1 {
         em.flush();         // should throw TransactionRequiredException
     }
 
-    public void createEmployee(String name, String address, int id) {
+    public Company createEmployee(String name, String address, int id) {
 
 
         Employee emp = new Employee();
@@ -80,7 +80,7 @@ public class SFSB1 {
         } catch (Exception e) {
             throw new RuntimeException("couldn't start tx", e);
         }
-
+        return theCompany;
     }
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19392 adds a workaround that will enable `bytecode enhancement` which may help some applications that are already specifying any of the "hibernate.enhancer.*" persistence unit hints.  If any of these hints are specified, then WildFly will setup https://jakarta.ee/specifications/persistence/3.1/apidocs/jakarta.persistence/jakarta/persistence/spi/classtransformer to be used by Hibernate ORM to do the "bytecode enhancement".  



