### PR TITLE
[WFLY-19585][WFLY-19586] Upgrade SmallRye Reactive Messaging (4.24.0) and SmallRye Config (3.9.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <version.io.smallrye.open-api>3.10.0</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.5.0</version.io.smallrye.smallrye-common>
-        <version.io.smallrye.smallrye-config>3.8.3</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>3.9.0</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.3.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.4</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>

--- a/pom.xml
+++ b/pom.xml
@@ -431,18 +431,18 @@
         <version.io.reactivex.rxjava3>3.1.8</version.io.reactivex.rxjava3>
         <version.io.smallrye.open-api>3.10.0</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
-        <version.io.smallrye.smallrye-common>2.4.0</version.io.smallrye.smallrye-common>
+        <version.io.smallrye.smallrye-common>2.5.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.8.3</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.3.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.4</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.6.1</version.io.smallrye.smallrye-mutiny>
-        <version.io.smallrye.smallrye-mutiny-vertx>3.12.0</version.io.smallrye.smallrye-mutiny-vertx>
+        <version.io.smallrye.smallrye-mutiny-vertx>3.13.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.0</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.6.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-reactive-messaging>4.21.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
-        <version.io.vertx.vertx>4.5.8</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.5.9</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>


### PR DESCRIPTION
Doing these together since they might as well come in at the same time.
Just routine upgrades to the latest.

https://issues.redhat.com/browse/WFLY-19585
https://issues.redhat.com/browse/WFLY-19586