### PR TITLE
Include hidden files when uploading the artifact; use action to download

### DIFF
--- a/.github/workflows/dep-diff-pull_request.yml
+++ b/.github/workflows/dep-diff-pull_request.yml
@@ -189,3 +189,4 @@ jobs:
         with:
           name: input-artifacts
           path: ${{ steps.prepare.outputs.artifacts }}
+          include-hidden-files: true

--- a/.github/workflows/dep-diff-workflow_run.yml
+++ b/.github/workflows/dep-diff-workflow_run.yml
@@ -24,36 +24,15 @@ jobs:
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Download artifacts
-        # It would have been nice to be able to use actions/download-artifact@v2
-        # for this, but as the artifacts are uploaded by another workflow it does
-        # not seem possible - so we need to do this stuff instead
-        uses: actions/github-script@v7.0.1
+      - uses: actions/download-artifact@v4
         with:
-          script: |
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            console.log(artifacts);
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "input-artifacts"
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/input.zip', Buffer.from(download.data));
-
+          name: input-artifacts
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Set needed env vars in outputs
         id: prepare
         run: |
-          unzip input.zip
           echo current directory contents
           ls -al
           echo "deps_ok_label_name=${DEPS_OK_LABEL_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This was a breaking change in a recent release of the artifact: https://github.com/actions/download-artifact/issues/351#issuecomment-2328758148

Switching to the download-artifact action changes what we download, so adjust that
