### PR TITLE
[WFLY-19537] Bind misc external testsuite servers to the server address to avoid test env networking issues

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/JMXConnectorTestCase.java
@@ -60,7 +60,7 @@ public class JMXConnectorTestCase {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         final String address = managementClient.getMgmtAddress();
         rmiServerJndiName = "rmi://" + address + ":" + port + "/jmxrmi";
-        jmxServiceURL = new JMXServiceURL("service:jmx:rmi:///jndi/"+rmiServerJndiName);
+        jmxServiceURL = new JMXServiceURL("service:jmx:rmi://" + address + "/jndi/"+rmiServerJndiName);
         connectorServer = JMXConnectorServerFactory.newJMXConnectorServer(jmxServiceURL, null, mbs);
         connectorServer.start();
     }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/Util.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/Util.java
@@ -15,6 +15,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import org.jboss.as.arquillian.container.NetworkUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.omg.CORBA.SystemException;
 import org.omg.CORBA.ORBPackage.InvalidName;
 
@@ -36,6 +37,7 @@ public class Util {
 
     public static void presetOrb() throws InvalidName, SystemException {
         Properties properties = new Properties();
+        properties.setProperty(ORBConstants.SERVER_HOST_PROPERTY, TestSuiteEnvironment.getServerAddress());
         properties.setProperty(ORBConstants.PERSISTENT_SERVER_PORT_PROPERTY, "15151");
         properties.setProperty(ORBConstants.ORB_SERVER_ID_PROPERTY, "1");
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/batch/stoprestart/StopFromDifferentNodeTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -89,7 +90,12 @@ public class StopFromDifferentNodeTestCase {
             if (h2Server == null) {
                 //We need a TCP server that can be shared between the two servers.
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                h2Server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                try {
+                    System.setProperty("h2.bindAddress", TestSuiteEnvironment.getServerAddress());
+                    h2Server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                } finally {
+                    System.clearProperty("h2.bindAddress");
+                }
             }
 
             if (savedDefaultJobRepository == null) {

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
@@ -78,7 +79,12 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
             if (server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                try {
+                    System.setProperty("h2.bindAddress", TestSuiteEnvironment.getServerAddress());
+                    server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                } finally {
+                    System.clearProperty("h2.bindAddress");
+                }
             }
 
             final ModelNode compositeOp = new ModelNode();

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -7,7 +7,6 @@ package org.jboss.as.test.multinode.ejb.timer.database;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.getRemoteContext;
@@ -38,6 +37,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
@@ -66,9 +66,6 @@ public class DatabaseTimerServiceMultiNodeTestCase {
 
     private static final int TIMER_DELAY = 400;
 
-    static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs");
-    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(SERVICE, "timer-service").append("database-data-store", "dbstore");
-
     @AfterClass
     public static void afterClass() {
         if(server != null) {
@@ -88,7 +85,12 @@ public class DatabaseTimerServiceMultiNodeTestCase {
             if(server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                try {
+                    System.setProperty("h2.bindAddress", TestSuiteEnvironment.getServerAddress());
+                    server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                } finally {
+                    System.clearProperty("h2.bindAddress");
+                }
             }
 
             final ModelNode compositeOp = new ModelNode();

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
@@ -8,7 +8,6 @@ package org.jboss.as.test.multinode.ejb.timer.database;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.getRemoteContext;
@@ -40,6 +39,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -55,9 +55,6 @@ public class DatabaseTimerServiceRefreshTestCase {
     private static final String ARCHIVE_NAME = "testTimerServiceRefresh";
     private static Server server;
     private static final long TIMER_DELAY = TimeUnit.MINUTES.toMillis(20);
-
-    static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs");
-    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(SERVICE, "timer-service").append("database-data-store", "dbstore");
 
     @AfterClass
     public static void afterClass() {
@@ -78,7 +75,12 @@ public class DatabaseTimerServiceRefreshTestCase {
             if (server == null) {
                 //we need a TCP server that can be shared between the two servers
                 //To allow remote connections, start the TCP server using the option -tcpAllowOthers
-                server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                try {
+                    System.setProperty("h2.bindAddress", TestSuiteEnvironment.getServerAddress());
+                    server = Server.createTcpServer("-tcpAllowOthers", "-ifNotExists").start();
+                } finally {
+                    System.clearProperty("h2.bindAddress");
+                }
             }
 
             final ModelNode compositeOp = new ModelNode();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19537

Various tests on the s390 CI job fail because the server can't connect to test processes listening on InetAddress.getLocalHost(). Avoid this by binding the test processes to the same address as the WF server.

It's not clear why they can't connect but it's safer to KISS and use the same address as the server.
