### PR TITLE
[WFLY-19899] Upgrade WildFly Core to 27.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19899

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/27.0.0.Beta1...27.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7036'>WFCORE-7036</a>] -         TransformationUtils.modelToResource() sometimes returns an undefined model
</li>
</ul>
                                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7034'>WFCORE-7034</a>] -         Upgrade JBoss Remoting to 5.0.30.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7037'>WFCORE-7037</a>] -         Upgrade io.smallrye:jandex from 3.2.2 to 3.2.3
</li>
</ul>
</details>

