### PR TITLE
[WFLY-19769] Prove that appclient main can access ear/lib jar classes

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/AppClientMain.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/AppClientMain.java
@@ -24,7 +24,8 @@ public class AppClientMain {
 
     public static void main(final String[] params) {
         logger.trace("Main method invoked");
-
+        Status status = new Status();
+        logger.info("Status class accessed via classloader = " + status.getClass().getClassLoader());
         if(!appclient) {
             logger.error("InAppClientContainer was not true");
             throw new RuntimeException("InAppClientContainer was not true");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase.java
@@ -44,6 +44,11 @@ public class SimpleApplicationClientTestCase extends AbstractSimpleApplicationCl
         lib.addClasses(Employee.class);
         lib.addAsManifestResource(PersistenceUnitPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsLibrary(lib);
+
+        final JavaArchive otherLib = ShrinkWrap.create(JavaArchive.class, "otherlib.jar");
+        otherLib.addClass(Status.class);
+        ear.addAsLibrary(otherLib);
+
         final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejb.addClasses(SimpleApplicationClientTestCase.class, AppClientStateSingleton.class);
         ear.addAsModule(ejb);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/SimpleApplicationClientTestCase2.java
@@ -44,6 +44,11 @@ public class SimpleApplicationClientTestCase2 extends AbstractSimpleApplicationC
         lib.addClasses(Employee.class);
         lib.addAsManifestResource(PersistenceUnitPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsLibrary(lib);
+
+        final JavaArchive otherLib = ShrinkWrap.create(JavaArchive.class, "otherlib.jar");
+        otherLib.addClass(Status.class);
+        ear.addAsLibrary(otherLib);
+
         final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejb.addClasses(SimpleApplicationClientTestCase2.class, AppClientStateSingleton.class);
         ear.addAsModule(ejb);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/Status.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/Status.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.appclient.basic;
+
+/**
+ * Status
+ *
+ * @author Scott Marlow
+ */
+public class Status {
+    public String getStatus() {
+        return "there were no test failures accessing the Status class!";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/UnspecifiedApplicationClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/UnspecifiedApplicationClientTestCase.java
@@ -46,6 +46,11 @@ public class UnspecifiedApplicationClientTestCase  extends AbstractSimpleApplica
         lib.addClasses(Employee.class);
         lib.addAsManifestResource(PersistenceUnitPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsLibrary(lib);
+
+        final JavaArchive otherLib = ShrinkWrap.create(JavaArchive.class, "otherlib.jar");
+        otherLib.addClass(Status.class);
+        ear.addAsLibrary(otherLib);
+
         final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejb.addClasses(SimpleApplicationClientTestCase.class, AppClientStateSingleton.class);
         ear.addAsModule(ejb);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19769

I'm not sure why this wouldn't run locally after building WildFly so created this pr:

> mvn clean install -Dtest=org.jboss.as.test.integration.ee.appclient.basic.UnspecifiedApplicationClientTestCase
> Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project wildfly-naming: No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.) -> [Help 1
