### PR TITLE
[WFLY-19637] Upgrade WildFly Core to 25.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <version.org.opensaml.opensaml>4.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.6</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>25.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>25.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19637

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/25.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/25.0.0.Final...25.0.1.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6953'>WFCORE-6953</a>] -         java.lang.ClassNotFoundException: java.util.logging.Logger from Module &quot;org.bouncycastle.bcpg&quot;
</li>
</ul>
                                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6952'>WFCORE-6952</a>] -         Upgrade WildFly Elytron to 2.5.1.Final
</li>
</ul>
</details>

