### PR TITLE
[WFLY-19393] Persistence container bytecode enhancement should be enabled by default

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -7,7 +7,6 @@ package org.jboss.as.jpa.config;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -227,8 +226,6 @@ public class Configuration {
     private static final String EE_DEFAULT_DATASOURCE = "java:comp/DefaultDataSource";
     // key = provider class name, value = module name
     private static final Map<String, String> providerClassToModuleName = new HashMap<String, String>();
-    private static final String HIBERNATE = "Hibernate";
-    private static final String HIBERNATE_ENHANCER = "hibernate.enhancer";
 
     static {
         // always choose the default hibernate version for the Hibernate provider class mapping
@@ -272,34 +269,7 @@ public class Configuration {
         if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
             return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
         }
-        if (isHibernateProvider(pu.getPersistenceProviderClassName())) {
-
-            return isAnyHibernateEnhancerPropertySpecified(pu);
-        }
         return true;
-    }
-
-    /**
-     * Consider jboss.as.jpa.classtransformer to be set to true if any hibernate.enhancer properties are set to true.
-     *
-     * @param pu
-     * @return true if any hibernate.enhancer property is detected otherwise return false
-     */
-    private static boolean isAnyHibernateEnhancerPropertySpecified(PersistenceUnitMetadata pu) {
-
-        Set<String> set = pu.getProperties().stringPropertyNames();
-        for (String key : set) {
-            if (key.startsWith(HIBERNATE_ENHANCER) &&
-                    (true == Boolean.parseBoolean(pu.getProperties().getProperty(key)))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isHibernateProvider(String provider) {
-        // If the persistence provider is not specified (null case), Hibernate ORM will be used as the persistence provider.
-        return provider == null || provider.contains(HIBERNATE);
     }
 
     // key = provider class name, value = adapter module name
@@ -440,5 +410,4 @@ public class Configuration {
         }
         return result;
     }
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EmployeeWithLastName.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EmployeeWithLastName.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Ensure that this entity class is enhanced even though is has property accessor (lastName) referencing field (last)
+ * that doesn't match the property name (lastName).
+ * The entity class will be enhanced since the property accessors (get/set/is methods) does not use any Jakarta Persistence annotations.
+ * This covers the https://hibernate.atlassian.net/browse/HHH-16572 added logic that approves EmployeeWithLastName to be enhanced.
+ * For reference see org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImpl#checkUnsupportedAttributeNaming
+ *
+ * It is worth pointing out that this class is badly written though as the property accessor method name(s) should match the field names.
+ * For example, instead of getLastName() + setLastName(), the method name should match the field name, so better would be getName() + setName().
+ *
+ * @author Scott Marlow
+ */
+@Entity
+@Cacheable(true)
+public class EmployeeWithLastName {
+
+    @Id
+    @Column
+    private String id;
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        id = value;
+    }
+
+
+    private String last;
+
+    private String address;
+
+    public String getLastName() {
+        return last;
+    }
+
+    public void setLastName(String name) {
+        this.last = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EmployeeWithLastNameNotEnhanced.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EmployeeWithLastNameNotEnhanced.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * The entity class will not be enhanced since the property accessors (get/set/is methods) have Jakarta Persistence annotations.
+ * This covers https://hibernate.atlassian.net/browse/HHH-16572 determination that EmployeeWithLastNameNotEnhanced should not be enhanced.
+ * The reason being that the property accessor also has a jakarta.persistence annnotation (note that jakarta.persistence.Transient
+ * would be ignored) that cannot currently be enhanced.
+ *
+ * For reference see org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImpl#checkUnsupportedAttributeNaming which will eventually
+ * be removed in a future Hibernate ORM (minor or major) release.  When EnhancerImpl#checkUnsupportedAttributeNaming is removed, this test will
+ * likely fail and either can be changed or removed at that time.
+ *
+ * It is worth pointing out that this class is badly written though as the property accessor method name(s) should match the field names.
+ * For example, instead of getLastName() + setLastName(), the method name should match the field name, so better would be getName() + setName().
+ *
+ * @author Scott Marlow
+ */
+@Entity
+@Cacheable(true)
+public class EmployeeWithLastNameNotEnhanced {
+    @Id
+    Long id;
+
+    private String last;
+
+    private String address;
+
+    public String getLastName() {
+        return last;
+    }
+
+    public void setLastName(String name) {
+        this.last = name;
+    }
+
+    @Basic
+    @Access(AccessType.PROPERTY)
+    public String getPropertyMethod() {
+        return "from getter: " + last;
+    }
+    public void setPropertyMethod(String property) {
+        this.last = property;
+    }
+    public String getAddress() {
+    return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBWithLastName.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBWithLastName.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.hibernate;
+
+import jakarta.ejb.Stateful;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+public class SFSBWithLastName {
+    @PersistenceContext(unitName = "mypc")
+    EntityManager em;
+
+    public void createEmployee(String name, String address, String id) {
+        EmployeeWithLastName emp = new EmployeeWithLastName();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setLastName(name);
+        em.persist(emp);
+    }
+
+    public EmployeeWithLastName getEmployeeNoTX(String id) {
+        return em.find(EmployeeWithLastName.class, id, LockModeType.NONE);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
@@ -14,10 +14,9 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.integration.jpa.hibernate.Employee;
-import org.jboss.as.test.integration.jpa.hibernate.SFSB1;
-import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSession;
-import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSessionFactory;
+import org.jboss.as.test.integration.jpa.hibernate.EmployeeWithLastName;
+import org.jboss.as.test.integration.jpa.hibernate.EmployeeWithLastNameNotEnhanced;
+import org.jboss.as.test.integration.jpa.hibernate.SFSBWithLastName;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,10 +41,9 @@ public class ClassFileTransformerTestCase {
 
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addClasses(ClassFileTransformerTestCase.class,
-                Employee.class,
-                SFSB1.class,
-                SFSBHibernateSession.class,
-                SFSBHibernateSessionFactory.class
+                EmployeeWithLastName.class,
+                EmployeeWithLastNameNotEnhanced.class,
+                SFSBWithLastName.class
         );
         jar.addAsManifestResource(ClassFileTransformerTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         return jar;
@@ -66,19 +64,27 @@ public class ClassFileTransformerTestCase {
 
     @Test
     public void testhibernate_ejb_use_class_enhancer() throws Exception {
-        SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
-        sfsb1.createEmployee("Kelly Smith", "Watford, England", 10);
-        sfsb1.createEmployee("Alex Scott", "London, England", 20);
-        Employee emp = sfsb1.getEmployeeNoTX(10);
+        SFSBWithLastName sfsbWithLastName = lookup("SFSBWithLastName", SFSBWithLastName.class);
+        sfsbWithLastName.createEmployee("Kelly Smith", "Watford, England", "10");
+        sfsbWithLastName.createEmployee("Alex Scott", "London, England", "20");
+        EmployeeWithLastName emp = sfsbWithLastName.getEmployeeNoTX("10");
 
         assertTrue("was able to read database row with hibernate.ejb.use_class_enhancer enabled", emp != null);
     }
 
     @Test
-    public void testHibernateByteCodeEnhancementIsDisabledByDefault() {
+    public void testHibernateByteCodeEnhancementIsEnabledByDefault() {
         // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
         // accordingly.
-        assertFalse("Employee class is not bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(Employee.class));
+        assertTrue("EmployeeWithLastName class is bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(EmployeeWithLastName.class));
     }
+
+    @Test
+    public void testHibernateByteCodeEnhancementIsDisabled() {
+        // Note: ManagedTypeHelper is an internal Hibernate ORM class, if it is removed or renamed then this test can be updated
+        // accordingly.
+        assertFalse("EmployeeWithLastNameNotEnhanced class is not bytecode enhanced", org.hibernate.engine.internal.ManagedTypeHelper.isManagedType(EmployeeWithLastNameNotEnhanced.class));
+    }
+
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19393

https://hibernate.atlassian.net/browse/HHH-16572 was addressed in Hibernate ORM 6.6.2.Final and this (WFLY-19393) change enables bytecode enhancement for Persistence application deployments by default.

Note that we now expect Jakarta EE 10 TCK test jpa/core/query/flushmode (https://github.com/jakartaee/platform-tck/blob/master/src/com/sun/ts/tests/jpa/core/query/flushmode/Client.java#L355 #flushModeTest5 to pass (with ByteCode enhancement enabled by default) since [HHH-16572](https://hibernate.atlassian.net/browse/HHH-16572) was addressed.