### PR TITLE
Fix for WFLY-19423, Upgrade to Galleon Plugins 7.1.0.Final

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -182,9 +182,6 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability-level>experimental</minimum-stability-level>
-                            <config-stability-level>community</config-stability-level>
-                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/ee-feature-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.3" producer="wildfly-ee@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.4" producer="wildfly-ee@maven(org.jboss.universe:community-universe):current">
 
     <default-packages>
         <package name="modules.all"/>
@@ -14,6 +14,11 @@
         <package name="bin"/>
     </default-packages>
 
+    <stability-levels>
+        <minimum-stability-level>experimental</minimum-stability-level>
+        <config-stability-level>community</config-stability-level>
+        <package-stability-level>experimental</package-stability-level>
+    </stability-levels>
     <!--
       When building this feature pack the WildFly Galleon Plugin generates a docs.schema Galleon package,
       which is used to provision the contents of the 'docs/schema' directory in a WildFly installation.

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -194,9 +194,6 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability-level>experimental</minimum-stability-level>
-                            <config-stability-level>community</config-stability-level>
-                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/galleon-feature-pack/wildfly-feature-pack-build.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="wildfly@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.4" producer="wildfly@maven(org.jboss.universe:community-universe):current">
 
     <dependencies>
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
@@ -35,6 +35,11 @@
         <package name="docs.examples"/>
     </default-packages>
 
+    <stability-levels>
+        <minimum-stability-level>experimental</minimum-stability-level>
+        <config-stability-level>community</config-stability-level>
+        <package-stability-level>experimental</package-stability-level>
+    </stability-levels>
     <!--
       When building this feature pack the WildFly Galleon Plugin generates a docs.schema Galleon package,
       which is used to provision the contents of the 'docs/schema' directory in a WildFly installation.

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Final</version.org.wildfly.plugin>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -213,9 +213,6 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
-                            <minimum-stability-level>experimental</minimum-stability-level>
-                            <config-stability-level>preview</config-stability-level>
-                            <package-stability-level>experimental</package-stability-level>
                         </configuration>
                     </execution>
                 </executions>

--- a/preview/feature-pack/wildfly-feature-pack-build.xml
+++ b/preview/feature-pack/wildfly-feature-pack-build.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="wildfly-preview@maven(org.jboss.universe:community-universe):current">
+<build xmlns="urn:wildfly:feature-pack-build:3.4" producer="wildfly-preview@maven(org.jboss.universe:community-universe):current">
 
     <default-packages>
         <package name="modules.all"/>
@@ -14,6 +14,11 @@
         <package name="bin"/>
     </default-packages>
 
+    <stability-levels>
+        <minimum-stability-level>experimental</minimum-stability-level>
+        <config-stability-level>preview</config-stability-level>
+        <package-stability-level>experimental</package-stability-level>
+    </stability-levels>
     <!--
       When building this feature pack the WildFly Galleon Plugin generates a docs.schema Galleon package,
       which is used to provision the contents of the 'docs/schema' directory in a WildFly installation.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19423

The stability information currently located in the maven plugin configuration has been moved to the wildfly-feature-pack-build.xml file. These are not options you should control from Maven.