### PR TITLE
[WFLY-19402] Upgrade WildFly Preview to jakarta.persistence:jakarta-p…

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -41,7 +41,7 @@
         <version.jakarta.enterprise>4.1.0</version.jakarta.enterprise>
         <version.jakarta.faces.jakarta-faces-api>4.1.0-M1</version.jakarta.faces.jakarta-faces-api>
         <version.jakarta.interceptor.jakarta-interceptors-api>2.2.0</version.jakarta.interceptor.jakarta-interceptors-api>
-        <version.jakarta.persistence>3.2.0-M2</version.jakarta.persistence>
+        <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
         <version.jakarta.security.enterprise>4.0.0-M2</version.jakarta.security.enterprise>
         <version.jakarta.servlet.jakarta-servlet-api>6.1.0-M2</version.jakarta.servlet.jakarta-servlet-api>
         <!-- TODO requires a Jastow upgrade to remove PageContextImpl.getVariableResolver()


### PR DESCRIPTION
…ersistence-api 3.2.0

https://issues.redhat.com/browse/WFLY-19402

This is against the EE11 branch as PRs against that branch result in CI jobs focused on WFP, which is what this updates.

I will combine this and a number of other PRs like this into a single aggregate PR to update main.
