### PR TITLE
WFLY-17605 Stabilize TwoConnectorsEJBFailoverTestCase + mark as intermittent for more testing before enabling in upstream CI

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -26,11 +26,9 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionSupplier;
-
 
 import javax.naming.Context;
 
@@ -38,10 +36,8 @@ import javax.naming.Context;
  * A test of failover when both legacy remoting connector and HTTP Upgrade connector are enabled.
  * @author Richard Achmatowicz
  */
-
 @ServerSetup(TwoConnectorsEJBFailoverTestCase.ServerSetupTask.class)
 @RunWith(Arquillian.class)
-@Ignore("WFLY-17605")
 public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final int COUNT = 20;
@@ -117,6 +113,10 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
      * A SFSB failover test which accepts an EJBDirectory provider parameter to adjust client behaviour
      */
     public void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
+
+        // give the servers a moment to stabilize before invocation start
+        Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
         try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -20,12 +20,14 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorB
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.CLIServerSetupTask;
+import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionSupplier;
@@ -39,6 +41,11 @@ import javax.naming.Context;
 @ServerSetup(TwoConnectorsEJBFailoverTestCase.ServerSetupTask.class)
 @RunWith(Arquillian.class)
 public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        IntermittentFailure.thisTestIsFailingIntermittently("https://issues.redhat.com/browse/WFLY-17605");
+    }
 
     private static final int COUNT = 20;
     private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -19,8 +19,8 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.CLIServerSetupTask;
 import org.jboss.as.test.shared.IntermittentFailure;
+import org.jboss.as.test.shared.ManagementServerSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
@@ -36,6 +36,7 @@ import javax.naming.Context;
 
 /**
  * A test of failover when both legacy remoting connector and HTTP Upgrade connector are enabled.
+ *
  * @author Richard Achmatowicz
  */
 @ServerSetup(TwoConnectorsEJBFailoverTestCase.ServerSetupTask.class)
@@ -93,7 +94,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
             //props.put(Context.PROVIDER_URL, String.format("%s://%s:%s/wildfly-services", "https", "localhost", "8080"));
             props.put(Context.PROVIDER_URL, String.format("%s://%s:%s", "remote+http", "localhost", "8080"));
         }
-        return props ;
+        return props;
     }
 
 
@@ -102,7 +103,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
      */
     @Test
     public void testEJBClientUsingHttpUpgradeProtocol() throws Exception {
-        log.infof(MODULE_NAME+ " : testing failover with client using HTTP Upgrade");
+        log.infof(MODULE_NAME + " : testing failover with client using HTTP Upgrade");
         test(() -> new RemoteEJBDirectory(MODULE_NAME, getProperties(false)));
     }
 
@@ -140,7 +141,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
                 Assert.assertEquals(String.valueOf(i), target, result.getNode());
             }
 
-            undeploy(this.findDeployment(target));
+            undeploy(findDeployment(target));
 
             Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
 
@@ -151,7 +152,7 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
             Assert.assertEquals(count++, result.getValue().intValue());
             Assert.assertNotEquals(target, failoverTarget);
 
-            deploy(this.findDeployment(target));
+            deploy(findDeployment(target));
 
             // Allow sufficient time for client to receive new topology
             Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
@@ -213,21 +214,30 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
         }
     }
 
-        /*
+    /**
      * Set up the server to use both legacy and HTTP Upgrade remoting connectors
      */
-    public static class ServerSetupTask extends CLIServerSetupTask {
-        public ServerSetupTask() {
-            this.builder.node(TWO_NODES)
-                    .setup("/socket-binding-group=standard-sockets/socket-binding=remoting:add(port=4447)")
-                    .setup("/subsystem=remoting/connector=remoting-connector:add(socket-binding=remoting, sasl-authentication-factory=application-sasl-authentication)")
-                    .setup("/subsystem=remoting/connector=remoting-connector/property=SSL_ENABLED:add(value=false)")
-                    // this step results in a capabilities error if the list is not formatted correctly for CLI
-                    .setup("/subsystem=ejb3/service=remote:list-add(name=connectors, value=remoting-connector)")
-                    .teardown("/subsystem=ejb3/service=remote:list-remove(name=connectors, value=remoting-connector)")
-                    .teardown("/subsystem=remoting/connector=remoting-connector:remove")
-                    .teardown("/socket-binding-group=standard-sockets/socket-binding=remoting:remove")
-            ;
+    static class ServerSetupTask extends ManagementServerSetupTask {
+        ServerSetupTask() {
+            super(NODE_1_2, createContainerConfigurationBuilder()
+                    .setupScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/socket-binding-group=standard-sockets/socket-binding=remoting:add(port=4447)")
+                            .add("/subsystem=remoting/connector=remoting-connector:add(socket-binding=remoting, sasl-authentication-factory=application-sasl-authentication)")
+                            .add("/subsystem=remoting/connector=remoting-connector/property=SSL_ENABLED:add(value=false)")
+                            // this step results in a capability error if the list is not formatted correctly for CLI
+                            .add("/subsystem=ejb3/service=remote:list-add(name=connectors, value=remoting-connector)")
+                            .endBatch()
+                            .build())
+                    .tearDownScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=ejb3/service=remote:list-remove(name=connectors, value=remoting-connector)")
+                            .add("/subsystem=remoting/connector=remoting-connector:remove")
+                            .add("/socket-binding-group=standard-sockets/socket-binding=remoting:remove")
+                            .endBatch()
+                            .build())
+                    .build());
         }
     }
+
 }


### PR DESCRIPTION
Replaces https://github.com/wildfly/wildfly/pull/16741 by incorporating it + mark as intermittent for more testing before enabling in upstream CI + cleneanup so that the change is mergeable.

Jira
https://issues.redhat.com/browse/WFLY-17605