### PR TITLE
[mp-7-wip] WFLY-19592 Update MicroProfile Fault Tolerance Subsystem documentatio…

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Fault_Tolerance_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Fault_Tolerance_SmallRye.adoc
@@ -11,9 +11,9 @@ endif::[]
 
 == Specification
 
-WildFly's MicroProfile Fault Tolerance subsystem implements MicroProfile Fault Tolerance 4.0.
+WildFly's MicroProfile Fault Tolerance subsystem implements MicroProfile Fault Tolerance 4.1.
 
-This MicroProfile specification provides the following interceptor bindings:
+This MicroProfile specification provides the following interceptor bindings in its `org.eclipse.microprofile.faulttolerance` package:
 
 * `@Timeout` to define a maximum duration or an execution.
 * `@Retry` to attempt execution again in case of a failure.
@@ -22,10 +22,10 @@ This MicroProfile specification provides the following interceptor bindings:
 * `@Bulkhead` to limit concurrent executions so that one method doesn't overload the entire system.
 * `@Asynchronous` to execute a method asynchronously.
 
-For complete documentation please refer to MicroProfile Fault Tolerance 4.0 https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0/microprofile-fault-tolerance-spec-4.0.html[specification].
+For complete documentation please refer to MicroProfile Fault Tolerance 4.1 https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.1/microprofile-fault-tolerance-spec-4.1.html[specification].
 
 Support for https://microprofile.io/project/eclipse/microprofile-fault-tolerance[MicroProfile Fault Tolerance] is
-provided as by the `microprofile-fault-tolerance-smallrye` subsystem.
+provided by the `microprofile-fault-tolerance-smallrye` subsystem.
 
 The MicroProfile Fault Tolerance implementation is provided by the https://github.com/smallrye/smallrye-fault-tolerance[SmallRye Fault Tolerance] project.
 
@@ -34,13 +34,18 @@ The MicroProfile Fault Tolerance implementation is provided by the https://githu
 == Required Extension
 
 This extension is automatically included in the `standalone-microprofile` server profiles,
-however, it is not included by default in the default configuration of WildFly.
+however, it is not included in the default configuration of WildFly.
 
-NOTE: The MicroProfile Metrics extension and subsystem are required by this extension to provide Metrics integration,
-please follow the instructions in the <<required-extension-microprofile-metrics-smallrye,MicroProfile Metrics Subsystem Configuration section>>.
-If the Metrics subsystem is not available, no metrics data will be collected.
+This extension requires the MicroProfile Telemetry extension and subsystem
+to provide metrics collection integration as defined by the specification.
+Please follow the instructions in the <<MicroProfile_Telemetry,MicroProfile Telemetry Subsystem section>>.
+If the MicroProfile Telemetry subsystem is not available, metrics collection will be collected using Micrometer.
+If neither subsystem is available, no Fault Tolerance metrics data will be collected.
 
-You can add the extension to a configuration without it either by using the following CLI operations:
+NOTE: Please note that while the specification defines metrics integration with MicroProfile Metrics,
+WildFly no longer provides this specification implementation, subsystem and thus neither the integration.
+
+You can add the extension to an existing server profile by using the following CLI operations:
 
 [source,options="nowrap"]
 ----
@@ -58,7 +63,7 @@ You can add the extension to a configuration without it either by using the foll
 [standalone@localhost:9990 /] reload
 ----
 
-Or by adding an element to the application server profile XML to `<extensions>` section:
+Alternatively, the same can be achieved by adding an element to the application server profile XML to `<extensions>` section:
 
 [source,xml,options="nowrap"]
 ----
@@ -72,13 +77,13 @@ and then the subsystem in the `<profile>` section:
 <subsystem xmlns="urn:wildfly:microprofile-fault-tolerance-smallrye:1.0"/>
 ----
 
-The subsystem itself does not have any configurable elements.
+The subsystem itself does not have any configurable attributes nor resources.
 
 
 == Configuration
 
 Apart from configuration properties defined by the specification, the SmallRye implementation provides the following
-configuration properties:
+configuration properties which can be provided using standard MicroProfile Config mechanisms:
 
 .SmallRye Fault Tolerance configuration properties
 |===


### PR DESCRIPTION
…n section.

Community documentation for https://issues.redhat.com/browse/WFLY-19592

Docs only - so no CI needed.