### PR TITLE
WFLY-19798 Fixing couple of mistakes / typos in pom.xml files

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -328,7 +328,7 @@
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
-                <version>${project.version}</version>
+                <version>${ee.maven.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -564,7 +564,7 @@
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>wildfly-elytron-oidc-client-subsystem</artifactId>
-                <version>${full.maven.version}</version>
+                <version>${ee.maven.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -186,7 +186,7 @@
             <dependency>
                 <groupId>${full.maven.groupId}</groupId>
                 <artifactId>wildfly-microprofile-reactive-messaging-amqp</artifactId>
-                <version>${project.version}</version>
+                <version>${full.maven.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -689,20 +689,6 @@
 
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
-                <artifactId>wildfly-feature-pack</artifactId>
-                <version>${ee.maven.version}</version>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>${ee.maven.groupId}</groupId>
-                <artifactId>wildfly-feature-pack</artifactId>
-                <version>${ee.maven.version}</version>
-                <type>zip</type>
-            </dependency>
-
-            <dependency>
-                <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>wildfly-legacy-ee-bom</artifactId>
                 <version>${ee.maven.version}</version>
                 <type>pom</type>
@@ -838,7 +824,7 @@
             <dependency>
                 <groupId>${full.maven.groupId}</groupId>
                 <artifactId>wildfly-legacy-expansion-bom</artifactId>
-                <version>${ee.maven.version}</version>
+                <version>${full.maven.version}</version>
                 <type>pom</type>
             </dependency>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19798

I work on an experimental downstream effort to validate generated channel manifests. The intended validation is sort of like: "If there is set of dependencies in pom.xml using the same version property, the versions of those dependencies in generated manifests should also be identical."

These fixes have no functional impact, but they would help me to sort out some flukes I see in my results.