### PR TITLE
[WFLY-19587] Make MP Health tests more resilient

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationLiveTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationLiveTestBase.java
@@ -28,7 +28,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.setup.ReloadServerSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -41,6 +43,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@ServerSetup(ReloadServerSetupTask.class)
 public abstract class MicroProfileHealthApplicationLiveTestBase {
 
     abstract void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresTestBase.java
@@ -5,12 +5,16 @@
 
 package org.wildfly.test.integration.microprofile.health;
 
+import java.io.IOException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.setup.ReloadServerSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -18,10 +22,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 @RunWith(Arquillian.class)
 @RunAsClient
+@ServerSetup(ReloadServerSetupTask.class)
 public abstract class MicroProfileHealthDisabledDefaultProceduresTestBase {
 
     abstract void checkGlobalOutcome(final ManagementClient managementClient, final String operation, final boolean mustBeUP,


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19587

Add ReloadServerSetupTask to tests with no SST