### PR TITLE
[WFLY-19610]  @PostConstruct on Servlet may be called twice

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/DuplicatePostConstructTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/DuplicatePostConstructTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.web.postcontstruct;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.CdiUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.web.postcontstruct.beanjar.SimpleServlet;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DuplicatePostConstructTestCase {
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        JavaArchive beanJar = ShrinkWrap.create(JavaArchive.class)
+                .addPackage(SimpleServlet.class.getPackage())
+                .addAsManifestResource(CdiUtils.createBeansXml(), "beans.xml")
+                .addAsManifestResource(SimpleServlet.class.getPackage(), "web-fragment.xml",
+                        "web-fragment.xml");
+        return ShrinkWrap.create(WebArchive.class).addAsLibrary(beanJar);
+    }
+
+    @Test
+    public void test() throws URISyntaxException, IOException, InterruptedException {
+        String response = HttpClient.newHttpClient()
+                .send(
+                        HttpRequest.newBuilder().uri(url.toURI()).build(),
+                        HttpResponse.BodyHandlers.ofString())
+                .body();
+
+        Assert.assertEquals("1", response);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleBean.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleBean.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.web.postcontstruct.beanjar;
+
+public class SimpleBean {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleServlet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.web.postcontstruct.beanjar;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class SimpleServlet extends HttpServlet {
+    protected AtomicInteger m_postCount = new AtomicInteger(0);
+
+    @Resource(name = "envEntry", type = Integer.class)
+    protected Integer m_cInteger;
+
+    @Inject
+    private SimpleBean bean;
+
+    @PostConstruct
+    protected void post() {
+        m_postCount.incrementAndGet();
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        resp.getWriter().write(""+m_postCount.get());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/WrapperServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/WrapperServlet.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.web.postcontstruct.beanjar;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class WrapperServlet extends HttpServlet {
+    private HttpServlet delegate;
+
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        delegate = config.getServletContext().createServlet(SimpleServlet.class);
+    }
+
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        delegate.service(req, resp);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/web-fragment.xml
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/web-fragment.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<web-fragment version='5.0' xmlns='https://jakarta.ee/xml/ns/jakartaee'
+              xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+              xsi:schemaLocation='https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd'
+              metadata-complete="true">
+    <context-param>
+        <param-name>foo</param-name>
+        <param-value>bar</param-value>
+    </context-param>
+    <servlet>
+        <servlet-name>test</servlet-name>
+        <servlet-class>org.wildfly.test.integration.web.postcontstruct.beanjar.WrapperServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>test</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+    <env-entry>
+        <env-entry-name>envEntry</env-entry-name>
+        <env-entry-type>java.lang.Integer</env-entry-type>
+        <env-entry-value>33</env-entry-value>
+    </env-entry>
+</web-fragment>

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -81,13 +81,15 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service {
                 Object instance;
                 BasicInjectionTarget target = injectionTarget instanceof BasicInjectionTarget ? (BasicInjectionTarget) injectionTarget: null;
                 if(target != null && target.getBean() != null) {
+                    // instance is a bean, Weld will trigger injection and post construct as part of bean creation
                     instance = beanManager.getReference(target.getBean(), target.getAnnotatedType().getBaseType(), context);
                 } else {
+                    // instance is not a bean, invoke produce/inject/postConstruct manually
                     instance = injectionTarget.produce(context);
+                    injectionTarget.inject(instance, context);
+                    injectionTarget.postConstruct(instance);
                 }
 
-                injectionTarget.inject(instance, context);
-                injectionTarget.postConstruct(instance);
                 return new WeldManagedReference(injectionTarget, context, instance);
             }
         };


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19610

- Attempt to prevent double post construct invocation for injection targets that are beans
- Add reproducer/test