### PR TITLE
WFLY-19935 Upgrade Weld version in Preview to 6.0.0.CR1

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -53,8 +53,8 @@
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.0</version.org.glassfish.jakarta.faces>
         <version.org.jboss.resteasy>7.0.0.Alpha3</version.org.jboss.resteasy>
-        <version.org.jboss.weld.weld>6.0.0.Beta4</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>6.0.Beta5</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>6.0.0.CR1</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>6.0.CR1</version.org.jboss.weld.weld-api>
         <version.org.hibernate.validator>9.0.0.Beta2</version.org.hibernate.validator>
     </properties>
 


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-19935

Weld 6 CR1 has re-enabled all CDI TCK testing (including finally released Jakarta EE platform TCK artifact) and I got a pass on WFLY.
Unless there are further issues, I am planning to perform a Final release with no further modifications/fixes.