### PR TITLE
[WFLY-19759] Test MicroProfile Reactive messaging multiple deployments

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/EmptyClass.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/EmptyClass.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment;
+
+public class EmptyClass {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.amqp.AmqpMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.kafka.KafkaMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.memory.InVmMessagingBean;
+
+/**
+ * Within an EAR file the channel names need to be unique. e.g. We can't use the same channel names for the
+ * contained Kafka and AMQP subdeployments
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
+public class MultiDeploymentReactiveMessagingTestCase extends AbstractCliTestBase {
+
+    private static final String BASE_NAME = "multideployment-rm";
+    private static final String INVM_BASE_BANE = BASE_NAME + "-invm";
+    private static final String KAFKA_BASE_BANE = BASE_NAME + "-kafka";
+    private static final String AMQP_BASE_BANE = BASE_NAME + "-amqp";
+
+    private static final int TIMEOUT = TimeoutUtil.adjust(20);
+
+    @ArquillianResource
+    URL url;
+
+    @Before
+    public void before() throws Exception {
+        initCLI();
+    }
+
+    @After
+    public void after() throws Exception {
+        closeCLI();
+    }
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        // Empty deployment to satisfy Arquillian
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
+        ja.addClass(EmptyClass.class);
+        return ja;
+    }
+
+    private Path createInVmDeployment() throws Exception {
+        WebArchive inVm = ShrinkWrap.create(WebArchive.class, INVM_BASE_BANE + ".war")
+                .addPackage(InVmMessagingBean.class.getPackage())
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+        return exportArchive(inVm);
+    }
+
+    private Path createAmqpDeployment() throws Exception {
+        WebArchive amqp = ShrinkWrap.create(WebArchive.class, AMQP_BASE_BANE + ".war")
+            .addPackage(AmqpMessagingBean.class.getPackage())
+            .addAsWebInfResource(AmqpMessagingBean.class.getPackage(), "microprofile-config.properties", "classes/META-INF/microprofile-config.properties")
+            .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+        return exportArchive(amqp);
+    }
+
+    private Path createKafkaDeployment() throws Exception {
+        WebArchive kafka = ShrinkWrap.create(WebArchive.class, KAFKA_BASE_BANE + ".war")
+            .addPackage(KafkaMessagingBean.class.getPackage())
+            .addAsWebInfResource(KafkaMessagingBean.class.getPackage(), "microprofile-config.properties", "classes/META-INF/microprofile-config.properties")
+            .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+        return exportArchive(kafka);
+    }
+
+    private Path exportArchive(Archive<?> archive) throws Exception{
+        Path p = Paths.get("./target", archive.getName()).toAbsolutePath();
+        if (Files.exists(p)) {
+            Files.delete(p);
+        }
+        archive.as(ZipExporter.class).exportTo(p.toFile());
+        return p;
+    }
+
+    @Test
+    public void testMultipleReactiveMessagingModules() throws Exception {
+        List<Path> archives = new ArrayList<>();
+        archives.add(createInVmDeployment());
+        archives.add(createKafkaDeployment());
+        archives.add(createAmqpDeployment());
+
+        List<String> deployed = new ArrayList<>();
+
+        try {
+
+            for (Path p : archives) {
+                String name = p.getFileName().toString();
+                cli.sendLine("deploy " + p);
+                deployed.add(name);
+            }
+
+            String inVmUrl = getBaseURL(url) + INVM_BASE_BANE;
+            String kafkaUrl = getBaseURL(url) + KAFKA_BASE_BANE;
+            String amqpUrl = getBaseURL(url) + AMQP_BASE_BANE;
+
+            try (CloseableHttpClient client = HttpClientBuilder.create().build()){
+                postData(client, inVmUrl, "VM-1");
+                postData(client, inVmUrl, "VM-2");
+                postData(client, inVmUrl, "VM-3");
+
+                postData(client, kafkaUrl, "KF-1");
+                postData(client, kafkaUrl, "KF-2");
+                postData(client, kafkaUrl, "KF-3");
+
+                postData(client, amqpUrl, "AM-1");
+                postData(client, amqpUrl, "AM-2");
+                postData(client, amqpUrl, "AM-3");
+
+                checkData(client, inVmUrl, TIMEOUT, "VM-1", "VM-2", "VM-3");
+                checkData(client, kafkaUrl, TIMEOUT, "KF-1", "KF-2", "KF-3");
+                checkData(client, amqpUrl, TIMEOUT, "AM-1", "AM-2", "AM-3");
+            }
+        } finally {
+            try {
+                for (int i = deployed.size() - 1 ; i >= 0 ; i--) {
+                    String name = deployed.get(i);
+                    cli.sendLine("undeploy " + name);
+                }
+            } finally {
+                for (Path p : archives) {
+                    if (Files.exists(p)) {
+                        Files.delete(p);
+                    }
+                }
+            }
+        }
+    }
+
+    private String deploy(Path p) throws Exception {
+        String name = p.getFileName().toString();
+        cli.sendLine("deploy --url=" + p.toUri().toURL().toExternalForm() + " --name=" + name + " --headers={rollback-on-runtime-failure=false}");
+        return name;
+    }
+
+    private void postData(CloseableHttpClient client, String url, String value) throws Exception {
+        HttpPost post = new HttpPost(url);
+        List<NameValuePair> nvps = new ArrayList<>();
+        nvps.add(new BasicNameValuePair("value", value));
+        post.setEntity(new UrlEncodedFormEntity(nvps));
+
+        try (CloseableHttpResponse response = client.execute(post);){
+            assertEquals(200, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    private void checkData(CloseableHttpClient client, String url, int timeoutSeconds, String... expected) throws Exception {
+        long end = System.currentTimeMillis() + timeoutSeconds * 1000L;
+        List<String> lines = Collections.emptyList();
+        boolean ok = false;
+        while (System.currentTimeMillis() < end) {
+            lines = getData(client, url);
+            if (lines.size() < expected.length) {
+                Thread.sleep(2000);
+                continue;
+            }
+
+            for (int i = 0; i < expected.length; i++) {
+                Assert.assertTrue(lines.get(i).contains(expected[i]));
+            }
+            ok = true;
+            break;
+        }
+        if (ok) {
+            Assert.assertEquals(expected.length, lines.size());
+        } else {
+            Assert.fail("Timeout reading " + url);
+        }
+    }
+
+    private List<String> getData(CloseableHttpClient client, String url) throws Exception {
+        HttpGet get = new HttpGet(url);
+        List<String> lines = new ArrayList<>();
+
+        try (CloseableHttpResponse response = client.execute(get)){
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    return ModelNode.fromJSONString(line).asList().stream().map(ModelNode::asString).collect(Collectors.toList());
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private String getUrl() {
+        return url.toString() + "/" + BASE_NAME + "/";
+//        int i = s.lastIndexOf('/');
+//        s = s.substring(0, i + i);
+//        s += BASE_NAME;
+//        return s;
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.amqp;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class AmqpApplication extends Application {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpEndpoint.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpEndpoint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.amqp;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+public class AmqpEndpoint {
+
+    @Inject
+    AmqpMessagingBean amqpMessagingBean;
+
+    @POST
+    @Path("/")
+    public Response publish(@FormParam("value") String value) {
+        amqpMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/")
+    public List<String> readMessages() {
+        return amqpMessagingBean.getReceived();
+    }
+
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/AmqpMessagingBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.amqp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class AmqpMessagingBean {
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("source")
+    Emitter<String> emitter;
+
+    @Incoming("sink")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/microprofile-config.properties
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/microprofile-config.properties
@@ -1,0 +1,12 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+mp.messaging.outgoing.source.connector=smallrye-amqp
+mp.messaging.outgoing.source.address=testing
+
+mp.messaging.incoming.sink.connector=smallrye-amqp
+mp.messaging.incoming.sink.address=testing
+
+
+

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.kafka;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class KafkaApplication extends Application {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaEndpoint.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaEndpoint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.kafka;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+public class KafkaEndpoint {
+
+    @Inject
+    KafkaMessagingBean kafkaMessagingBean;
+
+    @POST
+    @Path("/")
+    public Response publish(@FormParam("value") String value) {
+        kafkaMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/")
+    public List<String> readMessages() {
+        return kafkaMessagingBean.getReceived();
+    }
+
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/KafkaMessagingBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaMessagingBean {
+
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("source")
+    Emitter<String> emitter;
+
+    @Incoming("sink")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/microprofile-config.properties
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mp.messaging.outgoing.source.connector=smallrye-kafka
+mp.messaging.outgoing.source.topic=testing
+mp.messaging.outgoing.source.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.incoming.sink.connector=smallrye-kafka
+mp.messaging.incoming.sink.topic=testing
+mp.messaging.incoming.sink.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+# Needed as per https://github.com/smallrye/smallrye-reactive-messaging/issues/845 since the consumer
+# joins after the messages are sent
+mp.messaging.incoming.sink.auto.offset.reset=earliest
+
+
+

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.memory;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class InVmApplication extends Application {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmEndpoint.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmEndpoint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.memory;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+public class InVmEndpoint {
+
+    @Inject
+    InVmMessagingBean inVmMessagingBean;
+
+    @POST
+    @Path("/")
+    public Response publish(@FormParam("value") String value) {
+        inVmMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/")
+    public List<String> readMessages() {
+        return inVmMessagingBean.getReceived();
+    }
+
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/memory/InVmMessagingBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment.memory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class InVmMessagingBean {
+
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("source")
+    Emitter<String> emitter;
+
+    @Incoming("source")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.amqp.AmqpMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.kafka.KafkaMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.memory.InVmMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.war.MultiModuleEndpoint;
+
+/**
+ * Within an EAR file the channel names need to be unique. e.g. We can't use the same channel names for the
+ * contained Kafka and AMQP subdeployments
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
+public class MultiEarModuleReactiveMessagingTestCase {
+
+    private static final String BASE_NAME = "multimodule-rm";
+
+    private static final int TIMEOUT = TimeoutUtil.adjust(20);
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive jaxrs = ShrinkWrap.create(WebArchive.class, BASE_NAME + ".war")
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
+                .addPackage(MultiModuleEndpoint.class.getPackage());
+
+        JavaArchive inVm = ShrinkWrap.create(JavaArchive.class, BASE_NAME + "-invm.jar")
+                .addPackage(InVmMessagingBean.class.getPackage())
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+
+        JavaArchive kafka = ShrinkWrap.create(JavaArchive.class, BASE_NAME + "-kafka.jar")
+                .addPackage(KafkaMessagingBean.class.getPackage())
+                .addAsManifestResource(KafkaMessagingBean.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+
+        JavaArchive amqp = ShrinkWrap.create(JavaArchive.class, BASE_NAME + "-amqp.jar")
+                .addPackage(AmqpMessagingBean.class.getPackage())
+                .addAsManifestResource(AmqpMessagingBean.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, BASE_NAME + ".ear")
+                .addAsModule(jaxrs)
+                .addAsLibrary(inVm)
+                .addAsLibrary(kafka)
+                .addAsLibrary(amqp);
+
+        return ear;
+    }
+
+    @Test
+    public void testMultipleReactiveMessagingModules() throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()){
+            postData(client, "multi/invm", "VM-1");
+            postData(client, "multi/invm", "VM-2");
+            postData(client, "multi/invm", "VM-3");
+
+            postData(client, "multi/kafka", "KF-1");
+            postData(client, "multi/kafka", "KF-2");
+            postData(client, "multi/kafka", "KF-3");
+
+            postData(client, "multi/amqp", "AM-1");
+            postData(client, "multi/amqp", "AM-2");
+            postData(client, "multi/amqp", "AM-3");
+
+            checkData(client, "multi/invm", TIMEOUT, "VM-1", "VM-2", "VM-3");
+            checkData(client, "multi/kafka", TIMEOUT, "KF-1", "KF-2", "KF-3");
+            checkData(client, "multi/amqp", TIMEOUT, "AM-1", "AM-2", "AM-3");
+        }
+    }
+
+    private void postData(CloseableHttpClient client, String path, String value) throws Exception {
+        HttpPost post = new HttpPost(url + path);
+        List<NameValuePair> nvps = new ArrayList<>();
+        nvps.add(new BasicNameValuePair("value", value));
+        post.setEntity(new UrlEncodedFormEntity(nvps));
+
+        try (CloseableHttpResponse response = client.execute(post);){
+            assertEquals(200, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    private void checkData(CloseableHttpClient client, String path, int timeoutSeconds, String... expected) throws Exception {
+        long end = System.currentTimeMillis() + timeoutSeconds * 1000L;
+        List<String> lines = Collections.emptyList();
+        boolean ok = false;
+        while (System.currentTimeMillis() < end) {
+            lines = getData(client, path);
+            if (lines.size() < expected.length) {
+                Thread.sleep(2000);
+                continue;
+            }
+
+            for (int i = 0; i < expected.length; i++) {
+                Assert.assertTrue(lines.get(i).contains(expected[i]));
+            }
+            ok = true;
+            break;
+        }
+        if (ok) {
+            Assert.assertEquals(expected.length, lines.size());
+        } else {
+            Assert.fail("Timeout reading " + path);
+        }
+    }
+
+    private List<String> getData(CloseableHttpClient client, String path) throws Exception {
+        HttpGet get = new HttpGet(url + path);
+        List<String> lines = new ArrayList<>();
+
+        try (CloseableHttpResponse response = client.execute(get)){
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    return ModelNode.fromJSONString(line).asList().stream().map(ModelNode::asString).collect(Collectors.toList());
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/AmqpMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/AmqpMessagingBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.amqp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class AmqpMessagingBean {
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("amqp")
+    Emitter<String> emitter;
+
+    @Incoming("amqp-sink")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/microprofile-config.properties
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/microprofile-config.properties
@@ -1,0 +1,12 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+mp.messaging.outgoing.amqp.connector=smallrye-amqp
+mp.messaging.outgoing.amqp.address=testing
+
+mp.messaging.incoming.amqp-sink.connector=smallrye-amqp
+mp.messaging.incoming.amqp-sink.address=testing
+
+
+

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/KafkaMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/KafkaMessagingBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaMessagingBean {
+
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("kafka")
+    Emitter<String> emitter;
+
+    @Incoming("kafka-sink")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/microprofile-config.properties
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mp.messaging.outgoing.kafka.connector=smallrye-kafka
+mp.messaging.outgoing.kafka.topic=testing
+mp.messaging.outgoing.kafka.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.incoming.kafka-sink.connector=smallrye-kafka
+mp.messaging.incoming.kafka-sink.topic=testing
+mp.messaging.incoming.kafka-sink.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+# Needed as per https://github.com/smallrye/smallrye-reactive-messaging/issues/845 since the consumer
+# joins after the messages are sent
+mp.messaging.incoming.kafka-sink.auto.offset.reset=earliest
+
+
+

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/memory/InVmMessagingBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/memory/InVmMessagingBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.memory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class InVmMessagingBean {
+
+    private final List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @Channel("invm")
+    Emitter<String> emitter;
+
+    @Incoming("invm")
+    public void sink(String word) {
+        System.out.println("Received " + word);
+        received.add(word);
+    }
+
+    public void send(String word) {
+        System.out.println("Sending " + word);
+        emitter.send(word);
+    }
+
+    public List<String> getReceived() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/war/MultiModuleApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/war/MultiModuleApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.war;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class MultiModuleApplication extends Application {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/war/MultiModuleEndpoint.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/war/MultiModuleEndpoint.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.war;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.amqp.AmqpMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.kafka.KafkaMessagingBean;
+import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.earmodule.memory.InVmMessagingBean;
+
+/**
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Path("/multi")
+@Produces(MediaType.APPLICATION_JSON)
+@ApplicationScoped
+public class MultiModuleEndpoint {
+
+    @Inject
+    InVmMessagingBean inVmMessagingBean;
+
+    @Inject
+    KafkaMessagingBean kafkaMessagingBean;
+
+    @Inject
+    AmqpMessagingBean amqpMessagingBean;
+
+    @POST
+    @Path("/invm")
+    public Response publishInVm(@FormParam("value") String value) {
+        inVmMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/invm")
+    public List<String> readInVmMessages() {
+        return inVmMessagingBean.getReceived();
+    }
+
+    @POST
+    @Path("/kafka")
+    public Response publishKafka(@FormParam("value") String value) {
+        kafkaMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/kafka")
+    public List<String> readKafkaMessages() {
+        return kafkaMessagingBean.getReceived();
+    }
+
+    @POST
+    @Path("/amqp")
+    public Response publishAmqp(@FormParam("value") String value) {
+        amqpMessagingBean.send(value);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/amqp")
+    public List<String> readAmqpMessages() {
+        return amqpMessagingBean.getReceived();
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19759

If deployed within an .ear, the channel names need to be unique within that .ear.

If deployed as separate top-level archives, the channel names don't need to be unique.