### PR TITLE
[WFLY-19655] Upgrade JBeret to 3.0.0.Final

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -29,7 +29,6 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.logging"/>
         <module name="org.wildfly.security.elytron-private"/>
-        <module name="com.google.guava"/>
         <module name="com.h2database.h2" optional="true"/>
         <module name="java.xml"/>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <version.org.infinispan>14.0.30.Final</version.org.infinispan>
         <version.org.infinispan.protostream>4.6.5.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
-        <version.org.jberet>2.2.1.Final</version.org.jberet>
+        <version.org.jberet>3.0.0.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>2.0.2.Final</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>5.0.7.Final</version.org.jboss.ejb-client>


### PR DESCRIPTION
- https://issues.redhat.com/browse/WFLY-19655

The guava dependency can be dropped from JBeret. Here's the relative change:

- [drop guava depdendency by liweinan · Pull Request \#551 · jberet/jsr352](https://github.com/jberet/jsr352/pull/551)

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-196550](https://issues.redhat.com/browse/WFLY-196550)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)