### PR TITLE
[WFLY-19733] Upgrade WildFly Core to 26.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>1.1.1.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>26.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19733

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/26.0.0.Beta3...26.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6894'>WFCORE-6894</a>] -         SuspendController exposes MSC lifecycle to consumers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6976'>WFCORE-6976</a>] -         acmeAccount variable is not being used on CertificateAuthoritiesTestCase.java class
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6982'>WFCORE-6982</a>] -         Compile-time annotation processing fails with SE 23
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6837'>WFCORE-6837</a>] -         Update SubsystemTransformerTestCase for the elytron subsystem to test for rejection and transformation using dynamic-client-ssl-context
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6966'>WFCORE-6966</a>] -         Remove org.jboss.as.controller.parsing.Namespace
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6980'>WFCORE-6980</a>] -         Replace usage of wildfly-jar-maven-plugin  with wildfly-maven-plugin
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6994'>WFCORE-6994</a>] -         Add ModelTestControllerVersion.EAP_XP_5
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6968'>WFCORE-6968</a>] -         Upgrade WildFly Elytron to 2.5.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6973'>WFCORE-6973</a>] -         CVE-2024-7885 Upgrade Undertow to 2.3.17.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6978'>WFCORE-6978</a>] -         Upgrade JBoss Marshalling to 2.2.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6983'>WFCORE-6983</a>] -         Upgrade JBoss Logging to 3.6.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6663'>WFCORE-6663</a>] -         Add typed AttributeDefinition to simplify dependency logic during runtime operation handling
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6974'>WFCORE-6974</a>] -         Add convenience factory method to create a ServiceDependency from a Supplier
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6975'>WFCORE-6975</a>] -         Add convenience method to combine a ServiceDependency with another
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6984'>WFCORE-6984</a>] -         Allow ResourceDefinition.builder(ResourceRegistration, ResourceDescriptionResolver, SubsystemModel) to accept a null deprecated model
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6993'>WFCORE-6993</a>] -         Add constants for common int/long range validators
</li>
</ul>
</details>