### PR TITLE
[WFLY-19547] Upgrade WildFly Core to 25.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19547

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Beta5...25.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6834'>WFCORE-6834</a>] -         wildfly-elytron-integration jar duplicated in server modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6877'>WFCORE-6877</a>] -         SubsystemPersistence factory method for manual parser/writer cannot find writer
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6892'>WFCORE-6892</a>] -         duplicate declaration of plugin org.apache.maven.plugins:maven-resources-plugin
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6866'>WFCORE-6866</a>] -         Create ServiceDescriptor for management executor
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6870'>WFCORE-6870</a>] -         Remove deprecated ModuleSpecification members
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6871'>WFCORE-6871</a>] -         Deprecate use of ModuleIdentifier in the ModuleSpecification API
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6876'>WFCORE-6876</a>] -         Enhance unit testing of ModuleSpecification
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6886'>WFCORE-6886</a>] -         Update unstable API scanner to 1.0.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6888'>WFCORE-6888</a>] -         Upgrade WildFly Elytron to 2.5.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6900'>WFCORE-6900</a>] -         CVE-2024-3653 CVE-2024-5971 Upgrade Undertow to 2.3.15.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6661'>WFCORE-6661</a>] -         More accurate, resettable start time calculation
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6887'>WFCORE-6887</a>] -         Introduce new phase STRUCTURE_NAMING_JDK_DEPENDENCIES
</li>
</ul>
</details>
