### PR TITLE
[WFLY-19638] Upgrade com.google.guava:failureaccess from 1.0.1 to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <version.com.google.api.grpc>2.0.1</version.com.google.api.grpc>
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
         <version.com.google.guava>32.1.2-jre</version.com.google.guava>
-        <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
+        <version.com.google.guava.failureaccess>1.0.2</version.com.google.guava.failureaccess>
         <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
         <version.com.h2database>2.2.224</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19638

previously https://github.com/wildfly/wildfly/pull/17363 was closed, but this is behinds downstream now.