### PR TITLE
Fix for WFLY-19702, Replace usage of wildfly-jar-maven-plugin with wildfly-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,6 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.1.2.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
-        <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.0.Final</version.org.wildfly.unstable.annotation.api>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1432,13 +1432,31 @@
             </plugin>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <configuration>
+                    <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                    <record-provisioning-state>false</record-provisioning-state>
+                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                    <galleon-options>
+                        <jboss-maven-dist/>
+                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                        <optional-packages>passive+</optional-packages>
+                    </galleon-options>
+                    <bootableJar>true</bootableJar>
+                    <skipDeployment>true</skipDeployment>
+                </configuration>
                 <executions>
                     <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
                     <execution>
                         <id>bootable-jar-packaging</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
-                            <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
+                            <bootableJarName>test-wildfly-cloud-profile.jar</bootableJarName>
                             <extra-server-content-dirs>
                                 <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                             </extra-server-content-dirs>
@@ -1454,7 +1472,7 @@
                         </goals>
                         <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
-                            <output-file-name>test-wildfly-jpa.jar</output-file-name>
+                            <bootableJarName>test-wildfly-jpa.jar</bootableJarName>
                             <extra-server-content-dirs>
                                 <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
                             </extra-server-content-dirs>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -507,22 +507,40 @@
             </plugin>
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <artifactId>wildfly-maven-plugin</artifactId>
                 <executions>
                     <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
                     <execution>
                         <id>bootable-jar-packaging</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
-                            <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-cloud-profile.jar</bootableJarName>
                             <!-- content that is installed in wildfly home -->
                             <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                            <cli-sessions>
+                            <packaging-scripts>
                                 <cli-session>
-                                    <script-files>
+                                    <javaOpts>
+                                        <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                    </javaOpts>
+                                    <scripts>
                                         <script>clustering-ha-bootable-jar.cli</script>
-                                    </script-files>
+                                    </scripts>
                                 </cli-session>
-                            </cli-sessions>
+                            </packaging-scripts>
                             <provisioning-file>target/glow-scan/ts.surefire.clustering.microprofile/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -535,14 +553,28 @@
                         </goals>
                         <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
-                            <output-file-name>test-wildfly-jpa-distributed.jar</output-file-name>
-                            <cli-sessions>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-jpa-distributed.jar</bootableJarName>
+                            <packaging-scripts>
                                 <cli-session>
-                                    <script-files>
+                                    <javaOpts>
+                                        <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                    </javaOpts>
+                                    <scripts>
                                         <script>clustering-ha-bootable-jar.cli</script>
-                                    </script-files>
+                                    </scripts>
                                 </cli-session>
-                            </cli-sessions>
+                            </packaging-scripts>
                             <provisioning-file>target/glow-scan/ts.surefire.clustering.all.jpa2lc/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -555,14 +587,28 @@
                         </goals>
                         <phase>${ts.bootable-jar-packaging.phase}</phase>
                         <configuration>
-                            <output-file-name>test-wildfly-cloud-profile-load-balancer.jar</output-file-name>
-                            <cli-sessions>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-cloud-profile-load-balancer.jar</bootableJarName>
+                            <packaging-scripts>
                                 <cli-session>
-                                    <script-files>
+                                    <javaOpts>
+                                        <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                    </javaOpts>
+                                    <scripts>
                                         <script>clustering-load-balancer-bootable-jar.cli</script>
-                                    </script-files>
+                                    </scripts>
                                 </cli-session>
-                            </cli-sessions>
+                            </packaging-scripts>
                             <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -173,42 +173,46 @@
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.org.wildfly.plugin}</version>
-                <configuration>
-                    <offline>true</offline>
-                    <jboss-home>${wildfly.dir}</jboss-home>
-                    <stdout>none</stdout>
-                    <java-opts>${modular.jdk.args}</java-opts>
-                    <system-properties>
-                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
-                        <module.path>${jboss.dist}/modules</module.path>
-                    </system-properties>
-                </configuration>
                 <executions>
                     <execution>
+                        <configuration>
+                            <offline>true</offline>
+                            <jboss-home>${wildfly.dir}</jboss-home>
+                            <stdout>none</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
+                            <system-properties>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                <module.path>${jboss.dist}/modules</module.path>
+                            </system-properties>
+                        </configuration>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>execute-commands</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <executions>
-                    <!-- Provision a cloud server -->
                     <execution>
                         <id>bootable-jar-packaging</id>
+                        <configuration>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
+                            <!-- content that is installed in wildfly home -->
+                            <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly.jar</bootableJarName>
+                            <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
+                        </configuration>
                         <goals>
                             <goal>package</goal>
                         </goals>
                         <phase>${ts.bootable-jar-packaging.phase}</phase>
-                        <configuration>
-                            <!-- content that is installed in wildfly home -->
-                            <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                            <output-file-name>test-wildfly.jar</output-file-name>
-                            <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -580,6 +580,14 @@
                         <version>${version.org.wildfly.plugin}</version>
                         <configuration>
                             <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
                         </configuration>
                         <executions>
                             <execution>
@@ -590,9 +598,6 @@
                                 <phase>generate-test-resources</phase>
                                 <configuration>
                                     <provisioning-dir>${project.build.directory}/${wildfly.instance.name}</provisioning-dir>
-                                    <record-provisioning-state>false</record-provisioning-state>
-                                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                                    <offline-provisioning>${galleon.offline}</offline-provisioning>
                                     <feature-packs>
                                         <feature-pack>
                                             <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -617,11 +622,6 @@
                                             </included-configs>
                                         </feature-pack>
                                     </feature-packs>
-                                    <galleon-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                        <optional-packages>passive+</optional-packages>
-                                    </galleon-options>
                                 </configuration>
                             </execution>
                         </executions>
@@ -861,9 +861,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <properties>
-                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
@@ -881,27 +878,6 @@
                                 <id>ts.copy-wildfly</id>
                                 <goals>
                                     <goal>copy-resources</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.plugin}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>execute-commands</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                            <!-- Disable the default provisioning -->
-                            <execution>
-                                <id>server-provisioning</id>
-                                <goals>
-                                    <goal>provision</goal>
                                 </goals>
                                 <phase>none</phase>
                             </execution>
@@ -941,22 +917,45 @@
                     </plugin>
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
                         <executions>
-                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <!-- Disable the default provisioning -->
+                            <execution>
+                                <id>server-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
                             <execution>
                                 <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-classes</phase>
                                 <configuration>
-                                    <output-file-name>test-wildfly.jar</output-file-name>
+                                    <bootableJar>true</bootableJar>
+                                    <skipDeployment>true</skipDeployment>
+                                    <bootableJarName>test-wildfly.jar</bootableJarName>
                                     <!-- content that is installed in wildfly home -->
                                     <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                                    <cli-sessions>
+                                    <packaging-scripts>
                                         <cli-session>
-                                            <script-files>
+                                            <javaOpts>
+                                                <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                            </javaOpts>
+                                            <scripts>
                                                 <script>modify-elytron-config-bootable.cli</script>
-                                            </script-files>
+                                            </scripts>
                                         </cli-session>
-                                    </cli-sessions>
+                                    </packaging-scripts>
                                     <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/microprofile-tck/config/pom.xml
+++ b/testsuite/integration/microprofile-tck/config/pom.xml
@@ -111,27 +111,38 @@
                             <goal>execute-commands</goal>
                         </goals>
                         <configuration>
+                            <offline>true</offline>
+                            <jboss-home>${basedir}/target/wildfly</jboss-home>
+                            <stdout>${project.build.directory}/wildfly/standalone/log/weld-configuration.log</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
+                            <system-properties>
+                                <maven.repo.local>${maven.repo.local}</maven.repo.local>
+                                <module.path>${project.build.directory}/wildfly/modules</module.path>
+                                <module.path>${jboss.dist}/modules${path.separator}${basedir}/target/modules</module.path>
+                            </system-properties>
                             <commands>
                                 <command>embed-server --server-config=standalone-microprofile.xml</command>
                                 <command>/subsystem=weld:write-attribute(name=legacy-empty-beans-xml-treatment,value=true)</command>
                                 <command>stop-embedded-server</command>
                             </commands>
-                            <system-properties combine.children="append">
-                                <module.path>${jboss.dist}/modules${path.separator}${basedir}/target/modules</module.path>
-                            </system-properties>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable-jar-packaging</id>
+                        <configuration>
+                            <packaging-scripts>
+                                <cli-session>
+                                    <javaOpts>
+                                        <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                    </javaOpts>
+                                    <scripts>
+                                        <script>${basedir}/src/test/resources/configure-weld-subsystem.cli</script>
+                                    </scripts>
+                                </cli-session>
+                            </packaging-scripts>
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <offline>true</offline>
-                    <jboss-home>${basedir}/target/wildfly</jboss-home>
-                    <stdout>${project.build.directory}/wildfly/standalone/log/weld-configuration.log</stdout>
-                    <java-opts>${modular.jdk.args}</java-opts>
-                    <system-properties>
-                        <maven.repo.local>${maven.repo.local}</maven.repo.local>
-                        <module.path>${project.build.directory}/wildfly/modules</module.path>
-                    </system-properties>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -168,28 +179,6 @@
                 <!-- Disable 'configure-weld-subsystem' since that is for a standalone server -->
                 <config.configure-weld-subsystem.phase>none</config.configure-weld-subsystem.phase>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>bootable-jar-packaging</id>
-                                <configuration>
-                                    <cli-sessions>
-                                        <cli-session>
-                                            <script-files>
-                                                <script>${basedir}/src/test/resources/configure-weld-subsystem.cli</script>
-                                            </script-files>
-                                        </cli-session>
-                                    </cli-sessions>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         
         <profile>
@@ -207,28 +196,6 @@
                 <!-- Disable 'configure-weld-subsystem' since that is for a standalone server -->
                 <config.configure-weld-subsystem.phase>none</config.configure-weld-subsystem.phase>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>bootable-jar-packaging</id>
-                                <configuration>
-                                    <cli-sessions>
-                                        <cli-session>
-                                            <script-files>
-                                                <script>${basedir}/src/test/resources/configure-weld-subsystem.cli</script>
-                                            </script-files>
-                                        </cli-session>
-                                    </cli-sessions>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -145,6 +145,15 @@
                 <version>${version.org.wildfly.plugin}</version>
                 <configuration>
                     <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                    <record-provisioning-state>false</record-provisioning-state>
+                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                    <galleon-options>
+                        <jboss-maven-dist/>
+                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                        <optional-packages>passive+</optional-packages>
+                    </galleon-options>
+                    <provisioning-file>target/glow-scan/default-test/provisioning.xml</provisioning-file>
                 </configuration>
                 <executions>
                     <!-- Provision a server slimmed to only what we want for a particular TCK. -->
@@ -158,29 +167,21 @@
                         <phase>${ts.microprofile-tck-provisioning.phase}</phase>
                         <configuration>
                             <provisioning-dir>${project.build.directory}/wildfly</provisioning-dir>
-                            <record-provisioning-state>false</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>${galleon.offline}</offline-provisioning>
-                            <galleon-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </galleon-options>
-                            <provisioning-file>target/glow-scan/default-test/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <executions>
                     <execution>
                         <id>bootable-jar-packaging</id>
                         <configuration>
-                            <output-file-name>test-wildfly-microprofile-tck.jar</output-file-name>
-                            <provisioning-file>target/glow-scan/default-test/provisioning.xml</provisioning-file>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-microprofile-tck.jar</bootableJarName>
                         </configuration>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <!-- Use a property to drive whether this execution is enabled.
+                             Default is 'none', i.e. disabled. -->
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -324,16 +325,6 @@
                             <!-- Provision a server slimmed to only what we want for a particular TCK. -->
                             <execution>
                                 <id>microprofile-tck-provisioning</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>bootable-jar-microprofile-tck-packaging</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -373,6 +373,36 @@
                             </feature-packs>
                         </configuration>
                     </execution>
+                     <!-- Override the bootable jar packaging from the parent to add res-client tck specific settings -->
+                    <execution>
+                        <id>bootable-jar-packaging</id>
+                        <configuration>
+                            <packaging-scripts>
+                                <cli-session>
+                                    <javaOpts>
+                                        <opt>-Dmaven.repo.local=${maven.repo.local}</opt>
+                                    </javaOpts>
+                                    <scripts>
+                                        <script>wiremock-bootable.cli</script>
+                                    </scripts>
+                                    <propertiesFiles>${project.build.outputDirectory}/wiremock-bootable-cli.properties</propertiesFiles>
+                                </cli-session>
+                            </packaging-scripts>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>${testsuite.full.galleon.pack.groupId}</groupId>
+                                    <artifactId>${testsuite.full.galleon.pack.artifactId}</artifactId>
+                                    <version>${testsuite.full.galleon.pack.version}</version>
+                                    <!-- The wiremock module we add as part of the test fixture needs Apache Commons Lang
+                                    but the layers we want don't result in it being provisioned, so explicitly tell Galleon to
+                                    provision it. -->
+                                    <included-packages>
+                                        <package>org.apache.commons.lang3</package>
+                                    </included-packages>
+                                </feature-pack>
+                            </feature-packs>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -419,39 +449,6 @@
                                     <value>${basedir}/beans.xml</value>
                                 </property>
                             </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <executions>
-                    <!-- Override the bootable jar packaging from the parent to add res-client tck specific settings -->
-                    <execution>
-                        <id>bootable-jar-packaging</id>
-                        <configuration>
-                            <cli-sessions>
-                                <cli-session>
-                                    <script-files>
-                                        <script>wiremock-bootable.cli</script>
-                                    </script-files>
-                                    <properties-file>${project.build.outputDirectory}/wiremock-bootable-cli.properties</properties-file>
-                                </cli-session>
-                            </cli-sessions>
-                            <feature-packs>
-                                <feature-pack>
-                                    <groupId>${testsuite.full.galleon.pack.groupId}</groupId>
-                                    <artifactId>${testsuite.full.galleon.pack.artifactId}</artifactId>
-                                    <version>${testsuite.full.galleon.pack.version}</version>
-                                    <!-- The wiremock module we add as part of the test fixture needs Apache Commons Lang
-                                    but the layers we want don't result in it being provisioned, so explicitly tell Galleon to
-                                    provision it. -->
-                                    <included-packages>
-                                        <package>org.apache.commons.lang3</package>
-                                    </included-packages>
-                                </feature-pack>
-                            </feature-packs>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -445,41 +445,50 @@
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.org.wildfly.plugin}</version>
-                <configuration>
-                    <offline>true</offline>
-                    <scripts>
-                        <script>${wildfly.dir}/docs/examples/enable-microprofile.cli</script>
-                    </scripts>
-                    <jboss-home>${wildfly.dir}</jboss-home>
-                    <stdout>none</stdout>
-                    <java-opts>${modular.jdk.args}</java-opts>
-                    <system-properties>
-                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
-                        <module.path>${jboss.dist}/modules</module.path>
-                    </system-properties>
-                </configuration>
                 <executions>
                     <execution>
+                        <configuration>
+                            <offline>true</offline>
+                            <scripts>
+                                <script>${wildfly.dir}/docs/examples/enable-microprofile.cli</script>
+                            </scripts>
+                            <jboss-home>${wildfly.dir}</jboss-home>
+                            <stdout>none</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
+                            <system-properties>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                <module.path>${jboss.dist}/modules</module.path>
+                            </system-properties>
+                        </configuration>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>execute-commands</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <executions>
                     <!-- Provision a cloud server including all the MicroProfile specs layers -->
                     <execution>
                         <id>bootable-jar-packaging</id>
                         <configuration>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <record-provisioning-state>false</record-provisioning-state>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <galleon-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </galleon-options>
                             <!-- content that is installed in wildfly home -->
                             <extra-server-content-dirs>${wildfly.dir}</extra-server-content-dirs>
-                            <output-file-name>test-wildfly.jar</output-file-name>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly.jar</bootableJarName>
                             <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -494,6 +494,14 @@
                 <version>${version.org.wildfly.plugin}</version>
                 <configuration>
                     <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                    <record-provisioning-state>false</record-provisioning-state>
+                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                    <galleon-options>
+                        <jboss-maven-dist/>
+                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                        <optional-packages>passive+</optional-packages>
+                    </galleon-options>
                 </configuration>
                 <executions>
                     <execution>
@@ -504,14 +512,6 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <provisioning-dir>${project.build.directory}/wildfly</provisioning-dir>
-                            <record-provisioning-state>false</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>${galleon.offline}</offline-provisioning>
-                            <galleon-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
@@ -535,6 +535,19 @@
                                     </included-configs>
                                 </feature-pack>
                             </feature-packs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bootable-jar-provisioning</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
+                        <configuration>
+                            <skipDeployment>true</skipDeployment>
+                            <provisioning-file>target/glow-scan/microprofile.surefire/provisioning.xml</provisioning-file>
+                            <bootableJar>true</bootableJar>
+                            <bootableJarName>test-wildfly-cloud-profile.jar</bootableJarName>
                         </configuration>
                     </execution>
                 </executions>
@@ -578,20 +591,6 @@
                         <configuration>
                             <expected-discovery>[sar]==>ee-core-profile-server,sar</expected-discovery>
                             <surefire-execution-for-included-classes>legacy-sar-layers.surefire</surefire-execution-for-included-classes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <executions>
-                    <!-- Package a cloud-profile server with the default 'bootable-jar-packaging' execution -->
-                    <execution>
-                        <id>bootable-jar-packaging</id>
-                        <configuration>
-                            <output-file-name>test-wildfly-cloud-profile.jar</output-file-name>
-                            <provisioning-file>target/glow-scan/microprofile.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
                 </executions>
@@ -857,7 +856,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
                 <glow.phase.observability>test-compile</glow.phase.observability>
             </properties>
             <build>
@@ -944,7 +943,7 @@
                 </dependency>
             </dependencies>
             <properties>
-                <ts.bootable-jar-packaging.phase>test-compile</ts.bootable-jar-packaging.phase>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
                 <glow.phase.observability>test-compile</glow.phase.observability>
             </properties>
             <build>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -322,21 +322,29 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-jar-maven-plugin</artifactId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <!-- Package a datasources-web-server with the default 'bootable-jar-packaging' execution -->
                     <execution>
                         <id>bootable-jar-packaging</id>
                         <configuration>
-                            <output-file-name>test-wildfly-web-profile.jar</output-file-name>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-web-profile.jar</bootableJarName>
                             <extra-server-content-dirs>
                                 <extra-content>${basedir}/target/wildfly-users</extra-content>
                                 <extra-content>${basedir}/target/external-taglib-module</extra-content>
                             </extra-server-content-dirs>
                             <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -283,35 +283,6 @@
                    </executions>
                </plugin>
 
-                <!-- Basic configuration for bootable jar packaging, if enabled -->
-                <plugin>
-                    <groupId>org.wildfly.plugins</groupId>
-                    <artifactId>wildfly-jar-maven-plugin</artifactId>
-                    <version>${version.org.wildfly.jar.plugin}</version>
-                    <configuration>
-                        <hollowJar>true</hollowJar>
-                        <record-state>false</record-state>
-                        <log-time>${galleon.log.time}</log-time>
-                        <offline>true</offline>
-                        <plugin-options>
-                            <jboss-maven-dist/>
-                            <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                        </plugin-options>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>bootable-jar-packaging</id>
-                            <goals>
-                                <goal>package</goal>
-                            </goals>
-                            <!-- This execution's phase is controlled by a property that defaults to 'none'.
-                                 Profiles that want it to run set the property to a different phase-->
-                            <phase>${ts.bootable-jar-packaging.phase}</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-
-
                <!-- WFLY-3361 - use external xalan for XML transformations to
                ensure consistent behaviour on all platrforms.-->
                <plugin>
@@ -516,36 +487,6 @@
             <id>scripts_.module.profile</id>
             <activation><property><name>ts.scripts</name></property></activation>
             <modules><module>scripts</module></modules>
-        </profile>
-
-        <profile>
-            <!-- Use the latest version of the standard channels when provisioning a bootable jar. -->
-            <id>latest.standard.channels.profile</id>
-            <activation><property><name>latest.standard.channels</name></property></activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <configuration>
-                            <channels>
-                                <channel>
-                                    <manifest>
-                                        <groupId>${channels.maven.groupId}</groupId>
-                                        <artifactId>wildfly-ee</artifactId>
-                                    </manifest>
-                                </channel>
-                                <channel>
-                                    <manifest>
-                                        <groupId>${channels.maven.groupId}</groupId>
-                                        <artifactId>wildfly</artifactId>
-                                    </manifest>
-                                </channel>
-                            </channels>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>

--- a/testsuite/preview/basic/pom.xml
+++ b/testsuite/preview/basic/pom.xml
@@ -196,6 +196,14 @@
                 <version>${version.org.wildfly.plugin}</version>
                 <configuration>
                     <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                    <record-provisioning-state>false</record-provisioning-state>
+                    <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                    <offline-provisioning>${galleon.offline}</offline-provisioning>
+                    <galleon-options>
+                        <jboss-maven-dist/>
+                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                        <optional-packages>passive+</optional-packages>
+                    </galleon-options>
                 </configuration>
                 <executions>
                     <!-- Provision a non-slimmed server -->
@@ -207,14 +215,6 @@
                         <phase>${full-provisioning.phase}</phase>
                         <configuration>
                             <provisioning-dir>${project.build.directory}/wildfly</provisioning-dir>
-                            <record-provisioning-state>false</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>${galleon.offline}</offline-provisioning>
-                            <galleon-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </galleon-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${full.maven.groupId}</groupId>
@@ -234,14 +234,6 @@
                         <phase>${hibernate-search-provisioning.phase}</phase>
                         <configuration>
                             <provisioning-dir>${project.build.directory}/wildfly-hibernate-search</provisioning-dir>
-                            <record-provisioning-state>false</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>${galleon.offline}</offline-provisioning>
-                            <galleon-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </galleon-options>
                             <provisioning-file>target/glow-scan/hibernate-search.layer.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -255,14 +247,45 @@
                         <phase>${mvc-provisioning.phase}</phase>
                         <configuration>
                             <provisioning-dir>${project.build.directory}/wildfly-mvc</provisioning-dir>
-                            <record-provisioning-state>false</record-provisioning-state>
-                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
-                            <offline-provisioning>${galleon.offline}</offline-provisioning>
-                            <galleon-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                <optional-packages>passive+</optional-packages>
-                            </galleon-options>
+                            <provisioning-file>target/glow-scan/mvc.layer.surefire/provisioning.xml</provisioning-file>
+                        </configuration>
+                    </execution>
+                    <!-- Package a server with hibernate-search -->
+                    <execution>
+                        <id>bootable-jar-hibernate-search-packaging</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
+                        <configuration>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-hibernate-search.jar</bootableJarName>
+                            <extra-server-content-dirs>
+                                <!-- Uncomment if we add extra content
+                                <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
+                                -->
+                            </extra-server-content-dirs>
+                            <provisioning-file>target/glow-scan/hibernate-search.layer.surefire/provisioning.xml</provisioning-file>
+                        </configuration>
+                    </execution>
+
+                    <!-- Package a server with mvc -->
+                    <execution>
+                        <id>bootable-jar-mvc-packaging</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>${ts.bootable-jar-packaging.phase}</phase>
+                        <configuration>
+                            <bootableJar>true</bootableJar>
+                            <skipDeployment>true</skipDeployment>
+                            <bootableJarName>test-wildfly-mvc.jar</bootableJarName>
+                            <extra-server-content-dirs>
+                                <!-- Uncomment if we add extra content
+                                <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
+                                -->
+                            </extra-server-content-dirs>
                             <provisioning-file>target/glow-scan/mvc.layer.surefire/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
@@ -504,6 +527,7 @@
                 <glow.hibernate-search.phase>test-compile</glow.hibernate-search.phase>
                 <glow.mvc.phase>test-compile</glow.mvc.phase>
                 <ts.copy-wildfly-standalone-embedded-broker.phase>none</ts.copy-wildfly-standalone-embedded-broker.phase>
+                <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
             </properties>
             <build>
                 <plugins>
@@ -535,47 +559,6 @@
                                             </includes>
                                         </resource>
                                     </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <executions>
-                            <!-- Package a server with hibernate-search -->
-                            <execution>
-                                <id>bootable-jar-hibernate-search-packaging</id>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                                <phase>process-test-classes</phase>
-                                <configuration>
-                                    <output-file-name>test-wildfly-hibernate-search.jar</output-file-name>
-                                    <extra-server-content-dirs>
-                                        <!-- Uncomment if we add extra content
-                                        <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
-                                        -->
-                                    </extra-server-content-dirs>
-                                    <provisioning-file>target/glow-scan/hibernate-search.layer.surefire/provisioning.xml</provisioning-file>
-                                </configuration>
-                            </execution>
-
-                            <!-- Package a server with mvc -->
-                            <execution>
-                                <id>bootable-jar-mvc-packaging</id>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                                <phase>process-test-classes</phase>
-                                <configuration>
-                                    <output-file-name>test-wildfly-mvc.jar</output-file-name>
-                                    <extra-server-content-dirs>
-                                        <!-- Uncomment if we add extra content
-                                        <extraServerContent>${project.build.directory}/extraContent/</extraServerContent>
-                                        -->
-                                    </extra-server-content-dirs>
-                                    <provisioning-file>target/glow-scan/mvc.layer.surefire/provisioning.xml</provisioning-file>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19702

Replaced usage in the tests of WildFly JAR Maven plugin with WildFly Maven plugin support for Bootable JAR.
