### PR TITLE
Bump version.org.eclipse.jetty from 9.4.55.v20240627 to 9.4.56.v20240826 #18219

### DIFF
--- a/boms/preview-test-expansion/pom.xml
+++ b/boms/preview-test-expansion/pom.xml
@@ -27,7 +27,7 @@
     <name>WildFly Preview: Dependency Management (Expansion Test Dependencies)</name>
 
     <properties>
-        <version.org.eclipse.jetty>9.4.56.v20240826</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>11.0.20</version.org.eclipse.jetty>
         <version.org.eclipse.microprofile.rest.client.api>4.0</version.org.eclipse.microprofile.rest.client.api>
         <version.org.jboss.resteasy.microprofile>3.0.0.Final</version.org.jboss.resteasy.microprofile>
         <version.org.testng>7.10.2</version.org.testng>


### PR DESCRIPTION
Fix #18219 