### PR TITLE
WFLY-19590 Update MicrometerSetupTask package name to new package.

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
@@ -19,6 +19,7 @@ import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -27,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.FaultToleranceMicrometerIntegrationTestCase;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deployment.FaultTolerantApplication;
-import org.wildfly.test.integration.observability.setuptask.MicrometerSetupTask;
 
 /**
  * Test that reuses existing {@link FaultTolerantApplication} application which deploys twice simultaneously with


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19590

Resolves conflicting change merge with https://github.com/wildfly/wildfly/pull/18191 where the MicrometerSetupTask package name changed by @jasondlee