### PR TITLE
[WFLY-19583-33.x] Deployment-related undertow metrics are not exported

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/OpenTelemetryCollectorContainer.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/OpenTelemetryCollectorContainer.java
@@ -4,9 +4,18 @@
  */
 package org.wildfly.test.integration.observability.container;
 
-import java.util.Collections;
-import java.util.List;
+import static jakarta.ws.rs.client.ClientBuilder.newClient;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.WebTarget;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
@@ -72,18 +81,77 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     }
 
     public String getOtlpGrpcEndpoint() {
-        return otlpGrpcEndpoint;
+        return "http://localhost:" + getMappedPort(OTLP_GRPC_PORT);
     }
 
     public String getOtlpHttpEndpoint() {
-        return otlpHttpEndpoint;
+        return "http://localhost:" + getMappedPort(OTLP_HTTP_PORT);
     }
 
     public String getPrometheusUrl() {
-        return prometheusUrl;
+        return "http://localhost:" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
     }
 
     public List<JaegerTrace> getTraces(String serviceName) throws InterruptedException {
         return (jaegerContainer != null ? jaegerContainer.getTraces(serviceName) : Collections.emptyList());
+    }
+
+    public List<PrometheusMetric> fetchMetrics(String nameToMonitor) throws InterruptedException {
+        String body = "";
+        try (Client client = newClient()) {
+            WebTarget target = client.target(getPrometheusUrl());
+
+            int attemptCount = 0;
+            boolean found = false;
+
+            // Request counts can vary. Setting high to help ensure test stability
+            while (!found && attemptCount < 30) {
+                // Wait to give Micrometer time to export
+                Thread.sleep(1000);
+
+                body = target.request().get().readEntity(String.class);
+                found = body.contains(nameToMonitor);
+                attemptCount++;
+            }
+        }
+
+        return buildPrometheusMetrics(body);
+    }
+
+    private List<PrometheusMetric> buildPrometheusMetrics(String body) {
+        if (body.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String[] entries = body.split("\n");
+        Map<String, String> help = new HashMap<>();
+        Map<String, String> type = new HashMap<>();
+        List<PrometheusMetric> metrics = new LinkedList<>();
+        Arrays.stream(entries).forEach(e -> {
+            if (e.startsWith("# HELP")) {
+                extractMetadata(help, e);
+            } else if (e.startsWith("# TYPE")) {
+                extractMetadata(type, e);
+            } else {
+                String[] parts = e.split("[{}]");
+                String key = parts[0];
+                Map<String, String> tags = Arrays.stream(parts[1].split(","))
+                        .map(t -> t.split("="))
+                        .collect(Collectors.toMap(i -> i[0],
+                                i -> i[1]
+                                        .replaceAll("^\"", "")
+                                        .replaceAll("\"$", "")
+                        ));
+                metrics.add(new PrometheusMetric(key, tags, parts[2].trim(), type.get(key), help.get(key)));
+            }
+        });
+
+        return metrics;
+    }
+
+    private void extractMetadata(Map<String, String> target, String source) {
+        String[] parts = source.split(" ");
+        target.put(parts[2],
+                Arrays.stream(Arrays.copyOfRange(parts, 3, parts.length))
+                        .reduce("", (total, element) -> total + " " + element));
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/PrometheusMetric.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/container/PrometheusMetric.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.container;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class PrometheusMetric {
+    private final String key;
+    private final Map<String, String> tags;
+    private final String value;
+    private final String type;
+    private final String help;
+
+    public PrometheusMetric(String key,
+                            Map<String, String> tags,
+                            String value,
+                            String type,
+                            String help) {
+        this.key = key;
+        this.tags = Collections.unmodifiableMap(tags);
+        this.value = value;
+        this.type = type;
+        this.help = help;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getHelp() {
+        return help;
+    }
+
+    @Override
+    public String toString() {
+        return "PrometheusMetric{" +
+                "key='" + key + '\'' +
+                ", tags=" + tags +
+                ", value='" + value + '\'' +
+                ", type='" + type + '\'' +
+                ", help='" + help + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19583

- Ensure that MetricsCollector runs against a deployment at the proper time 
- Backport test for deployment undertow statistics

Upstream: #18103