### PR TITLE
[WFLY-19908] Forces user BOMs to channel version in reactor

### DIFF
--- a/boms/user/client/ejb-client/pom.xml
+++ b/boms/user/client/ejb-client/pom.xml
@@ -85,6 +85,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-ee</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/client/jaxws-client/pom.xml
+++ b/boms/user/client/jaxws-client/pom.xml
@@ -85,6 +85,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-ee</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/client/jms-client/pom.xml
+++ b/boms/user/client/jms-client/pom.xml
@@ -85,6 +85,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-ee</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/pom.xml
+++ b/boms/user/pom.xml
@@ -30,6 +30,9 @@
     <properties>
         <!-- the BOMs built's artifactId prefix-->
         <bomArtifactIdPrefix>wildfly</bomArtifactIdPrefix>
+        <!-- overridable channel versions -->
+        <version.boms.channel.ee>${ee.maven.version}</version.boms.channel.ee>
+        <version.boms.channel.full>${full.maven.version}</version.boms.channel.full>
     </properties>
 
     <licenses>

--- a/boms/user/server/ee/preview/pom.xml
+++ b/boms/user/server/ee/preview/pom.xml
@@ -82,6 +82,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-preview</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/server/ee/standard/pom.xml
+++ b/boms/user/server/ee/standard/pom.xml
@@ -82,6 +82,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-ee</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/server/expansion/preview/pom.xml
+++ b/boms/user/server/expansion/preview/pom.xml
@@ -82,6 +82,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-preview</artifactId>
+                                        <version>${version.boms.channel.full}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/server/expansion/standard/pom.xml
+++ b/boms/user/server/expansion/standard/pom.xml
@@ -82,6 +82,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly</artifactId>
+                                        <version>${version.boms.channel.full}</version>
                                     </manifest>
                                 </channel>
                             </channels>

--- a/boms/user/tools/pom.xml
+++ b/boms/user/tools/pom.xml
@@ -82,6 +82,7 @@
                                     <manifest>
                                         <groupId>org.wildfly.channels</groupId>
                                         <artifactId>wildfly-ee</artifactId>
+                                        <version>${version.boms.channel.ee}</version>
                                     </manifest>
                                 </channel>
                             </channels>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19908