### PR TITLE
WFLY-19425: update model definition and bump schema

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -97,6 +97,7 @@ public class JcaExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.JCA_4_0.getUriString(), () -> ConnectorSubsystemParser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.JCA_5_0.getUriString(), () -> ConnectorSubsystemParser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.JCA_6_0.getUriString(), () -> ConnectorSubsystemParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.JCA_6_1.getUriString(), () -> ConnectorSubsystemParser.INSTANCE);
     }
 
     static final class ConnectorSubsystemParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>,
@@ -309,6 +310,7 @@ public class JcaExtension implements Extension {
             while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
                 Namespace readerNs = Namespace.forUri(reader.getNamespaceURI());
                 switch (readerNs) {
+                    case JCA_6_1:
                     case JCA_6_0:
                     case JCA_5_0:
                     case JCA_4_0:
@@ -371,7 +373,8 @@ public class JcaExtension implements Extension {
                                 if (Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_3_0) ||
                                     Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_4_0) ||
                                     Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_5_0) ||
-                                    Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_6_0))
+                                    Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_6_0) ||
+                                    Namespace.forUri(reader.getNamespaceURI()).equals(Namespace.JCA_6_1))
                                 {
                                     list.add(parseTracer(reader, address));
                                 } else {
@@ -512,7 +515,8 @@ public class JcaExtension implements Extension {
                     case ELYTRON_ENABLED: {
                         switch (readerNS) {
                             case JCA_5_0:
-                            case JCA_6_0: {
+                            case JCA_6_0:
+                            case JCA_6_1: {
                                 String value = rawElementText(reader);
                                 JcaWorkManagerDefinition.WmParameters.ELYTRON_ENABLED.getAttribute().parseAndSetParameter(value, workManagerOperation, reader);
                                 break;
@@ -605,7 +609,8 @@ public class JcaExtension implements Extension {
                             case JCA_3_0:
                             case JCA_4_0:
                             case JCA_5_0:
-                            case JCA_6_0:{
+                            case JCA_6_0:
+                            case JCA_6_1:{
                                 parsePolicy(reader, distributedWorkManagerOperation);
                                 break;
                             }
@@ -621,7 +626,8 @@ public class JcaExtension implements Extension {
                             case JCA_3_0:
                             case JCA_4_0:
                             case JCA_5_0:
-                            case JCA_6_0:{
+                            case JCA_6_0:
+                            case JCA_6_1:{
                                 parseSelector(reader, distributedWorkManagerOperation);
                                 break;
                             }
@@ -635,6 +641,7 @@ public class JcaExtension implements Extension {
                         switch (readerNS) {
                             case JCA_5_0:
                             case JCA_6_0:
+                            case JCA_6_1:
                             {
                                 String value = rawElementText(reader);
                                 ((SimpleAttributeDefinition) JcaDistributedWorkManagerDefinition.DWmParameters.ELYTRON_ENABLED.getAttribute()).parseAndSetParameter(value, distributedWorkManagerOperation, reader);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/Namespace.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/Namespace.java
@@ -27,13 +27,15 @@ public enum Namespace {
 
     JCA_5_0("urn:jboss:domain:jca:5.0"),
 
-    JCA_6_0("urn:jboss:domain:jca:6.0");
+    JCA_6_0("urn:jboss:domain:jca:6.0"),
+
+    JCA_6_1("urn:jboss:domain:jca:6.1");
 
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = JCA_6_0;
+    public static final Namespace CURRENT = JCA_6_1;
 
     private final String name;
 

--- a/connector/src/main/resources/schema/wildfly-jca_6_1.xsd
+++ b/connector/src/main/resources/schema/wildfly-jca_6_1.xsd
@@ -1,0 +1,382 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:jca:6.1"
+           xmlns="urn:jboss:domain:jca:6.1"
+           xmlns:threads="urn:jboss:domain:threads:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="2.0">
+
+    <xs:import namespace="urn:jboss:domain:threads:1.1" schemaLocation="jboss-as-threads_1_1.xsd"/>
+
+    <xs:element name="subsystem" type="subsystemType"/>
+
+    <xs:complexType name="subsystemType">
+        <xs:sequence>
+            <xs:element name="archive-validation"
+                        type="archive-validationType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Toggle archive validation for the deployment
+                        units. If it's not present it's considered true
+                        with default attributes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="bean-validation"
+                        type="bean-validationType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Toggle bean validation (JSR-303) for the
+                        deployment units. If it's not present it's
+                        considered true
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="tracer"
+                        type="tracer-Type" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Toggle Tracer for the
+                        deployment units. If it's not present it's
+                        considered false
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="default-workmanager" type="defaultWorkmanagerType" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The default work manager and its thread pools
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="workmanager" type="workmanagerType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A custom work manager definition and its thread pools
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="distributed-workmanager" type="distributedWorkmanagerType" minOccurs="0"
+                        maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A distributed work manager definition and its thread pools
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="bootstrap-contexts" type="bootstrap-contextsType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Definition of custom bootstrap contexts
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="cached-connection-manager" type="cached-connection-managerType" minOccurs="0" maxOccurs="1"></xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="archive-validationType">
+        <xs:attribute name="enabled" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Specify whether archive validation is enabled.  Default: true
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fail-on-error" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Should an archive validation error report fail the deployment. Default: true
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fail-on-warn" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Should an archive validation warning report fail the deployment. Default: false
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bean-validationType">
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specify whether bean validation is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="tracer-Type">
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specify whether tracer is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="defaultWorkmanagerType">
+        <xs:all>
+            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for short running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="long-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for long running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Indicates that Elytron is responsible for security for this workmanager. Default is true
+                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerType">
+        <xs:all>
+            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for short running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="long-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for long running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Indicates that Elytron is responsible for security for this workmanager. Default is true
+                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the name of the work manager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="distributedWorkmanagerType">
+        <xs:all>
+            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for short running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="long-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Thread pool for long running jobs.
+                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="policy" type="policyType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="selector" type="selectorType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Indicates that Elytron is responsible for security for this workmanager. Default is false
+                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the name of the work manager. Note, that custom work managers need
+                    to have a name defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bootstrap-contextsType">
+        <xs:sequence>
+            <xs:element name="bootstrap-context" type="bootstrap-contextType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="bootstrap-contextType">
+        <xs:annotation>
+            <xs:documentation>
+                This provides a mechanism to pass a bootstrap context to a resource adapter instance when it is bootstrapped.
+                The bootstrap context contains references to useful facilities that could be used by the resource adapter instance.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the name of the bootstrap context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="workmanager" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the name of the work manager to use for this context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cached-connection-managerType">
+        <xs:attribute name="debug" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable/disable debug information logging
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="error" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable/disable error information logging
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ignore-unknown-connections" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Do not cache unknown connections
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                See threads:blocking-bounded-queue-thread-pool.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="core-threads" type="threads:countType" minOccurs="0"/>
+            <xs:element name="queue-length" type="threads:countType"/>
+            <xs:element name="max-threads" type="threads:countType"/>
+            <xs:element name="keepalive-time" type="threads:time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="threads:ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="allow-core-timeout" use="optional" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="policyType">
+        <xs:sequence>
+            <xs:element name="option" type="optionType" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    When to distribute the work instance
+                    Supported policies
+                    - NEVER
+                    Never distribute the Work instance to another node.
+                    - ALWAYS
+                    Always distribute the Work instance to another node.
+                    - WATERMARK
+                    Distribute the Work instance to another node based on how many free worker threads the current
+                    node has available.
+
+                    Default is WATERMARK with a watermark of 0
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="NEVER"/>
+                    <xs:enumeration value="ALWAYS"/>
+                    <xs:enumeration value="WATERMARK"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+
+
+    </xs:complexType>
+    <xs:complexType name="selectorType">
+        <xs:sequence>
+            <xs:element name="option" type="optionType" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    To which work manager instance should the Work instance be distributed to
+                    Supported selectors
+                    - FIRST_AVAILABLE
+                    Select the first available node in the list
+                    - PING_TIME
+                    Select the node with the lowest ping time
+                    - MAX_FREE_THREADS
+                    Select the node with highest number of free worker threads
+
+                    Default is PING_TIME
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="FIRST_AVAILABLE"/>
+                    <xs:enumeration value="PING_TIME"/>
+                    <xs:enumeration value="MAX_FREE_THREADS"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="optionType">
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the option to be set
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/connector/src/main/resources/schema/wildfly-jca_6_1.xsd
+++ b/connector/src/main/resources/schema/wildfly-jca_6_1.xsd
@@ -29,8 +29,7 @@
                 </xs:annotation>
             </xs:element>
 
-            <xs:element name="bean-validation"
-                        type="bean-validationType" minOccurs="0">
+            <xs:element name="bean-validation" type="enabledType" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Toggle bean validation (JSR-303) for the
@@ -40,8 +39,7 @@
                 </xs:annotation>
             </xs:element>
 
-            <xs:element name="tracer"
-                        type="tracer-Type" minOccurs="0">
+            <xs:element name="tracer" type="enabledType" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Toggle Tracer for the
@@ -84,7 +82,7 @@
                 </xs:annotation>
             </xs:element>
 
-            <xs:element name="cached-connection-manager" type="cached-connection-managerType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="cached-connection-manager" type="cached-connection-managerType" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -112,21 +110,11 @@
         </xs:attribute>
     </xs:complexType>
 
-    <xs:complexType name="bean-validationType">
+    <xs:complexType name="enabledType">
         <xs:attribute name="enabled" type="xs:boolean" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    Specify whether bean validation is enabled.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="tracer-Type">
-        <xs:attribute name="enabled" type="xs:boolean" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    Specify whether tracer is enabled.
+                    Specify whether this part is enabled.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -134,7 +122,7 @@
 
     <xs:complexType name="defaultWorkmanagerType">
         <xs:all>
-            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
+            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Thread pool for short running jobs.
@@ -150,7 +138,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
+            <xs:element name="elytron-enabled" type="xs:boolean" default="true" maxOccurs="1" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         <![CDATA[[
@@ -163,45 +151,22 @@
     </xs:complexType>
 
     <xs:complexType name="workmanagerType">
-        <xs:all>
-            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        Thread pool for short running jobs.
-                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="long-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>
-                        Thread pool for long running jobs.
-                        Long running jobs are identified by the HintsContext.LONGRUNNING_HINT with a value of true.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>
-                        <![CDATA[[
-                Indicates that Elytron is responsible for security for this workmanager. Default is true
-                ]]>
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:all>
-        <xs:attribute name="name" type="xs:token" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    Specifies the name of the work manager.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+        <xs:complexContent>
+            <xs:extension base="defaultWorkmanagerType">
+                <xs:attribute name="name" type="xs:token" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the name of the work manager.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="distributedWorkmanagerType">
         <xs:all>
-            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="1">
+            <xs:element name="short-running-threads" type="thread-pool" maxOccurs="1" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Thread pool for short running jobs.
@@ -217,13 +182,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="policy" type="policyType" maxOccurs="1" minOccurs="0" />
-            <xs:element name="selector" type="selectorType" maxOccurs="1" minOccurs="0" />
-            <xs:element name="elytron-enabled" type="xs:boolean" maxOccurs="1" minOccurs="0">
+            <xs:element name="policy" type="policyType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="selector" type="selectorType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="elytron-enabled" type="xs:boolean" default="true" maxOccurs="1" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         <![CDATA[[
-                Indicates that Elytron is responsible for security for this workmanager. Default is false
+                Indicates that Elytron is responsible for security for this workmanager. Default is true
                 ]]>
                     </xs:documentation>
                 </xs:annotation>
@@ -241,7 +206,7 @@
 
     <xs:complexType name="bootstrap-contextsType">
         <xs:sequence>
-            <xs:element name="bootstrap-context" type="bootstrap-contextType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+            <xs:element name="bootstrap-context" type="bootstrap-contextType" maxOccurs="unbounded" minOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -338,8 +303,6 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-
-
     </xs:complexType>
     <xs:complexType name="selectorType">
         <xs:sequence>
@@ -371,12 +334,16 @@
     </xs:complexType>
 
     <xs:complexType name="optionType">
-        <xs:attribute name="name" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    Name of the option to be set
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute name="name" type="xs:token" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Name of the option to be set
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
 </xs:schema>

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -49,7 +49,7 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-jca_6_0.xsd";
+        return "schema/wildfly-jca_6_1.xsd";
     }
 
     @Override

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -44,7 +44,7 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("jca.xml");
+        return readResource("jca-full.xml");
     }
 
     @Override

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/jca.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/jca.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
             <bean-validation enabled="true"/>
             <default-workmanager>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/minimal-jca.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/minimal-jca.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
             <default-workmanager>
                 <short-running-threads>
                     <queue-length count="50"/>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-default-elytron.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-default-elytron.xml
@@ -3,10 +3,10 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
     <default-workmanager>
         <!-- test empty value -->
-        <elytron-enabled></elytron-enabled>
+        <elytron-enabled/>
         <short-running-threads allow-core-timeout="true">
             <!--Optional:-->
             <core-threads count="3"/>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-full-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-full-expression.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
   <!--Optional:-->
   <archive-validation enabled="${test.expr:true}" fail-on-error="${test.expr:true}" fail-on-warn="${test.expr:false}"/>
   <!--Optional:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-full.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-full.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
   <!--Optional:-->
   <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
   <!--Optional:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-minimal.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca-minimal.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
     <default-workmanager>
         <short-running-threads>
             <core-threads count="50"/>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/jca/jca.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:jca:6.0">
+<subsystem xmlns="urn:jboss:domain:jca:6.1">
     <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
     <bean-validation enabled="true"/>
     <default-workmanager>


### PR DESCRIPTION
Issue: [WFLY-19425](https://issues.redhat.com/browse/WFLY-19425)

The major change here is changing the `option` element in xsd to allow text content (since that's how we write down the key-value pair), and some smaller changes dealing with default values and wrongly declared minimal occurrences.

The second commit is just refactoring the schema since there are some needless repetitions, ideally the `distributed-workmanager` would also just extend `workmanager` but that's not possible without imposing an order on the child elements and that would also require a change in the writer (although I guess the writer always has some implicit order to it, so maybe we should never be using `xs:all`). I will squash it into one commit but wanted to keep it separate for easier comparison.