### PR TITLE
[WFLY-19936]:Upgrade woodstox-core from 6.4.0 to 7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
         <version.org.bitbucket.jose4j>0.9.6</version.org.bitbucket.jose4j>
         <version.org.bytebuddy>1.14.18</version.org.bytebuddy>
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
-        <version.org.codehaus.woodstox.woodstox-core>6.4.0</version.org.codehaus.woodstox.woodstox-core>
+        <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.eclipse.angus.angus-activation>2.0.2</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>2.0.3</version.org.eclipse.angus.angus-mail>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19936