### PR TITLE
[WFLY-19673] Upgrade to SmallRye Reactive Messaging 4.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>3.13.0</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.0</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.6.0</version.io.smallrye.smallrye-opentelemetry>
-        <version.io.smallrye.smallrye-reactive-messaging>4.21.0</version.io.smallrye.smallrye-reactive-messaging>
+        <version.io.smallrye.smallrye-reactive-messaging>4.24.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.9</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19673

Edit 30 Aug 2024:
I did a previous attempt at this in #18083 but upgraded everything apart from Reactive Messaging itself!