### PR TITLE
[WFLY-19820] Upgrade WildFly Core to 26.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>26.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19820

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/26.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/26.0.0.Beta5...26.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7003'>WFCORE-7003</a>] -         ServerController&#39;s startInAdminOnly and startSuspended are silently ignored with bootable jar testing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7005'>WFCORE-7005</a>] -         wildfly-core testsuite: InvalidAddressOperationTestCase failing intermittently
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7007'>WFCORE-7007</a>] -         Fix typo in pom.xml - goal &quot;provisioning&quot; to &quot;provision&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7010'>WFCORE-7010</a>] -         DomainLifecycleUtil ignores the &quot;Default&quot; stability level setting
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7012'>WFCORE-7012</a>] -         ServerEnvironmentTestCase#testAliasNotWorkingInDefaultStability depends on other test to work properly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7015'>WFCORE-7015</a>] -         ProvisioningConsistencyTestCase fails with -Drelease
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7016'>WFCORE-7016</a>] -         YamlExtensionTestCase#testPostStartCLIChangesToModelDoNotSurviveRestart should be ignore for Botable JAR packaging
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6959'>WFCORE-6959</a>] -         Create a test case to validate the endpoint name if the JBoss server name and &#39;jboss.node.name&#39; are both provided to the server 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6972'>WFCORE-6972</a>] -         Move the default testsuite/domain configurations back to use Default stability level only
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7013'>WFCORE-7013</a>] -         Make ServerEnvironmentTestCase#testAliasFunctionality to assume the expected stability level
</li>
</ul>
                                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7009'>WFCORE-7009</a>] -         Upgrade SLF4J from 2.0.13 to 2.0.16
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6955'>WFCORE-6955</a>] -         Add a CI job to check for non-i18n INFO/WARN/ERROR logging
</li>
</ul>
</details>
