### PR TITLE
WFLY-19500 Replace deprecated calls to the JBoss Logger methods

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
@@ -8,6 +8,7 @@ package org.jboss.as.appclient.logging;
 import static org.jboss.logging.Logger.Level.ERROR;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 
 import javax.xml.stream.Location;
@@ -32,7 +33,7 @@ public interface AppClientLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    AppClientLogger ROOT_LOGGER = Logger.getMessageLogger(AppClientLogger.class, "org.jboss.as.appclient");
+    AppClientLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), AppClientLogger.class, "org.jboss.as.appclient");
 
 //    /**
 //     * Logs a generic error message using the {@link Throwable#toString() t.toString()} for the error message.

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
@@ -5,6 +5,7 @@
 
 package org.wildfly.extension.batch.jberet._private;
 
+import java.lang.invoke.MethodHandles;
 import java.security.Permission;
 import jakarta.batch.operations.BatchRuntimeException;
 import jakarta.batch.operations.JobSecurityException;
@@ -31,7 +32,7 @@ public interface BatchLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.batch}.
      */
-    BatchLogger LOGGER = Logger.getMessageLogger(BatchLogger.class, "org.wildfly.extension.batch");
+    BatchLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), BatchLogger.class, "org.wildfly.extension.batch");
 
     /**
      * Creates an exception indicating there was an error processing the batch jobs directory.

--- a/bean-validation/src/main/java/org/wildfly/extension/beanvalidation/logging/BeanValidationLogger.java
+++ b/bean-validation/src/main/java/org/wildfly/extension/beanvalidation/logging/BeanValidationLogger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.beanvalidation.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
@@ -15,6 +17,6 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYBV", length = 4)
 public interface BeanValidationLogger extends BasicLogger {
 
-    BeanValidationLogger ROOT_LOGGER = Logger.getMessageLogger(BeanValidationLogger.class, "org.wildfly.extension.beanvalidation");
+    BeanValidationLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), BeanValidationLogger.class, "org.wildfly.extension.beanvalidation");
 
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/logging/ClusteringLogger.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/logging/ClusteringLogger.java
@@ -7,6 +7,7 @@ package org.jboss.as.clustering.logging;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 import org.jboss.as.controller.OperationFailedException;
@@ -28,7 +29,7 @@ public interface ClusteringLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    ClusteringLogger ROOT_LOGGER = Logger.getMessageLogger(ClusteringLogger.class, ROOT_LOGGER_CATEGORY);
+    ClusteringLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ClusteringLogger.class, ROOT_LOGGER_CATEGORY);
 
     @Message(id = 1, value = "%2$g is not a valid value for parameter %1$s. The value must be %3$s %4$g")
     OperationFailedException parameterValueOutOfBounds(String name, double value, String relationalOperator, double bound);

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/logging/Logger.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/logging/Logger.java
@@ -6,6 +6,8 @@ package org.wildfly.clustering.ee.infinispan.logging;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -20,7 +22,7 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface Logger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.clustering.ee.infinispan";
 
-    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(Logger.class, ROOT_LOGGER_CATEGORY);
+    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(MethodHandles.lookup(), Logger.class, ROOT_LOGGER_CATEGORY);
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Failed to cancel %s on primary owner.")

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/logging/InfinispanEjbLogger.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/logging/InfinispanEjbLogger.java
@@ -6,6 +6,8 @@ package org.wildfly.clustering.ejb.infinispan.logging;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -26,7 +28,7 @@ public interface InfinispanEjbLogger extends BasicLogger {
     /**
      * A logger with the category of the default clustering package.
      */
-    InfinispanEjbLogger ROOT_LOGGER = Logger.getMessageLogger(InfinispanEjbLogger.class, ROOT_LOGGER_CATEGORY);
+    InfinispanEjbLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), InfinispanEjbLogger.class, ROOT_LOGGER_CATEGORY);
 
 //    @LogMessage(level = WARN)
 //    @Message(id = 1, value = "Failed to passivate stateful session bean %s")

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/logging/InfinispanLogger.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/logging/InfinispanLogger.java
@@ -8,6 +8,7 @@ package org.jboss.as.clustering.infinispan.logging;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
@@ -30,7 +31,7 @@ public interface InfinispanLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    InfinispanLogger ROOT_LOGGER = Logger.getMessageLogger(InfinispanLogger.class, ROOT_LOGGER_CATEGORY);
+    InfinispanLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), InfinispanLogger.class, ROOT_LOGGER_CATEGORY);
 
     /**
      * Logs an informational message indicating the Infinispan subsystem is being activated.

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -8,6 +8,7 @@ package org.jboss.as.clustering.jgroups.logging;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -33,7 +34,7 @@ public interface JGroupsLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    JGroupsLogger ROOT_LOGGER = Logger.getMessageLogger(JGroupsLogger.class, ROOT_LOGGER_CATEGORY);
+    JGroupsLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JGroupsLogger.class, ROOT_LOGGER_CATEGORY);
 
     /**
      * Logs an informational message indicating the JGroups subsystem is being activated.

--- a/clustering/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/ClusteringServerLogger.java
+++ b/clustering/server/infinispan/src/main/java/org/wildfly/clustering/server/infinispan/ClusteringServerLogger.java
@@ -6,6 +6,7 @@ package org.wildfly.clustering.server.infinispan;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -29,7 +30,7 @@ public interface ClusteringServerLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    ClusteringServerLogger ROOT_LOGGER = Logger.getMessageLogger(ClusteringServerLogger.class, ROOT_LOGGER_CATEGORY);
+    ClusteringServerLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ClusteringServerLogger.class, ROOT_LOGGER_CATEGORY);
 
     /* Command dispatcher messages */
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonLogger.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.clustering.singleton;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -21,7 +23,7 @@ import org.wildfly.clustering.singleton.service.SingletonPolicy;
 public interface SingletonLogger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.extension.clustering.singleton";
 
-    SingletonLogger ROOT_LOGGER = Logger.getMessageLogger(SingletonLogger.class, ROOT_LOGGER_CATEGORY);
+    SingletonLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), SingletonLogger.class, ROOT_LOGGER_CATEGORY);
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Singleton deployment detected. Deployment will reset using %s policy.")

--- a/clustering/singleton/server/src/main/java/org/wildfly/clustering/singleton/server/SingletonLogger.java
+++ b/clustering/singleton/server/src/main/java/org/wildfly/clustering/singleton/server/SingletonLogger.java
@@ -8,6 +8,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 
 import org.jboss.logging.BasicLogger;
@@ -29,7 +30,7 @@ public interface SingletonLogger extends BasicLogger {
     /**
      * The root logger.
      */
-    SingletonLogger ROOT_LOGGER = Logger.getMessageLogger(SingletonLogger.class, ROOT_LOGGER_CATEGORY);
+    SingletonLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), SingletonLogger.class, ROOT_LOGGER_CATEGORY);
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "This node will now operate as the singleton provider of the %s service")

--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/logging/Logger.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/logging/Logger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.clustering.web.cache.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -16,7 +18,7 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface Logger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.clustering.web.cache";
 
-    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(Logger.class, ROOT_LOGGER_CATEGORY);
+    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(MethodHandles.lookup(), Logger.class, ROOT_LOGGER_CATEGORY);
 
     @Message(id = 1, value = "Session %s is not valid")
     IllegalStateException invalidSession(String sessionId);

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/logging/Logger.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/logging/Logger.java
@@ -7,6 +7,8 @@ package org.wildfly.clustering.web.hotrod.logging;
 
 import static org.jboss.logging.Logger.Level.*;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -20,7 +22,7 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface Logger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.clustering.web.hotrod";
 
-    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(Logger.class, ROOT_LOGGER_CATEGORY);
+    Logger ROOT_LOGGER = org.jboss.logging.Logger.getMessageLogger(MethodHandles.lookup(), Logger.class, ROOT_LOGGER_CATEGORY);
 
     @LogMessage(level = WARN)
     @Message(id = 1, value = "Failed to expire session %s")

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/logging/InfinispanWebLogger.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/logging/InfinispanWebLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.clustering.web.infinispan.logging;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -25,7 +27,7 @@ import org.jboss.logging.annotations.MessageLogger;
 public interface InfinispanWebLogger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.clustering.web.infinispan";
 
-    InfinispanWebLogger ROOT_LOGGER = Logger.getMessageLogger(InfinispanWebLogger.class, ROOT_LOGGER_CATEGORY);
+    InfinispanWebLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), InfinispanWebLogger.class, ROOT_LOGGER_CATEGORY);
 
     @LogMessage(level = WARN)
     @Message(id = 1, value = "Failed to passivate attributes of session %s")

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/logging/UndertowClusteringLogger.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/logging/UndertowClusteringLogger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.clustering.web.undertow.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.Logger.Level;
@@ -15,7 +17,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYCLWEBUT", length = 4)
 public interface UndertowClusteringLogger extends BasicLogger {
 
-    UndertowClusteringLogger ROOT_LOGGER = Logger.getMessageLogger(UndertowClusteringLogger.class, "org.wildfly.clustering.web.undertow");
+    UndertowClusteringLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), UndertowClusteringLogger.class, "org.wildfly.clustering.web.undertow");
 
     @Message(id = 1, value = "Session %s is invalid")
     IllegalStateException sessionIsInvalid(String sessionId);

--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -10,6 +10,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Driver;
 import java.util.Set;
 
@@ -42,42 +43,42 @@ public interface ConnectorLogger extends BasicLogger {
     /**
      * The root logger with a category of the default package.
      */
-    ConnectorLogger ROOT_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector");
+    ConnectorLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector");
 
     /**
      * A logger with the category {@code org.jboss.as.connector.deployers.jdbc}.
      */
-    ConnectorLogger DEPLOYER_JDBC_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.deployers.jdbc");
+    ConnectorLogger DEPLOYER_JDBC_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.deployers.jdbc");
 
     /**
      * A logger with the category {@code org.jboss.as.deployment.connector}.
      */
-    ConnectorLogger DEPLOYMENT_CONNECTOR_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.deployment");
+    ConnectorLogger DEPLOYMENT_CONNECTOR_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.deployment");
 
     /**
      * A logger with the category {@code org.jboss.as.deployment.connector.registry}.
      */
-    ConnectorLogger DEPLOYMENT_CONNECTOR_REGISTRY_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.deployment.registry");
+    ConnectorLogger DEPLOYMENT_CONNECTOR_REGISTRY_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.deployment.registry");
 
     /**
      * A logger with the category {@code org.jboss.as.connector.deployer.dsdeployer}.
      */
-    ConnectorLogger DS_DEPLOYER_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.deployer.dsdeployer");
+    ConnectorLogger DS_DEPLOYER_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.deployer.dsdeployer");
 
     /**
      * A logger with the category {@code org.jboss.as.connector.services.mdr}.
      */
-    ConnectorLogger MDR_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.services.mdr");
+    ConnectorLogger MDR_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.services.mdr");
 
     /**
      * A logger with the category {@code org.jboss.as.connector.subsystems.datasources}.
      */
-    ConnectorLogger SUBSYSTEM_DATASOURCES_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.subsystems.datasources");
+    ConnectorLogger SUBSYSTEM_DATASOURCES_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.subsystems.datasources");
 
     /**
      * A logger with the category {@code org.jboss.as.connector.subsystems.resourceadapters}.
      */
-    ConnectorLogger SUBSYSTEM_RA_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector.subsystems.resourceadapters");
+    ConnectorLogger SUBSYSTEM_RA_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector.subsystems.resourceadapters");
 
     /**
      * Logs an informational message indicating the data source has been bound.

--- a/connector/src/main/java/org/jboss/as/connector/metadata/common/CredentialImpl.java
+++ b/connector/src/main/java/org/jboss/as/connector/metadata/common/CredentialImpl.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.connector.metadata.common;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
@@ -25,7 +26,7 @@ public class CredentialImpl implements Credential {
 
     private static final long serialVersionUID = 7990943957924515091L;
 
-    private static CommonBundle bundle = (CommonBundle) Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
     private final String userName;
     private final String password;
     private final String securityDomain;

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
@@ -8,6 +8,7 @@ package org.jboss.as.connector.services.resourceadapters;
 import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTOR_LOGGER;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,7 +46,7 @@ import org.jboss.msc.service.StopContext;
 public final class ResourceAdapterActivatorService extends AbstractResourceAdapterDeploymentService implements
         Service<ResourceAdapterDeployment> {
 
-    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(DeployersLogger.class, ResourceAdapterActivator.class.getName());
+    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), DeployersLogger.class, ResourceAdapterActivator.class.getName());
 
     private final ClassLoader cl;
     private final Connector cmd;

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
@@ -8,6 +8,7 @@ package org.jboss.as.connector.services.resourceadapters.deployment;
 import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTOR_LOGGER;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,7 +55,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 public final class ResourceAdapterDeploymentService extends AbstractResourceAdapterDeploymentService implements
         Service<ResourceAdapterDeployment> {
 
-    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(DeployersLogger.class, "org.jboss.as.connector.deployers.RADeployer");
+    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), DeployersLogger.class, "org.jboss.as.connector.deployers.RADeployer");
 
     private final ClassLoader classLoader;
     private final ConnectorXmlDescriptor connectorXmlDescriptor;

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
@@ -8,6 +8,7 @@ package org.jboss.as.connector.services.resourceadapters.deployment;
 import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTOR_LOGGER;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,7 +44,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 public final class ResourceAdapterXmlDeploymentService extends AbstractResourceAdapterDeploymentService implements
         Service<ResourceAdapterDeployment> {
 
-    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(DeployersLogger.class, "org.jboss.as.connector.deployers.RaXmlDeployer");
+    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), DeployersLogger.class, "org.jboss.as.connector.deployers.RaXmlDeployer");
 
     private final Module module;
     private final ConnectorXmlDescriptor connectorXmlDescriptor;

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/StatisticsExecutorImpl.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/StatisticsExecutorImpl.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.connector.services.workmanager;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.threads.ManagedJBossThreadPoolExecutorService;
 import org.jboss.as.threads.ManagedQueueExecutorService;
 import org.jboss.as.threads.ManagedQueuelessExecutorService;
@@ -26,7 +28,8 @@ public class StatisticsExecutorImpl implements StatisticsExecutor {
     /**
      * The logger
      */
-    private static CoreLogger log = Logger.getMessageLogger(CoreLogger.class,
+    private static CoreLogger log = Logger.getMessageLogger(
+            MethodHandles.lookup(), CoreLogger.class,
             org.jboss.jca.core.workmanager.StatisticsExecutorImpl.class.getName());
 
     private final BlockingExecutor realExecutor;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -13,6 +13,7 @@ import javax.naming.Reference;
 import jakarta.resource.spi.ManagedConnectionFactory;
 import javax.sql.DataSource;
 import javax.sql.XADataSource;
+import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -101,7 +102,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
         return SERVICE_NAME_BASE.append(bindInfo.getBinderServiceName().getCanonicalName());
     }
 
-    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(DeployersLogger.class, AS7DataSourceDeployer.class.getName());
+    private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), DeployersLogger.class, AS7DataSourceDeployer.class.getName());
     protected final InjectedValue<TransactionIntegration> transactionIntegrationValue = new InjectedValue<TransactionIntegration>();
     private final InjectedValue<Driver> driverValue = new InjectedValue<Driver>();
     private final InjectedValue<ManagementRepository> managementRepositoryValue = new InjectedValue<ManagementRepository>();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
@@ -110,6 +110,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PER
 import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -149,7 +150,7 @@ public class DsParser extends AbstractParser {
     /**
      * The bundle
      */
-    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
 
     public void parse(final XMLExtendedStreamReader reader, final List<ModelNode> list, ModelNode parentAddress) throws Exception {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableDataSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableDataSource.java
@@ -5,6 +5,7 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -37,7 +38,7 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
     /**
      * The bundle
      */
-    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
     private final Boolean jta;
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableXaDataSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableXaDataSource.java
@@ -5,6 +5,7 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.jboss.jca.common.CommonBundle;
@@ -34,7 +35,7 @@ public class ModifiableXaDataSource extends XADataSourceImpl implements XaDataSo
     /**
      * The bundle
      */
-    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
 
     /**

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
@@ -62,6 +62,7 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.XA_RE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -100,7 +101,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
     /**
      * The bundle
      */
-    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
 
     protected void parseConfigProperties(final XMLExtendedStreamReader reader, final Map<String, ModelNode> map) throws XMLStreamException, ParserException {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterParser.java
@@ -34,7 +34,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 
-
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +66,7 @@ public class ResourceAdapterParser extends CommonIronJacamarParser {
     /**
      * The bundle
      */
-    private static final CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static final CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
 
     public void parse(final XMLExtendedStreamReader reader, final ModelNode subsystemAddOperation, final List<ModelNode> list, ModelNode parentAddress) throws Exception {

--- a/connector/src/main/java/org/jboss/as/connector/util/AbstractParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/AbstractParser.java
@@ -10,6 +10,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.requireSingleAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 
+import java.lang.invoke.MethodHandles;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
@@ -32,7 +33,7 @@ public abstract class AbstractParser {
     /**
      * The bundle
      */
-    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
+    private static CommonBundle bundle = Messages.getBundle(MethodHandles.lookup(), CommonBundle.class);
 
 
     /**

--- a/connector/src/main/java/org/jboss/as/connector/util/ModelNodeUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/ModelNodeUtil.java
@@ -17,12 +17,13 @@ import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoadException;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ModelNodeUtil {
 
-    private static ConnectorLogger ROOT_LOGGER = Logger.getMessageLogger(ConnectorLogger.class, "org.jboss.as.connector");
+    private static ConnectorLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ConnectorLogger.class, "org.jboss.as.connector");
 
     public static Long getLongIfSetOrGetDefault(final OperationContext context, final ModelNode dataSourceNode, final SimpleAttributeDefinition key) throws OperationFailedException {
 

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/logging/AgroalLogger.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/logging/AgroalLogger.java
@@ -9,17 +9,18 @@ import io.agroal.api.AgroalDataSource;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.msc.service.StartException;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.SQLException;
 
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
-import static org.jboss.logging.Logger.getMessageLogger;
 
 /**
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
@@ -27,11 +28,11 @@ import static org.jboss.logging.Logger.getMessageLogger;
 @MessageLogger(projectCode = "WFLYAG", length = 4)
 public interface AgroalLogger extends BasicLogger {
 
-    AgroalLogger DRIVER_LOGGER = getMessageLogger(AgroalLogger.class, "org.wildfly.extension.datasources.agroal.driver");
+    AgroalLogger DRIVER_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), AgroalLogger.class, "org.wildfly.extension.datasources.agroal.driver");
 
-    AgroalLogger SERVICE_LOGGER = getMessageLogger(AgroalLogger.class, "org.wildfly.extension.datasources.agroal");
+    AgroalLogger SERVICE_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), AgroalLogger.class, "org.wildfly.extension.datasources.agroal");
 
-    AgroalLogger POOL_LOGGER = getMessageLogger(AgroalLogger.class, "io.agroal.pool");
+    AgroalLogger POOL_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), AgroalLogger.class, "io.agroal.pool");
 
     // --- Extension //
 

--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -11,6 +11,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -53,7 +54,7 @@ public interface EeLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    EeLogger ROOT_LOGGER = Logger.getMessageLogger(EeLogger.class, "org.jboss.as.ee");
+    EeLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EeLogger.class, "org.jboss.as.ee");
 
 //    /**
 //     * Logs a warning message indicating the transaction datasource, represented by the {@code className} parameter,

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -13,6 +13,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import java.io.File;
 import java.io.IOException;
 import java.io.InvalidClassException;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
 import java.sql.SQLException;
@@ -93,27 +94,27 @@ import org.jboss.msc.service.ServiceName;
 @MessageLogger(projectCode = "WFLYEJB", length = 4)
 public interface EjbLogger extends BasicLogger {
 
-    EjbLogger ROOT_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3");
+    EjbLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EjbLogger.class, "org.jboss.as.ejb3");
 
     /**
      * A logger with the category {@code org.jboss.as.ejb3.deployment} used for deployment log messages
      */
-    EjbLogger DEPLOYMENT_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.deployment");
+    EjbLogger DEPLOYMENT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EjbLogger.class, "org.jboss.as.ejb3.deployment");
 
     /**
      * A logger with the category {@code org.jboss.as.ejb3.remote} used for remote log messages
      */
-    EjbLogger REMOTE_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.remote");
+    EjbLogger REMOTE_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EjbLogger.class, "org.jboss.as.ejb3.remote");
 
     /**
      * logger use to log Jakarta Enterprise Beans invocation errors
      */
-    EjbLogger EJB3_INVOCATION_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.invocation");
+    EjbLogger EJB3_INVOCATION_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EjbLogger.class, "org.jboss.as.ejb3.invocation");
 
     /**
      * logger use to log Jakarta Enterprise Beans timer messages
      */
-    EjbLogger EJB3_TIMER_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.timer");
+    EjbLogger EJB3_TIMER_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), EjbLogger.class, "org.jboss.as.ejb3.timer");
 
 //    /**
 //     * Logs an error message indicating an exception occurred while removing an inactive bean.

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/_private/ElytronOidcLogger.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/_private/ElytronOidcLogger.java
@@ -8,6 +8,8 @@ package org.wildfly.extension.elytron.oidc._private;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
@@ -25,7 +27,7 @@ public interface ElytronOidcLogger extends BasicLogger {
     /**
      * The root logger with a category of the package name.
      */
-    ElytronOidcLogger ROOT_LOGGER = Logger.getMessageLogger(ElytronOidcLogger.class, ElytronOidcLogger.class.getPackage().getName());
+    ElytronOidcLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ElytronOidcLogger.class, ElytronOidcLogger.class.getPackage().getName());
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/health/src/main/java/org/wildfly/extension/health/_private/HealthLogger.java
+++ b/health/src/main/java/org/wildfly/extension/health/_private/HealthLogger.java
@@ -6,6 +6,8 @@ package org.wildfly.extension.health._private;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -23,7 +25,7 @@ public interface HealthLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.health}.
      */
-    HealthLogger LOGGER = Logger.getMessageLogger(HealthLogger.class, "org.wildfly.extension.health");
+    HealthLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), HealthLogger.class, "org.wildfly.extension.health");
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/logging/IIOPLogger.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/logging/IIOPLogger.java
@@ -26,6 +26,7 @@ import javax.naming.ConfigurationException;
 import javax.naming.InvalidNameException;
 import javax.naming.NamingException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 
 import static org.jboss.logging.Logger.Level.*;
@@ -39,7 +40,7 @@ import static org.jboss.logging.Logger.Level.*;
 @MessageLogger(projectCode = "WFLYIIOP", length = 4)
 public interface IIOPLogger extends BasicLogger {
 
-    IIOPLogger ROOT_LOGGER = Logger.getMessageLogger(IIOPLogger.class, "org.wildfly.iiop.openjdk");
+    IIOPLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), IIOPLogger.class, "org.wildfly.iiop.openjdk");
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Activating IIOP Subsystem")

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
@@ -9,6 +9,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
@@ -34,7 +35,7 @@ public interface JaxrsLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.jboss.jaxrs}.
      */
-    JaxrsLogger JAXRS_LOGGER = Logger.getMessageLogger(JaxrsLogger.class, "org.jboss.as.jaxrs");
+    JaxrsLogger JAXRS_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JaxrsLogger.class, "org.jboss.as.jaxrs");
 
     /**
      * Logs a warning message indicating the annotation, represented by the {@code annotation} parameter, not on Class,

--- a/jdr/src/main/java/org/jboss/as/jdr/logger/JdrLogger.java
+++ b/jdr/src/main/java/org/jboss/as/jdr/logger/JdrLogger.java
@@ -6,6 +6,7 @@ package org.jboss.as.jdr.logger;
 
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
@@ -27,7 +28,7 @@ public interface JdrLogger extends BasicLogger {
     /**
      * A logger with the category of the default jdr package.
      */
-    JdrLogger ROOT_LOGGER = Logger.getMessageLogger(JdrLogger.class, "org.jboss.as.jdr");
+    JdrLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JdrLogger.class, "org.jboss.as.jdr");
 
 //    /**
 //     * Indicates that a JDR report has been initiated.

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/JpaLogger.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/JpaLogger.java
@@ -8,6 +8,8 @@ package org.jboss.as.jpa.hibernate;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.hibernate.boot.archive.spi.ArchiveException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -28,7 +30,7 @@ public interface JpaLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.jipijapa}.
      */
-    JpaLogger JPA_LOGGER = Logger.getMessageLogger(JpaLogger.class, "org.jipijapa");
+    JpaLogger JPA_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JpaLogger.class, "org.jipijapa");
 
     /**
      * Inform that the Hibernate second level cache is enabled.

--- a/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/JpaHibernateSearchLogger.java
+++ b/jpa/hibernatesearch/src/main/java/org/jipijapa/hibernate/search/JpaHibernateSearchLogger.java
@@ -5,6 +5,8 @@
 
 package org.jipijapa.hibernate.search;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -21,7 +23,7 @@ public interface JpaHibernateSearchLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.jipijapa}.
      */
-    JpaHibernateSearchLogger JPA_HIBERNATE_SEARCH_LOGGER = Logger.getMessageLogger(JpaHibernateSearchLogger.class, "org.jipijapa");
+    JpaHibernateSearchLogger JPA_HIBERNATE_SEARCH_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JpaHibernateSearchLogger.class, "org.jipijapa");
 
     @Message(id = 20290, value = "Failed to parse property '%2$s' while integrating Hibernate Search into persistence unit '%1$s")
     IllegalStateException failOnPropertyParsingForIntegration(String puUnitName, String propertyKey, @Cause Exception cause);

--- a/jpa/spi/src/main/java/org/jipijapa/JipiLogger.java
+++ b/jpa/spi/src/main/java/org/jipijapa/JipiLogger.java
@@ -7,6 +7,8 @@ package org.jipijapa;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -25,7 +27,7 @@ public interface JipiLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.jboss.jpa}.
      */
-    JipiLogger JPA_LOGGER = Logger.getMessageLogger(JipiLogger.class, "org.jipijapa");
+    JipiLogger JPA_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JipiLogger.class, "org.jipijapa");
 
 
     /**

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -9,6 +9,8 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import jakarta.ejb.EJBException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceException;
@@ -36,7 +38,7 @@ public interface JpaLogger extends BasicLogger {
     /**
      * Default root level logger with the package name for he category.
      */
-    JpaLogger ROOT_LOGGER = Logger.getMessageLogger(JpaLogger.class, "org.jboss.as.jpa");
+    JpaLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JpaLogger.class, "org.jboss.as.jpa");
 
     /**
      * Logs a warning message indicating duplicate persistence.xml files were found.

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
@@ -10,6 +10,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -35,7 +36,7 @@ public interface JSFLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    JSFLogger ROOT_LOGGER = Logger.getMessageLogger(JSFLogger.class, "org.jboss.as.jsf");
+    JSFLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JSFLogger.class, "org.jboss.as.jsf");
 
 //    @LogMessage(level = WARN)
 //    @Message(id = 1, value = "WildFlyConversationAwareViewHandler was improperly initialized. Expected ViewHandler parent.")

--- a/legacy/keycloak/src/main/java/org/keycloak/subsystem/adapter/logging/KeycloakLogger.java
+++ b/legacy/keycloak/src/main/java/org/keycloak/subsystem/adapter/logging/KeycloakLogger.java
@@ -4,6 +4,8 @@
  */
 package org.keycloak.subsystem.adapter.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -21,7 +23,7 @@ public interface KeycloakLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    KeycloakLogger ROOT_LOGGER = Logger.getMessageLogger(KeycloakLogger.class, "org.jboss.keycloak");
+    KeycloakLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), KeycloakLogger.class, "org.jboss.keycloak");
 
     //@LogMessage(level = INFO)
     //@Message(value = "Keycloak subsystem override for deployment %s")

--- a/legacy/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
+++ b/legacy/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.microprofile.opentracing;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -16,7 +18,7 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFLYTRACEXT", length = 4)
 public interface TracingExtensionLogger extends BasicLogger {
-    TracingExtensionLogger ROOT_LOGGER = Logger.getMessageLogger(TracingExtensionLogger.class, TracingExtensionLogger.class.getPackage().getName());
+    TracingExtensionLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), TracingExtensionLogger.class, TracingExtensionLogger.class.getPackage().getName());
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Activating MicroProfile OpenTracing Subsystem")

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailLogger.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailLogger.java
@@ -9,6 +9,8 @@ import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -28,7 +30,7 @@ interface MailLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    MailLogger ROOT_LOGGER = Logger.getMessageLogger(MailLogger.class, "org.jboss.as.mail.extension");
+    MailLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MailLogger.class, "org.jboss.as.mail.extension");
 
     /**
      * Logs an info message indicating a jakarta.mail.Session was bound into JNDI.

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/_private/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/_private/MessagingLogger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.messaging.activemq._private;
 
+import java.lang.invoke.MethodHandles;
+
 import jakarta.jms.IllegalStateRuntimeException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -21,7 +23,7 @@ public interface MessagingLogger extends BasicLogger {
     /**
      * The logger with the category of the package.
      */
-    MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MessagingLogger.class, "org.wildfly.extension.messaging-activemq");
+    MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MessagingLogger.class, "org.wildfly.extension.messaging-activemq");
 
     /**
      * Create an exception when calling a method not allowed on injected JMSContext.

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/_private/MessagingLogger.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/_private/MessagingLogger.java
@@ -26,6 +26,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -45,7 +46,7 @@ public interface MessagingLogger extends BasicLogger {
     /**
      * The logger with the category of the package.
      */
-    MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MessagingLogger.class, "org.wildfly.extension.messaging-activemq");
+    MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MessagingLogger.class, "org.wildfly.extension.messaging-activemq");
 
     /**
      * Logs a info message indicating AIO was not found.

--- a/metrics/src/main/java/org/wildfly/extension/metrics/_private/MetricsLogger.java
+++ b/metrics/src/main/java/org/wildfly/extension/metrics/_private/MetricsLogger.java
@@ -10,6 +10,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.Logger.Level.ERROR;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.logging.BasicLogger;
@@ -28,7 +29,7 @@ public interface MetricsLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.batch}.
      */
-    MetricsLogger LOGGER = Logger.getMessageLogger(MetricsLogger.class, "org.wildfly.extension.metrics");
+    MetricsLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MetricsLogger.class, "org.wildfly.extension.metrics");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/_private/MicroProfileConfigLogger.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/_private/MicroProfileConfigLogger.java
@@ -8,6 +8,7 @@ package org.wildfly.extension.microprofile.config.smallrye._private;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.jboss.as.controller.OperationFailedException;
@@ -26,7 +27,7 @@ public interface MicroProfileConfigLogger extends BasicLogger {
     /**
      * The root logger with a category of the package name.
      */
-    MicroProfileConfigLogger ROOT_LOGGER = Logger.getMessageLogger(MicroProfileConfigLogger.class,"org.wildfly.extension.microprofile.config.smallrye");
+    MicroProfileConfigLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileConfigLogger.class,"org.wildfly.extension.microprofile.config.smallrye");
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/microprofile/fault-tolerance-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/faulttolerance/MicroProfileFaultToleranceLogger.java
+++ b/microprofile/fault-tolerance-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/faulttolerance/MicroProfileFaultToleranceLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.microprofile.faulttolerance;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -19,7 +21,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYMPFTEXT", length = 4)
 public interface MicroProfileFaultToleranceLogger extends BasicLogger {
 
-    MicroProfileFaultToleranceLogger ROOT_LOGGER = Logger.getMessageLogger(MicroProfileFaultToleranceLogger.class, MicroProfileFaultToleranceLogger.class.getPackage().getName());
+    MicroProfileFaultToleranceLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileFaultToleranceLogger.class, MicroProfileFaultToleranceLogger.class.getPackage().getName());
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Activating MicroProfile Fault Tolerance subsystem.")

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
@@ -8,6 +8,8 @@ package org.wildfly.extension.microprofile.health._private;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -25,7 +27,7 @@ public interface MicroProfileHealthLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.batch}.
      */
-    MicroProfileHealthLogger LOGGER = Logger.getMessageLogger(MicroProfileHealthLogger.class, "org.wildfly.extension.microprofile.health.smallrye");
+    MicroProfileHealthLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileHealthLogger.class, "org.wildfly.extension.microprofile.health.smallrye");
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/microprofile/jwt-smallrye/src/main/java/org/wildfly/extension/microprofile/jwt/smallrye/_private/MicroProfileJWTLogger.java
+++ b/microprofile/jwt-smallrye/src/main/java/org/wildfly/extension/microprofile/jwt/smallrye/_private/MicroProfileJWTLogger.java
@@ -8,6 +8,8 @@ package org.wildfly.extension.microprofile.jwt.smallrye._private;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -24,7 +26,7 @@ public interface MicroProfileJWTLogger extends BasicLogger {
     /**
      * The root logger with a category of the package name.
      */
-    MicroProfileJWTLogger ROOT_LOGGER = Logger.getMessageLogger(MicroProfileJWTLogger.class, "org.wildfly.extension.microprofile.jwt.smallrye");
+    MicroProfileJWTLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileJWTLogger.class, "org.wildfly.extension.microprofile.jwt.smallrye");
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/_private/MicroProfileLRACoordinatorLogger.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/_private/MicroProfileLRACoordinatorLogger.java
@@ -18,13 +18,15 @@ import org.jboss.msc.service.StartException;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Log messages for WildFly microprofile-lra-coordinator Extension.
  */
 @MessageLogger(projectCode = "WFLYTXLRACOORD", length = 4)
 public interface MicroProfileLRACoordinatorLogger extends BasicLogger {
 
-    MicroProfileLRACoordinatorLogger LOGGER = Logger.getMessageLogger(MicroProfileLRACoordinatorLogger.class, "org.wildfly.extension.microprofile.lra.coordinator");
+    MicroProfileLRACoordinatorLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(),MicroProfileLRACoordinatorLogger.class, "org.wildfly.extension.microprofile.lra.coordinator");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/_private/MicroProfileLRAParticipantLogger.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/_private/MicroProfileLRAParticipantLogger.java
@@ -18,13 +18,15 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Log messages for WildFly microprofile-lra-participant Extension.
  */
 @MessageLogger(projectCode = "WFLYTXLRAPARTICIPANT", length = 4)
 public interface MicroProfileLRAParticipantLogger extends BasicLogger {
 
-    MicroProfileLRAParticipantLogger LOGGER = Logger.getMessageLogger(MicroProfileLRAParticipantLogger.class, "org.wildfly.extension.microprofile.lra.participant");
+    MicroProfileLRAParticipantLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileLRAParticipantLogger.class, "org.wildfly.extension.microprofile.lra.participant");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.microprofile.metrics._private;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -21,7 +23,7 @@ public interface MicroProfileMetricsLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.batch}.
      */
-    MicroProfileMetricsLogger ROOT_LOGGER = Logger.getMessageLogger(MicroProfileMetricsLogger.class,
+    MicroProfileMetricsLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileMetricsLogger.class,
             "org.wildfly.extension.microprofile.metrics.smallrye");
 
     // no longer used

--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/logging/MicroProfileOpenAPILogger.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/logging/MicroProfileOpenAPILogger.java
@@ -8,6 +8,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 import org.jboss.logging.BasicLogger;
@@ -24,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
  */
 @MessageLogger(projectCode = "WFLYMPOAI", length = 4)
 public interface MicroProfileOpenAPILogger extends BasicLogger {
-    MicroProfileOpenAPILogger LOGGER = Logger.getMessageLogger(MicroProfileOpenAPILogger.class, "org.wildfly.extension.microprofile.openapi.smallrye");
+    MicroProfileOpenAPILogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileOpenAPILogger.class, "org.wildfly.extension.microprofile.openapi.smallrye");
 
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Activating MicroProfile OpenAPI Subsystem")

--- a/microprofile/reactive-messaging-smallrye/amqp/src/main/java/org/wildfly/microprofile/reactive/messaging/config/amqp/ssl/context/_private/MicroProfileReactiveMessagingAmqpLogger.java
+++ b/microprofile/reactive-messaging-smallrye/amqp/src/main/java/org/wildfly/microprofile/reactive/messaging/config/amqp/ssl/context/_private/MicroProfileReactiveMessagingAmqpLogger.java
@@ -6,6 +6,8 @@
 
 package org.wildfly.microprofile.reactive.messaging.config.amqp.ssl.context._private;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
@@ -18,7 +20,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYRMAMQP", length = 4)
 public interface MicroProfileReactiveMessagingAmqpLogger extends BasicLogger {
 
-    MicroProfileReactiveMessagingAmqpLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveMessagingAmqpLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
+    MicroProfileReactiveMessagingAmqpLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileReactiveMessagingAmqpLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
 
     // No log messages here yet
 

--- a/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/_private/MicroProfileReactiveMessagingCommonLogger.java
+++ b/microprofile/reactive-messaging-smallrye/common/src/main/java/org/wildfly/microprofile/reactive/messaging/common/_private/MicroProfileReactiveMessagingCommonLogger.java
@@ -13,6 +13,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Log messages for WildFly microprofile-reactive-messaging-smallrye Extension.
  *
@@ -21,7 +23,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 @MessageLogger(projectCode = "WFLYRXMKAF", length = 4)
 public interface MicroProfileReactiveMessagingCommonLogger extends BasicLogger {
 
-    MicroProfileReactiveMessagingCommonLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveMessagingCommonLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
+    MicroProfileReactiveMessagingCommonLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileReactiveMessagingCommonLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/_private/MicroProfileReactiveMessagingLogger.java
+++ b/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/_private/MicroProfileReactiveMessagingLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.microprofile.reactive.messaging._private;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.BasicLogger;
@@ -23,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYRXMESS", length = 4)
 public interface MicroProfileReactiveMessagingLogger extends BasicLogger {
 
-    MicroProfileReactiveMessagingLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveMessagingLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
+    MicroProfileReactiveMessagingLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileReactiveMessagingLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/_private/MicroProfileReactiveMessagingKafkaLogger.java
+++ b/microprofile/reactive-messaging-smallrye/kafka/src/main/java/org/wildfly/microprofile/reactive/messaging/config/kafka/ssl/context/_private/MicroProfileReactiveMessagingKafkaLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.microprofile.reactive.messaging.config.kafka.ssl.context._pr
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -22,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYRXMKAF", length = 4)
 public interface MicroProfileReactiveMessagingKafkaLogger extends BasicLogger {
 
-    MicroProfileReactiveMessagingKafkaLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveMessagingKafkaLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
+    MicroProfileReactiveMessagingKafkaLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileReactiveMessagingKafkaLogger.class, "org.wildfly.extension.microprofile.reactive.messaging");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/reactive-streams-operators-smallrye/cdi-provider/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/cdi/_private/CdiProviderLogger.java
+++ b/microprofile/reactive-streams-operators-smallrye/cdi-provider/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/cdi/_private/CdiProviderLogger.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.microprofile.reactive.streams.operators.cdi._private;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
@@ -18,7 +20,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYRXSTOPSCDI", length = 4)
 public interface CdiProviderLogger extends BasicLogger {
 
-    CdiProviderLogger LOGGER = Logger.getMessageLogger(CdiProviderLogger.class, "org.wildfly.extension.microprofile.reactive.streams.operators.cdi");
+    CdiProviderLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), CdiProviderLogger.class, "org.wildfly.extension.microprofile.reactive.streams.operators.cdi");
 
     @Message(id = 1, value = "No implementation of the %s found in the classpath")
     IllegalStateException noImplementationFound(String className);

--- a/microprofile/reactive-streams-operators-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/_private/MicroProfileReactiveStreamsOperatorsLogger.java
+++ b/microprofile/reactive-streams-operators-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/streams/operators/_private/MicroProfileReactiveStreamsOperatorsLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.microprofile.reactive.streams.operators._private;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -22,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYRXSTOPS", length = 4)
 public interface MicroProfileReactiveStreamsOperatorsLogger extends BasicLogger {
 
-    MicroProfileReactiveStreamsOperatorsLogger LOGGER = Logger.getMessageLogger(MicroProfileReactiveStreamsOperatorsLogger.class, "org.wildfly.extension.microprofile.reactive.streams.operators");
+    MicroProfileReactiveStreamsOperatorsLogger LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), MicroProfileReactiveStreamsOperatorsLogger.class, "org.wildfly.extension.microprofile.reactive.streams.operators");
 
     /**
      * Logs an informational message indicating the subsystem is being activated.

--- a/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryExtensionLogger.java
+++ b/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryExtensionLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.microprofile.telemetry;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -16,7 +18,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFLYMPTEL", length = 4)
 interface MicroProfileTelemetryExtensionLogger extends BasicLogger {
-    MicroProfileTelemetryExtensionLogger MPTEL_LOGGER = Logger.getMessageLogger(MicroProfileTelemetryExtensionLogger.class,
+    MicroProfileTelemetryExtensionLogger MPTEL_LOGGER = Logger.getMessageLogger(
+            MethodHandles.lookup(), MicroProfileTelemetryExtensionLogger.class,
             MicroProfileTelemetryExtensionLogger.class.getPackage().getName());
 
     @LogMessage(level = INFO)

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterLogger.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterLogger.java
@@ -8,6 +8,8 @@ package org.wildfly.extension.mod_cluster;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -25,7 +27,7 @@ interface ModClusterLogger extends BasicLogger {
     /**
      * The root logger with a category of the package name.
      */
-    ModClusterLogger ROOT_LOGGER = Logger.getMessageLogger(ModClusterLogger.class, "org.wildfly.extension.mod_cluster");
+    ModClusterLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ModClusterLogger.class, "org.wildfly.extension.mod_cluster");
 
     /**
      * Logs an error message indicating an error when adding metrics.

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -9,6 +9,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.security.Permission;
 
 import javax.naming.Context;
@@ -44,7 +45,7 @@ public interface NamingLogger extends BasicLogger {
     /**
      * The root logger with a category of the package name.
      */
-    NamingLogger ROOT_LOGGER = Logger.getMessageLogger(NamingLogger.class, "org.jboss.as.naming");
+    NamingLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), NamingLogger.class, "org.jboss.as.naming");
 
     /**
      * Logs an informational message indicating the naming subsystem is being activated.

--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerExtensionLogger.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerExtensionLogger.java
@@ -10,6 +10,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.logging.BasicLogger;
@@ -21,7 +22,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFLYMMTREXT", length = 4)
 public interface MicrometerExtensionLogger extends BasicLogger {
-    MicrometerExtensionLogger MICROMETER_LOGGER = Logger.getMessageLogger(MicrometerExtensionLogger.class,
+    MicrometerExtensionLogger MICROMETER_LOGGER = Logger.getMessageLogger(
+            MethodHandles.lookup(), MicrometerExtensionLogger.class,
             MicrometerExtensionLogger.class.getPackage().getName());
 
     @LogMessage(level = INFO)

--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetryExtensionLogger.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetryExtensionLogger.java
@@ -9,6 +9,8 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.wildfly.extension.opentelemetry.OpenTelemetryConfigurationConstants.EXPORTER_OTLP;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -19,7 +21,7 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "WFLYOTELEXT", length = 4)
 interface OpenTelemetryExtensionLogger extends BasicLogger {
-    OpenTelemetryExtensionLogger OTEL_LOGGER = Logger.getMessageLogger(OpenTelemetryExtensionLogger.class,
+    OpenTelemetryExtensionLogger OTEL_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), OpenTelemetryExtensionLogger.class,
             OpenTelemetryExtensionLogger.class.getPackage().getName());
 
     @LogMessage(level = INFO)

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/logging/PicketLinkLogger.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/logging/PicketLinkLogger.java
@@ -7,6 +7,8 @@ package org.wildfly.extension.picketlink.logging;
 
 import static org.jboss.logging.Logger.Level.INFO;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -21,7 +23,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYPL", length = 4)
 public interface PicketLinkLogger extends BasicLogger {
 
-    PicketLinkLogger ROOT_LOGGER = Logger.getMessageLogger(PicketLinkLogger.class, "org.wildfly.extension.picketlink");
+    PicketLinkLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), PicketLinkLogger.class, "org.wildfly.extension.picketlink");
 
     // General Messages 1-49
     @LogMessage(level = INFO)

--- a/pojo/src/main/java/org/jboss/as/pojo/logging/PojoLogger.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/logging/PojoLogger.java
@@ -21,6 +21,7 @@ import org.jboss.vfs.VirtualFile;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 /**
@@ -33,7 +34,7 @@ public interface PojoLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    PojoLogger ROOT_LOGGER = Logger.getMessageLogger(PojoLogger.class, "org.jboss.as.pojo");
+    PojoLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), PojoLogger.class, "org.jboss.as.pojo");
 
     /**
      * Log old namespace usage.

--- a/rts/src/main/java/org/wildfly/extension/rts/logging/RTSLogger.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/logging/RTSLogger.java
@@ -16,6 +16,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
@@ -24,7 +26,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 @MessageLogger(projectCode = "WFLYRTS", length = 4)
 public interface RTSLogger extends BasicLogger {
 
-    RTSLogger ROOT_LOGGER = Logger.getMessageLogger(RTSLogger.class, "org.wildfly.extension.rts");
+    RTSLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), RTSLogger.class, "org.wildfly.extension.rts");
 
     @Message(id = 1, value = "Can't import global transaction to wildfly transaction client.")
     IllegalStateException failueOnImportingGlobalTransactionFromWildflyClient(@Cause jakarta.transaction.SystemException se);

--- a/sar/src/main/java/org/jboss/as/service/logging/SarLogger.java
+++ b/sar/src/main/java/org/jboss/as/service/logging/SarLogger.java
@@ -8,6 +8,7 @@ package org.jboss.as.service.logging;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
 import javax.xml.namespace.QName;
 import javax.management.ObjectName;
 
@@ -32,7 +33,7 @@ public interface SarLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    SarLogger ROOT_LOGGER = Logger.getMessageLogger(SarLogger.class, "org.jboss.as.service");
+    SarLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), SarLogger.class, "org.jboss.as.service");
 
     /**
      * A message indicating a failure to execute a legacy service method, represented by the {@code methodName}

--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -4,6 +4,7 @@
  */
 
 package org.jboss.as.security.logging;
+import java.lang.invoke.MethodHandles;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
@@ -25,7 +26,7 @@ public interface SecurityLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    SecurityLogger ROOT_LOGGER = Logger.getMessageLogger(SecurityLogger.class, "org.jboss.as.security");
+    SecurityLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), SecurityLogger.class, "org.jboss.as.security");
 
 //   /** Logs a message indicating the current version of the PicketBox library
 //    *

--- a/system-jmx/src/main/java/org/jboss/system/logging/ServiceMBeanLogger.java
+++ b/system-jmx/src/main/java/org/jboss/system/logging/ServiceMBeanLogger.java
@@ -5,6 +5,8 @@
 
 package org.jboss.system.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
@@ -17,7 +19,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYSYSJMX", length = 4)
 public interface ServiceMBeanLogger extends BasicLogger {
 
-    ServiceMBeanLogger ROOT_LOGGER = Logger.getMessageLogger(ServiceMBeanLogger.class, "org.jboss.system");
+    ServiceMBeanLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), ServiceMBeanLogger.class, "org.jboss.system");
 
     @Message(id = 1, value = "Null method name")
     IllegalArgumentException nullMethodName();

--- a/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
+++ b/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
@@ -9,6 +9,8 @@ import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.invoke.MethodHandles;
+
 import jakarta.resource.spi.work.Work;
 import jakarta.resource.spi.work.WorkCompletedException;
 import jakarta.transaction.Synchronization;
@@ -36,7 +38,7 @@ public interface TransactionLogger extends BasicLogger {
     /**
      * A logger with the category of the default transaction package.
      */
-    TransactionLogger ROOT_LOGGER = Logger.getMessageLogger(TransactionLogger.class, "org.jboss.as.txn");
+    TransactionLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), TransactionLogger.class, "org.jboss.as.txn");
 
     /**
      * If a transaction could not be rolled back

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -11,6 +11,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -40,7 +41,7 @@ public interface UndertowLogger extends BasicLogger {
     /**
      * A root logger with the category of the package name.
      */
-    UndertowLogger ROOT_LOGGER = Logger.getMessageLogger(UndertowLogger.class, "org.wildfly.extension.undertow");
+    UndertowLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), UndertowLogger.class, "org.wildfly.extension.undertow");
 
 
     /*

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/logging/WSLogger.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/logging/WSLogger.java
@@ -12,6 +12,7 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 
 import jakarta.xml.ws.WebServiceException;
@@ -39,7 +40,7 @@ import org.jboss.wsf.spi.deployment.DeploymentAspect;
 @MessageLogger(projectCode = "WFLYWS", length = 4)
 public interface WSLogger extends BasicLogger {
 
-    WSLogger ROOT_LOGGER = Logger.getMessageLogger(WSLogger.class, "org.jboss.as.webservices");
+    WSLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WSLogger.class, "org.jboss.as.webservices");
 
     @LogMessage(level = WARN)
     @Message(id = 1, value = "Cannot load WS deployment aspects from %s")

--- a/weld/common/src/main/java/org/jboss/as/weld/logging/WeldLogger.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/logging/WeldLogger.java
@@ -8,6 +8,7 @@ package org.jboss.as.weld.logging;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -41,12 +42,12 @@ public interface WeldLogger extends BasicLogger {
     /**
      * A logger with a category of the package name.
      */
-    WeldLogger ROOT_LOGGER = Logger.getMessageLogger(WeldLogger.class, "org.jboss.as.weld");
+    WeldLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WeldLogger.class, "org.jboss.as.weld");
 
     /**
      * A logger with the category {@code org.jboss.weld}.
      */
-    WeldLogger DEPLOYMENT_LOGGER = Logger.getMessageLogger(WeldLogger.class, "org.jboss.weld.deployer");
+    WeldLogger DEPLOYMENT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WeldLogger.class, "org.jboss.weld.deployer");
 
 
     @LogMessage(level= Logger.Level.ERROR)

--- a/weld/ejb/src/main/java/org/jboss/as/weld/_private/WeldEjbLogger.java
+++ b/weld/ejb/src/main/java/org/jboss/as/weld/_private/WeldEjbLogger.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.weld._private;
 
+import java.lang.invoke.MethodHandles;
+
 import jakarta.ejb.NoSuchEJBException;
 
 import org.jboss.logging.BasicLogger;
@@ -15,7 +17,7 @@ import org.jboss.logging.annotations.MessageLogger;
 @MessageLogger(projectCode = "WFLYWELDEJB", length = 4)
 public interface WeldEjbLogger extends BasicLogger {
 
-    WeldEjbLogger ROOT_LOGGER = Logger.getMessageLogger(WeldEjbLogger.class, "org.jboss.as.weld.ejb");
+    WeldEjbLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), WeldEjbLogger.class, "org.jboss.as.weld.ejb");
 
     @Message(id = 1, value = "EJB has been removed: %s")
     NoSuchEJBException ejbHashBeenRemoved(Object ejbComponent);

--- a/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
+++ b/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
@@ -8,6 +8,8 @@ package org.jboss.as.xts.logging;
 import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.Logger.Level.ERROR;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.xts.XTSException;
 import org.jboss.logging.BasicLogger;
@@ -29,7 +31,7 @@ public interface XtsAsLogger extends BasicLogger {
     /**
      * A logger with the category of the package name.
      */
-    XtsAsLogger ROOT_LOGGER = Logger.getMessageLogger(XtsAsLogger.class, "org.jboss.as.xts");
+    XtsAsLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), XtsAsLogger.class, "org.jboss.as.xts");
 
     /**
      * Creates an exception indicating that the TxBridge inbound recovery service failed to start.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19500

Now, this one is only a draft since it requires a PR for the core to be merged and released (https://github.com/wildfly/wildfly-core/pull/6058).

Same as in the core PR `wildfly-maven-plugin` requires an override of jboss-logging to make things pass the simple build.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19684](https://issues.redhat.com/browse/WFLY-19684)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)