### PR TITLE
[WFLY-19831] unstable-api-annotation-index package should be provisio…

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -26,6 +26,6 @@
         <package name="cleanup.domain.log.dir" optional="true"/>
         <package name="cleanup.domain.data.dir" optional="true"/>
         <!-- Unstable API Annotation Index -->
-        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack"/>
+        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack" optional="true" valid-for-stability="preview"/>
     </packages>
 </config>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -27,5 +27,7 @@
         <package name="cleanup.domain.data.dir" optional="true"/>
         <!-- Unstable API Annotation Index -->
         <package name="unstable-api-annotation-index.wildfly-ee-feature-pack" optional="true" valid-for-stability="preview"/>
+        <package name="org.wildfly.unstable.annotation.api.indexer" optional="true" valid-for-stability="preview" />
+        <package name="org.wildfly._internal.unstable-api-annotation-index" optional="true" valid-for-stability="preview" />
     </packages>
 </config>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -40,5 +40,7 @@
         <package name="docs.licenses.merge" optional="true"/>
         <!-- Unstable API Annotation Index -->
         <package name="unstable-api-annotation-index.wildfly-ee-feature-pack" optional="true" valid-for-stability="preview"/>
+        <package name="org.wildfly.unstable.annotation.api.indexer" optional="true" valid-for-stability="preview" />
+        <package name="org.wildfly._internal.unstable-api-annotation-index" optional="true" valid-for-stability="preview" />
     </packages>
 </config>

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -39,6 +39,6 @@
         <package name="docs.licenses" optional="true"/>
         <package name="docs.licenses.merge" optional="true"/>
         <!-- Unstable API Annotation Index -->
-        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack"/>
+        <package name="unstable-api-annotation-index.wildfly-ee-feature-pack" optional="true" valid-for-stability="preview"/>
     </packages>
 </config>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/package.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-ee-feature-pack/package.xml
@@ -5,5 +5,5 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<package-spec xmlns="urn:jboss:galleon:package:2.0" name="unstable-api-annotation-index.wildfly-ee-feature-pack">
+<package-spec xmlns="urn:jboss:galleon:package:3.0" name="unstable-api-annotation-index.wildfly-ee-feature-pack" stability-level="preview">
 </package-spec>

--- a/galleon-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -10,6 +10,6 @@
         <package name="product.conf" optional="true"/>
         <package name="misc.domain"/>
         <!-- Unstable API Annotation Index -->
-        <package name="unstable-api-annotation-index.wildfly-galleon-pack"/>
+        <package name="unstable-api-annotation-index.wildfly-galleon-pack" optional="true" valid-for-stability="preview"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -13,6 +13,6 @@
         <package name="docs.licenses" optional="true"/>
         <package name="docs.licenses.merge" optional="true"/>
         <!-- Unstable API Annotation Index -->
-        <package name="unstable-api-annotation-index.wildfly-galleon-pack"/>
+        <package name="unstable-api-annotation-index.wildfly-galleon-pack" optional="true" valid-for-stability="preview"/>
     </packages>
 </config>

--- a/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/package.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/packages/unstable-api-annotation-index.wildfly-galleon-pack/package.xml
@@ -5,5 +5,5 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<package-spec xmlns="urn:jboss:galleon:package:2.0" name="unstable-api-annotation-index.wildfly-galleon-pack">
+<package-spec xmlns="urn:jboss:galleon:package:3.0" name="unstable-api-annotation-index.wildfly-galleon-pack" stability-level="preview">
 </package-spec>

--- a/preview/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/preview/galleon-local/src/main/resources/configs/domain/model.xml
@@ -27,5 +27,9 @@
         <package name="cleanup.domain.data.dir" optional="true"/>
 
         <package name="org.wildfly.deployment.transformation"/>
+
+        <!-- Unstable API Annotation Index -->
+        <package name="org.wildfly.unstable.annotation.api.indexer" optional="true" valid-for-stability="preview" />
+        <package name="org.wildfly._internal.unstable-api-annotation-index" optional="true" valid-for-stability="preview" />
     </packages>
 </config>

--- a/preview/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/preview/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -37,5 +37,9 @@
         <package name="org.wildfly.deployment.transformation"/>
         <package name="docs.licenses" optional="true"/>
         <package name="docs.licenses.merge" optional="true"/>
+
+        <!-- Unstable API Annotation Index -->
+        <package name="org.wildfly.unstable.annotation.api.indexer" optional="true" valid-for-stability="preview" />
+        <package name="org.wildfly._internal.unstable-api-annotation-index" optional="true" valid-for-stability="preview" />
     </packages>
 </config>


### PR DESCRIPTION
…ned only when preview stability level is enabled

Jira issue: https://issues.redhat.com/browse/WFLY-19831


The tricky part is that dist/build verifications depend on the galleon-pack stability level configuration, so as soon as we change the galleon-pack provisioning all to "community", these verification files will fail since this annotation-index package won't be provisioned. I think it is ok since what we are verifying is what we are provisioning, although making them more dynamic would be better, I guess it could be done with multiple properties (per galleon pack) in the main pom.xml