### PR TITLE
[WFLY-19760] - Distributions contain zips of feature packs index at their root

### DIFF
--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -34,12 +34,20 @@
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.zip</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>false</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack-unstable-api-annotation-index.zip</location>
       <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/wildfly-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>false</exists>
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>

--- a/ee-dist/src/verifier/verifications.xml
+++ b/ee-dist/src/verifier/verifications.xml
@@ -86,8 +86,12 @@
       <exists>false</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
       <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>false</exists>
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-txn_5_0.xsd</location>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -132,7 +132,7 @@
                         </goals>
                         <configuration>
                             <!-- Just copy here rather than trying to get from the shared zip, since nothing else is using the zip -->
-                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/content</outputDirectory>
+                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${galleon.shared.generated.resources.directory}</directory>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -4234,7 +4234,7 @@
                 <groupId>org.wildfly.unstable.api.annotation</groupId>
                 <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
                 <configuration>
-                    <outputFile>${project.build.directory}/index/wildfly-ee-feature-pack.zip</outputFile>
+                    <outputFile>${project.build.directory}/index/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</outputFile>
                     <filters>
                         <filter>
                             <annotation>org.hibernate.Incubating</annotation>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/pm/wildfly/tasks.xml
@@ -5,6 +5,6 @@
   -->
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
-        <copy-path src="wildfly-ee-feature-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-feature-pack.zip"/>
+        <copy-path src="wildfly-ee-galleon-pack-unstable-api-annotation-index.zip" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip"/>
 
 </tasks>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -128,7 +128,7 @@
                         </goals>
                         <configuration>
                             <!-- Just copy here rather than trying to get from the shared zip, since nothing else is using the zip -->
-                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/content</outputDirectory>
+                            <outputDirectory>${basedir}/target/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${galleon.shared.generated.resources.directory}</directory>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -657,7 +657,7 @@
                 <groupId>org.wildfly.unstable.api.annotation</groupId>
                 <artifactId>unstable-api-annotation-classpath-indexer-plugin</artifactId>
                 <configuration>
-                    <outputFile>${project.build.directory}/index/wildfly-galleon-pack.zip</outputFile>
+                    <outputFile>${project.build.directory}/index/wildfly-galleon-pack-unstable-api-annotation-index.zip</outputFile>
                     <filters>
                         <filter>
                             <annotation>io.smallrye.common.annotation.Experimental</annotation>

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/pm/wildfly/tasks.xml
@@ -5,5 +5,5 @@
   -->
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
-    <copy-path src="wildfly-galleon-pack.zip" relative-to="content" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack.zip"/>
+    <copy-path src="wildfly-galleon-pack-unstable-api-annotation-index.zip" target="modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack-unstable-api-annotation-index.zip"/>
 </tasks>


### PR DESCRIPTION
* The zip of the WildFly galleon packs's index must not be present at the root of the feature packs but only in the modules tree
* Renamed the zip to clarify their content:
  * wildfly-galleon-pack.zip has been renamed wildfly-galleon-pack-unstable-api-annotation-index.zip
  * wildfly-ee-feature-pack.zip has been renamed wildfly-ee-galleon-pack-unstable-api-annotation-index.zip

JIRA: https://issues.redhat.com/browse/WFLY-19760
