### PR TITLE
[WFLY-19339] If Naming subsystem is activated then add both jdk.naming.dns & jdk.naming.rmi dependencies to deployments

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/deployment/JdkDependenciesProcessor.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/JdkDependenciesProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.naming.deployment;
+
+import org.jboss.as.naming.logging.NamingLogger;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A processor which adds jdk naming modules to deployments.
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+public final class JdkDependenciesProcessor implements DeploymentUnitProcessor {
+
+    private static final String[] JDK_NAMING_MODULES = {
+            "jdk.naming.dns",
+            "jdk.naming.rmi"
+    };
+
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+        final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+        for (String moduleName : JDK_NAMING_MODULES) {
+            try {
+                moduleLoader.loadModule(moduleName);
+                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleName, false, false, false, false));
+            } catch (ModuleLoadException ex) {
+                NamingLogger.ROOT_LOGGER.debugf("Module not found: %s", moduleName);
+            }
+        }
+    }
+}

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
@@ -13,6 +13,7 @@ import org.jboss.as.naming.context.external.ExternalContexts;
 import org.jboss.as.naming.context.external.ExternalContextsNavigableSet;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.deployment.ExternalContextsProcessor;
+import org.jboss.as.naming.deployment.JdkDependenciesProcessor;
 import org.jboss.as.naming.deployment.JndiNamingDependencyProcessor;
 import org.jboss.as.naming.management.JndiViewExtensionRegistry;
 import org.jboss.as.naming.remote.HttpRemoteNamingServerService;
@@ -104,6 +105,8 @@ public class NamingSubsystemAdd extends AbstractBoottimeAddStepHandler {
             @Override
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS, new ExternalContextsProcessor(externalContexts));
+                // TODO: replace Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS + 1 with Phase.STRUCTURE_NAMING_JDK_DEPENDENCIES
+                processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS + 1, new JdkDependenciesProcessor());
                 processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JNDI_DEPENDENCIES, new JndiNamingDependencyProcessor());
             }
         }, OperationContext.Stage.RUNTIME);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/dns/DnsContextLookupBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/dns/DnsContextLookupBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.naming.dns;
+
+import jakarta.ejb.Stateless;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.Hashtable;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+@Stateless
+public class DnsContextLookupBean {
+
+    public void testDnsContextLookup(String serverAddress) throws Exception {
+        final Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        env.put(Context.PROVIDER_URL, "dns://" + serverAddress);
+
+        Context ctx = new InitialContext(env);
+        ctx.close();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/dns/DnsContextLookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/dns/DnsContextLookupTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.naming.dns;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+
+import java.net.SocketPermission;
+
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
+
+/**
+ * Test which ensures DNS Context is available in JNDI.
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+@RunWith(Arquillian.class)
+public class DnsContextLookupTestCase {
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        return ShrinkWrap.create(WebArchive.class, DnsContextLookupTestCase.class.getSimpleName() + ".war")
+            .addClasses(DnsContextLookupTestCase.class, DnsContextLookupBean.class)
+            .addAsManifestResource(createPermissionsXmlAsset(
+                    new SocketPermission("*:10389", "connect,resolve"),
+                    new RuntimePermission("accessClassInPackage.com.sun.jndi.dns"),
+                    new RuntimePermission("accessClassInPackage.com.sun.jndi.url.dns")
+            ), "permissions.xml");
+    }
+
+    @Test
+    public void testTaskSubmit() throws Exception {
+        final DnsContextLookupBean bean =  InitialContext.doLookup("java:module/" + DnsContextLookupBean.class.getSimpleName());
+        bean.testDnsContextLookup("8.8.8.8");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
@@ -9,7 +9,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,10 +18,8 @@ import javax.naming.InitialContext;
 import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 /**
- *
  * Test which ensures RMI Context is available in JNDI.
  * @author Eduardo Martins
- *
  */
 @RunWith(Arquillian.class)
 public class RmiContextLookupTestCase {
@@ -34,7 +31,6 @@ public class RmiContextLookupTestCase {
     public static WebArchive getDeployment() {
         return ShrinkWrap.create(WebArchive.class, RmiContextLookupTestCase.class.getSimpleName() + ".war")
             .addClasses(RmiContextLookupTestCase.class, RmiContextLookupBean.class)
-            .addAsManifestResource(new StringAsset("Dependencies: jdk.naming.rmi\n"), "MANIFEST.MF")
             .addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessClassInPackage.com.sun.jndi.url.rmi")), "permissions.xml");
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19339