### PR TITLE
[WFLY-19717] Remove unused Elytron permissions in MDBRoleTestCase, RunAsPrincipalTestCase, RunAsTestCase, RunAsEjbMdbTestCase, RunAsMDBUnitTestCase and LegacyCompliantPrincipalPropagationTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MDBRoleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MDBRoleTestCase.java
@@ -74,7 +74,6 @@ public class MDBRoleTestCase {
       // TODO WFLY-15289 The Elytron permissions need to be checked, should a deployment really need these?
       deployment.addAsResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read"),
                                                          new ElytronPermission("setRunAsPrincipal"),
-                                                         new ElytronPermission("handleSecurityEvent"),
                                                          new ChangeRoleMapperPermission("ejb")), "META-INF/jboss-permissions.xml");
       return deployment;
    }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
@@ -81,7 +81,6 @@ public class RunAsEjbMdbTestCase {
         // TODO WFLY-15289 Should these permissions be required?
         jar.addAsResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read"),
                                                     new ElytronPermission("setRunAsPrincipal"),
-                                                    new ElytronPermission("handleSecurityEvent"),
                                                     new ChangeRoleMapperPermission("ejb")), "META-INF/jboss-permissions.xml");
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment.runasmdbejb-ejb2.jar  \n"), "MANIFEST.MF");
         return jar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/RunAsMDBUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/RunAsMDBUnitTestCase.java
@@ -87,7 +87,6 @@ public class RunAsMDBUnitTestCase {
         jar.addPackage(CommonCriteria.class.getPackage());
         // TODO WFLY-15289 Should these permissions be required?
         jar.addAsResource(createPermissionsXmlAsset(new ElytronPermission("setRunAsPrincipal"),
-                new ElytronPermission("handleSecurityEvent"),
                 new ChangeRoleMapperPermission("ejb")), "META-INF/jboss-permissions.xml");
         return jar;
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19717

is incorporated by: https://issues.redhat.com/browse/WFLY-15289