### PR TITLE
[WFLY-19730] The com.google.protobuf module is no longer unreferenced

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/vertx/grpc-common/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/vertx/grpc-common/main/module.xml
@@ -15,6 +15,7 @@
     </resources>
 
     <dependencies>
+        <module name="com.google.protobuf"/>
         <module name="io.netty.netty-buffer" />
         <module name="io.netty.netty-codec" />
         <module name="io.netty.netty-codec-http" />

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <version.io.smallrye.smallrye-opentelemetry>2.6.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-reactive-messaging>4.21.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.7.Final</version.io.undertow.jastow>
-        <version.io.vertx.vertx>4.5.8</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.5.10</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -235,7 +235,6 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.micrometer",
             "org.wildfly.micrometer.deployment",
             "io.micrometer",
-            "com.google.protobuf",
             "io.opentelemetry.proto",
             // Extension not included in the default config
             "org.wildfly.extension.mvc-krazo",


### PR DESCRIPTION
Resolves the Galleon test failure in #18183 by adding another commit

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19730](https://issues.redhat.com/browse/WFLY-19730)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)