### PR TITLE
WFLY-19473: fix and bump schema

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Namespace.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Namespace.java
@@ -34,12 +34,14 @@ public enum Namespace {
 
     RESOURCEADAPTERS_7_0("urn:jboss:domain:resource-adapters:7.0"),
 
-    RESOURCEADAPTERS_7_1("urn:jboss:domain:resource-adapters:7.1");
+    RESOURCEADAPTERS_7_1("urn:jboss:domain:resource-adapters:7.1"),
+
+    RESOURCEADAPTERS_7_2("urn:jboss:domain:resource-adapters:7.2");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = RESOURCEADAPTERS_7_1;
+    public static final Namespace CURRENT = RESOURCEADAPTERS_7_2;
 
     private final String name;
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -310,17 +310,15 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
         poolRequired = poolRequired || capacityRequired;
 
         if (poolRequired) {
+            streamWriter.writeStartElement(isXa ? ConnectionDefinition.Tag.XA_POOL.getLocalName() : ConnectionDefinition.Tag.POOL.getLocalName());
+            MIN_POOL_SIZE.marshallAsElement(conDef, streamWriter);
+            INITIAL_POOL_SIZE.marshallAsElement(conDef, streamWriter);
+            MAX_POOL_SIZE.marshallAsElement(conDef, streamWriter);
+            POOL_PREFILL.marshallAsElement(conDef, streamWriter);
+            POOL_FAIR.marshallAsElement(conDef, streamWriter);
+            POOL_USE_STRICT_MIN.marshallAsElement(conDef, streamWriter);
+            POOL_FLUSH_STRATEGY.marshallAsElement(conDef, streamWriter);
             if (isXa) {
-
-                streamWriter.writeStartElement(ConnectionDefinition.Tag.XA_POOL.getLocalName());
-                MIN_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                INITIAL_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                MAX_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                POOL_PREFILL.marshallAsElement(conDef, streamWriter);
-                POOL_FAIR.marshallAsElement(conDef, streamWriter);
-                POOL_USE_STRICT_MIN.marshallAsElement(conDef, streamWriter);
-                POOL_FLUSH_STRATEGY.marshallAsElement(conDef, streamWriter);
-
                 SAME_RM_OVERRIDE.marshallAsElement(conDef, streamWriter);
                 if (conDef.hasDefined(INTERLEAVING.getName()) && conDef.get(INTERLEAVING.getName()).getType().equals(ModelType.BOOLEAN)
                         && conDef.get(INTERLEAVING.getName()).asBoolean()) {
@@ -336,17 +334,6 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
                 }
                 PAD_XID.marshallAsElement(conDef, streamWriter);
                 WRAP_XA_RESOURCE.marshallAsElement(conDef, streamWriter);
-
-
-            } else {
-                streamWriter.writeStartElement(ConnectionDefinition.Tag.POOL.getLocalName());
-                MIN_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                INITIAL_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                MAX_POOL_SIZE.marshallAsElement(conDef, streamWriter);
-                POOL_PREFILL.marshallAsElement(conDef, streamWriter);
-                POOL_USE_STRICT_MIN.marshallAsElement(conDef, streamWriter);
-                POOL_FLUSH_STRATEGY.marshallAsElement(conDef, streamWriter);
-
             }
             if (capacityRequired) {
                 streamWriter.writeStartElement(Pool.Tag.CAPACITY.getLocalName());

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -373,6 +373,7 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
                 || conDef.hasDefined(SECURITY_DOMAIN_AND_APPLICATION.getName())
                 || conDef.hasDefined(ELYTRON_ENABLED.getName())) {
             streamWriter.writeStartElement(ConnectionDefinition.Tag.SECURITY.getLocalName());
+            ELYTRON_ENABLED.marshallAsElement(conDef, streamWriter);
             if (conDef.hasDefined(APPLICATION.getName()) && conDef.get(APPLICATION.getName()).getType().equals(ModelType.BOOLEAN) && conDef.get(APPLICATION.getName()).asBoolean()) {
                 streamWriter.writeEmptyElement(APPLICATION.getXmlName());
             } else {
@@ -380,7 +381,6 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
             }
             SECURITY_DOMAIN.marshallAsElement(conDef, streamWriter);
             SECURITY_DOMAIN_AND_APPLICATION.marshallAsElement(conDef, streamWriter);
-            ELYTRON_ENABLED.marshallAsElement(conDef, streamWriter);
             AUTHENTICATION_CONTEXT.marshallAsElement(conDef, streamWriter);
             AUTHENTICATION_CONTEXT_AND_APPLICATION.marshallAsElement(conDef, streamWriter);
 
@@ -424,8 +424,8 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
                 RECOVERY_USERNAME.marshallAsAttribute(conDef, streamWriter);
                 RECOVERY_PASSWORD.marshallAsAttribute(conDef, streamWriter);
                 RECOVERY_CREDENTIAL_REFERENCE.marshallAsElement(conDef, streamWriter);
-                RECOVERY_SECURITY_DOMAIN.marshallAsElement(conDef, streamWriter);
                 RECOVERY_ELYTRON_ENABLED.marshallAsElement(conDef, streamWriter);
+                RECOVERY_SECURITY_DOMAIN.marshallAsElement(conDef, streamWriter);
                 RECOVERY_AUTHENTICATION_CONTEXT.marshallAsElement(conDef, streamWriter);
                 streamWriter.writeEndElement();
             }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
@@ -84,6 +84,7 @@ public class ResourceAdaptersExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_6_1.getUriString(), resourceAdapterSubsystemParser);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_7_0.getUriString(), resourceAdapterSubsystemParser);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_7_1.getUriString(), resourceAdapterSubsystemParser);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_7_2.getUriString(), resourceAdapterSubsystemParser);
     }
 
 }

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_7_2.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_7_2.xsd
@@ -20,7 +20,7 @@
         </xs:all>
     </xs:complexType>
 
-    <xs:complexType name="boolean-presenceType"></xs:complexType>
+    <xs:complexType name="boolean-presenceType"/>
 
     <xs:complexType name="config-propertyType" mixed="true">
         <xs:annotation>
@@ -140,7 +140,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute default="false" name="statistics-enabled" type="xs:boolean">
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[[
@@ -196,7 +196,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute default="true" name="use-java-context" type="xs:boolean">
+        <xs:attribute name="use-java-context" type="xs:boolean" default="true">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[[
@@ -228,7 +228,7 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
-        <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+        <xs:attributeGroup ref="common-attribute"/>
     </xs:complexType>
 
     <xs:complexType name="timeoutType">
@@ -428,7 +428,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="use-ccm" type="xs:boolean" default="true" use="optional">
             <xs:annotation>
@@ -458,7 +458,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute default="false" name="connectable" type="xs:boolean">
+        <xs:attribute name="connectable" type="xs:boolean" default="false">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[[
@@ -494,7 +494,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+        <xs:attributeGroup ref="common-attribute"/>
     </xs:complexType>
 
     <xs:complexType name="poolType">
@@ -807,9 +807,9 @@
     </xs:complexType>
     <xs:complexType name="extensionType">
         <xs:sequence>
-            <xs:element name="config-property" type="config-propertyType"></xs:element>
+            <xs:element name="config-property" type="config-propertyType"/>
         </xs:sequence>
-        <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+        <xs:attribute name="class-name" type="xs:token" use="required"/>
     </xs:complexType>
     <xs:complexType name="credentialType">
         <xs:sequence>
@@ -1109,7 +1109,7 @@
     </xs:complexType>
 
     <xs:complexType name="report-directoryType">
-        <xs:attribute name="path" type="xs:token" use="required"></xs:attribute>
+        <xs:attribute name="path" type="xs:token" use="required"/>
     </xs:complexType>
 
 </xs:schema>

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_7_2.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_7_2.xsd
@@ -1,0 +1,1115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:resource-adapters:7.2" xmlns="urn:jboss:domain:resource-adapters:7.2"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+
+    <xs:element name="subsystem" type="subsystemType"/>
+
+    <xs:complexType name="subsystemType">
+        <xs:all>
+            <xs:element name="resource-adapters" type="resource-adaptersType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="report-directory" type="report-directoryType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="boolean-presenceType"></xs:complexType>
+
+    <xs:complexType name="config-propertyType" mixed="true">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[[
+          Specifies an override for a config-property element in ra.xml or a @ConfigProperty
+         ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:token">
+                <xs:attribute use="required" name="name" type="xs:token">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Specifies the name of the config-property
+               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="resource-adapterType">
+        <xs:sequence>
+            <xs:element name="archive" type="xs:token" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the resource adapter archive to be activated
+              E.g. <archive>myra.rar</archive>
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="module" type="moduleType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                      Specifies the resource adapter module to be activated
+                      E.g. <archive>org.jboss.ironjacamar.ra16out</archive>
+                     ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="bean-validation-groups" type="bean-validation-groupsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies bean validation group that should be used
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="bootstrap-context" type="xs:token" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the unique name of the bootstrap context that should be used
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+               The config-property specifies resource adapter configuration properties.
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="transaction-support" type="transaction-supportType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the transaction support level of the resource adapter
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workmanager" type="workmanagerType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                    Specifies the settings for the WorkManager used by this resource adapter
+                   ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="connection-definitions" type="connection-definitionsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the connection definitions
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="admin-objects" type="admin-objectsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the administration objects
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            An unique identifier for the resource adapter
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute default="false" name="statistics-enabled" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                      Enable statistics for this resource-adapter
+                     ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="transaction-supportType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[[
+          Define the type of transaction supported by this resource adapter.
+          Valid values are: NoTransaction, LocalTransaction, XATransaction
+         ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NoTransaction" />
+            <xs:enumeration value="LocalTransaction" />
+            <xs:enumeration value="XATransaction" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:attributeGroup name="common-attribute">
+        <xs:attribute name="class-name" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Specifies the the fully qualified class name of a managed connection factory
+            or admin object
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="jndi-name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Specifies the JNDI name
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled" type="xs:boolean" default="true" form="unqualified" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Should the object in question be activated
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute default="true" name="use-java-context" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Specifies if a java:/ JNDI context should be used
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pool-name" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Specifies the pool name for the object
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="admin-objectType">
+        <xs:sequence>
+            <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The config-property specifies administration object configuration properties.
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+    </xs:complexType>
+
+    <xs:complexType name="timeoutType">
+        <xs:sequence>
+            <xs:element name="blocking-timeout-millis" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                The blocking-timeout-millis element indicates the maximum time in
+                milliseconds to block while waiting for a connection before throwing an exception.
+                Note that this blocks only while waiting for a permit for a connection, and
+                will never throw an exception if creating a new connection takes an inordinately
+                long time. The default is 30000 (30 seconds).
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="idle-timeout-minutes" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The idle-timeout-minutes elements indicates the maximum time in minutes
+              a connection may be idle before being closed. The actual maximum time depends
+              also on the IdleRemover scan time, which is 1/2 the smallest idle-timeout-minutes
+              of any pool.
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="allocation-retry" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The allocation retry element indicates the number of times that allocating
+              a connection should be tried before throwing an exception. The default is
+              0.
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="allocation-retry-wait-millis" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The allocation retry wait millis element indicates the time in milliseconds
+              to wait between retrying to allocate a connection. The default is 5000 (5
+              seconds).
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="xa-resource-timeout" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Passed to XAResource.setTransactionTimeout(). Default is zero which does not invoke the setter.
+              Specified in seconds - e.g. 5 minutes
+              <xa-resource-timeout>300</xa-resource-timeout>
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="validationType">
+        <xs:sequence>
+            <xs:element name="validate-on-match" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The validate-on-match element indicates whether or not connection
+              level validation should be done when a connection factory attempts to match
+              a managed connection for a given set. This is typically exclusive to the
+              use of background validation
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="background-validation" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              An element to specify that connections should be validated on a background
+              thread versus being validated prior to use
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="background-validation-millis" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+               The background-validation-millis element specifies the amount of
+               time, in millis, that background validation will run.
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-fast-fail" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Whether fail a connection allocation on the first connection if it
+                is invalid (true) or keep trying until the pool is exhausted of all potential
+                connections (false) default false. e.g. <use-fast-fail>true</use-fast-fail>
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="resource-adaptersType">
+        <xs:sequence>
+            <xs:element name="resource-adapter" type="resource-adapterType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies activation of a resource adapter
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="connection-definitionsType">
+        <xs:sequence>
+            <xs:element name="connection-definition" type="connection-defintionType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies a connection definition
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="connection-defintionType">
+        <xs:sequence>
+            <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+             The config-property specifies managed connection factory configuration properties.
+            ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice>
+                <xs:element name="pool" type="poolType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                  Specifies pooling settings
+                 ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xa-pool" type="xa-poolType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                  Specifies xa-pooling settings
+                 ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="security" type="securityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies security settings
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeout" type="timeoutType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies timeout settings
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="validation" type="validationType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies validation settings
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
+        </xs:sequence>
+        <xs:attribute name="use-ccm" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Enable cached connection manager
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sharable" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Defines the connections as sharable which allows lazy association to be enabled
+                if supported
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enlistment" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Defines if lazy enlistment should be used if supported by the resource adapter
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute default="false" name="connectable" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                 Enable CMR functionality on this connection
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tracking" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Defines if IronJacamar should track connection handles across transaction boundaries
+          ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mcp" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Defines the ManagedConnectionPool implementation, f.ex. org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreArrayListManagedConnectionPool
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Defines if WildFly/IronJacamar should record enlistment traces
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+    </xs:complexType>
+
+    <xs:complexType name="poolType">
+        <xs:sequence>
+            <xs:element name="min-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The min-pool-size element indicates the minimum number of connections
+              a pool should hold. These are not created until a Subject is known from a
+              request for a connection. This default to 0. Ex: <min-pool-size>1</min-pool-size>
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="initial-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                    The initial-pool-size element indicates the initial number of connections
+                    a pool should hold. This default to 0. Ex: <initial-pool-size>1</initial-pool-size>
+                   ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              The max-pool-size element indicates the maximum number of connections
+              for a pool. No more than max-pool-size connections will be created in each sub-pool.
+              This defaults to 20.
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefill" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Whether to attempt to prefill the connection pool. Default is false.
+              e.g. <prefill>false</prefill>.
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fair" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Defines if pool use should be fair
+              Default true
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-strict-min" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Define if the min-pool-size should be considered strict.
+              Default false
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="flush-strategy" type="xs:token" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies how the pool should be flush in case of an error.
+              Valid values are: FailingConnectionOnly (default), InvalidIdleConnections, IdleConnections, Gracefully, EntirePool,
+                                              AllInvalidIdleConnections, AllIdleConnections, AllGracefully, AllConnections
+                           ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="capacityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                            Specifies the capacity policies for the pool
+                           ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="xa-poolType">
+        <xs:complexContent>
+            <xs:extension base="poolType">
+                <xs:sequence>
+                    <xs:element name="is-same-rm-override" type="xs:boolean" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[[
+                  The is-same-rm-override element allows one to unconditionally
+                  set whether the javax.transaction.xa.XAResource.isSameRM(XAResource) returns
+                  true or false. Ex: <is-same-rm-override>true</is-same-rm-override>
+                 ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="interleaving" type="boolean-presenceType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[[
+                  An element to enable interleaving for XA connection factories
+                  Ex: <interleaving/>
+                 ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="no-tx-separate-pools" type="boolean-presenceType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[[
+                  Oracle does not like XA connections getting used both inside and outside a JTA transaction.
+                  To workaround the problem you can create separate sub-pools for the different contexts
+                  using <no-tx-separate-pools/>
+                  Ex: <no-tx-separate-pools/>
+                 ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="pad-xid" type="xs:boolean" default="false" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[[
+                   Should the Xid be padded
+                   Ex: <pad-xid>true</pad-xid>
+                 ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="wrap-xa-resource" type="xs:boolean" default="true" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[[
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
+                   instance
+                   Ex: <wrap-xa-resource>true</wrap-xa-resource>
+                 ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="securityType">
+        <xs:sequence>
+            <xs:element name="elytron-enabled" type="xs:boolean" default="false" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via either authentication-context or authentication-context-and-application),
+                Elytron will use that specified context for authenticating. Else, Elytron will use the
+                current authentication context of the caller that is retrieving the connection.
+                Ex:
+                <elytron-enabled>true</elytron-enabled>
+              ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice>
+                <xs:element name="application" type="boolean-presenceType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Indicates that app supplied parameters (such as from getConnection(user, pw))
+                are used to distinguish connections in the pool.
+                Ex:
+                <application/>
+              ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="security-domain" type="xs:token" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Indicates Subject (from security domain) are used to distinguish connections in the pool.
+                The content of the security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+                Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="security-domain-and-application" type="xs:token" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Indicates that either app supplied parameters (such as from
+                getConnection(user, pw)) or Subject (from security domain) are used to
+                distinguish connections in the pool. The content of the
+                security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+
+                Ex:
+                <security-domain-and-application>HsqlDbRealm</security-domain-and-application>
+              ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="authentication-context" type="xs:token">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+          Indicates the Elytron context that will be used for authenticating connections during
+          container-managed sign-on.
+          The resulting Subject will be used to distinguish connections in the pool.
+          The authentication-context name correlates to the authentication context defined in
+          the Elytron subsystem.
+          Ex:
+            <elytron-enabled>true</elytron-enabled>
+            <authentication-context>HsqlDbContext</authentication-context>
+          ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="authentication-context-and-application" type="xs:token">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    <![CDATA[[
+                  Indicates that either app supplied parameters (such as from
+                  getConnection(user, pw)) or an authenticated Subject (resulting of container-managed sign-on
+                  authentication) are used to distinguish connections in the pool.
+                  The authentication-context name correlates to the authentication context defined in
+                  the Elytron subsystem.
+                  Ex:
+                    <elytron-enabled>true</elytron-enabled>
+                    <authentication-context-and-application>HsqlDbContext</authentication-context-and-application>
+                  ]]>
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="admin-objectsType">
+        <xs:sequence>
+            <xs:element name="admin-object" type="admin-objectType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the setup for an admin object
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="bean-validation-groupsType">
+        <xs:sequence>
+            <xs:element name="bean-validation-group" type="xs:token" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the fully qualified class name for a bean validation group that
+              should be used for validation
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="recoverType">
+        <xs:sequence>
+            <xs:element name="recover-credential" type="credentialType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the security options used when creating a connection during recovery.
+              Note: if this credential is not specified the security credential is used for recovery too
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="recover-plugin" type="extensionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+              Specifies the extension plugin used in spi (core.spi.xa)
+              which can be implemented by various plugins to provide better feedback to the XA recovery system.
+             ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="no-recovery" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+            Specify if the xa-datasource should be excluded from recovery.
+            Default false.
+           ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="extensionType">
+        <xs:sequence>
+            <xs:element name="config-property" type="config-propertyType"></xs:element>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="credentialType">
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="elytron-enabled" type="xs:boolean" minOccurs="0" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via authentication-context), Elytron will use the specified context
+                for authenticating. Else, Elytron will use the current authentication context of the caller that
+                is retrieving the connection.
+                Ex:
+                  <elytron-enabled>true</elytron-enabled>
+                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice>
+                <xs:element name="security-domain" type="xs:token" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Indicates Subject (from security domain) are used to distinguish connections in the pool.
+                The content of the security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+                Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="authentication-context" type="xs:token" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[[
+                Indicates the Elytron context that will be used for authenticating connections during
+                container-managed sign-on.
+                The resulting Subject will be used to distinguish connections in the pool.
+                The authentication-context name correlates to the authentication context defined in
+                the Elytron subsystem.
+                Ex:
+                  <elytron-enabled>true</elytron-enabled>
+                  <authentication-context>HsqlDbContext</authentication-context>
+                ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="user-name" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Specify the username used when creating a new connection.
+                Ex: user-name="sa"
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="password" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Specify the password used when creating a new connection.
+                Ex: password="sa"
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="moduleType">
+        <xs:attribute name="id" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                   The module id
+                               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="slot" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                   The module slot
+                               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerType">
+        <xs:sequence>
+            <xs:element name="security" type="workmanagerSecurityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines the security model used by the WorkManager instance
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityType">
+        <xs:sequence>
+            <xs:element name="mapping-required" type="xs:boolean" minOccurs="0" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines if a mapping is required for security credentials. A value of false means
+                  "Case 1" as defined in section 16.4.3, and a value of true means "Case 2" as
+                  defined in section 16.4.4.
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="domain" type="xs:token" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines the name of the security domain that should be used
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="elytron-security-domain" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Indicates that Elytron is responsible for WorkManager security. It defines the name of the Elytron
+                  security domain that should be used
+                  Ex:
+                    <elytron-security-domain>ApplicationDomain</elytron-security-domain>
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="default-principal" type="xs:token" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines a default principal name that should be added to the used Subject instance
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="default-groups" type="workmanagerSecurityGroupsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines a default groups that should be added to the used Subject instance
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mappings" type="workmanagerSecurityMappingsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines the mappings that should be applied for Case 2
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                  Indicates whether the security for WorkManager is enabled
+                 ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityGroupsType">
+        <xs:sequence>
+            <xs:element name="group" type="xs:token" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  The name of the group
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityMappingsType">
+        <xs:sequence>
+            <xs:element name="users" type="workmanagerSecurityMappingsUsersType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  The mappings for the users
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="groups" type="workmanagerSecurityMappingsGroupsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  The mappings for the groups
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityMappingsUsersType">
+        <xs:sequence>
+            <xs:element name="map" type="workmanagerSecurityMappingType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  A user mapping
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityMappingsGroupsType">
+        <xs:sequence>
+            <xs:element name="map" type="workmanagerSecurityMappingType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  A group mapping
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workmanagerSecurityMappingType">
+        <xs:sequence>
+        </xs:sequence>
+        <xs:attribute name="from" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Specify the original value
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                Specify the mapped value
+               ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="capacityType">
+        <xs:sequence>
+            <xs:element name="incrementer" type="extensionType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines the policy for incrementing connections in the pool
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="decrementer" type="extensionType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[[
+                  Defines the policy for decrementing connections in the pool
+                 ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="report-directoryType">
+        <xs:attribute name="path" type="xs:token" use="required"></xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
@@ -35,7 +35,7 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-resource-adapters_7_1.xsd";
+        return "schema/wildfly-resource-adapters_7_2.xsd";
     }
 
     @Override

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersTransformersTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersTransformersTestCase.java
@@ -45,12 +45,12 @@ public class ResourceAdaptersTransformersTestCase extends AbstractSubsystemBaseT
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("resource-adapters-transform_7_1.xml");
+        return readResource("resource-adapters-transform_7_2.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() {
-        return "schema/wildfly-resource-adapters_7_1.xsd";
+        return "schema/wildfly-resource-adapters_7_2.xsd";
     }
 
     /**
@@ -86,7 +86,7 @@ public class ResourceAdaptersTransformersTestCase extends AbstractSubsystemBaseT
      * @throws Exception if an error occurs during the kernel initialization or the subsystem transformation validation.
      */
     private void testTransformer(final ModelTestControllerVersion controllerVersion) throws Exception {
-        String subsystemXml = "resource-adapters-transform_7_1.xml";
+        String subsystemXml = "resource-adapters-transform_7_2.xml";
         ModelVersion modelVersion = getResourceAdapterModel(controllerVersion);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXmlResource(subsystemXml);
         KernelServices mainServices = initialKernelServices(builder, controllerVersion);

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
@@ -3,77 +3,73 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
-            <resource-adapters>
-                <resource-adapter id="myRA">
-                    <archive>some.rar</archive>
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
+    <resource-adapters>
+        <resource-adapter id="myRA">
+            <archive>some.rar</archive>
             <bean-validation-groups>
-               <bean-validation-group>Class0</bean-validation-group>
-               <bean-validation-group>Class00</bean-validation-group>
+                <bean-validation-group>Class0</bean-validation-group>
+                <bean-validation-group>Class00</bean-validation-group>
             </bean-validation-groups>
             <bootstrap-context>someContext</bootstrap-context>
             <config-property name="Property">A</config-property>
             <transaction-support>XATransaction</transaction-support>
-                    <connection-definitions>
-                        <connection-definition
-                                class-name="Class1"
-                                jndi-name="java:jboss/name1"
-                                pool-name="Pool1"
-                use-ccm="true"
-                use-java-context="false"
-                enabled="false">
-                            <config-property name="Property">B</config-property>
-                <xa-pool>
-                  <min-pool-size>1</min-pool-size>
-                  <max-pool-size>5</max-pool-size>
-                  <prefill>true</prefill>
-                   <use-strict-min>true</use-strict-min>
-                   <flush-strategy>IdleConnections</flush-strategy>
-                   <is-same-rm-override>true</is-same-rm-override>
-                   <interleaving/>
-                   <no-tx-separate-pools/>
-                 <pad-xid>true</pad-xid>
-                <wrap-xa-resource>true</wrap-xa-resource>
-                </xa-pool>
-                <security>
-                  <application/>
-                </security>
-               <timeout>
-                  <blocking-timeout-millis>5000</blocking-timeout-millis>
-                  <idle-timeout-minutes>4</idle-timeout-minutes>
-                  <allocation-retry>2</allocation-retry>
-                  <allocation-retry-wait-millis>3000</allocation-retry-wait-millis>
-                  <xa-resource-timeout>300</xa-resource-timeout>
-                </timeout>
-                 <validation>
-                  <background-validation>true</background-validation>
-                  <background-validation-millis>5000</background-validation-millis>
-                  <use-fast-fail>true</use-fast-fail>
-                </validation>
-                <recovery no-recovery="false">
-                  <recover-credential user-name="sa" password="sa-pass">
-                    <security-domain>HsqlDbRealm</security-domain>
-                  </recover-credential>
-                  <recover-plugin class-name="someClass2">
-                    <config-property name="Property">C</config-property>
-                  </recover-plugin>
-                </recovery>
-
-              </connection-definition>
-                    </connection-definitions>
-
-                    <admin-objects>
-                        <admin-object
-                                class-name="Class3"
-                                jndi-name="java:jboss/Name3"
-                pool-name="Pool2"
-                use-java-context="false"
-                enabled="true">
-                            <config-property name="Property">D</config-property>
-                        </admin-object>
-                    </admin-objects>
-
-                </resource-adapter>
-            </resource-adapters>
-
-        </subsystem>
+            <connection-definitions>
+                <connection-definition
+                        class-name="Class1"
+                        jndi-name="java:jboss/name1"
+                        pool-name="Pool1"
+                        use-ccm="true"
+                        use-java-context="false"
+                        enabled="false">
+                    <config-property name="Property">B</config-property>
+                    <xa-pool>
+                        <min-pool-size>1</min-pool-size>
+                        <max-pool-size>5</max-pool-size>
+                        <prefill>true</prefill>
+                        <use-strict-min>true</use-strict-min>
+                        <flush-strategy>IdleConnections</flush-strategy>
+                        <is-same-rm-override>true</is-same-rm-override>
+                        <interleaving/>
+                        <no-tx-separate-pools/>
+                        <pad-xid>true</pad-xid>
+                        <wrap-xa-resource>true</wrap-xa-resource>
+                    </xa-pool>
+                    <security>
+                      <application/>
+                    </security>
+                    <timeout>
+                        <blocking-timeout-millis>5000</blocking-timeout-millis>
+                        <idle-timeout-minutes>4</idle-timeout-minutes>
+                        <allocation-retry>2</allocation-retry>
+                        <allocation-retry-wait-millis>3000</allocation-retry-wait-millis>
+                        <xa-resource-timeout>300</xa-resource-timeout>
+                    </timeout>
+                    <validation>
+                        <background-validation>true</background-validation>
+                        <background-validation-millis>5000</background-validation-millis>
+                        <use-fast-fail>true</use-fast-fail>
+                    </validation>
+                    <recovery no-recovery="false">
+                        <recover-credential user-name="sa" password="sa-pass">
+                            <security-domain>HsqlDbRealm</security-domain>
+                        </recover-credential>
+                        <recover-plugin class-name="someClass2">
+                            <config-property name="Property">C</config-property>
+                        </recover-plugin>
+                    </recovery>
+                </connection-definition>
+            </connection-definitions>
+            <admin-objects>
+                <admin-object
+                        class-name="Class3"
+                        jndi-name="java:jboss/Name3"
+                        pool-name="Pool2"
+                        use-java-context="false"
+                        enabled="true">
+                    <config-property name="Property">D</config-property>
+                </admin-object>
+            </admin-objects>
+        </resource-adapter>
+    </resource-adapters>
+</subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra2.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra2.xml
@@ -3,19 +3,19 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:4.0">
- <resource-adapters>
-  <resource-adapter id="myRA">
-   <archive>multiple.rar</archive>
-      <transaction-support>NoTransaction</transaction-support>
-        <connection-definitions>
-            <connection-definition  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"  pool-name="Pool1">    </connection-definition>
-            <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name2"  pool-name="Pool2"> </connection-definition>
-        </connection-definitions>
-        <admin-objects>
-          <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl"  jndi-name="java:jboss/Name3"    pool-name="Pool3">  </admin-object>
-          <admin-object  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl" jndi-name="java:jboss/Name4" pool-name="Pool4"> </admin-object>
-         </admin-objects>
-    </resource-adapter>
-  </resource-adapters>
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
+    <resource-adapters>
+        <resource-adapter id="myRA">
+            <archive>multiple.rar</archive>
+            <transaction-support>NoTransaction</transaction-support>
+            <connection-definitions>
+                <connection-definition  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1" pool-name="Pool1" />
+                <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name2" pool-name="Pool2" />
+            </connection-definitions>
+            <admin-objects>
+                  <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl"  jndi-name="java:jboss/Name3" pool-name="Pool3" />
+                  <admin-object  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl" jndi-name="java:jboss/Name4" pool-name="Pool4" />
+            </admin-objects>
+        </resource-adapter>
+    </resource-adapters>
 </subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/empty-resourceadapters.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/empty-resourceadapters.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.0" />
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2" />

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-full.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-full.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="myRA" statistics-enabled="false">
             <archive>archive</archive>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled-expression.xml
@@ -3,23 +3,23 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <!--Optional:-->
     <resource-adapters>
         <!--1 or more repetitions:-->
         <resource-adapter id="myRA" statistics-enabled="${test.expr:true}">
             <!--Optional:-->
-            <module id="moduleID" slot="main    "/>
-            <!--Optional:-->
-            <bootstrap-context>${test.expr:bootstrapContext}</bootstrap-context>
+            <module id="moduleID" slot="main"/>
             <bean-validation-groups>
                 <!--1 or more repetitions:-->
                 <bean-validation-group>${test.expr:group}</bean-validation-group>
             </bean-validation-groups>
             <!--Optional:-->
-            <transaction-support>${test.expr:NoTransaction}</transaction-support>
+            <bootstrap-context>${test.expr:bootstrapContext}</bootstrap-context>
             <!--Zero or more repetitions:-->
             <config-property name="config1">${test.expr:value}</config-property>
+            <!--Optional:-->
+            <transaction-support>${test.expr:NoTransaction}</transaction-support>
             <workmanager>
                 <security enabled="${test.expr:true}">
                     <mapping-required>${test.expr:true}</mapping-required>
@@ -86,8 +86,9 @@
                             <!--Optional:-->
                             <credential-reference store="teststore" alias="${test.expr:myalias}"/>
                             <!--Optional:-->
-                            <elytron-enabled>${test.expr:true}</elytron-enabled>
                             <authentication-context>AnotherAuthenticationContext</authentication-context>
+                            <!--Optional:-->
+                            <elytron-enabled>${test.expr:true}</elytron-enabled>
                         </recover-credential>
                         <!--Optional:-->
                         <recover-plugin class-name="${test.expr:aClass}">

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-transform_7_2.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-transform_7_2.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->
@@ -44,7 +44,7 @@
                 <!--Optional:-->
                 <is-same-rm-override>${test.expr:true}</is-same-rm-override>
                 <!--Optional:-->
-                <interleaving>${test.expr:false}</interleaving>
+                <interleaving/>
                 <!--Optional:-->
                 <no-tx-separate-pools/>
                 <!--Optional:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->
@@ -44,7 +44,7 @@
             <!--Optional:-->
             <is-same-rm-override>true</is-same-rm-override>
             <!--Optional:-->
-            <interleaving>false</interleaving>
+            <interleaving/>
             <!--Optional:-->
             <no-tx-separate-pools />
             <!--Optional:-->
@@ -79,9 +79,7 @@
           <!--Optional:-->
           <recovery no-recovery="false">
             <!--Optional:-->
-            <recover-credential user-name="userName" password="pwd">
-              <!--Optional:-->
-            </recover-credential>
+            <recover-credential user-name="userName" password="pwd"/>
             <!--Optional:-->
             <recover-plugin class-name="aClass">
               <config-property name="config3">value</config-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
@@ -74,7 +74,7 @@ public class NoRaAnnoTestCase {
             String xml = FileUtils.readFile(NoRaAnnoTestCase.class,
                     "ra16anno.xml");
             List<ModelNode> operations = xmlToModelOperations(xml,
-                    Namespace.RESOURCEADAPTERS_1_0.getUriString(),
+                    Namespace.CURRENT.getUriString(),
                     new ResourceAdapterSubsystemParser());
             address = operations.get(1).get("address");
             executeOperation(operationListToCompositeOperation(operations));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
@@ -73,7 +73,7 @@ public class RaAnnoTestCase {
             String xml = FileUtils.readFile(RaAnnoTestCase.class,
                     "ra16anno.xml");
             List<ModelNode> operations = xmlToModelOperations(xml,
-                    Namespace.RESOURCEADAPTERS_1_0.getUriString(),
+                    Namespace.CURRENT.getUriString(),
                     new ResourceAdapterSubsystemParser());
             address = operations.get(1).get("address");
             executeOperation(operationListToCompositeOperation(operations));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/ra16anno.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/ra16anno.xml
@@ -3,21 +3,21 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:1.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
-        <resource-adapter>
+        <resource-adapter id="ra16">
             <archive>ra16anno.rar</archive>
             <transaction-support>NoTransaction</transaction-support>
             <connection-definitions>
                 <connection-definition
                         class-name="org.jboss.as.test.integration.jca.annorar.AnnoManagedConnectionFactory"
-                        jndi-name="java:/eis/ra16anno" pool-name="Pool1">
-                </connection-definition>
+                        jndi-name="java:/eis/ra16anno" pool-name="Pool1"/>
             </connection-definitions>
-            <admin-object
-                    class-name="org.jboss.as.test.integration.jca.annorar.AnnoAdminObjectImpl"
-                    jndi-name="java:/eis/ao/ra16anno" pool-name="Pool2">
-            </admin-object>
+            <admin-objects>
+                <admin-object
+                        class-name="org.jboss.as.test.integration.jca.annorar.AnnoAdminObjectImpl"
+                        jndi-name="java:/eis/ao/ra16anno" pool-name="Pool2"/>
+            </admin-objects>
         </resource-adapter>
     </resource-adapters>
 </subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/basic.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/basic.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="basic">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/double.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/double.xml
@@ -3,11 +3,11 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="double">
-            <config-property name="name">overRA</config-property>
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>
+            <config-property name="name">overRA</config-property>
             <connection-definitions>
                 <connection-definition
                         class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/inflow.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/inflow.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="inflow2">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/mod-2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/mod-2.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="mod2">
             <module slot="main" id="org.jboss.ironjacamar.ra16out1"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/multi.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/multi.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="multi">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/pure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/pure.xml
@@ -3,9 +3,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
-        <resource-adapter>
+        <resource-adapter id="ra">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>
             <connection-definitions>
                 <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/second.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/second.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:resource-adapters:7.1">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:7.2">
     <resource-adapters>
         <resource-adapter id="second">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>


### PR DESCRIPTION
Issue: [WFLY-19473](https://issues.redhat.com/browse/WFLY-19473)

This is the last one, the issue here is that certain elements in the schema were configured as mutually exclusive - specifically `elytron-enabled` is not mutually exclusive with anything according to the model but was declared as such in both `security` and `recovery`. Some elements had to be reordered as a result.

`elytron-enabled` was also changed from booleanPresence to boolean, but we should just pick one (or they could be attributes) since it looks randomly assigned, e.g. in `xa-pool` we've got
* is-same-rm-override (boolean)
* interleaving (boolean-presenceType)
* no-tx-separate-pools (boolean-presenceType)
* pad-xid (boolean)
* wrap-xa-resource (boolean)
though I imagine this pops in other subsytems too.

In the parser refactor the `pool-fair` attribute was never being written in a non-xa pool, so that is also fixed. I noticed most of the pool attributes are shared with datasources so maybe there should be another refactor of the whole "wildfly/connector" so that both the RA schema and parser import from datasources.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19573](https://issues.redhat.com/browse/WFLY-19573)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)