### PR TITLE
[34.x] [WFLY-19927] & [WFLY-19928] Upgrade RESTEasy in WildFly and WildFly Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -52,7 +52,7 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.0</version.org.glassfish.jakarta.faces>
-        <version.org.jboss.resteasy>7.0.0.Alpha3</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>7.0.0.Alpha4</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Beta4</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Beta5</version.org.jboss.weld.weld-api>
         <version.org.hibernate.validator>9.0.0.Beta2</version.org.hibernate.validator>

--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <version.org.jboss.mod_cluster>2.0.4.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.0.2.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>6.2.10.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.11.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>2.1.5.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.1.3.Final</version.org.jboss.resteasy.spring>


### PR DESCRIPTION
# 6.2.11.Final (WildFly)

Issue: https://issues.redhat.com/browse/WFLY-19927
Tag: https://github.com/resteasy/resteasy/releases/tag/6.2.11.Final
Diff: https://github.com/resteasy/resteasy/compare/6.2.10.Final...6.2.11.Final

# 7.0.0.Alpha4 (WildFly Preview)

Issue: https://issues.redhat.com/browse/WFLY-19928
Tag: https://github.com/resteasy/resteasy/releases/tag/7.0.0.Alpha4
Diff: https://github.com/resteasy/resteasy/compare/7.0.0.Alpha3...7.0.0.Alpha4

Upstream: #18358 