### PR TITLE
[WFLY-19864] Update HostExcludesTestCase configuration to work with WF34

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -72,7 +72,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
     private final boolean isFullDistribution = AssumeTestGroupUtil.isFullDistribution();
     private final boolean isPreviewGalleonPack = AssumeTestGroupUtil.isWildFlyPreview();
 
-    private static final String MAJOR = "34.";
+    private static final String MAJOR = "35.";
 
     /**
      * Maintains the list of expected extensions for each host-exclude name for previous releases.
@@ -203,7 +203,8 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.wildfly.extension.mvc-krazo"
         ), List.of(), true),
         WILDFLY_33_0("WildFly33.0", WILDFLY_32_0, List.of(), List.of(), true),
-        CURRENT(MAJOR, WILDFLY_33_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
+        WILDFLY_34_0("WildFly34.0", WILDFLY_33_0, List.of(), List.of(), true),
+        CURRENT(MAJOR, WILDFLY_34_0, getCurrentAddedExtensions(), getCurrentRemovedExtensions(), true);
 
         private static List<String> getCurrentAddedExtensions() {
             // If an extension is added to this list, also check if it is supplied only by wildfly-galleon-pack. If so, add it also
@@ -229,6 +230,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
         }
 
         private final String name;
+        private final ExtensionConf parent;
         private final Set<String> extensions = new HashSet<>();
         private final Set<String> removed = new HashSet<>();
         private static final Map<String, ExtensionConf> MAP;
@@ -282,6 +284,7 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
          */
         ExtensionConf(String name, ExtensionConf parent, List<String> addedExtensions, List<String> removedExtensions, boolean supported) {
             this.name = name;
+            this.parent = parent;
             this.modified = (addedExtensions != null && !addedExtensions.isEmpty()) || (removedExtensions != null && !removedExtensions.isEmpty());
             if (addedExtensions != null) {
                 this.extensions.addAll(addedExtensions);
@@ -446,9 +449,34 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
         for(ExtensionConf extensionConf : ExtensionConf.values()) {
             if (extensionConf != ExtensionConf.CURRENT && extensionConf.isSupported() && !processedExclusionsIds.contains(extensionConf.getName())) {
                 Set<String> extensions = extensionConf.getExtensions(isFullDistribution, isPreviewGalleonPack);
-                extensions.removeAll(ExtensionConf.forName(MAJOR).getRemovedExtensions());
+                ExtensionConf major = ExtensionConf.forName(MAJOR);
+                extensions.removeAll(major.getRemovedExtensions());
                 if (!extensions.equals(availableExtensions)) {
-                    fail(String.format("The %s exclusion id is not defined as host exclusion for the current release.", extensionConf.getName()));
+                    boolean fail = !isPreviewGalleonPack;
+                    if (!fail) {
+                        // If a preview-only extension remains preview-only beyond its initial release, there may be
+                        // no host-exclude for its initial release, if nothing else added later needed an exclude
+                        // for that release. But it also won't be in 'extensions'. We don't want to track in which
+                        // release it arrived, so for any version between current and the first one where we have
+                        // a host-exclude, treat it as if it were present.
+                        // This opens the possibility of this test missing that the developer added the extension
+                        // to existing host-exclude entries but forgot to add a new host-exclude,
+                        // but the alternative is complete tracking of when extensions come and go from WFP.
+                        fail = true;
+                        ExtensionConf conf = major;
+                        while (conf != null && !processedExclusionsIds.contains(conf.getName())) {
+                            if (conf == extensionConf) {
+                                extensions.addAll(major.previewExtensions);
+                                fail = !extensions.equals(availableExtensions);
+                                break;
+                            }
+                            conf = conf.parent;
+                        }
+                    }
+                    if (fail) {
+                        fail(String.format("The %s exclusion id is not defined as host exclusion for the current release. Extension diff: %s",
+                                extensionConf.getName(), diff.apply(availableExtensions, extensions)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
I had to add special handling for preview-only extensions like jakarta-data continuing as such beyond their initial release.

https://issues.redhat.com/browse/WFLY-19864