### PR TITLE
WFLY-19610 Attempt to prevent double post construct invocation for injection targets that are beans

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -81,13 +81,15 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service {
                 Object instance;
                 BasicInjectionTarget target = injectionTarget instanceof BasicInjectionTarget ? (BasicInjectionTarget) injectionTarget: null;
                 if(target != null && target.getBean() != null) {
+                    // instance is a bean, Weld will trigger injection and post construct as part of bean creation
                     instance = beanManager.getReference(target.getBean(), target.getAnnotatedType().getBaseType(), context);
                 } else {
+                    // instance is not a bean, invoke produce/inject/postConstruct manually
                     instance = injectionTarget.produce(context);
+                    injectionTarget.inject(instance, context);
+                    injectionTarget.postConstruct(instance);
                 }
 
-                injectionTarget.inject(instance, context);
-                injectionTarget.postConstruct(instance);
                 return new WeldManagedReference(injectionTarget, context, instance);
             }
         };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/WFLY-19610

This PR is to see what CI has to say about this change and reveal any use cases for which it might have been coded that way,
If it passes, we should add a test similar to the reproducer in WFLY-19610 before merging.

cc @jasondlee 