### PR TITLE
[WFLY-19695] Upgrade to Hibernate Search 7.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,7 +517,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.4.10.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.1.1.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.1.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.30.Final</version.org.infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19695

Just in case we won't get the Hibernate Search 7.2 into the next version, here's an update to the currently used 7.1. There are a couple of bug fixes in it (https://in.relation.to/2024/08/30/hibernate-search-maintenance-releases#other-since-last-7-1) that may be useful to the users.
