### PR TITLE
Cloud tests should run in the wildfly-extras repo

### DIFF
--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 env:
   # Repository where the cloud tests will be run
-  REPOSITORY: kabir/wildfly-cloud-tests
+  REPOSITORY: wildfly-extras/wildfly-cloud-tests
   # This must be set to a PAT with 'repo' permission for the target repository
   TOKEN: ${{ secrets.CLOUD_TESTS_REMOTE_DISPATCH_TOKEN }}
   # Just an identifier for the event - this one triggers the cloud tests


### PR DESCRIPTION
At the moment they have been running in kabir/wildfly-cloud-tests