### PR TITLE
[WFLY-19339] Use Phase.STRUCTURE_NAMING_JDK_DEPENDENCIES that was created for JdkDependenciesProcessor

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
@@ -105,8 +105,7 @@ public class NamingSubsystemAdd extends AbstractBoottimeAddStepHandler {
             @Override
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS, new ExternalContextsProcessor(externalContexts));
-                // TODO: replace Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS + 1 with Phase.STRUCTURE_NAMING_JDK_DEPENDENCIES
-                processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_NAMING_EXTERNAL_CONTEXTS + 1, new JdkDependenciesProcessor());
+                processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_NAMING_JDK_DEPENDENCIES, new JdkDependenciesProcessor());
                 processorTarget.addDeploymentProcessor(NamingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JNDI_DEPENDENCIES, new JndiNamingDependencyProcessor());
             }
         }, OperationContext.Stage.RUNTIME);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19339