### PR TITLE
[WFLY-19641] Upgrade joda-time from 2.12.6 to 2.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.2</version.jakarta.xml.bind.jakarta-xml-bind-api>
         <version.jboss.jaxbintros>2.0.1</version.jboss.jaxbintros>
-        <version.joda-time>2.12.6</version.joda-time>
+        <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>2.35.0</version.org.apache.activemq.artemis>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19641

Upgrade joda-time from 2.12.6 to 2.12.7