### PR TITLE
Fix for WFLY-19172, Add a 'Installing with the WildFly Maven Plugin' section to the 'Installation Guide'

### DIFF
--- a/docs/src/main/asciidoc/Bootable_Guide.adoc
+++ b/docs/src/main/asciidoc/Bootable_Guide.adoc
@@ -28,21 +28,23 @@ ifdef::basebackend-html[toc::[]]
 [[wildfly_bootable_JAR_development]]
 = WildFly bootable JAR application development
 
+[WARNING]
+The usage of the link:https://github.com/wildfly-extras/wildfly-jar-maven-plugin[WildFly Bootable JAR Maven plugin] has been deprecated. 
+This link:https://docs.wildfly.org/33/Bootable_Guide.html[documentation] covers its usage.
+This chapter covers the creation of a bootable JAR using the link:https://docs.wildfly.org/wildfly-maven-plugin[WildFly Maven Plugin].
+
 This document details the steps to follow in order to develop a WildFly application
-packaged as a bootable JAR. A bootable JAR can be run both on bare-metal and cloud platforms.
+packaged as a bootable JAR. A WildFly bootable JAR should target a bare-metal or virtualized platform. For the cloud platform, 
+you should read the link:WildFly_Maven_Plugin_Guide{outfilesuffix}[WildFly Maven Plugin Guide] that explains how to produce a WildFly installation 
+ready to run on the cloud.
 
-Developing an application packaged as a bootable JAR is not different from developing an application for a traditional
-WildFly server installation using Maven.
-The extra steps required to package your application inside a bootable JAR are handled by the 
-https://github.com/wildfly-extras/wildfly-jar-maven-plugin[_org.wildfly.plugins:wildfly-jar-maven-plugin_] Maven plugin.
+Developing an application packaged as a bootable JAR is no different from developing an application using the WildFly Maven Plugin.
+Additional configuration items instruct the plugin to produce a WildFly Bootable JAR.
 
-This document contains the minimal information set required to build and run a WildFly bootable JAR. 
-Complete information on the Maven plugin usage can be found in the bootable JAR https://docs.wildfly.org/bootablejar/[documentation].
+[[wildfly-maven-plugin-jar-pom-configuration]]
+== Configuring the WildFly Maven plugin
 
-[[wildfly-jar-maven-plugin-pom-configuration]]
-== Adding the bootable JAR Maven plugin to your pom file
-
-This is done by adding an extra build step to your application deployment Maven pom.xml file.
+Maven Plugin configuration example:
 
 [source,xml]
 ----
@@ -50,118 +52,17 @@ This is done by adding an extra build step to your application deployment Maven 
   <plugins>
     <plugin>
       <groupId>org.wildfly.plugins</groupId>
-      <artifactId>wildfly-jar-maven-plugin</artifactId>
+      <artifactId>wildfly-maven-plugin</artifactId>
       <configuration>
-        ...
-      </configuration>
-      <executions>
-        <execution>
-          <goals>
-            <goal>package</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
-----
-
-The next chapter covers the plugin configuration items that are required to identify the WildFly server version and content.
-
-[[wildfly-jar-maven-plugin-galleon-configuration]]
-== Galleon configuration
-
-The Bootable JAR Maven plugin depends on https://docs.wildfly.org/galleon/[Galleon] to construct the WildFly server contained in the JAR file. 
-
-Galleon is configured thanks to the Maven plugin ```<configuration>``` element.
-
-The first required piece of information that Galleon needs is a reference to the WildFly Galleon feature-pack. 
-The WildFly Galleon feature-pack is a maven artifact that contains everything needed to dynamically provision a server. 
-This feature-pack, as well as the feature-packs on which its depends,
-are deployed in public maven repositories. 
-
-When the bootable JAR Maven plugin builds a JAR, WildFly feature-packs are retrieved and 
-their content is assembled to create the server contained in the JAR.
-
-Once you have identified a WildFly Galleon feature-pack, you need to select a set of 
-link:#wildfly_layers[WildFly Layers] that are used to compose the server.
-
-The set of Galleon layers to include is driven by the needs of the application you are developing.
-The list of link:#wildfly_layers[WildFly Layers] provides details on 
-the server features that each layer brings. Make sure that the API and server features you are using (eg: Jakarta RESTful Web Services, MicroProfile Config, datasources)
-are provided by the layers you are choosing.
-
-If you decide not to specify Galleon layers, a server containing all MicroProfile subsystems is
-provisioned. (The server configuration is identical to the ```standalone-microprofile.xml``` configuration
-in the traditional WildFly server zip.)
-
-Maven Plugin configuration extract example:
-
-[source,xml]
-----
-<build>
-  <plugins>
-    <plugin>
-      <groupId>org.wildfly.plugins</groupId>
-      <artifactId>wildfly-jar-maven-plugin</artifactId>
-      <configuration>
-        <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)</feature-pack-location> (1)
-        <layers>
-          <layer>jaxrs-server</layer> (2)
-        </layers>
-      </configuration>
-      <executions>
-        <execution>
-          <goals>
-            <goal>package</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
-----
-
-(1) In this plugin configuration extract, we are retrieving the latest WildFly Galleon feature-pack installed in the
- ```org.jboss.universe:community-universe``` Galleon universe. In case you would like to provision a specific version of the server,
-you would need to specify the server version, for example ```wildfly@maven(org.jboss.universe:community-universe)#21.0.0.Final```
-
-(2) The link:#gal.jaxrs-server[jaxrs-server layer] and all its dependencies are provisioned.
-
-[NOTE]
-====
-
-If your project is using link:WildFly_and_WildFly_Preview{outfilesuffix}[WildFly Preview], the ``feature-pack-location`` to use
-is ``wildfly-preview@maven(org.jboss.universe:community-universe)``.
-====
-
-[[wildfly-jar-maven-plugin-galleon-stability-level]]
-=== Setting a stability level when building a Bootable JAR
-
-In order to support xref:Admin_Guide.adoc#Feature_stability_levels[WildFly feature stability levels], Galleon defines 
-some http://docs.wildfly.org/galleon/#_built_in_and_product_specific_options[options] that can be used at provisioning time 
-to provision server features at a specific stability level.
-
-The stability levels handling described in the xref:Galleon_Guide.adoc#WildFly_Galleon_stability[Stability levels at provisioning time] 
-applies when building a WildFly Bootable JAR.
-
-For example, building a WildFly Bootable JAR that includes `preview` features and packages: 
-
-[source,xml]
-----
-<build>
-  <plugins>
-    <plugin>
-      <groupId>org.wildfly.plugins</groupId>
-      <artifactId>wildfly-jar-maven-plugin</artifactId>
-      <configuration>
-        <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)</feature-pack-location>
+        <feature-packs>
+          <feature-pack>
+            <location>wildfly@maven(org.jboss.universe:community-universe)</location>
+          </feature-pack>
+        </feature-packs>
         <layers>
           <layer>jaxrs-server</layer>
         </layers>
-        <plugin-options>
-          <stability-level>preview</stability-level>
-        </plugin-options>
+        <bootable-jar>true</bootable-jar> (1)
       </configuration>
       <executions>
         <execution>
@@ -175,35 +76,13 @@ For example, building a WildFly Bootable JAR that includes `preview` features an
 </build>
 ----
 
-include::_galleon/Galleon_layers.adoc[]
+(1) This option will cause the plugin produce a bootable JAR. 
+By default the file `server-bootable.jar` is generated in the project `target` directory. You can use the option `<bootable-jar-name>[jar name]</bootable-jar-name>` to change the jar name. 
 
-[[wildfly-jar-maven-plugin-additional-configuration]]
-== Additional configuration
-
-The plugin allows you to specify additional configuration items:
-
-* A set of WildFly CLI scripts to execute to fine tune the server configuration. 
-* Some extra content to be copied inside the bootable JAR (e.g.: server keystore).
-
-Check https://docs.wildfly.org/bootablejar[this documentation] for more details on how to configure execution of
-CLI scripts and to package extra content.
-
-[[wildfly-jar-maven-plugin-build]]
-== Packaging your application
-
-Call ``` mvn package```  to package both your application and the bootable JAR in the file ```<project build directory>/<project final name>-bootable.jar```
-
-In order to speed-up the development of your application (avoid rebuilding the JAR each time your application is re-compiled), 
-the Maven plugin offers a _development_ mode that allows you to build and start the bootable JAR only once.
-
-Check https://docs.wildfly.org/bootablejar[this documentation] for more details on the _development_ mode.
-
-[[wildfly-jar-maven-plugin-run]]
+[[wildfly-maven-plugin-jar-run]]
 == Running your application
 
 Call ```java -jar <path to bootable JAR> <arguments>```
-
-In additon, you can use the ```wildfly-jar:run``` and ```wildfly-jar:start``` plugin goals to launch the bootable JAR.
 
 [[wildfly-bootable-jar-arguments]]
 === Bootable JAR arguments

--- a/docs/src/main/asciidoc/Cloud_References.adoc
+++ b/docs/src/main/asciidoc/Cloud_References.adoc
@@ -15,8 +15,6 @@
 
 === WildFly
 * https://docs.wildfly.org/wildfly-maven-plugin/[WildFly Maven Plugin (wildfly-maven-plugin)]
-* https://github.com/wildfly-extras/wildfly-jar-maven-plugin[Bootable Jar GitHub repository]
-* https://docs.wildfly.org/bootablejar/[Bootable Jar Documentation]
 * https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/doc/index.md[WildFly Cloud Galleon Pack’s documentation]
 * https://github.com/wildfly-extras/wildfly-datasources-galleon-pack/[WildFly Datasources Galleon Pack github repository]
 * https://www.wildfly.org/news/2022/11/09/WildFly-s2i-wildfly-27-final/[What's new for WildFly 27 in the cloud]

--- a/docs/src/main/asciidoc/Getting_Started_on_OpenShift.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_on_OpenShift.adoc
@@ -65,8 +65,6 @@ It is possible to use a specific https://github.com/wildfly/quickstart/tags[quic
 ```
 --set build.ref={WildFlyQuickStartRepoTag}
 ```
-Take a look at the `bootable-jar-openshift` profile configuration in the `todo-backend` quickstart's https://github.com/wildfly/quickstart/blob/main/todo-backend/pom.xml#L254-L304[pom.xml]. The Maven profile named `bootable-jar-openshift` is used by the Helm chart to provision the server with the quickstart deployed. Notice the `wildfly-jar-maven-plugin` configuration defined in this profile. It specifies the link:Galleon_Guide{outfilesuffix}[layer] that should be used when provisioning WildFly. For more details about this, take a look at the https://github.com/wildfly/quickstart/tree/main/todo-backend#architecture[Architecture] section in the quickstart's README.
-
 We have named this application `todo-backend`. This may be changed to a different name, if desired.
 
 The application will now begin to build. The build can be observed via:

--- a/docs/src/main/asciidoc/Installation_Guide.adoc
+++ b/docs/src/main/asciidoc/Installation_Guide.adoc
@@ -29,7 +29,7 @@ ifdef::basebackend-html[toc::[]]
 :numbered:
 
 link:#Zipped_Installation[Zipped distribution], 
-link:#Galleon_Provisioning[Galleon provisioning] or link:#Bootable_JAR[bootable JAR], this guide helps you identify the 
+link:#Galleon_Provisioning[Galleon provisioning], link:#WildFly_Maven_Plugin_Provisioning[WildFly Maven Plugin] or link:#Bootable_JAR[bootable JAR], this guide helps you identify the 
 installation strategy that best fits your application requirements.
 
 = WildFly or WildFly Preview
@@ -86,6 +86,27 @@ provision customized WildFly server using Galleon.
 Started Developing Applications Guide] shows you how to build Jakarta EE
 applications and deploy them to WildFly.
 
+[[WildFly_Maven_Plugin_Provisioning]]
+= Installing WildFly with the WildFly Maven Plugin
+
+The link:https://docs.wildfly.org/wildfly-maven-plugin[WildFly Maven Plugin] exposes a `package` goal that allows you 
+to provision a customized WildFly installation containing your application.
+
+Using the WildFly Maven Plugin is well suited when:
+
+* You are building your application using Maven.
+* Your application requires only a subset of the Jakarta EE or MicroProfile platform APIs
+(although the WildFly Maven Plugin can provision a server that supports the full set of Jakarta EE and MicroProfile platform APIs).
+* You are concerned by server installation size and memory footprint.
+* You are only using standalone operating mode (with support for High Availability or not).
+* Your server instances will contain one or more application deployments.
+* You are using WildFly link:https://docs.wildfly.org/wildfly-charts/[Helm Charts] to deploy your application on the cloud.
+
+If that is the kind of installation you are aiming at, the guide that you should read next is:
+
+* The link:WildFly_Maven_Plugin_Guide{outfilesuffix}[WildFly Maven Plugin Guide] 
+shows you how to configure a Maven `pom.xml` file to provision a customized WildFly server containing your application.
+
 [[Bootable_JAR]]
 = WildFly Bootable JAR
 
@@ -93,8 +114,12 @@ A bootable JAR contains both a customized WildFly server and your deployment. Su
 then run with a simple java command such as ``java -jar myapp-bootable.jar``
 
 A bootable JAR is built using Maven. You need to integrate the  
-link:https://github.com/wildfly-extras/wildfly-jar-maven-plugin[bootable JAR Maven plugin] 
+link:https://github.com/wildfly/wildfly-maven-plugin[WildFly Maven plugin] 
 in the Maven project of your application.
+
+[NOTE]
+The ability to build a WildFly Bootable JAR has been added to the link:https://docs.wildfly.org/wildfly-maven-plugin[WildFly Maven Plugin].  
+The use of the link:https://github.com/wildfly-extras/wildfly-jar-maven-plugin[WildFly Bootable JAR Maven plugin] has been deprecated. 
 
 A Bootable JAR is well suited when:
 
@@ -104,7 +129,9 @@ A Bootable JAR is well suited when:
 * You are only using standalone operating mode (with support for High Availability or not).
 * You are building your application using Maven.
 
-If that is the kind of installation you are aiming at, the guide that you should read next is:
+If that is the kind of installation you are aiming at, the guides that you should read next are:
 
+* The link:WildFly_Maven_Plugin_Guide{outfilesuffix}[WildFly Maven Plugin Guide] 
+shows you how to configure a Maven `pom.xml` file to provision a customized WildFly server containing your application.
 * The link:Bootable_Guide{outfilesuffix}[Bootable JAR Guide] shows you how to package your application and the WildFly server
 into a bootable JAR.

--- a/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
+++ b/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
@@ -1,0 +1,416 @@
+[[WildFly_Maven_Plugin_Guide]]
+= WildFly Maven Plugin Guide
+WildFly team;
+:revnumber: {version}
+:revdate: {localdate}
+:toc: macro
+:toclevels: 3
+:toc-title: WildFly Maven Plugin Guide
+:doctype: book
+:icons: font
+:source-highlighter: coderay
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+// ifndef::ebook-format[:leveloffset: 1]
+
+(C) 2024 The original authors.
+
+ifdef::basebackend-html[toc::[]]
+:numbered:
+
+[[wildfly_maven_plugin]]
+= WildFly Maven Plugin
+
+This document details the steps to follow in order to develop a WildFly application
+using the https://docs.wildfly.org/wildfly-maven-plugin[WildFly Maven Plugin].
+
+Developing an application is not different from developing an application for a traditional
+WildFly server installation using Maven.
+The extra steps required to provision the WildFly server and deploy your application inside the server are handled by the 
+https://docs.wildfly.org/wildfly-maven-plugin[_org.wildfly.plugins:wildfly-maven-plugin_] Maven plugin `package` goal.
+
+In addition to the `package` goal, the plugin defines two other goals that can be used to provision a WildFly server:
+
+* The `provision` goal. This goal provisions a WildFly server with no application deployment. 
+* The `image` goal. This goal builds (and pushes) an application image containing the provisioned server and the deployment.
+
+This document contains the minimal information set required to use the WildFly Maven Plugin. 
+Complete information on the Maven plugin usage can be found in the WildFly Maven Plugin https://docs.wildfly.org/wildfly-maven-plugin/[documentation].
+
+[[wildfly-maven-plugin-pom-configuration]]
+== Adding the WildFly Maven plugin to your pom file
+
+This is done by adding an extra build step to your application deployment Maven pom.xml file.
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        ...
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+The next chapter covers the plugin configuration items that are required to identify the WildFly server version and content.
+
+[[wildfly-maven-plugin-galleon-configuration]]
+== Galleon configuration
+
+The WildFly Maven plugin depends on https://docs.wildfly.org/galleon/[Galleon] to provision a WildFly server installation. 
+
+Galleon is configured thanks to the Maven plugin ```<configuration>``` element.
+
+The first required piece of information that Galleon needs is a reference to the WildFly Galleon feature-pack. 
+The WildFly Galleon feature-pack is a maven artifact that contains everything needed to dynamically provision a server. 
+This feature-pack, as well as the feature-packs on which its depends,
+are deployed in public maven repositories. 
+
+At plugin execution time the WildFly feature-packs are retrieved and their content is assembled to provision a server.
+
+Once you have identified a WildFly Galleon feature-pack, you need to select a set of 
+link:#wildfly_layers[WildFly Layers] that are used to compose the server.
+
+The set of Galleon layers to include is driven by the needs of the application you are developing.
+The list of link:#wildfly_layers[WildFly Layers] provides details on 
+the server features that each layer brings. Make sure that the API and server features you are using (eg: Jakarta RESTful Web Services, MicroProfile Config, datasources)
+are provided by the layers you are choosing.
+
+If you decide not to specify Galleon layers, a complete server (WildFly server zip content) is provisioned.
+
+Following is a WildFly Maven Plugin configuration extract example:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <feature-packs>
+          <feature-pack>
+            <location>wildfly@maven(org.jboss.universe:community-universe)</location> (1)
+          </feature-pack>
+        </feature-packs>
+        <layers>
+          <layer>jaxrs-server</layer> (2)
+        </layers>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+(1) In this plugin configuration extract, we are retrieving the latest WildFly Galleon feature-pack installed in the
+ ```org.jboss.universe:community-universe``` Galleon universe. In case you would like to provision a specific version of the server,
+you would need to specify the server version, for example ```wildfly@maven(org.jboss.universe:community-universe)#33.0.0.Final```
+
+(2) The link:#gal.jaxrs-server[jaxrs-server layer] and all its dependencies are provisioned.
+
+[NOTE]
+====
+
+If your project is using link:WildFly_and_WildFly_Preview{outfilesuffix}[WildFly Preview], the ``location`` to use
+is ``wildfly-preview@maven(org.jboss.universe:community-universe)``.
+
+====
+
+==== Specifying additional JBoss Modules modules
+
+In general, the JBoss Modules modules your application requires are provisioned by the specified Galleon layers. 
+To handle some special cases -- for example some uses of Jakarta REST where optional RESTEasy modules are not provided 
+by the `jaxrs` layer -- you can explicitly add some JBoss Modules modules:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <feature-packs>
+          <feature-pack>
+            <location>wildfly@maven(org.jboss.universe:community-universe)</location>
+            <included-packages>
+              <included-package>org.jboss.resteasy.resteasy-rxjava2</included-package> (1)
+            </included-packages>
+          </feature-pack>
+        </feature-packs>
+        ...
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+(1) The Specified JBoss Modules module will be included in the provisioned server.
+
+[[wildfly-maven-plugin-glow-discovery]]
+=== Discovering the required Galleon configuration using The WildFly Glow
+
+link:https://github.com/wildfly/wildfly-glow[WildFly Glow] Galleon configuration 
+discovery feature has been integrated in the WildFly Maven Plugin. WildFly Glow scans the application deployment to generate 
+a Galleon `provisioning.xml` file containing the Galleon feature-packs and layers 
+that are used by the WildFly Maven plugin to provision the server.
+
+Complete documentation of the discovery plugin configuration can be found in the 
+link:https://docs.wildfly.org/wildfly-glow/#glow_wildfly_maven_plugin[WildFly Glow Documentation].
+
+Maven Plugin configuration extract example:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <discover-provisioning-info/> (1)
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+(1) This option enables the discovery of Galleon feature-packs and layers. 
+
+[[wildfly-maven-plugin-galleon-stability-level]]
+=== Setting a stability level
+
+In order to support xref:Admin_Guide.adoc#Feature_stability_levels[WildFly feature stability levels], Galleon defines 
+some http://docs.wildfly.org/galleon/#_built_in_and_product_specific_options[options] that can be used at provisioning time 
+to provision server features at a specific stability level.
+
+The stability level handling described in the xref:Galleon_Guide.adoc#WildFly_Galleon_stability[Stability levels at provisioning time] 
+applies when provisioning a WildFly server.
+
+For example, provisioning a WildFly server that includes `preview` features and packages: 
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <feature-packs>
+          <feature-pack>
+            <location>wildfly@maven(org.jboss.universe:community-universe)</location>
+          </feature-pack>
+        </feature-packs>
+        <layers>
+          <layer>jaxrs-server</layer>
+        </layers>
+        <galleon-options>
+          <stability-level>preview</stability-level>
+        </galleon-options>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+[[wildfly-maven-plugin-additional-configuration]]
+== Additional configuration
+
+The plugin allows you to specify additional configuration items:
+
+* A set of WildFly CLI scripts to execute to fine tune the server configuration. 
+* Some extra content to be copied inside the server (e.g.: server keystore).
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        ...
+        <packaging-scripts> (1)
+          <packaging-script>
+            <scripts>
+              <script>scripts/script1.cli</script>
+            </scripts>
+          </packaging-script>
+        </packaging-scripts>
+        <extra-server-content-dirs> (2)
+          <dir>extra-content/</dir>
+        <extra-server-content-dirs>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+(1) Execute the `scripts/script1.cli` script
+(2) Copy the content of the `extra-content/` directory to the root of the provisioned server.
+
+You can check https://docs.wildfly.org/wildfly-maven-plugin/[this documentation] 
+for more details on how to configure the WildFly Maven Plugin `package` goal and in particular how to 
+execute CLI scripts and add some extra content.
+
+[[wildfly-maven-plugin-build]]
+== Packaging your application
+
+Call ```mvn package```  to provision a server and deploy your application. The 
+directory ```${project.build.directory}/server``` contains the WildFly installation.
+
+In order to speed-up the development of your application (avoid rebuilding the server each time your application is re-compiled), 
+the Maven plugin offers a `dev` goal that allows you to provision and start the server only once.
+
+The `dev` goal runs a local instance of WildFly and watches the source directories for changes. 
+If required, your deployment will be recompiled and possibly redeployed. 
+
+You can check https://docs.wildfly.org/wildfly-maven-plugin[this documentation] for more details on the `dev` goal.
+
+[[wildfly-maven-plugin-cloud]]
+== Packaging your application for the cloud
+
+The WildFly project provides a complete tool chain and workflow to deploy a WildFly application on the cloud.
+
+The steps to follow are:
+
+* Configure the WildFly Maven Plugin to provision a cloud ready WildFly server.
+* Push your Maven project to a Git repository (such as github.com).
+* Use the https://docs.wildfly.org/wildfly-charts/[Helm Chart for WildFly] to initiate the build and deployment.
+
+Example of a cloud ready WildFly Maven Plugin configuration. Such configuration must include 
+a reference to the https://github.com/wildfly-extras/wildfly-cloud-galleon-pack[WildFly cloud feature-pack]:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <feature-packs>
+            <feature-pack>
+                <location>org.wildfly:wildfly-galleon-pack:33.0.0.Final</location>
+            </feature-pack>
+            <feature-pack>
+                <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:7.0.0.Final</location>
+            </feature-pack>
+            <layers>
+                <layer>cloud-server</layer>
+            </layers>
+        </feature-packs>
+        <layers>
+          <layer>jaxrs-server</layer>
+        </layers>
+        <galleon-options>
+          <stability-level>preview</stability-level>
+        </galleon-options>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+[NOTE]
+====
+
+When using WildFly Glow, you need to specify the `cloud` context in order to provision a cloud ready server.
+For example:
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.plugins</groupId>
+      <artifactId>wildfly-maven-plugin</artifactId>
+      <configuration>
+        <discover-provisioning-info>
+          <context>cloud</context> (1)
+        </discover-provisioning-info>
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>package</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+
+(1) Enable discovery for the cloud execution context.
+
+====
+Examples of projects that produce WildFly applications for the cloud 
+can be found in the https://github.com/wildfly/quickstart/[WildFly quickstarts]. 
+
+You can check https://github.com/wildfly-extras/wildfly-cloud-galleon-pack/blob/main/README.md[this documentation] 
+for more details on the WildFly cloud feature-pack .
+
+include::_galleon/Galleon_layers.adoc[]

--- a/docs/src/main/asciidoc/_elytron/Keycloak_SAML_Integration.adoc
+++ b/docs/src/main/asciidoc/_elytron/Keycloak_SAML_Integration.adoc
@@ -52,8 +52,8 @@ using both the `web-server` and `keycloak-client-saml` layers:
 ----
 <plugin>
     <groupId>org.wildfly.plugins</groupId>
-    <artifactId>wildfly-jar-maven-plugin</artifactId>
-    <version>${version.wildfly.jar.maven.plugin}</version>
+    <artifactId>wildfly-maven-plugin</artifactId>
+    <version>${version.wildfly.maven.plugin}</version>
     <configuration>
         <feature-packs>
             <feature-pack>
@@ -69,14 +69,15 @@ using both the `web-server` and `keycloak-client-saml` layers:
             <layer>web-server</layer>
             <layer>keycloak-client-saml</layer>
         </layers>
-        <context-root>simple-webapp</context-root>
-        <cli-sessions>
-            <cli-session>
-                <script-files>
-                    <script>configure-saml.cli</script>
-                </script-files>
-            </cli-session>
-        </cli-sessions>
+        <bootable-jar>true</bootable-jar>
+        <name>simple-webapp.war</name>
+        <packaging-scripts>
+          <packaging-script>
+            <scripts>
+              <script>configure-saml.cli</script>
+            </scripts>
+          </packaging-script>
+        </packaging-scripts>
     </configuration>
     <executions>
         <execution>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19172

* Add the WildFly Maven Plugin chapter to the Installation Guide. Covers both with and without Glow configuration.
* Rewrote the Bootable Jar Guide to use the WildFly Maven Plugin. Make it clear that the WildFly JAR Maven Plugin is deprecated.
* Replaced usage of the WildFly JAR Maven Plugin with the usage of the WildFly Maven Plugin.
