### PR TITLE
The preview boms should not depend on the standard boms

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -61,11 +61,11 @@
         <dependencies>
 
             <!--
-                Re-expose the standard-ee deps.
+                Re-expose the common-ee deps.
              -->
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
-                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <artifactId>wildfly-common-ee-dependency-management</artifactId>
                 <version>${ee.maven.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/boms/preview-expansion/pom.xml
+++ b/boms/preview-expansion/pom.xml
@@ -48,12 +48,12 @@
             </dependency>
 
             <!--
-                Re-expose the standard-expansion deps.
+                Re-expose the common-expansion deps.
              -->
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
-                <artifactId>wildfly-standard-expansion-bom</artifactId>
-                <version>${ee.maven.version}</version>
+                <artifactId>wildfly-common-expansion-dependency-management</artifactId>
+                <version>${full.maven.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Just an experiment to see what CI says.
