### PR TITLE
WFLY-19419 Distributed timer service should consolidate timeouts that would execute in the past

### DIFF
--- a/clustering/ejb/cache/src/main/java/org/wildfly/clustering/ejb/cache/timer/IntervalTimerMetaDataEntry.java
+++ b/clustering/ejb/cache/src/main/java/org/wildfly/clustering/ejb/cache/timer/IntervalTimerMetaDataEntry.java
@@ -19,7 +19,8 @@ public class IntervalTimerMetaDataEntry<C> extends AbstractTimerMetaDataEntry<C>
     private final Duration interval;
 
     public IntervalTimerMetaDataEntry(C context, IntervalTimerConfiguration config) {
-        this(context, config.getStart(), config.getInterval());
+        super(context, config);
+        this.interval = config.getInterval();
     }
 
     public IntervalTimerMetaDataEntry(C context, Instant start, Duration interval) {

--- a/clustering/ejb/cache/src/main/java/org/wildfly/clustering/ejb/cache/timer/ScheduleTimerOperatorFactory.java
+++ b/clustering/ejb/cache/src/main/java/org/wildfly/clustering/ejb/cache/timer/ScheduleTimerOperatorFactory.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.clustering.ejb.cache.timer;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.time.Instant;
 import java.util.ServiceLoader;
 import java.util.function.UnaryOperator;
@@ -25,7 +27,12 @@ public enum ScheduleTimerOperatorFactory implements ScheduleTimerOperationProvid
     }
 
     private static ScheduleTimerOperationProvider load() {
-        return ServiceLoader.load(ScheduleTimerOperationProvider.class, ScheduleTimerOperationProvider.class.getClassLoader()).findFirst().orElseThrow(IllegalStateException::new);
+        return AccessController.doPrivileged(new PrivilegedAction<>() {
+            @Override
+            public ScheduleTimerOperationProvider run() {
+                return ServiceLoader.load(ScheduleTimerOperationProvider.class, ScheduleTimerOperationProvider.class.getClassLoader()).findFirst().orElseThrow(IllegalStateException::new);
+            }
+        });
     }
 
     @Override

--- a/clustering/ejb/cache/src/test/java/org/wildfly/clustering/ejb/cache/timer/AbstractIntervalTimerMetaDataEntryTestCase.java
+++ b/clustering/ejb/cache/src/test/java/org/wildfly/clustering/ejb/cache/timer/AbstractIntervalTimerMetaDataEntryTestCase.java
@@ -7,6 +7,7 @@ package org.wildfly.clustering.ejb.cache.timer;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,7 +27,7 @@ public abstract class AbstractIntervalTimerMetaDataEntryTestCase extends Abstrac
 
     @Parameters
     public static Iterable<IntervalTimerConfiguration> parameters() {
-        Instant start = Instant.now();
+        Instant start = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         return List.of(new IntervalTimerConfiguration() {
             @Override
             public Instant getStart() {

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
@@ -138,7 +138,7 @@ public class TimerScheduler<I, V, C> extends AbstractCacheEntryScheduler<I, Immu
 
                         // Safeguard : ensure timeout was not already triggered elsewhere
                         if (currentTimeoutReference.isEmpty()) {
-                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Unexpected timeout event triggered.", id);
+                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Unexpected timeout event triggered for %s", id);
                             return false;
                         }
                         Instant currentTimeout = currentTimeoutReference.get();
@@ -149,9 +149,9 @@ public class TimerScheduler<I, V, C> extends AbstractCacheEntryScheduler<I, Immu
 
                         Timer<I> timer = factory.createTimer(id, metaData, manager, scheduler);
 
-                        InfinispanEjbLogger.ROOT_LOGGER.debugf("Triggering timeout for timer %s [%s]", id, timer.getMetaData().getContext());
+                        InfinispanEjbLogger.ROOT_LOGGER.debugf("Triggering timeout for timer %s @ %s", id, currentTimeout);
 
-                        // In case we need to reset the last timeout
+                        // Capture original last timeout in case we need to reset it
                         Optional<Instant> lastTimeout = metaData.getLastTimeout();
                         // Record last timeout - expected to be set prior to triggering timeout
                         metaData.setLastTimeout(currentTimeout);
@@ -166,6 +166,7 @@ public class TimerScheduler<I, V, C> extends AbstractCacheEntryScheduler<I, Immu
                             InfinispanEjbLogger.ROOT_LOGGER.debugf("EJB component is suspended - could not invoke timeout for timer %s", id);
                             // Reset last timeout
                             metaData.setLastTimeout(lastTimeout.orElse(null));
+                            batch.discard();
                             return false;
                         }
 

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/timer/TimerScheduler.java
@@ -141,43 +141,50 @@ public class TimerScheduler<I, V, C> extends AbstractCacheEntryScheduler<I, Immu
                             InfinispanEjbLogger.ROOT_LOGGER.debugf("Unexpected timeout event triggered for %s", id);
                             return false;
                         }
+
+                        Instant now = Instant.now();
                         Instant currentTimeout = currentTimeoutReference.get();
-                        if (currentTimeout.isAfter(Instant.now())) {
-                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Timeout for timer %s initiated prematurely.", id);
+                        if (currentTimeout.isAfter(now)) {
+                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Timeout for timer %s initiated prematurely @ %s", id, currentTimeout);
                             return false;
                         }
 
-                        Timer<I> timer = factory.createTimer(id, metaData, manager, scheduler);
-
-                        InfinispanEjbLogger.ROOT_LOGGER.debugf("Triggering timeout for timer %s @ %s", id, currentTimeout);
-
-                        // Capture original last timeout in case we need to reset it
-                        Optional<Instant> lastTimeout = metaData.getLastTimeout();
-                        // Record last timeout - expected to be set prior to triggering timeout
+                        // Capture previous last timeout in case we need to reset it
+                        Optional<Instant> originalLastTimeout = metaData.getLastTimeout();
+                        // Record new last timeout - expected to be set prior to triggering timeout
                         metaData.setLastTimeout(currentTimeout);
-
-                        try {
-                            timer.invoke();
-                        } catch (ExecutionException e) {
-                            // Log error and proceed as if it was successful
-                            InfinispanEjbLogger.ROOT_LOGGER.error(e.getLocalizedMessage(), e);
-                        } catch (RejectedExecutionException e) {
-                            // Component is not started or is suspended
-                            InfinispanEjbLogger.ROOT_LOGGER.debugf("EJB component is suspended - could not invoke timeout for timer %s", id);
-                            // Reset last timeout
-                            metaData.setLastTimeout(lastTimeout.orElse(null));
-                            batch.discard();
-                            return false;
-                        }
-
-                        // If timeout callback canceled this timer
-                        if (timer.isCanceled()) {
-                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Timeout callback canceled timer %s", id);
-                            return true;
-                        }
 
                         // Determine next timeout
                         Optional<Instant> nextTimeout = metaData.getNextTimeout();
+                        // WFLY-19361: If next timeout is in the past do not trigger event
+                        if (nextTimeout.orElse(now).isBefore(now)) {
+                            // This has the effect of consolidating missed timeouts into a single event
+                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Skipping notification of missed timeout for timer %s @ %s", id, currentTimeout);
+                        } else {
+                            InfinispanEjbLogger.ROOT_LOGGER.debugf("Triggering timeout for timer %s @ %s", id, currentTimeout);
+
+                            Timer<I> timer = factory.createTimer(id, metaData, manager, scheduler);
+                            try {
+                                timer.invoke();
+                            } catch (ExecutionException e) {
+                                // Log error and proceed as if it was successful
+                                InfinispanEjbLogger.ROOT_LOGGER.error(e.getLocalizedMessage(), e);
+                            } catch (RejectedExecutionException e) {
+                                // Component is not started or is suspended
+                                InfinispanEjbLogger.ROOT_LOGGER.debugf("EJB component is suspended - could not invoke timeout for timer %s", id);
+                                // Reset last timeout
+                                metaData.setLastTimeout(originalLastTimeout.orElse(null));
+                                batch.discard();
+                                return false;
+                            }
+
+                            // If timeout callback canceled this timer
+                            if (timer.isCanceled()) {
+                                InfinispanEjbLogger.ROOT_LOGGER.debugf("Timeout callback canceled timer %s", id);
+                                return true;
+                            }
+                        }
+
                         if (nextTimeout.isEmpty()) {
                             InfinispanEjbLogger.ROOT_LOGGER.debugf("Timer %s has expired", id);
                             registry.unregister(id);
@@ -192,7 +199,7 @@ public class TimerScheduler<I, V, C> extends AbstractCacheEntryScheduler<I, Immu
                         }
 
                         // Reschedule using next timeout
-                        InfinispanEjbLogger.ROOT_LOGGER.debugf("Rescheduling timer %s for next timeout %s", id, nextTimeout);
+                        InfinispanEjbLogger.ROOT_LOGGER.debugf("Rescheduling timer %s for next timeout %s", id, nextTimeout.get());
                         entries.add(id, nextTimeout.get());
                         return false;
                     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/CalendarTimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/CalendarTimerTask.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import org.jboss.as.ejb3.timerservice.schedule.CalendarBasedTimeout;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
 
 /**
@@ -52,14 +53,17 @@ public class CalendarTimerTask extends TimerTask {
         if (currentTimeout == null) {
             return null;
         }
-        Calendar cal = new GregorianCalendar();
-        cal.setTime(currentTimeout);
-        // now compute the next timeout date
-        Calendar nextTimeout = ((CalendarTimer) timer).getCalendarTimeout().getNextTimeout(cal);
-        if (nextTimeout != null) {
-            return nextTimeout.getTime();
-        }
-        return null;
+        Calendar nextTimeout = new GregorianCalendar();
+        nextTimeout.setTime(currentTimeout);
+
+        CalendarBasedTimeout timeout = ((CalendarTimer) timer).getCalendarTimeout();
+        Date now = new Date();
+        do {
+            nextTimeout = timeout.getNextTimeout(nextTimeout);
+            // Ensure next timeout is in the future
+        } while ((nextTimeout != null) && nextTimeout.getTime().before(now));
+
+        return (nextTimeout != null) ? nextTimeout.getTime() : null;
     }
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/AbstractTimerServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/AbstractTimerServiceTestCase.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -39,6 +40,7 @@ import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerBean;
 import org.jboss.as.test.clustering.cluster.ejb.timer.servlet.TimerServlet;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -60,6 +62,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
                 ;
     }
 
+    private static final Duration GRACE_PERIOD = Duration.ofSeconds(TimeoutUtil.adjust(2));
     private final String moduleName;
 
     protected AbstractTimerServiceTestCase() {
@@ -77,7 +80,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             // Create manual timers on node 1 only
             try (CloseableHttpResponse response = client.execute(new HttpPut(uris.get(NODE_1)))) {
@@ -98,7 +101,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
                 }
             }
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             Map<Class<? extends TimerBean>, Map<String, List<Instant>>> timeouts = new IdentityHashMap<>();
             for (Class<? extends TimerBean> beanClass : TimerServlet.TIMER_CLASSES) {
@@ -150,7 +153,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
                 }
             }
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             for (Map<String, List<Instant>> beanTimeouts : timeouts.values()) {
                 beanTimeouts.clear();
@@ -188,7 +191,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
             this.stop(NODE_1);
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             try (CloseableHttpResponse response = client.execute(new HttpHead(uris.get(NODE_2)))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -224,7 +227,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
             this.start(NODE_1);
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             for (Map<String, List<Instant>> beanTimeouts : timeouts.values()) {
                 beanTimeouts.clear();
@@ -253,7 +256,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
                 }
             }
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             for (Map<String, List<Instant>> beanTimeouts : timeouts.values()) {
                 beanTimeouts.clear();
@@ -284,7 +287,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
             this.stop(NODE_2);
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             for (Map<String, List<Instant>> beanTimeouts : timeouts.values()) {
                 beanTimeouts.clear();
@@ -308,7 +311,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
             this.start(NODE_2);
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             try (CloseableHttpResponse response = client.execute(new HttpDelete(uris.get(NODE_1)))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -316,7 +319,7 @@ public abstract class AbstractTimerServiceTestCase extends AbstractClusteringTes
 
             Instant cancellation = Instant.now();
 
-            TimeUnit.SECONDS.sleep(2);
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
 
             for (Map<String, List<Instant>> beanTimeouts : timeouts.values()) {
                 beanTimeouts.clear();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/CoalesceMissedTimeoutsTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/CoalesceMissedTimeoutsTestCase.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.DateUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AbstractManualTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AbstractTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentCalendarTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentIntervalTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.ManualTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerRecorder;
+import org.jboss.as.test.clustering.cluster.ejb.timer.servlet.AbstractTimerServlet;
+import org.jboss.as.test.clustering.cluster.ejb.timer.servlet.BurstTimerServlet;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Validates that the distributed timer service does not reschedule a timer whose next timeout is in the past.
+ * This has the effect of consolidating missed timer events into a single application callback.
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+public class CoalesceMissedTimeoutsTestCase extends AbstractClusteringTestCase {
+    private static final String MODULE_NAME = CoalesceMissedTimeoutsTestCase.class.getSimpleName();
+    private static final Duration GRACE_PERIOD = Duration.ofSeconds(TimeoutUtil.adjust(2));
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> deployment() {
+        return ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war")
+                .addClasses(BurstTimerServlet.class, AbstractTimerServlet.class)
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(BurstPersistentCalendarTimerBean.class, BurstPersistentIntervalTimerBean.class, BurstPersistentTimerBean.class, AbstractManualTimerBean.class, AbstractTimerBean.class, ManualTimerBean.class, TimerBean.class, TimerRecorder.class)
+                ;
+    }
+
+    public CoalesceMissedTimeoutsTestCase() {
+        super(Set.of(NODE_1));
+    }
+
+    @Test
+    public void test(@ArquillianResource(BurstTimerServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL, @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient managementClient) throws IOException, URISyntaxException {
+
+        URI uri = BurstTimerServlet.createURI(baseURL, MODULE_NAME);
+
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
+
+            // Burst timer will begin firing 5 seconds after creation.
+            try (CloseableHttpResponse response = client.execute(new HttpPut(uri))) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+            }
+
+            suspend(managementClient);
+
+            // After 10 seconds all timeouts should have elapsed
+            TimeUnit.SECONDS.sleep(BurstPersistentTimerBean.START_DURATION.plus(BurstPersistentTimerBean.BURST_DURATION).getSeconds());
+
+            resume(managementClient);
+
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
+
+            try (CloseableHttpResponse response = client.execute(new HttpGet(uri))) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                // Missed timeouts should have been consolidated into a single application callback
+                Assert.assertEquals(1, parseTimeouts(response.getHeaders(BurstPersistentCalendarTimerBean.class.getName())).size());
+                Assert.assertEquals(1, parseTimeouts(response.getHeaders(BurstPersistentIntervalTimerBean.class.getName())).size());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static List<Instant> parseTimeouts(Header[] headers) {
+        List<Instant> timeouts = new ArrayList<>(headers.length);
+        for (Header header : headers) {
+            timeouts.add(DateUtils.parseDate(header.getValue()).toInstant());
+        }
+        return timeouts;
+    }
+
+    private static void suspend(ManagementClient client) throws IOException {
+        execute(client, ModelDescriptionConstants.SUSPEND);
+    }
+
+    private static void resume(ManagementClient client) throws IOException {
+        execute(client, ModelDescriptionConstants.RESUME);
+    }
+
+    private static void execute(ManagementClient client, String operation) throws IOException {
+        ModelNode result = client.getControllerClient().execute(Util.createOperation(operation, PathAddress.EMPTY_ADDRESS));
+        Assert.assertEquals(result.toString(), ModelDescriptionConstants.SUCCESS, result.get(ModelDescriptionConstants.OUTCOME).asString());
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentCalendarTimerBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentCalendarTimerBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer.beans;
+
+import java.util.Date;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.ScheduleExpression;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.ejb.TimerConfig;
+
+/**
+ * @author Paul Ferraro
+ */
+@Singleton
+@Startup
+@Local(ManualTimerBean.class)
+public class BurstPersistentCalendarTimerBean extends BurstPersistentTimerBean {
+
+    public BurstPersistentCalendarTimerBean() {
+        // Fire every second for 5 seconds after waiting 5 seconds
+        super((service, entry) -> {
+            return service.createCalendarTimer(new ScheduleExpression().start(Date.from(entry.getKey())).end(Date.from(entry.getValue())).hour("*").minute("*").second("*"), new TimerConfig(BurstPersistentCalendarTimerBean.class.getName(), true));
+        });
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentIntervalTimerBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentIntervalTimerBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer.beans;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Date;
+
+import jakarta.ejb.Local;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.ejb.Timeout;
+import jakarta.ejb.Timer;
+import jakarta.ejb.TimerConfig;
+
+/**
+ * @author Paul Ferraro
+ */
+@Singleton
+@Startup
+@Local(ManualTimerBean.class)
+public class BurstPersistentIntervalTimerBean extends BurstPersistentTimerBean {
+
+    public BurstPersistentIntervalTimerBean() {
+        // Fire every second for 5 seconds after waiting 10 seconds
+        super((service, entry) -> {
+            return service.createIntervalTimer(Date.from(entry.getKey()), 1000L, new TimerConfig(new TimerInfo(entry.getValue()), true));
+        });
+    }
+
+    @Timeout
+    @Override
+    public void timeout(Timer timer) {
+        super.timeout(timer);
+        TimerInfo info = (TimerInfo) timer.getInfo();
+        if (!Instant.now().isBefore(info.end)) {
+            timer.cancel();
+        }
+    }
+
+    private static class TimerInfo implements Serializable {
+        private static final long serialVersionUID = -4612974784446686670L;
+
+        private final Instant end;
+
+        TimerInfo(Instant end) {
+            this.end = end;
+        }
+
+        @Override
+        public String toString() {
+            return BurstPersistentIntervalTimerBean.class.getName();
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentTimerBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/BurstPersistentTimerBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer.beans;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import jakarta.ejb.Timer;
+import jakarta.ejb.TimerService;
+
+/**
+ * @author Paul Ferraro
+ */
+public class BurstPersistentTimerBean extends AbstractManualTimerBean {
+    public static final Duration START_DURATION = Duration.ofSeconds(5);
+    public static final Duration BURST_DURATION = Duration.ofSeconds(5);
+
+    public BurstPersistentTimerBean(BiFunction<TimerService, Map.Entry<Instant, Instant>, Timer> timerFactory) {
+        // Fire every second for 5 seconds after waiting 5 seconds
+        super(service -> {
+            Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+            Instant start = now.plus(START_DURATION);
+            Instant end = start.plus(BURST_DURATION);
+            return timerFactory.apply(service, Map.entry(start, end));
+        });
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/AbstractTimerServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/AbstractTimerServlet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer.servlet;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.ManualTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.clustering.ejb.LocalEJBDirectory;
+
+/**
+ * @author Paul Ferraro
+ */
+public abstract class AbstractTimerServlet extends HttpServlet {
+    private static final long serialVersionUID = -5679222023732143513L;
+    protected static final String MODULE = "module";
+
+    private final Set<Class<? extends ManualTimerBean>> manualTimerClasses;
+    private final Set<Class<? extends TimerBean>> autoTimerClasses;
+
+    protected AbstractTimerServlet(Set<Class<? extends ManualTimerBean>> manualTimerClasses, Set<Class<? extends TimerBean>> autoTimerClasses) {
+        this.manualTimerClasses = manualTimerClasses;
+        this.autoTimerClasses = autoTimerClasses;
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.getServletContext().log(String.format("%s: http://%s:%s%s?%s", request.getMethod(), request.getServerName(), request.getServerPort(), request.getRequestURI(), request.getQueryString()));
+        super.service(request, response);
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String module = request.getParameter(MODULE);
+        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
+            for (Class<? extends ManualTimerBean> beanClass : this.manualTimerClasses) {
+                ManualTimerBean bean = directory.lookupSingleton(beanClass, ManualTimerBean.class);
+                bean.cancel();
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String module = request.getParameter(MODULE);
+        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
+            Map<Class<? extends TimerBean>, TimerBean> beans = new IdentityHashMap<>();
+            for (Class<? extends ManualTimerBean> beanClass : this.manualTimerClasses) {
+                beans.put(beanClass, directory.lookupSingleton(beanClass, ManualTimerBean.class));
+            }
+            for (Class<? extends TimerBean> beanClass : this.autoTimerClasses) {
+                beans.put(beanClass, directory.lookupSingleton(beanClass, TimerBean.class));
+            }
+            for (Map.Entry<Class<? extends TimerBean>, TimerBean> entry : beans.entrySet()) {
+                for (Instant timeout : entry.getValue().getTimeouts()) {
+                    response.addDateHeader(entry.getKey().getName(), timeout.toEpochMilli());
+                }
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String module = request.getParameter(MODULE);
+        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
+            Map<Class<? extends TimerBean>, TimerBean> beans = new IdentityHashMap<>();
+            for (Class<? extends ManualTimerBean> beanClass : this.manualTimerClasses) {
+                beans.put(beanClass, directory.lookupSingleton(beanClass, ManualTimerBean.class));
+            }
+            for (Class<? extends TimerBean> beanClass : this.autoTimerClasses) {
+                beans.put(beanClass, directory.lookupSingleton(beanClass, TimerBean.class));
+            }
+            for (Map.Entry<Class<? extends TimerBean>, TimerBean> entry : beans.entrySet()) {
+                response.addIntHeader(entry.getKey().getName(), entry.getValue().getTimers());
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String module = request.getParameter(MODULE);
+        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
+            for (Class<? extends ManualTimerBean> beanClass : this.manualTimerClasses) {
+                directory.lookupSingleton(beanClass, ManualTimerBean.class).createTimer();
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/BurstTimerServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/BurstTimerServlet.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.timer.servlet;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Set;
+
+import jakarta.servlet.annotation.WebServlet;
+
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentCalendarTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentIntervalTimerBean;
+
+/**
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { BurstTimerServlet.SERVLET_PATH })
+public class BurstTimerServlet extends AbstractTimerServlet {
+    private static final long serialVersionUID = 6726244990295355667L;
+    private static final String SERVLET_NAME = "burst-timer";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+
+    public static URI createURI(URL baseURL, String module) throws URISyntaxException {
+        return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append('?').append(MODULE).append('=').append(module).toString());
+    }
+
+    public BurstTimerServlet() {
+        super(Set.of(BurstPersistentCalendarTimerBean.class, BurstPersistentIntervalTimerBean.class), Set.of());
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/TimerServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/servlet/TimerServlet.java
@@ -5,22 +5,14 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.timer.servlet;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.time.Instant;
-import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AutoPersistentTimerBean;
 import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AutoTransientTimerBean;
@@ -32,19 +24,19 @@ import org.jboss.as.test.clustering.cluster.ejb.timer.beans.ManualTimerBean;
 import org.jboss.as.test.clustering.cluster.ejb.timer.beans.SingleActionPersistentTimerBean;
 import org.jboss.as.test.clustering.cluster.ejb.timer.beans.SingleActionTransientTimerBean;
 import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerBean;
-import org.jboss.as.test.clustering.ejb.EJBDirectory;
-import org.jboss.as.test.clustering.ejb.LocalEJBDirectory;
 
 /**
  * @author Paul Ferraro
  */
 @WebServlet(urlPatterns = { TimerServlet.SERVLET_PATH })
-public class TimerServlet extends HttpServlet {
+public class TimerServlet extends AbstractTimerServlet {
     private static final long serialVersionUID = 5393197778939188763L;
-
     private static final String SERVLET_NAME = "timer";
     static final String SERVLET_PATH = "/" + SERVLET_NAME;
-    private static final String MODULE = "module";
+
+    public static URI createURI(URL baseURL, String module) throws URISyntaxException {
+        return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append('?').append(MODULE).append('=').append(module).toString());
+    }
 
     public static final Set<Class<? extends TimerBean>> PERSISTENT_TIMER_CLASSES = Set.of(AutoPersistentTimerBean.class, CalendarPersistentTimerBean.class, IntervalPersistentTimerBean.class, SingleActionPersistentTimerBean.class);
     public static final Set<Class<? extends TimerBean>> TRANSIENT_TIMER_CLASSES = Set.of(AutoTransientTimerBean.class, CalendarTransientTimerBean.class, IntervalTransientTimerBean.class, SingleActionTransientTimerBean.class);
@@ -55,78 +47,7 @@ public class TimerServlet extends HttpServlet {
     public static final Set<Class<? extends TimerBean>> AUTO_TIMER_CLASSES = Set.of(AutoPersistentTimerBean.class, AutoTransientTimerBean.class);
     public static final Set<Class<? extends TimerBean>> SINGLE_ACTION_TIMER_CLASSES = Set.of(SingleActionPersistentTimerBean.class, SingleActionTransientTimerBean.class);
 
-    public static URI createURI(URL baseURL, String module) throws URISyntaxException {
-        return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append('?').append(MODULE).append('=').append(module).toString());
-    }
-
-    @Override
-    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        request.getServletContext().log(String.format("%s: http://%s:%s%s?%s", request.getMethod(), request.getServerName(), request.getServerPort(), request.getRequestURI(), request.getQueryString()));
-        super.service(request, response);
-    }
-
-    @Override
-    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String module = request.getParameter(MODULE);
-        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
-            for (Class<? extends ManualTimerBean> beanClass : MANUAL_TIMER_CLASSES) {
-                ManualTimerBean bean = directory.lookupSingleton(beanClass, ManualTimerBean.class);
-                bean.cancel();
-            }
-        } catch (Exception e) {
-            throw new ServletException(e);
-        }
-    }
-
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String module = request.getParameter(MODULE);
-        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
-            Map<Class<? extends TimerBean>, TimerBean> beans = new IdentityHashMap<>();
-            for (Class<? extends ManualTimerBean> beanClass : MANUAL_TIMER_CLASSES) {
-                beans.put(beanClass, directory.lookupSingleton(beanClass, ManualTimerBean.class));
-            }
-            for (Class<? extends TimerBean> beanClass : AUTO_TIMER_CLASSES) {
-                beans.put(beanClass, directory.lookupSingleton(beanClass, TimerBean.class));
-            }
-            for (Map.Entry<Class<? extends TimerBean>, TimerBean> entry : beans.entrySet()) {
-                for (Instant timeout : entry.getValue().getTimeouts()) {
-                    response.addDateHeader(entry.getKey().getName(), timeout.toEpochMilli());
-                }
-            }
-        } catch (Exception e) {
-            throw new ServletException(e);
-        }
-    }
-
-    @Override
-    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String module = request.getParameter(MODULE);
-        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
-            Map<Class<? extends TimerBean>, TimerBean> beans = new IdentityHashMap<>();
-            for (Class<? extends ManualTimerBean> beanClass : MANUAL_TIMER_CLASSES) {
-                beans.put(beanClass, directory.lookupSingleton(beanClass, ManualTimerBean.class));
-            }
-            for (Class<? extends TimerBean> beanClass : AUTO_TIMER_CLASSES) {
-                beans.put(beanClass, directory.lookupSingleton(beanClass, TimerBean.class));
-            }
-            for (Map.Entry<Class<? extends TimerBean>, TimerBean> entry : beans.entrySet()) {
-                response.addIntHeader(entry.getKey().getName(), entry.getValue().getTimers());
-            }
-        } catch (Exception e) {
-            throw new ServletException(e);
-        }
-    }
-
-    @Override
-    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String module = request.getParameter(MODULE);
-        try (EJBDirectory directory = new LocalEJBDirectory(module)) {
-            for (Class<? extends ManualTimerBean> beanClass : MANUAL_TIMER_CLASSES) {
-                directory.lookupSingleton(beanClass, ManualTimerBean.class).createTimer();
-            }
-        } catch (Exception e) {
-            throw new ServletException(e);
-        }
+    public TimerServlet() {
+        super(MANUAL_TIMER_CLASSES, AUTO_TIMER_CLASSES);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/CoalesceMissedTimeoutsTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/CoalesceMissedTimeoutsTestCase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.single.ejb.timer;
+
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.DEPLOYMENT_1;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.DateUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AbstractManualTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.AbstractTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentCalendarTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentIntervalTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.BurstPersistentTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.ManualTimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerBean;
+import org.jboss.as.test.clustering.cluster.ejb.timer.beans.TimerRecorder;
+import org.jboss.as.test.clustering.cluster.ejb.timer.servlet.AbstractTimerServlet;
+import org.jboss.as.test.clustering.cluster.ejb.timer.servlet.BurstTimerServlet;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Validates that the distributed timer service does not reschedule a timer whose next timeout is in the past.
+ * This has the effect of consolidating missed timer events into a single application callback.
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+public class CoalesceMissedTimeoutsTestCase {
+    private static final String MODULE_NAME = CoalesceMissedTimeoutsTestCase.class.getSimpleName();
+    private static final Duration GRACE_PERIOD = Duration.ofSeconds(TimeoutUtil.adjust(2));
+
+    @Deployment(name = DEPLOYMENT_1, testable = false)
+    public static Archive<?> deployment() {
+        return ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war")
+                .addClasses(BurstTimerServlet.class, AbstractTimerServlet.class)
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(BurstPersistentCalendarTimerBean.class, BurstPersistentIntervalTimerBean.class, BurstPersistentTimerBean.class, AbstractManualTimerBean.class, AbstractTimerBean.class, ManualTimerBean.class, TimerBean.class, TimerRecorder.class)
+                ;
+    }
+
+    @Test
+    public void test(@ArquillianResource(BurstTimerServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL, @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient managementClient) throws IOException, URISyntaxException {
+
+        URI uri = BurstTimerServlet.createURI(baseURL, MODULE_NAME);
+
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
+
+            // Burst timer will begin firing 5 seconds after creation.
+            try (CloseableHttpResponse response = client.execute(new HttpPut(uri))) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+            }
+
+            suspend(managementClient);
+
+            // After 10 seconds all timeouts should have elapsed
+            TimeUnit.SECONDS.sleep(BurstPersistentTimerBean.START_DURATION.plus(BurstPersistentTimerBean.BURST_DURATION).getSeconds());
+
+            resume(managementClient);
+
+            TimeUnit.SECONDS.sleep(GRACE_PERIOD.getSeconds());
+
+            try (CloseableHttpResponse response = client.execute(new HttpGet(uri))) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                // Missed timeouts should have been consolidated into a single application callback
+                Assert.assertEquals(1, parseTimeouts(response.getHeaders(BurstPersistentIntervalTimerBean.class.getName())).size());
+                Assert.assertEquals(1, parseTimeouts(response.getHeaders(BurstPersistentCalendarTimerBean.class.getName())).size());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static List<Instant> parseTimeouts(Header[] headers) {
+        List<Instant> timeouts = new ArrayList<>(headers.length);
+        for (Header header : headers) {
+            timeouts.add(DateUtils.parseDate(header.getValue()).toInstant());
+        }
+        return timeouts;
+    }
+
+    private static void suspend(ManagementClient client) throws IOException {
+        execute(client, ModelDescriptionConstants.SUSPEND);
+    }
+
+    private static void resume(ManagementClient client) throws IOException {
+        execute(client, ModelDescriptionConstants.RESUME);
+    }
+
+    private static void execute(ManagementClient client, String operation) throws IOException {
+        ModelNode result = client.getControllerClient().execute(Util.createOperation(operation, PathAddress.EMPTY_ADDRESS));
+        Assert.assertEquals(result.toString(), ModelDescriptionConstants.SUCCESS, result.get(ModelDescriptionConstants.OUTCOME).asString());
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19419

Also solves: WFLY-19271 Distributed timer service drops timeout events if server is suspended
https://issues.redhat.com/browse/WFLY-19271

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19514](https://issues.redhat.com/browse/WFLY-19514)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)