### PR TITLE
WFLY-19806 Restore singleton MDBs to working state.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -595,12 +595,12 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 @Override
                 public ServiceController<?> install(RequirementServiceTarget target) {
                     ServiceBuilder<?> builder = targetFactory.get().createSingletonServiceTarget(target).addService();
-                    return builder.setInstance(org.jboss.msc.Service.newInstance(builder.provides(CLUSTERED_SINGLETON_CAPABILITY.getCapabilityServiceName()), null))
+                    return builder.setInstance(org.jboss.msc.Service.newInstance(builder.provides(CLUSTERED_SINGLETON_CAPABILITY.getCapabilityServiceName()), Boolean.TRUE))
                             .setInitialMode(ServiceController.Mode.ON_DEMAND)
                             .install();
                 }
             };
-            ServiceInstaller.builder(installer, context.getCapabilityServiceSupport()).requires(targetFactory).build();
+            ServiceInstaller.builder(installer, context.getCapabilityServiceSupport()).requires(targetFactory).asPassive().build().install(context);
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19806

Due to having no test coverage, WFLY-18857 inadvertently broke singleton MDBs, i.e. WFLY-4661.
I've opened WFLY-19813 to address the missing tests.
Verified using messaging-clustering-singleton quickstart.