### PR TITLE
[WFLY-19644] Upgrade version.jakarta.websocket.jakarta-websocket-api …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,7 @@
         <version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>3.0.0</version.jakarta.servlet.jsp.jstl.jakarta-servlet-jsp-jstl-api>
         <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
         <version.jakarta.validation.jakarta-validation-api>3.0.2</version.jakarta.validation.jakarta-validation-api>
-        <version.jakarta.websocket.jakarta-websocket-api>2.1.0-jbossorg-2</version.jakarta.websocket.jakarta-websocket-api>
+        <version.jakarta.websocket.jakarta-websocket-api>2.1.1</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.2</version.jakarta.xml.bind.jakarta-xml-bind-api>
         <version.jboss.jaxbintros>2.0.1</version.jboss.jaxbintros>


### PR DESCRIPTION
…from 2.1.0-jbossorg-2 to 2.1.1

Issue: https://issues.redhat.com/browse/WFLY-19644

Upgrade version.jakarta.websocket.jakarta-websocket-api from 2.1.0-jbossorg-2 to 2.1.1

previous PR https://github.com/wildfly/wildfly/pull/17795