### PR TITLE
[WFLY-19578] Upgrade WildFly Core to 26.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
         <version.org.opensaml.opensaml>4.2.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19578

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Final...25.0.0.Beta1

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6908'>WFCORE-6908</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in wildfly-controller/host-controller/server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6909'>WFCORE-6909</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in core-management subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6910'>WFCORE-6910</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in domain-management
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6912'>WFCORE-6912</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in jmx subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6914'>WFCORE-6914</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in tests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6915'>WFCORE-6915</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in request-controller subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6916'>WFCORE-6916</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in security-manager subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6917'>WFCORE-6917</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in threads subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6918'>WFCORE-6918</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in wildfly-controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6919'>WFCORE-6919</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in core-management
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6920'>WFCORE-6920</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in deployment-scanner
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6921'>WFCORE-6921</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in domain-management
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6923'>WFCORE-6923</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in host-controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6924'>WFCORE-6924</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in IO subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6925'>WFCORE-6925</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in jmx subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6926'>WFCORE-6926</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in logging subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6927'>WFCORE-6927</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in remoting subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6928'>WFCORE-6928</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in wildfly-server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6929'>WFCORE-6929</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in request-controller subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6930'>WFCORE-6930</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in testsuite
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6874'>WFCORE-6874</a>] -         Apply server candidate phase logs are not saved in log files when using Management CLI
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6813'>WFCORE-6813</a>] -         Extract read-config-as-xml-file tests in individual test classes or methods
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6880'>WFCORE-6880</a>] -         Bump the kernel management API version to 27.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6897'>WFCORE-6897</a>] -         Remove usage of deprecated WildflyTestRunner class
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6855'>WFCORE-6855</a>] -         Upgrade JGit from to 6.10.0.202406032230-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6885'>WFCORE-6885</a>] -         Upgrade SSHD from 2.12.1 to 2.13.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6905'>WFCORE-6905</a>] -         Upgrade Galleon to 6.0.2.Final and Galleon Plugins to 7.1.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6906'>WFCORE-6906</a>] -         Upgrade Installation Manager API to 1.0.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6932'>WFCORE-6932</a>] -         Upgrade commons-lang3 from 3.14.0 to 3.15.0
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6869'>WFCORE-6869</a>] -         Update OpenSSLTLSTestCase to use PKCS#12 KeyStores
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6889'>WFCORE-6889</a>] -         Add a ModuleDependency.Builder class
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6895'>WFCORE-6895</a>] -         Add a grace period to Management CLI Installer Windows script
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6901'>WFCORE-6901</a>] -         Create Phase IDs for OpenTelemetry
</li>
</ul>
</details>

