### PR TITLE
WFLY-19727 jboss-ejb-client_1_5.xsd schema incorrectly requires <http-connections/>

### DIFF
--- a/ejb3/src/main/resources/schema/jboss-ejb-client_1_4.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-client_1_4.xsd
@@ -62,7 +62,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="http-connections" type="http-connectionsType" >
+            <xsd:element name="http-connections" type="http-connectionsType" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         Configures remote http-connection for EJB invocation

--- a/ejb3/src/main/resources/schema/jboss-ejb-client_1_5.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-client_1_5.xsd
@@ -62,7 +62,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="http-connections" type="http-connectionsType" >
+            <xsd:element name="http-connections" type="http-connectionsType" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         Configures remote http-connection for EJB invocation


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-19727

This schema https://github.com/wildfly/wildfly/blob/d6daeef76af540ca6a5e71ac101257f27c62bf5a/ejb3/src/main/resources/schema/jboss-ejb-client_1_4.xsd#L65 requires http-connections but the parser https://github.com/wildfly/wildfly/blob/1f68b0ad54b7899650a782a8efdde0cec196865c/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor14Parser.java#L75 does not.

Introduced by https://issues.redhat.com/browse/WFLY-13887 which was fixing https://issues.redhat.com/browse/WFLY-12190 which missed updating the XSD.