### PR TITLE
[WFLY-19621] Upgrade the keycloak-services and keycloak test dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
         <version.dom4j>2.1.4</version.dom4j>
         <version.httpunit>1.7.3</version.httpunit>
         <legacy.version.io.netty>4.0.19.Final</legacy.version.io.netty>
-        <version.io.rest-assured>3.0.7</version.io.rest-assured>
+        <version.io.rest-assured>5.5.0</version.io.rest-assured>
         <version.org.keycloak.keycloak-services>23.0.7</version.org.keycloak.keycloak-services>
         <legacy.version.jakarta.enterprise>2.0.2</legacy.version.jakarta.enterprise>
         <legacy.version.jakarta.inject.jakarta.inject-api>1.0.5</legacy.version.jakarta.inject.jakarta.inject-api>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <version.httpunit>1.7.3</version.httpunit>
         <legacy.version.io.netty>4.0.19.Final</legacy.version.io.netty>
         <version.io.rest-assured>3.0.7</version.io.rest-assured>
-        <version.org.keycloak.keycloak-services>3.1.0.Final</version.org.keycloak.keycloak-services>
+        <version.org.keycloak.keycloak-services>23.0.7</version.org.keycloak.keycloak-services>
         <legacy.version.jakarta.enterprise>2.0.2</legacy.version.jakarta.enterprise>
         <legacy.version.jakarta.inject.jakarta.inject-api>1.0.5</legacy.version.jakarta.inject.jakarta.inject-api>
         <version.jaxen>1.1.6</version.jaxen>
@@ -371,7 +371,7 @@
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</legacy.version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
-        <version.org.keycloak>18.0.2</version.org.keycloak>
+        <version.org.keycloak>25.0.2</version.org.keycloak>
         <version.org.mockito>3.10.0</version.org.mockito>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testcontainers>1.20.0</version.org.testcontainers>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19621

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19627](https://issues.redhat.com/browse/WFLY-19627)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)