### PR TITLE
[WFLY-19541] Upgrading Jastow to 2.2.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
         <version.io.smallrye.smallrye-mutiny-zero>1.1.0</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.6.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-reactive-messaging>4.21.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.undertow.jastow>2.2.7.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.8</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19541