### PR TITLE
WFLY-19573 Expand WeldCapability to include build compatible extensions

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -607,6 +607,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-weld-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-cli</artifactId>
             <scope>test</scope>
@@ -783,6 +788,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.discovery</groupId>
             <artifactId>wildfly-discovery-client</artifactId>
         </dependency>
@@ -814,6 +824,11 @@
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -919,6 +934,32 @@
                                 <include>**/META-INF/services/jakarta.enterprise.inject.spi.Extension</include>
                             </includes>
                             <finalName>weldTest</finalName>
+                            <classifier>bootableJar</classifier>
+                        </configuration>
+                    </execution><execution>
+                        <id>create-module-cdidBcExtensionModule</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>${bootable-jar-maven-jar-plugin.create.modules.phase}</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/extraContent/modules/test/build-compatible-extension/main</outputDirectory>
+                            <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
+                            <includes>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCEDeploymentUnitProcessor.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCESubsystemModel.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCESubsystemRegistrar.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCESubsystemRegistrar$1.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCESubsystemRegistrar$1$1.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension$BCESubsystemSchema.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredExtension.class</include>
+                                <include>**/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredBean.class</include>
+                                <include>**/META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension</include>
+                                <include>**/META-INF/services/org.jboss.as.controller.Extension</include>
+                                <include>**/META-INF/beans.xml</include>
+                            </includes>
+                            <finalName>bce-extension</finalName>
                             <classifier>bootableJar</classifier>
                         </configuration>
                     </execution>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/BCEExtension.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.weld.extensions.buildcompatible.subsystem;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentSubsystemSchema;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.ResourceRegistration;
+import org.jboss.as.controller.SubsystemModel;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.SubsystemSchema;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.xml.VersionedNamespace;
+import org.jboss.as.server.AbstractDeploymentChainStep;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.Phase;
+import org.jboss.as.version.Stability;
+import org.jboss.as.weld.Capabilities;
+import org.jboss.as.weld.WeldCapability;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.IntVersion;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.subsystem.SubsystemConfiguration;
+import org.wildfly.subsystem.SubsystemExtension;
+import org.wildfly.subsystem.SubsystemPersistence;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
+import org.wildfly.subsystem.resource.ResourceDescriptor;
+import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
+import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
+
+@MetaInfServices(Extension.class)
+public class BCEExtension extends SubsystemExtension<BCEExtension.BCESubsystemSchema> {
+
+    public BCEExtension() {
+        super(SubsystemConfiguration.of(BCESubsystemRegistrar.NAME, BCESubsystemModel.CURRENT,
+                BCESubsystemRegistrar::new), SubsystemPersistence.of(BCESubsystemSchema.CURRENT));
+    }
+
+    /**
+     * Model for the 'bce' subsystem.
+     */
+    public enum BCESubsystemModel implements SubsystemModel {
+        VERSION_1_0_0(1, 0, 0),
+        ;
+
+        static final BCESubsystemModel CURRENT = VERSION_1_0_0;
+
+        private final ModelVersion version;
+
+        BCESubsystemModel(int major, int minor, int micro) {
+            this.version = ModelVersion.create(major, minor, micro);
+        }
+
+        @Override
+        public ModelVersion getVersion() {
+            return this.version;
+        }
+    }
+
+    /**
+     * Schema for the 'bce' subsystem.
+     */
+    public enum BCESubsystemSchema implements PersistentSubsystemSchema<BCESubsystemSchema> {
+
+        VERSION_1_0(1, 0, Stability.DEFAULT),
+        ;
+
+        static final BCESubsystemSchema CURRENT = VERSION_1_0;
+
+        private final VersionedNamespace<IntVersion, BCESubsystemSchema> namespace;
+
+        BCESubsystemSchema(int major, int minor, Stability stability) {
+            this.namespace = SubsystemSchema.createSubsystemURN(BCESubsystemRegistrar.NAME, stability, new IntVersion(major, minor));
+        }
+
+        @Override
+        public VersionedNamespace<IntVersion, BCESubsystemSchema> getNamespace() {
+            return this.namespace;
+        }
+
+        @Override
+        public Stability getStability() {
+            return Stability.DEFAULT;
+        }
+
+        @Override
+        public PersistentResourceXMLDescription getXMLDescription() {
+            PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
+            return factory.builder(BCESubsystemRegistrar.PATH).build();
+        }
+    }
+
+    /**
+     * Registrar for the 'bce' subsystem root resource.
+     */
+    private static final class BCESubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
+
+        static final String NAME = "bce";
+        static final PathElement PATH = SubsystemResourceDefinitionRegistrar.pathElement(NAME);
+        static final ParentResourceDescriptionResolver RESOLVER = new SubsystemResourceDescriptionResolver(NAME, BCESubsystemRegistrar.class);
+
+        @Override
+        public ManagementResourceRegistration register(SubsystemRegistration parent, ManagementResourceRegistrationContext context) {
+            ManagementResourceRegistration registration = parent.registerSubsystemModel(ResourceDefinition.builder(ResourceRegistration.of(PATH), RESOLVER).build());
+            ResourceDescriptor descriptor = ResourceDescriptor.builder(RESOLVER)
+                    .withAddOperationRestartFlag(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                    .withRemoveOperationRestartFlag(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                    .withRuntimeHandler(new ResourceOperationRuntimeHandler() {
+                        @Override
+                        public void addRuntime(OperationContext context, ModelNode model) {
+                            if (context.isBooting()) {
+                                context.addStep(new AbstractDeploymentChainStep() {
+                                    @Override
+                                    protected void execute(DeploymentProcessorTarget processorTarget) {
+                                        processorTarget.addDeploymentProcessor(NAME, Phase.INSTALL, Phase.INSTALL_WELD_DEPLOYMENT, new BCEDeploymentUnitProcessor());
+
+                                    }
+                                }, OperationContext.Stage.RUNTIME);
+                            } else {
+                                context.reloadRequired();
+                            }
+                        }
+
+                        @Override
+                        public void removeRuntime(OperationContext context, ModelNode model) throws OperationFailedException {
+                            context.reloadRequired();
+                        }
+                    })
+                    .build();
+            ManagementResourceRegistrar.of(descriptor).register(registration);
+            return registration;
+        }
+    }
+
+    private static final class BCEDeploymentUnitProcessor implements DeploymentUnitProcessor {
+
+        @Override
+        public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+            final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+            try {
+                final WeldCapability weldCapability = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT)
+                        .getCapabilityRuntimeAPI(Capabilities.WELD_CAPABILITY_NAME, WeldCapability.class);
+                weldCapability.registerBuildCompatibleExtension(RegisteredExtension.class, deploymentUnit);
+            } catch (CapabilityServiceSupport.NoSuchCapabilityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/DummyBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/DummyBean.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.weld.extensions.buildcompatible.subsystem;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class DummyBean {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredBean.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.weld.extensions.buildcompatible.subsystem;
+
+// no bean defining annotation, processed via RegisteredExtension
+public class RegisteredBean {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredExtension.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/RegisteredExtension.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.weld.extensions.buildcompatible.subsystem;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Discovery;
+import jakarta.enterprise.inject.build.compatible.spi.ScannedClasses;
+
+public class RegisteredExtension implements BuildCompatibleExtension {
+
+    @Discovery
+    public void discovery(ScannedClasses sc) {
+        sc.add(RegisteredBean.class.getName());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/SubsystemBceRegistrationTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/SubsystemBceRegistrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.weld.extensions.buildcompatible.subsystem;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.net.URL;
+
+@RunWith(Arquillian.class)
+@ServerSetup(SubsystemBceRegistrationTest.SetupTask.class)
+public class SubsystemBceRegistrationTest {
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(SubsystemBceRegistrationTest.class, DummyBean.class, TestModule.class, RegisteredBean.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    DummyBean dummyBean;
+
+    @Inject
+    RegisteredBean registeredBean;
+
+    @Test
+    public void testBceRegisteredAndExecuted() {
+        // check plain WAR deployment
+        Assert.assertNotNull(dummyBean);
+
+        // verify BCE was executed; if so, RegisteredBean would now be resolvable
+        Assert.assertNotNull(registeredBean);
+    }
+
+    public static class SetupTask implements ServerSetupTask {
+        private static final String MODULE_NAME = "build-compatible-extension";
+        private static TestModule testModule;
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            URL url = BCEExtension.class.getResource(MODULE_NAME + "-module.xml");
+            File moduleXmlFile = new File(url.toURI());
+            testModule = new TestModule("test." + MODULE_NAME, moduleXmlFile);
+            testModule.addResource("bce-extension.jar")
+                    .addClasses(BCEExtension.class, RegisteredExtension.class, RegisteredBean.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                    .addAsServiceProvider(org.jboss.as.controller.Extension.class, BCEExtension.class);
+            testModule.create();
+
+            managementClient.getControllerClient().execute(Util.createAddOperation(PathAddress.pathAddress("extension", "test." + MODULE_NAME)));
+            managementClient.getControllerClient().execute(Util.createAddOperation(PathAddress.pathAddress("subsystem", "bce")));
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+
+            managementClient.getControllerClient().execute(Util.createRemoveOperation(PathAddress.pathAddress("subsystem", "bce")));
+            managementClient.getControllerClient().execute(Util.createRemoveOperation(PathAddress.pathAddress("extension", "test." + MODULE_NAME)));
+
+            testModule.remove();
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/build-compatible-extension-module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/extensions/buildcompatible/subsystem/build-compatible-extension-module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="test.build-compatible-extension">
+
+    <resources>
+        <resource-root path="bce-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.inject.api"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.weld.common"/>
+        <module name="org.jboss.as.version"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.wildfly.subsystem"/>
+    </dependencies>
+</module>

--- a/testsuite/integration/basic/src/test/modules/test/build-compatible-extension/main/module.xml
+++ b/testsuite/integration/basic/src/test/modules/test/build-compatible-extension/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="test.build-compatible-extension">
+
+    <resources>
+        <resource-root path="bce-extension-bootableJar.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.inject.api"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.weld.common"/>
+        <module name="org.jboss.as.version"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.wildfly.subsystem"/>
+    </dependencies>
+</module>

--- a/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/WeldCapability.java
@@ -6,6 +6,8 @@
 package org.jboss.as.weld;
 
 import java.util.function.Supplier;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -26,14 +28,27 @@ public interface WeldCapability {
      * Registers a CDI Portable Extension for the {@link DeploymentUnit} passed as argument to
      * this method.
      * <p>
-     * The extension is registered if only if the DeploymentUnit is part of a Weld Deployment. Specifically,
+     * The extension is registered if and only if the DeploymentUnit is part of a Weld Deployment. Specifically,
      * if a call to {@link #isPartOfWeldDeployment(DeploymentUnit)} using the DeploymentUnit argument
-     * returns {@code true}. Otherwise this method will return immediately.
+     * returns {@code true}. Otherwise, this method will return immediately.
      *
      * @param extension An instance of the CDI portable extension to add.
      * @param unit      The deployment unit where the extension will be registered.
      */
     void registerExtensionInstance(final Extension extension, final DeploymentUnit unit);
+
+    /**
+     * Registers a CDI Build Compatible Extension for the {@link DeploymentUnit} passed as argument to
+     * this method.
+     * <p>
+     * The extension is registered if and only if the DeploymentUnit is part of a Weld Deployment. Specifically,
+     * if a call to {@link #isPartOfWeldDeployment(DeploymentUnit)} using the DeploymentUnit argument
+     * returns {@code true}. Otherwise, this method will return immediately.
+     *
+     * @param extension An instance of the CDI portable extension to add.
+     * @param unit      The deployment unit where the extension will be registered.
+     */
+    void registerBuildCompatibleExtension(final Class<? extends BuildCompatibleExtension> extension, final DeploymentUnit unit);
 
     /**
      * Adds the Bean Manager service associated to the {@link DeploymentUnit} to ServiceBuilder passed as argument.

--- a/weld/common/src/main/java/org/jboss/as/weld/logging/WeldLogger.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/logging/WeldLogger.java
@@ -267,4 +267,7 @@ public interface WeldLogger extends BasicLogger {
 
     @Message(id = 63, value = "Original %s does not have a module")
     IllegalArgumentException originalClassDoesNotHaveAModule(Class<?> originalClass);
+
+    @Message(id = 64, value = "Incorrect setup for Weld's LiteExtensionTranslator initialization; a deployment unit has to be specified")
+    IllegalArgumentException incorrectBceTranslatorSetup();
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldCapabilityImpl.java
@@ -6,6 +6,7 @@ package org.jboss.as.weld;
 
 import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -30,6 +31,14 @@ public class WeldCapabilityImpl implements WeldCapability {
         if (isPartOfWeldDeployment(unit)) {
             WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(unit);
             extensions.registerExtensionInstance(extension, unit);
+        }
+    }
+
+    @Override
+    public void registerBuildCompatibleExtension(Class<? extends BuildCompatibleExtension> extension, DeploymentUnit unit) {
+        if (isPartOfWeldDeployment(unit)) {
+            WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(unit);
+            extensions.registerBuildCompatibleExtension(extension);
         }
     }
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -70,6 +70,7 @@ import org.jboss.weld.bootstrap.spi.Metadata;
 import org.jboss.weld.config.ConfigurationKey;
 import org.jboss.weld.configuration.spi.ExternalConfiguration;
 import org.jboss.weld.configuration.spi.helpers.ExternalConfigurationBuilder;
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
 import org.jboss.weld.manager.api.ExecutorServices;
 import org.jboss.weld.security.spi.SecurityServices;
 import org.jboss.weld.transaction.spi.TransactionServices;
@@ -213,8 +214,11 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
                 additional.getServices().add(entry.getKey(), Reflections.cast(entry.getValue()));
             }
         }
-
-        final Collection<Metadata<Extension>> extensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit).getExtensions();
+        WeldPortableExtensions portableExtensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit);
+        // register LiteExtensionTranslator as the last extension so that we have all info on registered BCEs
+        // NOTE: I chose to register it under the dep. unit of the top level deployment, using its CL, not sure if this is correct
+        portableExtensions.registerLiteExtensionTranslatorIfNeeded(classes -> new LiteExtensionTranslator(classes, module.getClassLoader()), deploymentUnit);
+        final Collection<Metadata<Extension>> extensions = portableExtensions.getExtensions();
 
         final WeldDeployment deployment = new WeldDeployment(beanDeploymentArchives, extensions, module, subDeploymentLoaders, deploymentUnit, rootBeanDeploymentModule, eeModuleDescriptors);
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldPortableExtensionProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldPortableExtensionProcessor.java
@@ -28,7 +28,6 @@ import org.jboss.as.weld.deployment.WeldPortableExtensions;
 import org.jboss.as.weld.logging.WeldLogger;
 import org.jboss.modules.Module;
 import org.jboss.vfs.VFSUtils;
-import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -74,14 +73,9 @@ public class WeldPortableExtensionProcessor implements DeploymentUnitProcessor {
             // load class and register for portable extensions
             Collection<Class<?>> loadedPortableExtensions = loadExtensions(module, portableExtensionServices, Object.class);
             registerPortableExtensions(deploymentUnit, extensions, loadedPortableExtensions);
-            // load class and register for portable extensions
-            // if there is at least one, add a portable extension processing them
-            List<Class<? extends BuildCompatibleExtension>> loadedBuildCompatExtensions =
-                    loadExtensions(module, buildCompatibleExtensionServices, BuildCompatibleExtension.class);
-            if (!loadedBuildCompatExtensions.isEmpty()) {
-                Extension extension = new LiteExtensionTranslator(loadedBuildCompatExtensions, module.getClassLoader());
-                // NOTE: I chose to register it under the same dep. unit as other extensions, not sure if this is correct
-                extensions.registerExtensionInstance(extension, deploymentUnit);
+            // load class and register for discovered build compatible extensions
+            for (Class<? extends BuildCompatibleExtension> extensionClass : loadExtensions(module, buildCompatibleExtensionServices, BuildCompatibleExtension.class)) {
+                extensions.registerBuildCompatibleExtension(extensionClass);
             }
         } catch (IOException e) {
             throw new DeploymentUnitProcessingException(e);


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-19573

The PR is a draft until I can test this somehow, ideally see if @ehsavoie's code can work with this.

~~Note that this initial version collects information on all BCEs inside `WeldPortableExtensionProcessor` so anyone registering them would have to do that in an earlier processor. I am not sure how much of an issue that presents, if any.
We could move it to a later phase by either passing it around into Weld bootstrap (req. changes directly in Weld) or perhaps we could try to modify where in WFLY we register `LiteExtensionTranslator` and do it shortly before starting bootstrap at which point we could retrieve and attach all found BCEs.~~

EDIT: The above is no longer true, see the comment below