### PR TITLE
Allow 10 open dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - dependency-name: 'com.carrotsearch:hppc'
       - dependency-name: 'org.apache.avro:avro'
     rebase-strategy: "disabled"
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 10
     registries:
       - maven-central
       - jboss-public-repository-group


### PR DESCRIPTION
Perhaps we should go as high as 15 but given we're close to a release I'd rather bump it up by 2 at a time so dependabot doesn't grab a bunch of CI at an inconvenient time.