### PR TITLE
[WFLY-19684] Upgrade WildFly Core to 26.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <version.org.opensaml.opensaml>4.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.core>26.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19684

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/26.0.0.Beta2...26.0.0.Beta3

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6931'>WFCORE-6931</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors in threads subsystem
</li>
</ul>
                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6956'>WFCORE-6956</a>] -         Wrong endpoint-name if the JBoss server name and &#39;jboss.node.name&#39; are both provided to the server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6962'>WFCORE-6962</a>] -         OverallInterfaceCriteriaUnitTestCase.testMultipleMatches* test cases fail on Win JDK21
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6963'>WFCORE-6963</a>] -         AbstractModelResource$DefaultResourceProvider.hasChildren inefficiency degrades with child count
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6722'>WFCORE-6722</a>] -         Standarize the error message shown when the server is launched with an valid but empty option
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6883'>WFCORE-6883</a>] -         Upgrade to jboss-logging 3.6.0 / jboss-logging-tools 3.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6958'>WFCORE-6958</a>] -         Upgrade Undertow to 2.3.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6965'>WFCORE-6965</a>] -         Upgrade Galleon to 6.0.3.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6881'>WFCORE-6881</a>] -         Support Stability Levels for the Management Parsers
</li>
</ul>
</details>
