### PR TITLE
[WFLY-19821] Suppress CVE-2024-45772 and [WFLY-19822]  Suppress CVE-2024-47554

### DIFF
--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -268,4 +268,13 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-.*@.*$</packageUrl>
       <cve>CVE-2024-45772</cve>
    </suppress>
+   <suppress until="2025-10-07">
+      <notes><![CDATA[
+      file name: velocity-engine-core-2.3.jar (shaded: commons-io:commons-io:2.8.0)
+
+      [WFLY-19822] Although some of commons-io is shaded in this affected class is not a part of the shading.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/commons-io/commons-io@.*$</packageUrl>
+      <vulnerabilityName>CVE-2024-47554</vulnerabilityName>
+   </suppress>
 </suppressions>

--- a/sca-overrides/owasp-suppressions.xml
+++ b/sca-overrides/owasp-suppressions.xml
@@ -259,4 +259,13 @@
       <packageUrl regex="true">^pkg:maven/io\.vertx/vertx-kafka-client@.*$</packageUrl>
       <cve>CVE-2024-8391</cve>
    </suppress>
+   <suppress until="2025-10-07">
+      <notes><![CDATA[
+      file name: lucene-core-9.11.1.jar
+
+      [WFLY-19821] Supress CVE-2024-45772 as we don't include the affected module.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.lucene/lucene-.*@.*$</packageUrl>
+      <cve>CVE-2024-45772</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
[WFLY-19821] Suppress CVE-2024-45772 as we don't include the affected module.

https://issues.redhat.com/browse/WFLY-19821

[WFLY-19822] Suppress CVE-2024-47554 against velocity-engine-core, the affected class is not shaded in.

https://issues.redhat.com/browse/WFLY-19822

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19822](https://issues.redhat.com/browse/WFLY-19822)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)