### PR TITLE
[WFLY-19287] Fail boot if EE 11 APIs are used and the security manage…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -1224,4 +1224,7 @@ public interface EeLogger extends BasicLogger {
 
     @Message(id = 140, value="Cannot add a HTTP connection which references a null/empty URI")
     IllegalArgumentException cannotAddHTTPConnection();
+
+    @Message(id = 141, value="Running with a SecurityManager enabled is not allowed in a Jakarta EE 11 or later environment")
+    OperationFailedException securityManagerNotAllowed();
 }

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/securitymanager/SecurityManagerRejectedTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/securitymanager/SecurityManagerRejectedTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.securitymanager;
+
+import static org.junit.Assert.assertFalse;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.After;
+import org.junit.AssumptionViolatedException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+
+/**
+ * Tests that starting a server with the SecurityManager enabled fails in an EE11 environment
+ */
+@RunAsClient()
+@RunWith(Arquillian.class)
+@ServerControl(manual = true)
+public class SecurityManagerRejectedTestCase {
+
+    private static final String SERVER_CONFIG_NAME = "forced-security-manager";
+    @ArquillianResource
+    private static volatile ContainerController containerController;
+
+    @BeforeClass
+    public static void ee11Only() {
+
+        // If we are running in a testsuite execution with the SM explicitly enabled everywhere,
+        // we can't be expecting servers to fail to boot with the SM.
+        // So no point going further
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+
+        // Use a missing ManagedBean class as an indicator that we are in an EE 11+ environment.
+        try {
+            SecurityManagerRejectedTestCase.class.getClassLoader().loadClass("jakarta.annotation.ManagedBean");
+            throw new AssumptionViolatedException("Not an EE 11+ environment");
+        } catch (ClassNotFoundException e) {
+            // not found means we want the test
+        }
+    }
+
+    @After
+    public void ensureContainerStopped() {
+        // If the test fails, don't leave a running server behind
+        if (containerController.isStarted(SERVER_CONFIG_NAME)) {
+            containerController.stop(SERVER_CONFIG_NAME);
+        }
+    }
+
+    @Test
+    public void testServerStart() {
+        assertFalse(containerController.isStarted(SERVER_CONFIG_NAME));
+        try {
+            // This config has -secmgr hard coded in its startup args, so it should fail to start
+            containerController.start(SERVER_CONFIG_NAME);
+        } catch (Exception ok) {
+            // good. fall through and confirm the effect of this is the container wasn't started
+        }
+        assertFalse(containerController.isStarted(SERVER_CONFIG_NAME));
+    }
+}

--- a/testsuite/integration/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/resources/arquillian.xml
@@ -529,6 +529,25 @@
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
+
+        <container qualifier="forced-security-manager" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.config.file.name:standalone-ha.xml}</property>
+                <!-- This container is used to check behavior with SM enabled, so we always want it on -->
+                <property name="jbossArguments">${jboss.args} -secmgr</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+                <property name="javaHome">${container.java.home}</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -342,7 +342,6 @@
                 <module>clustering</module>
                 <module>microprofile</module>
                 <module>microprofile-tck</module>
-                <module>secman</module>
                 <module>elytron</module>
                 <module>elytron-oidc-client</module>
                 <module>vdx</module>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -131,36 +131,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Test against WildFly Preview dist -->
-        <profile>
-            <id>preview.profile</id>
-            <activation>
-                <property>
-                    <name>ts.preview</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <!--Re-enable the default surefire execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <phase>test</phase>
-                                <configuration>
-                                    <environmentVariables>
-                                        <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
-                                    </environmentVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 </project>

--- a/testsuite/preview/manualmode/pom.xml
+++ b/testsuite/preview/manualmode/pom.xml
@@ -113,6 +113,13 @@
             <artifactId>wildfly-controller</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-test-runner</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-testsuite-shared</artifactId>

--- a/testsuite/preview/manualmode/src/test/java/org/wildfly/test/manual/securitymanager/SecurityManagerRejectedTestCase.java
+++ b/testsuite/preview/manualmode/src/test/java/org/wildfly/test/manual/securitymanager/SecurityManagerRejectedTestCase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.manual.securitymanager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+
+/**
+ * Tests that starting a server with the SecurityManager enabled fails in an EE11 environment
+ */
+@RunAsClient()
+@RunWith(Arquillian.class)
+@ServerControl(manual = true)
+public class SecurityManagerRejectedTestCase {
+
+    private static final String SERVER_CONFIG_NAME = "forced-security-manager";
+    @ArquillianResource
+    private static volatile ContainerController containerController;
+
+    @BeforeClass
+    public static void ee11Only() {
+
+        // If we are running in a testsuite execution with the SM explicitly enabled everywhere,
+        // we can't be expecting servers to fail to boot with the SM.
+        // So no point going further
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+
+        // Use a missing ManagedBean class as an indicator that we are in an EE 11+ environment.
+        try {
+            SecurityManagerRejectedTestCase.class.getClassLoader().loadClass("jakarta.annotation.ManagedBean");
+            // BES 2024/07/06 -- I've considered supporting ManagedBean in an EE 11+ env; if we do that it would
+            // likely require making the class available on the test classpath so test deployments can compile.
+            // If we do that this test should fail, so we can switch to a different mechanism for deciding if it
+            // should run or not. Check for this when testing WildFly Preview which no longer supports EE 10.
+            fail("Update this test if we begin putting ManagedBean on the classpath in an EE 11 environment");
+        } catch (ClassNotFoundException e) {
+            // not found means we want the test
+        }
+    }
+
+    @After
+    public void ensureContainerStopped() {
+        // If the test fails, don't leave a running server behind
+        if (containerController.isStarted(SERVER_CONFIG_NAME)) {
+            containerController.stop(SERVER_CONFIG_NAME);
+        }
+    }
+
+    @Test
+    public void testServerStart() {
+        assertFalse(containerController.isStarted(SERVER_CONFIG_NAME));
+        try {
+            // This config has -secmgr hard coded in its startup args, so it should fail to start
+            containerController.start(SERVER_CONFIG_NAME);
+        } catch (Exception ok) {
+            // good. fall through and confirm the effect of this is the container wasn't started
+        }
+        assertFalse(containerController.isStarted(SERVER_CONFIG_NAME));
+    }
+}

--- a/testsuite/preview/manualmode/src/test/resources/arquillian.xml
+++ b/testsuite/preview/manualmode/src/test/resources/arquillian.xml
@@ -46,6 +46,25 @@
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
         </container>
+
+        <container qualifier="forced-security-manager" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.config.file.name:standalone-ha.xml}</property>
+                <!-- This container is used to check behavior with SM enabled, so we always want it on -->
+                <property name="jbossArguments">${jboss.args} -secmgr</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
+                <property name="javaHome">${container.java.home}</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>


### PR DESCRIPTION
…r is enabled

https://issues.redhat.com/browse/WFLY-19287