### PR TITLE
Fix for WFLY-19834, Delay the construction of shaded jars at provisioning time

### DIFF
--- a/client/shade/assembly.xml
+++ b/client/shade/assembly.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>shaded-model</id>
+    <formats>
+       <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target/resources</directory>
+            <outputDirectory/>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>pom.xml</source>
+            <outputDirectory/>
+        </file>
+    </files>
+</assembly>

--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -378,6 +378,54 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.wildfly.galleon-plugins</groupId>
+                <artifactId>wildfly-galleon-maven-plugin</artifactId>
+                <configuration>
+                    <manifestEntries>
+                        <Multi-Release>true</Multi-Release>
+                        <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                        <Bundle-SymbolicName>org.jboss.client</Bundle-SymbolicName>
+                        <Bundle-Version>1.0</Bundle-Version>
+                        <Bundle-Name>Jakarta Enterprise Beans and Jakarta Messaging client library</Bundle-Name>
+                        <Fragment-Host>org.openjdk.jmc.rjmx</Fragment-Host>
+                        <Export-Package>*</Export-Package>
+                        <Automatic-Module-Name>org.jboss.client</Automatic-Module-Name>
+                    </manifestEntries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>generate-shaded-descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <recompressZippedFiles>true</recompressZippedFiles>
+                            <finalName>${project.build.finalName}-shaded</finalName>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+                            <tarLongFileMode>gnu</tarLongFileMode>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -30,6 +30,7 @@
         <galleon.shared.resources.directory>${basedir}/../galleon-shared/src/main/resources</galleon.shared.resources.directory>
         <galleon.shared.generated.resources.directory>${basedir}/../galleon-shared/target/index</galleon.shared.generated.resources.directory>
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
+        <galleon.client.resources.directory>${basedir}/../../client/shade/target/resources</galleon.client.resources.directory>
         <license.directory>${project.build.directory}/resources/content/docs/licenses</license.directory>
         <pruned.resources.directory>${basedir}/../pruned/src/main/resources</pruned.resources.directory>
     </properties>
@@ -76,6 +77,18 @@
                                 <artifactItem>
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-feature-pack-ee-10-api</artifactId>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-cli</artifactId>
+                                    <classifier>shaded-model</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-elytron-tool-wrapper</artifactId>
+                                    <classifier>shaded-model</classifier>
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
@@ -152,6 +165,22 @@
                             <resources>
                                 <resource>
                                     <directory>${galleon.local.resources.directory}</directory>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-galleon-client-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${galleon.client.resources.directory}</directory>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -2953,19 +2953,6 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-cli</artifactId>
-            <classifier>client</classifier>
-            <!-- TODO add global excludes in the wf core depMgmt -->
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-elytron-integration</artifactId>
             <exclusions>
                 <exclusion>
@@ -3427,6 +3414,28 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-client-all</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-client-properties</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/package.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/package.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="core-tools">
+    <dependencies>
+        <package name="org.wildfly.core.wildfly-elytron-tool-wrapper.shaded"/>
+    </dependencies>
+</package-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/pm/wildfly/tasks.xml
@@ -5,7 +5,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.2">
     <copy-artifact artifact="org.wildfly.core:wildfly-launcher" to-location="bin/launcher.jar"/>
-    <copy-artifact artifact="org.wildfly.core:wildfly-elytron-tool-wrapper" to-location="bin/wildfly-elytron-tool.jar"/>
+    <assemble-shaded-artifact shaded-model-package="org.wildfly.core.wildfly-elytron-tool-wrapper.shaded" to-location="bin/wildfly-elytron-tool.jar"/>
 </tasks>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/tools/package.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/tools/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="tools">
+    <dependencies>
+        <package name="org.wildfly.wildfly-client-all.shaded"/>
+        <package name="org.wildfly.core.wildfly-cli.shaded"/>
+    </dependencies>
+</package-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/tools/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/tools/pm/wildfly/tasks.xml
@@ -5,7 +5,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
-    <copy-artifact artifact="org.wildfly:wildfly-client-all" to-location="bin/client/jboss-client.jar"/>
-    <copy-artifact artifact="org.wildfly.core:wildfly-cli::client" to-location="bin/client/jboss-cli-client.jar"/>
+<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.2">
+    <assemble-shaded-artifact shaded-model-package="org.wildfly.wildfly-client-all.shaded" to-location="bin/client/jboss-client.jar"/>
+    <assemble-shaded-artifact shaded-model-package="org.wildfly.core.wildfly-cli.shaded" to-location="bin/client/jboss-cli-client.jar"/>
 </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.7.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.1.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>7.2.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.1.Final</version.org.wildfly.plugin>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -31,7 +31,7 @@
         <!-- WildFly and ee galleon contents -->
         <ee.galleon.shared.resources.directory>${basedir}/../../ee-feature-pack/galleon-shared/src/main/resources</ee.galleon.shared.resources.directory>
         <full.galleon.shared.resources.directory>${basedir}/../../galleon-pack/galleon-shared/src/main/resources</full.galleon.shared.resources.directory>
-
+        <galleon.client.resources.directory>${basedir}/../../client/shade/target/resources</galleon.client.resources.directory>
         <!-- WildFly Preview modules -->
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
 
@@ -84,6 +84,18 @@
                                 <artifactItem>
                                     <groupId>org.wildfly</groupId>
                                     <artifactId>mvc-krazo-galleon-shared</artifactId>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-cli</artifactId>
+                                    <classifier>shaded-model</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-elytron-tool-wrapper</artifactId>
+                                    <classifier>shaded-model</classifier>
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
@@ -161,6 +173,22 @@
                             <resources>
                                 <resource>
                                     <directory>${galleon.local.resources.directory}</directory>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-galleon-client-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${galleon.client.resources.directory}</directory>
                                 </resource>
                             </resources>
                             <overwrite>true</overwrite>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19834

WARNING: This PR will fail until an upgrade of wildFly-core containing: https://github.com/wildfly/wildfly-core/pull/6213 is done.
