### PR TITLE
[WFLY-19397] Jakarta Data support in WildFly Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -110,6 +110,17 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>jakarta.data</groupId>
+                <artifactId>jakarta.data-api</artifactId>
+                <version>${version.jakarta.data.jakarta-data-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.el</groupId>
                 <artifactId>jakarta.el-api</artifactId>
                 <version>${version.jakarta.el}</version>
@@ -560,6 +571,18 @@
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator-cdi</artifactId>
                 <version>${version.org.hibernate.validator}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>wildfly-jakarta-data</artifactId>
+                <version>${ee.maven.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -71,11 +71,11 @@ compliance of WildFly Preview should check the https://github.com/wildfly/certif
 [wildfly-preview-ee11]
 === EE 11 Support in WildFly Preview
 
-The 32 release introduces a significant inflection in how we are using WildFly Preview. Beginning with this release we are starting to use WildFly Preview to provide a look at what we're doing for Jakarta EE 11 support.  EE 11 is not yet GA, and standard WildFly won't support EE 11 before the WildFly 34 release, at earliest. But there are milestone, release candidate and final releases of many EE 11 specs and implementations available, so we decided to provide those in WildFly Preview. This means for a number of EE APIs, WildFly Preview no long provides an EE 10 compatible implementation.
+The 32 release introduces a significant inflection in how we are using WildFly Preview. Beginning with this release we are starting to use WildFly Preview to provide a look at what we're doing for Jakarta EE 11 support.  EE 11 is not yet GA, and standard WildFly won't support EE 11 before the WildFly 36 release, at earliest. But there are milestone, release candidate and final releases of many EE 11 specs and implementations available, so we decided to provide those in WildFly Preview. This means for a number of EE APIs, WildFly Preview no long provides an EE 10 compatible implementation.
 
 However, for a number of specifications that are planning changes for EE 11 we are still offering the EE 10 variant. In future releases we'll shift those to the EE 11 variants.
 
-The following table lists the various Jakarta technologies offered by WildFly Preview 32, along with information about which EE platform version the specification relates to. Note that a number of Jakarta specifications are unchanged between EE 10 and EE 11, while other EE technologies that WildFly offers are not part of EE 11.
+The following table lists the various Jakarta technologies offered by WildFly Preview, along with information about which EE platform version the specification relates to. Note that a number of Jakarta specifications are unchanged between EE 10 and EE 11, while other EE technologies that WildFly offers are not part of EE 11. Jakarta Data is a new specification added in EE 11.
 
 [cols=",,",options="header"]
 |=======================================================================
@@ -96,6 +96,9 @@ The following table lists the various Jakarta technologies offered by WildFly Pr
 |Jakarta Connectors| 2.1 |10 & 11
 
 |Jakarta Contexts and Dependency Injection| 4.1.0 |11
+
+|Jakarta Data
+(_xref:Admin_Guide.adoc#Feature_stability_levels[preview stability] only_)| 1.0 |11
 
 |Jakarta Debugging Support for Other Languages| 2.0 |10 & 11
 
@@ -120,7 +123,7 @@ The following table lists the various Jakarta technologies offered by WildFly Pr
 |Jakarta Messaging| 3.1 |10 & 11
 
 | Jakarta MVC
-(_preview stability only_)| 2.1| N/A xref:note2[^2^]
+(_xref:Admin_Guide.adoc#Feature_stability_levels[preview stability] only_)| 2.1| N/A xref:note2[^2^]
 
 |Jakarta Pages| 3.1 |10
 

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -285,6 +285,12 @@ link:#gal.naming[naming] +
 |
 link:#gal.base-server[base-server] +
 
+|[[gal.jaxrs-core]]jakarta-data
+|Support for Jakarta Data. (xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability] in xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview] only) The _link:#gal.jpa[jpa]_ dependency can be excluded and _link:#gal.jpa-distributed[jpa-distributed]_ used instead.
+|
+link:#gal.jpa[jpa] OR +
+link:#gal.jpa-distributed[jpa-distributed]
+
 |[[gal.jaxrs-core]]jaxrs-core
 |Support for Jakarta RESTful Web Services.
 |

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -23,6 +23,8 @@
         <module name="com.fasterxml.jackson.core.jackson-core" optional="true"/>
         <module name="com.fasterxml.jackson.core.jackson-databind" optional="true"/>
         <module name="jakarta.annotation.api"/>
+        <!-- If Jakarta Data is provisioned, depend on it -->
+        <module name="jakarta.data.api" optional="true"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.json.bind.api"/>
         <module name="jakarta.persistence.api"/>

--- a/jakarta-data/pom.xml
+++ b/jakarta-data/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>34.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-jakarta-data</artifactId>
+
+    <name>WildFly: Jakarta Data Integration</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <version>${ee.maven.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>wildfly-standard-test-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test depedencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/JakartaDataExtension.java
+++ b/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/JakartaDataExtension.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.jakarta.data;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.wildfly.extension.jakarta.data._private.JakartaDataLogger.ROOT_LOGGER;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentSubsystemSchema;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.ResourceRegistration;
+import org.jboss.as.controller.SubsystemModel;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.SubsystemSchema;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.as.controller.xml.VersionedNamespace;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.Phase;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.as.version.Stability;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.staxmapper.IntVersion;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.subsystem.SubsystemConfiguration;
+import org.wildfly.subsystem.SubsystemExtension;
+import org.wildfly.subsystem.SubsystemPersistence;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
+import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
+import org.wildfly.subsystem.resource.ResourceDescriptor;
+import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
+
+
+/**
+ * WildFly extension that provides Jakarta MVC support based on Eclipse Krazo.
+ *
+ * @author <a href="mailto:brian.stansberry@redhat.com">Brian Stansberry</a>
+ */
+@MetaInfServices(Extension.class)
+public class JakartaDataExtension extends SubsystemExtension<JakartaDataExtension.JakartaDataSubsystemSchema> {
+
+    /**
+     * The name of our subsystem within the model.
+     */
+    static final String SUBSYSTEM_NAME = "jakarta-data";
+    private static final Stability FEATURE_STABILITY = Stability.PREVIEW;
+
+    static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+
+    public JakartaDataExtension() {
+        super(SubsystemConfiguration.of(SUBSYSTEM_NAME, JakartaDataSubsystemModel.CURRENT, JakartaDataSubsystemRegistrar::new),
+                SubsystemPersistence.of(JakartaDataSubsystemSchema.CURRENT));
+    }
+
+    @Override
+    public Stability getStability() {
+        return FEATURE_STABILITY;
+    }
+
+    /**
+     * Model for the 'jakarta-data' subsystem.
+     */
+    public enum JakartaDataSubsystemModel implements SubsystemModel {
+        VERSION_1_0_0(1, 0, 0),
+        ;
+
+        static final JakartaDataSubsystemModel CURRENT = VERSION_1_0_0;
+
+        private final ModelVersion version;
+
+        JakartaDataSubsystemModel(int major, int minor, int micro) {
+            this.version = ModelVersion.create(major, minor, micro);
+        }
+
+        @Override
+        public ModelVersion getVersion() {
+            return this.version;
+        }
+    }
+
+    /**
+     * Schema for the 'jakarta-data' subsystem.
+     */
+    public enum JakartaDataSubsystemSchema implements PersistentSubsystemSchema<JakartaDataSubsystemSchema> {
+
+        VERSION_1_0_PREVIEW(1, 0, FEATURE_STABILITY),
+        ;
+
+        static final JakartaDataSubsystemSchema CURRENT = VERSION_1_0_PREVIEW;
+
+        private final VersionedNamespace<IntVersion, JakartaDataSubsystemSchema> namespace;
+
+        JakartaDataSubsystemSchema(int major, int minor, Stability stability) {
+            this.namespace = SubsystemSchema.createSubsystemURN(SUBSYSTEM_NAME, stability, new IntVersion(major, minor));
+        }
+
+        @Override
+        public VersionedNamespace<IntVersion, JakartaDataSubsystemSchema> getNamespace() {
+            return this.namespace;
+        }
+
+        @Override
+        public Stability getStability() {
+            return this.getNamespace().getStability();
+        }
+
+        @Override
+        public PersistentResourceXMLDescription getXMLDescription() {
+            PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
+            return factory.builder(SUBSYSTEM_PATH).build();
+        }
+    }
+
+    private static final class JakartaDataSubsystemRegistrar implements SubsystemResourceDefinitionRegistrar {
+
+        private static final RuntimeCapability<Void> JAKARTA_DATA_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jakarta.data")
+                .addRequirements("org.wildfly.jpa")
+                .build();
+        static final ParentResourceDescriptionResolver RESOLVER = new SubsystemResourceDescriptionResolver(SUBSYSTEM_NAME, JakartaDataSubsystemRegistrar.class);
+
+        static final String JAKARTA_DATA_API = "jakarta.data.api";
+
+        @Override
+        public ManagementResourceRegistration register(SubsystemRegistration parent, ManagementResourceRegistrationContext managementResourceRegistrationContext) {
+            ResourceDefinition definition = ResourceDefinition.builder(ResourceRegistration.of(SUBSYSTEM_PATH), RESOLVER).build();
+            ManagementResourceRegistration registration = parent.registerSubsystemModel(definition);
+            ResourceDescriptor descriptor = ResourceDescriptor.builder(RESOLVER)
+                    .addCapability(JAKARTA_DATA_CAPABILITY)
+                    .withDeploymentChainContributor(JakartaDataSubsystemRegistrar::registerDeploymentUnitProcessors)
+                    .build();
+            ManagementResourceRegistrar.of(descriptor).register(registration);
+            registration.registerAdditionalRuntimePackages(
+                    RuntimePackageDependency.required(JAKARTA_DATA_API)
+            );
+            return registration;
+        }
+
+        private static void registerDeploymentUnitProcessors(DeploymentProcessorTarget processorTarget) {
+            processorTarget.addDeploymentProcessor(JakartaDataExtension.SUBSYSTEM_NAME,
+                    Phase.DEPENDENCIES,
+                    Phase.DEPENDENCIES_JPA + 1,
+                    new DeploymentUnitProcessor() {
+                        @Override
+                        public void deploy(DeploymentPhaseContext phaseContext) {
+
+                            final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+                            final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+                            final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+
+                            // all applications get the jakarta.persistence module added to their deplyoment by default
+                            addDependencies(moduleSpecification, moduleLoader, deploymentUnit, JAKARTA_DATA_API);
+                        }
+                    });
+        }
+    }
+
+    private static void addDependencies(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
+                               DeploymentUnit deploymentUnit, String... moduleIdentifiers) {
+        for ( String moduleIdentifier : moduleIdentifiers) {
+            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+            ROOT_LOGGER.debugf("added %s dependency to %s", moduleIdentifier, deploymentUnit.getName());
+        }
+    }
+}

--- a/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/_private/JakartaDataLogger.java
+++ b/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/_private/JakartaDataLogger.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.jakarta.data._private;
+
+import java.lang.invoke.MethodHandles;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+
+@MessageLogger(projectCode = "WFLYJDATA", length = 4)
+public interface JakartaDataLogger extends BasicLogger {
+
+    JakartaDataLogger ROOT_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JakartaDataLogger.class, "org.wildfly.extension.jakarta.data");
+}

--- a/jakarta-data/src/main/resources/org/wildfly/extension/jakarta/data/LocalDescriptions.properties
+++ b/jakarta-data/src/main/resources/org/wildfly/extension/jakarta/data/LocalDescriptions.properties
@@ -1,0 +1,8 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+jakarta-data=The Jakarta Data subsystem.
+jakarta-data.add=Add the Jakarta Data subsystem.
+jakarta-data.remove=Remove the Jakarta Data subsystem.

--- a/jakarta-data/src/main/resources/schema/wildfly-jakarta-data_preview_1_0.xsd
+++ b/jakarta-data/src/main/resources/schema/wildfly-jakarta-data_preview_1_0.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:wildfly:jakarta-data:preview:1.0"
+            xmlns="urn:wildfly:jakarta-data:preview:1.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem" type="subsystem-type"/>
+
+    <xs:complexType name="subsystem-type"/>
+
+</xs:schema>

--- a/jakarta-data/src/test/java/org/wildfly/extension/jakarta/data/JakartaDataSubsystemTestCase.java
+++ b/jakarta-data/src/test/java/org/wildfly/extension/jakarta/data/JakartaDataSubsystemTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.jakarta.data;
+
+import java.util.EnumSet;
+
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.subsystem.test.AbstractSubsystemSchemaTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Standard subsystem tests for the jakarta-data subsystem.
+ */
+@RunWith(value = Parameterized.class)
+public class JakartaDataSubsystemTestCase extends AbstractSubsystemSchemaTest<JakartaDataExtension.JakartaDataSubsystemSchema> {
+    @Parameterized.Parameters
+    public static Iterable<JakartaDataExtension.JakartaDataSubsystemSchema> parameters() {
+        return EnumSet.allOf(JakartaDataExtension.JakartaDataSubsystemSchema.class);
+    }
+
+    public JakartaDataSubsystemTestCase(JakartaDataExtension.JakartaDataSubsystemSchema schema) {
+        super(JakartaDataExtension.SUBSYSTEM_NAME, new JakartaDataExtension(), schema, JakartaDataExtension.JakartaDataSubsystemSchema.CURRENT);
+    }
+
+    @Override
+    protected org.jboss.as.subsystem.test.AdditionalInitialization createAdditionalInitialization() {
+        return new AdditionalInit(getSubsystemSchema());
+    }
+
+    private static class AdditionalInit extends AdditionalInitialization.ManagementAdditionalInitialization {
+
+        private AdditionalInit(JakartaDataExtension.JakartaDataSubsystemSchema schema) {
+            super(schema);
+        }
+
+        @Override
+        protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
+            super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
+            registerCapabilities(capabilityRegistry, "org.wildfly.jpa");
+        }
+    }
+}

--- a/jakarta-data/src/test/resources/org/wildfly/extension/jakarta/data/jakarta-data-preview-1.0.xml
+++ b/jakarta-data/src/test/resources/org/wildfly/extension/jakarta/data/jakarta-data-preview-1.0.xml
@@ -1,0 +1,6 @@
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<subsystem xmlns="urn:wildfly:jakarta-data:preview:1.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <module>galleon-pack</module>
         <module>health</module>
         <module>iiop-openjdk</module>
+        <module>jakarta-data</module>
         <module>jaxrs</module>
         <module>jdr</module>
         <module>jpa</module>
@@ -450,6 +451,7 @@
         <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
+        <version.jakarta.data.jakarta-data-api>1.0.0</version.jakarta.data.jakarta-data-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>3.0.3</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>

--- a/preview/feature-pack/wildfly-feature-pack-build.xml
+++ b/preview/feature-pack/wildfly-feature-pack-build.xml
@@ -86,6 +86,7 @@
                 <extension>org.wildfly.extension.elytron</extension>
                 <extension>org.wildfly.extension.elytron-oidc-client</extension>
                 <extension>org.wildfly.extension.health</extension>
+                <extension>org.wildfly.extension.jakarta.data</extension>
                 <extension>org.wildfly.extension.io</extension>
                 <extension>org.wildfly.extension.messaging-activemq</extension>
                 <extension>org.wildfly.extension.metrics</extension>
@@ -141,6 +142,7 @@
                 <extension>org.wildfly.extension.discovery</extension>
                 <extension>org.wildfly.extension.ee-security</extension>
                 <extension>org.wildfly.extension.elytron</extension>
+                <extension>org.wildfly.extension.jakarta.data</extension>
                 <extension>org.wildfly.extension.io</extension>
                 <extension>org.wildfly.extension.messaging-activemq</extension>
                 <extension>org.wildfly.extension.microprofile.config-smallrye</extension>

--- a/preview/galleon-local/pom.xml
+++ b/preview/galleon-local/pom.xml
@@ -31,6 +31,10 @@
     <dependencies>
 
         <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
@@ -47,6 +51,11 @@
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-jakarta-data</artifactId>
         </dependency>
 
         <dependency>

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -10,54 +10,66 @@
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly28.0"/>
         <param name="host-release" value="WildFly28.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly29.0"/>
         <param name="host-release" value="WildFly29.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly30.0"/>
         <param name="host-release" value="WildFly30.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly31.0"/>
         <param name="host-release" value="WildFly31.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly32.0"/>
+        <param name="host-release" value="WildFly32.0"/>
+        <param name="excluded-extensions"
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly33.0"/>
+        <param name="host-release" value="WildFly33.0"/>
+        <param name="excluded-extensions"
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -10,66 +10,66 @@
         <param name="host-exclude" value="WildFly23.0"/>
         <param name="host-release" value="WildFly23.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly24.0"/>
         <param name="host-release" value="WildFly24.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.elytron-oidc-client&quot;,&quot;org.wildfly.extension.opentelemetry&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly25.0"/>
         <param name="host-release" value="WildFly25.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly26.0"/>
         <param name="host-release" value="WildFly26.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.clustering.ejb&quot;,&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly27.0"/>
         <param name="host-release" value="WildFly27.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.micrometer&quot;,&quot;org.wildfly.extension.microprofile.lra-participant&quot;,&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;,&quot;org.wildfly.extension.microprofile.telemetry&quot;,&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly28.0"/>
         <param name="host-release" value="WildFly28.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly29.0"/>
         <param name="host-release" value="WildFly29.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly30.0"/>
         <param name="host-release" value="WildFly30.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly31.0"/>
         <param name="host-release" value="WildFly31.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly32.0"/>
         <param name="host-release" value="WildFly32.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly33.0"/>
         <param name="host-release" value="WildFly33.0"/>
         <param name="excluded-extensions"
-               value="[&quot;org.wildfly.extension.mvc-krazo&quot;,&quot;org.wildfly.extension.jakarta.datao&quot;]"/>
+               value="[&quot;org.wildfly.extension.jakarta.data&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/preview/galleon-local/src/main/resources/layers/standalone/jakarta-data/layer-spec.xml
+++ b/preview/galleon-local/src/main/resources/layers/standalone/jakarta-data/layer-spec.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jakarta-data">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="jakarta.data"/>
+        <prop name="org.wildfly.rule.class" value="jakarta.data"/>
+    </props>
+    <dependencies>
+        <!-- TODO one or the other of jpa or jpa-distributed is required,
+             but I don't think that can be declared -->
+        <layer name="jpa" optional="true"/>
+    </dependencies>
+    <feature spec="subsystem.jakarta-data"/>
+</layer-spec>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/jakarta/data/api/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/jakarta/data/api/main/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<module name="jakarta.data.api" xmlns="urn:jboss:module:1.9">
+
+    <resources>
+        <artifact name="${jakarta.data:jakarta.data-api}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/wildfly/extension/jakarta/data/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/wildfly/extension/jakarta/data/main/module.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.wildfly.extension.jakarta.data">
+
+    <resources>
+        <artifact name="${org.wildfly:wildfly-jakarta-data}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.version"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.wildfly.subsystem"/>
+    </dependencies>
+</module>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -251,13 +251,14 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.wildfly.extension.microprofile.telemetry"
         ));
 
-        // List of extensions added only by the WildFly Preview
+        // List of extensions added only by WildFly Preview.
         // We do not track changes between different versions of WildFly Preview.
         // From the point of view of this test, all extensions added in WildFly Preview are always extensions
         // added in the latest release of WildFly Preview. It is out of the scope of Host Exclusion test
         // to compute on which WildFly Preview was added such a new extension and track the Host Exclusions between
         // different WildFly Preview releases.
         private final Set<String> previewExtensions = new HashSet<>(Arrays.asList(
+                "org.wildfly.extension.jakarta.data"
         ));
 
         ExtensionConf(String name, ExtensionConf parent, boolean supported) {

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -105,7 +105,7 @@
             </properties>
         </profile>
 
-        <!-- Test against EE 9 feature packs -->
+        <!-- Test against wildfly-preview feature pack -->
         <profile>
             <id>preview.profile</id>
             <activation>
@@ -187,6 +187,34 @@
                                             <layers>
                                                 <layer>datasources-web-server</layer>
                                                 <layer>observability</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jakarta-data-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>${provisioning.phase.preview.only}</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/jakarta-data</install-dir>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.full.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.full.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.full.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>jakarta-data</layer>
                                             </layers>
                                         </config>
                                     </configurations>
@@ -977,6 +1005,7 @@
                                                 <layer>infinispan</layer>
                                                 <layer>io</layer>
                                                 <layer>infinispan</layer>
+                                                <layer>jakarta-data</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>
@@ -1029,6 +1058,9 @@
                                                 <layer>microprofile-platform</layer>
                                                 <layer>mvc-krazo</layer>
                                             </layers>
+                                            <excluded-layers>
+                                                <layer>jpa-distributed</layer>
+                                            </excluded-layers>
                                         </config>
                                     </configurations>
                                 </configuration>
@@ -1083,6 +1115,7 @@
                                                 <layer>iiop-openjdk</layer>
                                                 <layer>infinispan</layer>
                                                 <layer>io</layer>
+                                                <layer>jakarta-data</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
                                                 <layer>jdr</layer>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -252,7 +252,10 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.mvc-krazo",
             "jakarta.mvc.api",
             "org.eclipse.krazo.core",
-            "org.eclipse.krazo.resteasy"
+            "org.eclipse.krazo.resteasy",
+            // Extension not included in the default config
+            "org.wildfly.extension.jakarta.data",
+            // "jakarta.data.api" this is an optional dep of org.hibernate
     };
 
     /**


### PR DESCRIPTION
Supersedes https://github.com/wildfly/wildfly/pull/18227



https://issues.redhat.com/browse/WFLY-19397

@scottmarlow Doing this is 97% boilerplate, so since I'm sadly responsible for most of the boilerplate details I took a shot at this while watching sports yesterday.

It's a new jakarta.data.api module, a minimal subsystem and a DUP to add the api to the deployment. Plus a galleon layer to allow adding the extension/subsystem. The new module, subsystem and layer are only integrated in WildFly Preview.

We need a subsystem so we can evolve any configuration or add any /deployment=foo.war/subsystem=jakarta-data stuff in the future without breaking people who were accustomed to not needing one. Plus it's just the normal way of adding technologies.

I'll spend a bit of time today trying to port https://github.com/jakartaredhat/hibernate-data-tck/tree/main/runner-web to wildfly-tck-runners. The TCK would be the primary way this would be tested initially.