### PR TITLE
[WFLY-19732] Suppress CVE-2024-7885 as it is addressed under UNDERTOW-2429.

### DIFF
--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -214,4 +214,13 @@
       <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-tracing\-api@.*$</packageUrl>
       <cve>CVE-2021-20293</cve>
    </suppress>
+   <suppress until="2025-09-13">
+      <notes><![CDATA[
+      file name: undertow-core-2.3.17.Final.jar
+
+      [WFLY-19732] This has been addressed under UNDERTOW-2429.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.undertow/undertow-core@.*$</packageUrl>
+      <vulnerabilityName>CVE-2024-7885</vulnerabilityName>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Just temporarily placing on hold as main has NOT been updated with the version of WildFly Core that contains the Undertow upgrade, once WildFly Core is updated with Undertow 2.3.17.Final and merged to main we can merge this PR.

https://issues.redhat.com/browse/WFLY-19732