### PR TITLE
Revert "[WFLY-19525] Switching JSTL implementation from org.glassfish.web:jakarta.servlet.jsp.jstl to org.glassfish.wasp:wasp"

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -3345,9 +3345,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish.wasp</groupId>
-                <artifactId>wasp</artifactId>
-                <version>${version.org.glassfish.wasp}</version>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+                <version>${version.org.glassfish.web.jakarta.servlet.jsp.jstl}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -1458,8 +1458,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.wasp</groupId>
-            <artifactId>wasp</artifactId>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
         </dependency>
 
         <dependency>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/servlet/jstl/api/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/jakarta/servlet/jstl/api/main/module.xml
@@ -8,7 +8,7 @@
 
     <resources>
         <artifact name="${jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api}"/>
-        <artifact name="${org.glassfish.wasp:wasp}"/>
+        <artifact name="${org.glassfish.web:jakarta.servlet.jsp.jstl}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
         <version.org.glassfish.jaxb>4.0.4</version.org.glassfish.jaxb>
         <version.org.glassfish.jaxb.jaxb-xjc>${version.org.glassfish.jaxb}</version.org.glassfish.jaxb.jaxb-xjc>
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
-        <version.org.glassfish.wasp>3.2.2</version.org.glassfish.wasp>
+        <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.4.4.Final</version.org.hibernate>
         <version.org.hibernate.search>7.1.1.Final</version.org.hibernate.search>


### PR DESCRIPTION
Reverts wildfly/wildfly#18033

We've identified significant memory issues related to this change when running the TCK, so I need to revert it.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19525](https://issues.redhat.com/browse/WFLY-19525)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)