### PR TITLE
WFLY-19306 Upgrade to Hibernate ORM 6.6.0.Final / WFLY-19632 Upgrade to Hibernate Search 7.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.4.10.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.1.2.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.31.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.4.10.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.0.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
         <version.org.eclipse.microprofile.telemetry>1.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.3</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.2</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>8.12.2</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.15.0</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.5</version.org.glassfish.jaxb>

--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>2.35.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
-        <version.org.apache.avro>1.11.3</version.org.apache.avro>
+        <version.org.apache.avro>1.12.0</version.org.apache.avro>
         <version.org.apache.cxf>4.0.5</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>4.0.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.james.apache-mime4j>0.8.11</version.org.apache.james.apache-mime4j>
         <version.org.apache.kafka>3.7.1</version.org.apache.kafka>
-        <version.org.apache.lucene>9.9.2</version.org.apache.lucene>
+        <version.org.apache.lucene>9.11.1</version.org.apache.lucene>
         <version.org.apache.neethi>3.2.0</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.4</version.org.apache.santuario>

--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.glassfish.jaxb.jaxb-xjc>${version.org.glassfish.jaxb}</version.org.glassfish.jaxb.jaxb-xjc>
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
-        <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
+        <version.org.hibernate.commons.annotations>7.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.6.0.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.1.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.6.0.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.1.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -14,7 +14,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.13.2";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.15.0";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/webtxem/TestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/webtxem/TestServlet.java
@@ -32,7 +32,7 @@ public class TestServlet extends HttpServlet {
 
     @PersistenceContext(unitName = "web_jpa_pc")
     EntityManager em;
-
+    Long databaseGeneratedID = null;
     @Resource
     private UserTransaction tx;
 
@@ -48,13 +48,28 @@ public class TestServlet extends HttpServlet {
 
                 if (mode.equals("write")) {
                     WebJPAEntity f = new WebJPAEntity();
-                    f.setId(1L);
+                    // Pasting from https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html:
+                    // "
+                    // Merge versioned entity when row is deleted
+                    // Previously, merging a detached entity resulted in a SQL insert whenever there was no matching row in the database (for example, if the object had been deleted in another transaction). This behavior was unexpected and violated the rules of optimistic locking.
+                    //
+                    // An OptimisticLockException is now thrown when it is possible to determine that an entity is definitely detached, but there is no matching row. For this determination to be possible, the entity must have either:
+                    //
+                    // *  a generated @Id field, or
+                    // *  a non-primitive @Version field.
+                    //
+                    // For entities which have neither, it’s impossible to distinguish a new instance from a deleted detached instance, and there is no change from the previous behavior.
+                    // "
+                    // Previously, we specified the WebJPAEntity id value but as mentioned ^ we can no longer do that.
+                    // f.setId(1L);
+
                     f.setName("WebJPAEntity One");
-                    em.merge(f);
+                    f = em.merge(f);
+                    databaseGeneratedID = f.getId();
 
                 } else if (mode.equals("read")) {
 
-                    WebJPAEntity f = em.find(WebJPAEntity.class, 1L);
+                    WebJPAEntity f = em.find(WebJPAEntity.class, databaseGeneratedID);
                     resp.setContentType("text/plain");
                     PrintWriter out = resp.getWriter();
                     out.print(f.getName());


### PR DESCRIPTION
A draft PR to get the tests running against a combination of these two PRs:
https://github.com/wildfly/wildfly/pull/18129
https://github.com/wildfly/wildfly/pull/18119

That update Hibernate ORM to 6.6.0 and Hibernate Search to 7.2.1

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19306](https://issues.redhat.com/browse/WFLY-19306)
> * [WFLY-19633](https://issues.redhat.com/browse/WFLY-19633)
> * [WFLY-19632](https://issues.redhat.com/browse/WFLY-19632)
> * [WFLY-19631](https://issues.redhat.com/browse/WFLY-19631)
> * [WFLY-19630](https://issues.redhat.com/browse/WFLY-19630)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)