### PR TITLE
[WFLY-19934] Bump version.org.wildfly.bom-builder-plugin to 2.0.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
         <version.org.jboss.galleon>6.0.2.Final</version.org.jboss.galleon>
         <version.org.jboss.wildscribe>3.1.0.Final</version.org.jboss.wildscribe>
         <version.org.owasp.dependency-check>10.0.2</version.org.owasp.dependency-check>
-        <version.org.wildfly.bom-builder-plugin>2.0.7.Final</version.org.wildfly.bom-builder-plugin>
+        <version.org.wildfly.bom-builder-plugin>2.0.8.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.2.1.Final</version.org.wildfly.galleon-plugins>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19934