### PR TITLE
[WFLY-19498] Upgrade WildFly Preview to Weld API 6.0.0.Beta5 and Weld…

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -52,8 +52,8 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.org.glassfish.jakarta.faces>4.1.0</version.org.glassfish.jakarta.faces>
         <version.org.jboss.resteasy>7.0.0.Alpha2</version.org.jboss.resteasy>
-        <version.org.jboss.weld.weld>6.0.0.Beta1</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>6.0.Beta4</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>6.0.0.Beta4</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>6.0.Beta5</version.org.jboss.weld.weld-api>
     </properties>
 
     <dependencyManagement>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -352,9 +352,7 @@
             </build>
         </profile>
 
-        <!-- Test against the ee 9 feature pack -->
-        <!-- TODO convert this to a bootable jar setup once a release
-             of the wildfly jar plugin with transformation support is available -->
+        <!-- Test against the wildfly-preview feature pack -->
         <profile>
             <id>preview.test.profile</id>
             <activation>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -1076,6 +1076,21 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Test against the wildfly-preview feature pack using layers-->
+        <profile>
+            <id>preview.layers.test.profile</id>
+            <activation>
+                <property>
+                    <name>testsuite.ee.galleon.pack.artifactId</name>
+                    <value>wildfly-preview-feature-pack</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Use preview stability when running the embedded server for pre-surefire-execution setup work -->
+                <embedded.server.stability>preview</embedded.server.stability>
+            </properties>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
… 6.0.0.Beta4

https://issues.redhat.com/browse/WFLY-19498

Draft against the EE11 branch to get the WF Preview focused CI used for PRs against that branch.