### PR TITLE
[WFLY-19376] Upgrade Wildscribe to 3.1.0.Final.

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -124,6 +124,7 @@
                     <display-name>${full.dist.product.release.name}</display-name>
                     <display-version>${product.docs.server.version}</display-version>
                     <site-dir>${project.build.directory}/generated-docs/wildscribe</site-dir>
+                    <stability>experimental</stability>
                     <required-extensions>
                         <required-extension>org.wildfly.extension.rts</required-extension>
                         <required-extension>org.jboss.as.xts</required-extension>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <version.org.jacoco>0.8.12</version.org.jacoco>
         <version.org.jboss.galleon>6.0.0.Final</version.org.jboss.galleon>
         <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
-        <version.org.jboss.wildscribe>2.1.0.Final</version.org.jboss.wildscribe>
+        <version.org.jboss.wildscribe>3.1.0.Final</version.org.jboss.wildscribe>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>


### PR DESCRIPTION
* Generate WildFly management model from its experimental stability level
* Display Ⓟ, Ⓒ, Ⓔ  characters next to resp. preview, community, and  experimental in the generated HTML pages

This fixes https://issues.redhat.com/browse/WFLY-19376

This is a replacement for #17927 only if we want it in sooner.

Note this is an upgrade to 3.1.0.Final instead of 3.0.0.Final. If we'd rather have a 3.0.1.Final, please let me know.