### PR TITLE
[WFLY-19757] [CVE-2024-7254] Upgrade protobuf-java to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
         <version.com.google.guava>33.0.0-jre</version.com.google.guava>
         <version.com.google.guava.failureaccess>1.0.2</version.com.google.guava.failureaccess>
-        <version.com.google.protobuf>3.19.6</version.com.google.protobuf>
+        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
         <version.com.h2database>2.2.224</version.com.h2database>
         <version.com.ibm.async.asyncutil>0.1.0</version.com.ibm.async.asyncutil>
         <version.com.microsoft.azure>8.6.6</version.com.microsoft.azure>


### PR DESCRIPTION

https://issues.redhat.com/browse/WFLY-19757

Doing a release comparison in GitHub doesn't really work but FYI:

https://github.com/protocolbuffers/protobuf/compare/v3.19.6...v3.25.5


https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254
https://github.com/advisories/GHSA-735f-pc8j-v9w8