### PR TITLE
[WFLY-19403] Upgrade WildFly Preview to jakarta.validation:jakarta.validation-api 3.1.0

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -47,7 +47,7 @@
         <!-- TODO requires a Jastow upgrade to remove PageContextImpl.getVariableResolver()
         <version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>4.0.0-M2</version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
         -->
-        <version.jakarta.validation.jakarta-validation-api>3.1.0-M2</version.jakarta.validation.jakarta-validation-api>
+        <version.jakarta.validation.jakarta-validation-api>3.1.0</version.jakarta.validation.jakarta-validation-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.2.0-M1</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.org.glassfish.jakarta.faces>4.1.0-M1</version.org.glassfish.jakarta.faces>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19403

This is against the EE11 branch as PRs against that branch result in CI jobs focused on WFP, which is what this updates.

I will combine this and a number of other PRs like this into a single aggregate PR to update main.

