### PR TITLE
[WFLY-19597] Bump version.org.wildfly.galleon-plugins from 7.1.1.Fina…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.6.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.1.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.1.2.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>


### PR DESCRIPTION
…l to 7.1.2.Final

https://issues.redhat.com/browse/WFLY-19597

WildFly Core PR: https://github.com/wildfly/wildfly-core/pull/6118

This also blocks https://github.com/wildfly/wildfly-core/pull/6058.