### PR TITLE
[WFLY-19602] Exclude the transitive dependencies from org.jboss.naray…

### DIFF
--- a/testsuite/integration/microprofile-tck/lra/pom.xml
+++ b/testsuite/integration/microprofile-tck/lra/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-test-arquillian-extension</artifactId>
             <version>${version.org.jboss.narayana}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…ana.rts:lra-test-arquillian-extension.

https://issues.redhat.com/browse/WFLY-19602

This blocks https://github.com/wildfly/wildfly-core/pull/6058.