### PR TITLE
[WFLY-19604] Upgrade to Hibernate Validator 9.0.0.Beta2 in the EE 11 Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -23,7 +23,7 @@
 
     <artifactId>wildfly-preview-ee-bom</artifactId>
     <description>
-        Build of materials that can be used to build WildFly Preview maven modules 
+        Build of materials that can be used to build WildFly Preview maven modules
         that provide traditional capabilities like Jakarta EE.
     </description>
     <packaging>pom</packaging>
@@ -54,6 +54,7 @@
         <version.org.jboss.resteasy>7.0.0.Alpha3</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Beta4</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Beta5</version.org.jboss.weld.weld-api>
+        <version.org.hibernate.validator>9.0.0.Beta2</version.org.hibernate.validator>
     </properties>
 
     <dependencyManagement>
@@ -523,6 +524,29 @@
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-web</artifactId>
                 <version>${version.org.jboss.weld.weld}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${version.org.hibernate.validator}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator-cdi</artifactId>
+                <version>${version.org.hibernate.validator}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -138,7 +138,7 @@ The following table lists the various Jakarta technologies offered by WildFly Pr
 
 |Jakarta Transactions| 2.0 |10 & 11
 
-|Jakarta Validation| 3.1.0-M2 |11
+|Jakarta Validation| 3.1.0 |11
 
 |Jakarta WebSocket| 2.2.0-M1 |11
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19604

Hibernate Validator 9.0 requires JDK 17+
Otherwise, Jakarta Validation 3.1 didn't introduce API changes.
We've also done some cleanups and updates in HV itself. 
This patch would require JBoss Logging 3.6 (https://github.com/wildfly/wildfly/pull/18015), so I'll open this PR as a draft 