### PR TITLE
[WFLY-19663] Upgrade WildFly Core to 26.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <version.org.opensaml.opensaml>4.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>26.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19663

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/26.0.0.Beta1...26.0.0.Beta2

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6911'>WFCORE-6911</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in elytron subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6913'>WFCORE-6913</a>] -         Remove usage of deprecated AbstractAddStepHandler constructors in logging subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6922'>WFCORE-6922</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in elytron subsystem
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6933'>WFCORE-6933</a>] -         Missing permissions in AbstractLoggingTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6945'>WFCORE-6945</a>] -         Required child resource logic in wildfly-subsystem is not stability-level aware
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6946'>WFCORE-6946</a>] -         Wrong word ordering in ControllerLogger coverage of secure expression resolution
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6953'>WFCORE-6953</a>] -         java.lang.ClassNotFoundException: java.util.logging.Logger from Module &quot;org.bouncycastle.bcpg&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6954'>WFCORE-6954</a>] -         wildfly-subsystem auto-registers add/remove operation handlers for runtime resources
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6891'>WFCORE-6891</a>] -         Remove support for parsing domain management schemas prior to urn:jboss:domain:1.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6936'>WFCORE-6936</a>] -         Allow the maven.test.redirectTestOutputToFile property to work from the command line
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6745'>WFCORE-6745</a>] -         Upgrade log4j2 from 2.22.1 to 2.23.1 and log4j2-jboss-logmanager to 2.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6938'>WFCORE-6938</a>] -         Bump version.org.wildfly.galleon-plugins from 7.1.1.Final to 7.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6949'>WFCORE-6949</a>] -         Upgrade io.smallrye:jandex from 3.2.0 to 3.2.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6950'>WFCORE-6950</a>] -         Upgrade SSHD from 2.13.1 to 2.13.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6951'>WFCORE-6951</a>] -         Upgrade Eclipse Parsson from 1.1.6 to 1.1.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6952'>WFCORE-6952</a>] -         Upgrade WildFly Elytron to 2.5.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6940'>WFCORE-6940</a>] -         Allow null ManagementResourceRegistrar.register(...)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6948'>WFCORE-6948</a>] -         Allow more precise control over which resource operations can be transformed via wildfly-subsystem
</li>
</ul>
</details>

