### PR TITLE
[WFLY-19889] Propagate the actual merge commit to cloud-tests

### DIFF
--- a/.github/workflows/cloud-test-pr-trigger.yml
+++ b/.github/workflows/cloud-test-pr-trigger.yml
@@ -38,20 +38,9 @@ jobs:
     - name: Get pull request number
       run: |
         event_name="${{ github.event_name }}"
-        
-        if [ "${event_name}" == "pull_request" ]; then
-          echo "This is a pull request"
-          echo "PR_NUMBER=${{ github.event.number }}" >> .job-env
-          echo "GITHUB_SHA_FOR_PR=${{ github.sha }}" >> .job-env
-          echo "GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> .job-env
-        elif [ "${event_name}" == "push" ]; then
-          echo "This is a push"
-          echo "PR_NUMBER=push" >> .job-env
-          echo "GITHUB_SHA=${{ github.sha }}" >> .job-env
-        else
-          echo "The ${event_name} event is not handled by this workflow"
-          exit 1
-        fi
+        echo "PR_NUMBER=${{ github.event.number }}" >> .job-env
+        echo "GITHUB_SHA_FOR_PR=${{ github.sha }}" >> .job-env
+        echo "GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> .job-env
         cat .job-env
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/cloud-test-pr-workflow-run.yml
+++ b/.github/workflows/cloud-test-pr-workflow-run.yml
@@ -95,7 +95,7 @@ jobs:
           
           CLIENT_PAYLOAD=$( jq -n \
                   --arg tr "$GITHUB_REPOSITORY" \
-                  --arg githubSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
+                  --arg githubSha "$GITHUB_SHA_FOR_PR" \
                   --arg prHeadSha "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" \
                   --arg pr "$PR_NUMBER" \
                   '{triggerRepo: $tr, githubSha: $githubSha, prHeadSha: $prHeadSha, pr: $pr}' )


### PR DESCRIPTION
Followup for https://issues.redhat.com/browse/WFLY-19889 / https://github.com/wildfly/wildfly/pull/18329

Remove the push case which isn't relevant here.

Propagate the merge commit to remote CI (was accidentally using the pr head).

This has been verified via a PR in my repository. https://github.com/kabir/wildfly/pull/59

The head of the PR is 6faf72591546dc66caba1ba4252548debc77ec79
At the time of writing the main branch sha is 2ed62572194a8f09dde55aca3ca4d80571629b17

The trigger job https://github.com/kabir/wildfly/actions/runs/11575716317 outputs
```
PR_NUMBER=59
GITHUB_SHA_FOR_PR=db1b5fc50d3e3008feffe64acdf44a24b710fc1e
GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=6faf72591546dc66caba1ba4252548debc77ec79
```

The workflow run job outputs
```
 curl -X POST -s https://api.github.com/repos/kabir/wildfly-cloud-tests/dispatches -H 'Accept: application/vnd.github.v3+json' -H 'Content-Type: application/json' -H 'Authorization: ***' -d '{"event_type": "trigger-cloud-tests-pr", "client_payload": {
  "triggerRepo": "kabir/wildfly",
  "githubSha": "db1b5fc50d3e3008feffe64acdf44a24b710fc1e",
  "prHeadSha": "6faf72591546dc66caba1ba4252548debc77ec79",
  "pr": "59"
} }'
```

And on the cloud tests side I see https://github.com/kabir/wildfly-cloud-tests/actions/runs/11575728467/job/32223011050

```
*****
{
  githubSha: db1b5fc50d3e3008feffe64acdf44a24b710fc1e,
  pr: 59,
  prHeadSha: 6faf72591546dc66caba1ba4252548debc77ec79,
  triggerRepo: kabir/wildfly
}
```
githubSha is what gets cloned when building wildfly https://github.com/wildfly-extras/wildfly-cloud-tests/blob/main/.github/workflows/wildfly-cloud-tests-callable.yml#L94-L102

And prHeadSha is used to communicate back about the progress (I know this works from the status on the test PR)