### PR TITLE
[WFLY-19636]: Upgrading Apache Artemis to 2.37.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
         <version.com.sun.xml.fastinfoset>2.1.1</version.com.sun.xml.fastinfoset>
         <version.com.sun.xml.messaging.saaj>3.0.0</version.com.sun.xml.messaging.saaj>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
-        <version.commons-codec>1.15</version.commons-codec>
+        <version.commons-codec>1.17.1</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-io>2.16.1</version.commons-io>
         <version.de.dentrassi.crypto>2.4.0</version.de.dentrassi.crypto>
@@ -474,7 +474,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.35.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.37.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.11.3</version.org.apache.avro>
         <version.org.apache.cxf>4.0.5</version.org.apache.cxf>


### PR DESCRIPTION
* Upgrading Artemis components to 2.37.0.
* Upgrading commons-codec to 1.17.1



https://activemq.apache.org/components/artemis/download/release-notes-2.36.0
https://activemq.apache.org/components/artemis/download/release-notes-2.37.0



Jira: https://issues.redhat.com/browse/WFLY-19636
      https://issues.redhat.com/browse/WFLY-19726

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19726](https://issues.redhat.com/browse/WFLY-19726)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)