### PR TITLE
[WFLY-19895]: Upgrade Apache Artemis to 2.38.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.37.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.38.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.0</version.org.apache.avro>
         <version.org.apache.cxf>4.0.5</version.org.apache.cxf>


### PR DESCRIPTION
* Upgrading Apache Artemis to 2.38.0
* Upgrading Jackson to 2.18.0
* Upgrading commons-io to 2.17.0

Jira: https://issues.redhat.com/browse/WFLY-19895
Release Note: https://activemq.apache.org/components/artemis/download/release-notes-2.38.0