### PR TITLE
WFLY-19888 Update documentation stating that JDK 17 is now required

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To run all the tests
 Using Eclipse
 -------------
 1. Install the latest version of eclipse
-2. Make sure Xmx in eclipse.ini is at least 1280M, and it's using Java 11
+2. Make sure Xmx in eclipse.ini is at least 1280M, and it's using JDK 17
 3. Launch eclipse and install the m2e plugin, make sure it uses your repo configs
    (get it from: http://www.eclipse.org/m2e/
    or install "Maven Integration for Eclipse" from the Eclipse Marketplace)

--- a/docs/src/main/asciidoc/_hacking/contributing.adoc
+++ b/docs/src/main/asciidoc/_hacking/contributing.adoc
@@ -10,14 +10,15 @@ ifdef::env-github[]
 endif::[]
 
 * Latest Maven build tool https://maven.apache.org/
-* OpenJDK 11 (eleven!) You can use any distribution in example Eclipse https://adoptium.net/
-* Eclipse https://www.eclipse.org/downloads/packages/[Eclipse Download] or any other IDE allowing correct source formatting (IntelliJ)
+* JDK 17 You can use any distribution in example Eclipse https://adoptium.net/
+* https://www.eclipse.org/downloads/packages/[Eclipse] or any other IDE allowing correct source formatting (IntelliJ)
 
 = Maven
 Use maven. Simplest is to use the build.sh or build.bat scripts in the root of the source tree. If you don't use those scripts and use the ```mvn``` command directly, note that WildFly's root pom will enforce a minimum maven version.
 
-Building WildFly requires Java 11 or newer. Make sure you have JAVA_HOME set to point to the JDK11 installation. Build uses Maven 3.
-
+Building WildFly requires JDK 17 or newer.
+Make sure you have JAVA_HOME set to point to the JDK 17 installation.
+Build uses Maven 3.
 
 [source,options="nowrap"]
 ----


### PR DESCRIPTION
No Jira required.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-19888](https://issues.redhat.com/browse/WFLY-19888)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)