### PR TITLE
[WFLY-19889] Split cloud tests trigger

### DIFF
--- a/.github/workflows/cloud-test-pr-reporter.yml
+++ b/.github/workflows/cloud-test-pr-reporter.yml
@@ -1,7 +1,14 @@
 name: Report Cloud Test Status
 on:
   repository_dispatch:
-    types: [report-cloud-tests-pr-pending, report-cloud-tests-pr-complete]
+    types:
+      # These two come from cloud-test-pr-workflow-run.yml which does the remote dispatch in the
+      # wildfly-cloud-tests repository
+      - report-cloud-tests-workflow-run-pending
+      - report-cloud-tests-workflow-run-failed
+      # These two come from the remote job in the wildfly-cloud-tests repository
+      - report-cloud-tests-pr-pending
+      - report-cloud-tests-pr-complete
 env:
   DESC: ${{ github.event.client_payload.desc }}
   GH_TOKEN: ${{ github.token }}
@@ -18,10 +25,8 @@ jobs:
     steps:
       - name: Output
         env:
-          #MESSAGE: ${{ github.event.client_payload.message }}
           MESSAGE: ${{ toJSON(github.event.client_payload) }}
         run: echo $MESSAGE
-
       - name: Report status
         run: |        
           JSON_STRING=$(jq -c -n \

--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -1,6 +1,6 @@
 name: Cloud Tests Trigger
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:
@@ -27,57 +27,34 @@ on:
 
 # Only run the latest job
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.ref || github.run_id }}'
   cancel-in-progress: true
-env:
-  # Repository where the cloud tests will be run
-  REPOSITORY: wildfly-extras/wildfly-cloud-tests
-  # This must be set to a PAT with 'repo' permission for the target repository
-  TOKEN: ${{ secrets.CLOUD_TESTS_REMOTE_DISPATCH_TOKEN }}
-  # Just an identifier for the event - this one triggers the cloud tests
-  EVENT_TYPE: trigger-cloud-tests-pr
 
 permissions: {}
 jobs:
-  run-tests:
+  trigger:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Remote Dispatch
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        if: ${{ env.TOKEN }}
-        run: |
-          echo $GITHUB_REPOSITORY
-          
-          echo "FILENAME=$FILENAME" >> $GITHUB_ENV
-          PR_NUMBER="${{github.event.number}}"
-          
-          CLIENT_PAYLOAD=$( jq -n \
-                  --arg tr "$GITHUB_REPOSITORY" \
-                  --arg githubSha "$GITHUB_SHA" \
-                  --arg prHeadSha "$PR_HEAD_SHA" \
-                  --arg pr "$PR_NUMBER" \
-                  '{triggerRepo: $tr, githubSha: $githubSha, prHeadSha: $prHeadSha, pr: $pr}' )
-          
-          echo "CLIENT_PAYLOAD: $CLIENT_PAYLOAD"
-
-          set -x
-
-          resp=$(curl -X POST -s "https://api.github.com/repos/${REPOSITORY}/dispatches" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${TOKEN}" \
-              -d "{\"event_type\": \"${EVENT_TYPE}\", \"client_payload\": ${CLIENT_PAYLOAD} }")
-          
-          set +x
-          
-          if [ -z "$resp" ]
-          then
-            sleep 2
-          else
-            echo "Workflow failed to trigger"
-            echo "$resp"
-            exit 1
-          fi
-
+    - name: Get pull request number
+      run: |
+        event_name="${{ github.event_name }}"
+        
+        if [ "${event_name}" == "pull_request" ]; then
+          echo "This is a pull request"
+          echo "PR_NUMBER=${{ github.event.number }}" >> .job-env
+          echo "GITHUB_SHA_FOR_PR=${{ github.sha }}" >> .job-env
+          echo "GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> .job-env
+        elif [ "${event_name}" == "push" ]; then
+          echo "This is a push"
+          echo "PR_NUMBER=push" >> .job-env
+          echo "GITHUB_SHA=${{ github.sha }}" >> .job-env
+        else
+          echo "The ${event_name} event is not handled by this workflow"
+          exit 1
+        fi
+        cat .job-env
+    - uses: actions/upload-artifact@v4
+      with:
+        name: .job-env
+        path: .job-env
+        include-hidden-files: true

--- a/.github/workflows/cloud-test-pr-workflow-run.yml
+++ b/.github/workflows/cloud-test-pr-workflow-run.yml
@@ -1,0 +1,154 @@
+# This will be invoked by the cloud-test-pr-trigger.yml workflow
+# The other job runs handles the 'pull_request' event and thus its GITHUB_SHA will have the value
+# of the merge commit from the PR into the main branch of WildFly. However, it can not access the secrets needed
+# to perform the remote dispatch.
+# So it stores that sha in an environment variable, along with the pull request head sha, and delegates to this job
+# which can read secrets and do the dispatch.
+name: Cloud Tests Workflow Run
+on:
+  workflow_run:
+    workflows:
+      - 'Cloud Tests Trigger'
+    types:
+      - completed
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} - ${{ github.event.workflow_run.event }}: ${{ github.event.workflow_run.head_repository.full_name }}@${{ github.event.workflow_run.head_branch }}'
+  cancel-in-progress: true
+env:
+  # This must be set to a PAT with 'repo' permission for the target repository
+  REMOTE_DISPATCH_TOKEN: ${{ secrets.CLOUD_TESTS_REMOTE_DISPATCH_TOKEN }}
+  # Just an identifier for the event - this one triggers the cloud tests
+  EVENT_TYPE: trigger-cloud-tests-pr
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/download-artifact@v4
+        with:
+          name: .job-env
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Read environment variables from the previous job
+        run: |
+          text="$(cat .job-env)"
+          echo "${text}"        
+          echo "${text}" >> "$GITHUB_ENV"
+
+      - name: Report Progress
+        # This workflow_run job is invisible on the pull requests, so we need to report back whether we work
+        # or fail.
+        # We do that by reporting back via the same mechanism as the remote cloud test does.
+        env:
+          REPORTER_EVENT_TYPE: report-cloud-tests-workflow-run-pending
+        run: |
+          STATUS="pending"
+          RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          DESC="Invoking remote job"
+          CLIENT_PAYLOAD=$( jq -n \
+                  --arg prHeadSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
+                  --arg state "$STATUS" \
+                  --arg runUrl "$RUN_URL" \
+                  --arg desc "$DESC" \
+                  '{prHeadSha: $prHeadSha, state: $state, runUrl: $runUrl, desc: $desc}' )
+
+          echo "CLIENT_PAYLOAD: $CLIENT_PAYLOAD"
+
+          set -x
+
+          resp=$(curl -X POST -s "https://api.github.com/repos/$GITHUB_REPOSITORY/dispatches" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${REMOTE_DISPATCH_TOKEN}" \
+              -d "{\"event_type\": \"${REPORTER_EVENT_TYPE}\", \"client_payload\": ${CLIENT_PAYLOAD} }")
+          
+          set +x
+          
+          if [ -z "$resp" ]
+          then
+            sleep 2
+          else
+            echo "Workflow failed to trigger"
+            echo "$resp"
+            exit 1
+          fi
+      - name: Remote Dispatch
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        if: ${{ env.REMOTE_DISPATCH_TOKEN }}
+        run: |
+          # If we are in the wildfly/wildfly repository, we should invoke the cloud tests in wildfly-extras
+          # Otherwise invoke in the user's organisation
+          if [ "${GITHUB_REPOSITORY_OWNER}" = "wildfly" ]; then
+            CLOUD_TESTS_REPOSITORY="wildfly-extras/wildfly-cloud-tests"
+          else
+            CLOUD_TESTS_REPOSITORY="${GITHUB_REPOSITORY_OWNER}/wildfly-cloud-tests"
+          fi
+          
+          echo "Remote repository: ${CLOUD_TESTS_REPOSITORY}"
+          
+          CLIENT_PAYLOAD=$( jq -n \
+                  --arg tr "$GITHUB_REPOSITORY" \
+                  --arg githubSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
+                  --arg prHeadSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
+                  --arg pr "$PR_NUMBER" \
+                  '{triggerRepo: $tr, githubSha: $githubSha, prHeadSha: $prHeadSha, pr: $pr}' )
+
+          echo "CLIENT_PAYLOAD: $CLIENT_PAYLOAD"
+
+          set -x
+
+          resp=$(curl -X POST -s "https://api.github.com/repos/${CLOUD_TESTS_REPOSITORY}/dispatches" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${REMOTE_DISPATCH_TOKEN}" \
+              -d "{\"event_type\": \"${EVENT_TYPE}\", \"client_payload\": ${CLIENT_PAYLOAD} }")
+          
+          set +x
+          
+          if [ -z "$resp" ]
+          then
+            sleep 2
+          else
+            echo "Workflow failed to trigger"
+            echo "$resp"
+            exit 1
+          fi
+
+      - name: Report failure
+        if: ${{ failure() }}
+        env:
+          REPORTER_EVENT_TYPE: report-cloud-tests-workflow-run-failed
+        run: |
+            # There is no 'cancelled' status, just error, failure, pending and success
+            STATUS="failure"
+            TEXT="The attempt to start the remote job failed, or was cancelled"
+            RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            CLIENT_PAYLOAD=$( jq -n \
+                    --arg prHeadSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
+                    --arg state "$STATUS" \
+                    --arg runUrl "$RUN_URL" \
+                    --arg desc "$TEXT" \
+                    '{prHeadSha: $prHeadSha, state: $state, runUrl: $runUrl, desc: $desc}' )
+            
+            echo "CLIENT_PAYLOAD: $CLIENT_PAYLOAD"
+  
+            resp=$(curl -X POST -s "https://api.github.com/repos/$GITHUB_REPOSITORY/dispatches" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${REMOTE_DISPATCH_TOKEN}" \
+                -d "{\"event_type\": \"${REPORTER_EVENT_TYPE}\", \"client_payload\": ${CLIENT_PAYLOAD} }")
+            if [ -z "$resp" ]
+            then
+              sleep 2
+            else
+              echo "Workflow failed to trigger"
+              echo "$resp"
+              exit 1
+            fi


### PR DESCRIPTION
This is so that we can get the proper sha to the merge of the PR into the main branch (the 'pull_request' workflow) and have access to the secret needed to do the remote dispatch (the 'workflow_run' workflow)

[WFLY-19889](https://issues.redhat.com/browse/WFLY-19889)