### PR TITLE
WFLY-19774 Upgrade MP OpenAPI TCK from 3.1.1 to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
         <version.org.eclipse.microprofile.health.api>4.0.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.jwt.api>2.1</version.org.eclipse.microprofile.jwt.api>
         <version.org.eclipse.microprofile.lra.api>2.0</version.org.eclipse.microprofile.lra.api>
-        <version.org.eclipse.microprofile.openapi>3.1.1</version.org.eclipse.microprofile.openapi>
+        <version.org.eclipse.microprofile.openapi>3.1.2</version.org.eclipse.microprofile.openapi>
         <version.org.eclipse.microprofile.reactive-messaging.api>3.0.1</version.org.eclipse.microprofile.reactive-messaging.api>
         <version.org.eclipse.microprofile.reactive-streams-operators.api>3.0</version.org.eclipse.microprofile.reactive-streams-operators.api>
         <version.org.eclipse.microprofile.rest.client.api>3.0.1</version.org.eclipse.microprofile.rest.client.api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19774

Resolves https://issues.redhat.com/browse/WFLY-19773 (Intermittent failures in MP OpenAPI TCK)