### PR TITLE
[WFLY-19765] Upgrade WildFly Core to 26.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>26.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19765

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Beta5
Diff: https://github.com/wildfly/wildfly-core/compare/26.0.0.Beta4...26.0.0.Beta5

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6830'>WFCORE-6830</a>] -         [Community] Add four attributes to the management interfaces for backlog, no-read-timeout, connection-high-water, connection-low-water
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6960'>WFCORE-6960</a>] -         Promote Simple config export for a server as an attachment from COMMUNITY to DEFAULT
</li>
</ul>
            
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6103'>WFCORE-6103</a>] -         Add org.aesh dependency for Elytron Tool
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6829'>WFCORE-6829</a>] -         Add a urn:jboss:domain:community:20.0 / wildfly-config_20_0_community.xsd schema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6998'>WFCORE-6998</a>] -         Prune obsolete DeploymentUnitPhaseBuilder
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6996'>WFCORE-6996</a>] -         Upgrade Apache Commons CLI from 1.8.0 to 1.9.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7000'>WFCORE-7000</a>] -         Upgrade wildfly-maven-plugin to 5.0.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7006'>WFCORE-7006</a>] -         Upgrade WildFly Elytron to 2.6.0.Final
</li>
</ul>
</details>
