### PR TITLE
[WFLY-19324] Anonymous 'captor' service does not reliably provide Ope…

### DIFF
--- a/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryDependencyProcessor.java
+++ b/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryDependencyProcessor.java
@@ -15,17 +15,25 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
-import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.opentelemetry.api.WildFlyOpenTelemetryConfig;
 import org.wildfly.service.ServiceDependency;
 
 class MicroProfileTelemetryDependencyProcessor implements DeploymentUnitProcessor {
+
+    private final ServiceDependency<WildFlyOpenTelemetryConfig> configServiceDependency;
+
+    MicroProfileTelemetryDependencyProcessor(ServiceDependency<WildFlyOpenTelemetryConfig> configServiceDependency) {
+        this.configServiceDependency = configServiceDependency;
+    }
+
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {
         addDependencies(phaseContext.getDeploymentUnit());
 
-        // Ensure the OpenTelemetryConfig is available before the next phase DeploymentUnitPhaseService starts
-        phaseContext.requires(ServiceDependency.on(ServiceName.parse(WildFlyOpenTelemetryConfig.SERVICE_DESCRIPTOR.getName())));
+        // Ensure the OpenTelemetryConfig is available to the Phase.POST_MODULE MicroProfileTelemetryDeploymentProcessor
+        // TODO WFCORE-6491 the kernel should support an API such that an OSH can record this requirement without
+        // needing to involve a DUP like this one that is separate from the one that consumes the dependency.
+        phaseContext.requires(configServiceDependency);
     }
 
     private void addDependencies(DeploymentUnit deploymentUnit) {

--- a/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetrySubsystemAdd.java
+++ b/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetrySubsystemAdd.java
@@ -7,8 +7,6 @@ package org.wildfly.extension.microprofile.telemetry;
 
 import static org.wildfly.extension.microprofile.telemetry.MicroProfileTelemetryExtensionLogger.MPTEL_LOGGER;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -16,12 +14,11 @@ import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.opentelemetry.api.WildFlyOpenTelemetryConfig;
-import org.wildfly.subsystem.service.ServiceDependency;
-import org.wildfly.subsystem.service.ServiceInstaller;
+import org.wildfly.service.ServiceDependency;
 
 public class MicroProfileTelemetrySubsystemAdd extends AbstractBoottimeAddStepHandler {
-    private final AtomicReference<WildFlyOpenTelemetryConfig> openTelemetryConfig = new AtomicReference<>();
 
     MicroProfileTelemetrySubsystemAdd() {
         super();
@@ -36,11 +33,8 @@ public class MicroProfileTelemetrySubsystemAdd extends AbstractBoottimeAddStepHa
 
         super.performBoottime(context, operation, model);
 
-        ServiceInstaller.builder(ServiceDependency.on(WildFlyOpenTelemetryConfig.SERVICE_DESCRIPTOR))
-                .withCaptor(openTelemetryConfig::set)
-                .build()
-                .install(context);
-
+        final ServiceDependency<WildFlyOpenTelemetryConfig> configServiceDependency =
+                ServiceDependency.on(ServiceName.parse(WildFlyOpenTelemetryConfig.SERVICE_DESCRIPTOR.getName()));
 
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
@@ -49,13 +43,13 @@ public class MicroProfileTelemetrySubsystemAdd extends AbstractBoottimeAddStepHa
                         MicroProfileTelemetryExtension.SUBSYSTEM_NAME,
                         Phase.DEPENDENCIES,
                         Phase.DEPENDENCIES_MICROPROFILE_TELEMETRY,
-                        new MicroProfileTelemetryDependencyProcessor()
+                        new MicroProfileTelemetryDependencyProcessor(configServiceDependency)
                 );
                 processorTarget.addDeploymentProcessor(
                         MicroProfileTelemetryExtension.SUBSYSTEM_NAME,
                         Phase.POST_MODULE,
                         Phase.POST_MODULE_MICROPROFILE_TELEMETRY,
-                        new MicroProfileTelemetryDeploymentProcessor(openTelemetryConfig::get));
+                        new MicroProfileTelemetryDeploymentProcessor(configServiceDependency));
             }
         }, OperationContext.Stage.RUNTIME);
     }


### PR DESCRIPTION
…nTelemetryConfig; use the DeploymentPhaseContext ServiceDependency requirement  mechanism

https://issues.redhat.com/browse/WFLY-19324

Follow up on https://github.com/wildfly/wildfly/pull/17878 to correct a wiring flaw I misunderstood when I reviewed it.

This is a draft because I also sent up #18096 with a different approach and reviewers can pick one.