### PR TITLE
[WFLY-19480] Upgrade WildFly Core to 25.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19480

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.0.Beta5
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Beta4...25.0.0.Beta5

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6503'>WFCORE-6503</a>] -         Add support for deployments with YAML extension
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6750'>WFCORE-6750</a>] -         [Preview] Scan for annotations indicating unstable API on deployment
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6857'>WFCORE-6857</a>] -         Unmanaged deployment cannot be deployed using yaml without calling deploy in CLI
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6865'>WFCORE-6865</a>] -         DefaultResourceAddDescriptionProvider omits the stability of the operation from its generated description
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6115'>WFCORE-6115</a>] -         Remove deprecated items in key server kernel modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6807'>WFCORE-6807</a>] -         Prune deprecations from wildfly-service and wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6863'>WFCORE-6863</a>] -         Add ServiceDescriptor convenience method for adding a requirement to a RuntimeCapability
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6872'>WFCORE-6872</a>] -         Add forRemoval=true|false attributes to @Deprecated items in key server kernel modules
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6860'>WFCORE-6860</a>] -         Upgrade XNIO to 3.8.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6861'>WFCORE-6861</a>] -         Upgrade JBoss Remoting to 5.0.29.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6862'>WFCORE-6862</a>] -         CVE-2024-6162 CVE-2024-27316 Upgrade Undertow to 2.3.14.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6867'>WFCORE-6867</a>] -         Upgrade WildFly Elytron to 2.5.0.CR1
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6868'>WFCORE-6868</a>] -         Update tests that use CAGenerationTool to use it to load KeyStores etc..
</li>
</ul>
</details>