### PR TITLE
[WFLY-19443] Upgrade WildFly Core to 25.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19443

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Beta3...25.0.0.Beta4

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6815'>WFCORE-6815</a>] -         [Community] Utility to reload domain to a different stability level in the testsuite
</li>
</ul>
                                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6847'>WFCORE-6847</a>] -         Upgrade io.smallrye:jandex from 3.1.8 to 3.2.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6850'>WFCORE-6850</a>] -         The bootable JAR entry point should set the module logger after the log manager is initialized
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6853'>WFCORE-6853</a>] -         Upgrade to Galleon Plugins 7.1.0.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4919'>WFCORE-4919</a>] -         ModelParserUtils should use the --timeout parameter with its embed-server and embed-host-controller calls
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6819'>WFCORE-6819</a>] -         Show current stability level with the server boot message
</li>
</ul>
</details>