### PR TITLE
Fix for WFLY-19544, Allows to make a Galleon package dependency valid for a given stability level

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -196,6 +196,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
+                            <!-- Any dependency to a package that has a stability level
+                                 lower than the minimum stability level will break the build.
+                                 Note that package dependencies that are only valid for
+                                 a minimum stability level are ignored. -->
+                            <forbid-lower-stability-level-package-reference>true</forbid-lower-stability-level-package-reference>
                             <release-name>${ee.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -15,7 +15,10 @@
         <prop name="--internal-remove-config" value=""/>
     </props>
     <packages>
-        <package name="banner" optional="true"/>
+        <!-- In case the feature-pack containing this model.xml is constrained at build time
+             to a level that doesn't imply 'experimental', the banner package will be not packaged inside the feature-pack.
+             'valid-for-stability' attribute allows to keep this dependency that will be ignored at provisioning time. -->
+        <package name="banner" optional="true" valid-for-stability="experimental"/>
         <package name="product.conf" optional="true"/>
         <package name="org.jboss.as.product" optional="true"/>
         <package name="misc.standalone"/>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -208,6 +208,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
+                            <!-- Any dependency to a package that has a stability level
+                                 lower than the minimum stability level will break the build.
+                                 Note that package dependencies that are only valid for
+                                 a minimum stability level are ignored. -->
+                            <forbid-lower-stability-level-package-reference>true</forbid-lower-stability-level-package-reference>
                             <release-name>${full.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -316,13 +316,13 @@
         <version.ant.junit>1.10.14</version.ant.junit>
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.12</version.org.jacoco>
-        <version.org.jboss.galleon>6.0.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.0.2.Final</version.org.jboss.galleon>
         <version.org.jboss.wildscribe>3.1.0.Final</version.org.jboss.wildscribe>
         <version.org.owasp.dependency-check>10.0.2</version.org.owasp.dependency-check>
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.1.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -209,6 +209,11 @@
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>
+                            <!-- Any dependency to a package that has a stability level
+                                 lower than the minimum stability level will break the build.
+                                 Note that package dependencies that are only valid for
+                                 a minimum stability level are ignored. -->
+                            <forbid-lower-stability-level-package-reference>true</forbid-lower-stability-level-package-reference>
                             <release-name>${preview.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19544

Contains Galleon upgrade to 6.0.2.Final and WildFly Galleon Plugins 7.1.1.Final
