### PR TITLE
[WFLY-19938] OpenTelemetrySetupTask should not remove the subsystem if it did not add it

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
@@ -22,14 +22,19 @@ public class OpenTelemetrySetupTask extends AbstractSetupTask {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollectorContainer;
 
+    private volatile boolean addedExtension;
+    private volatile boolean addedSubsystem;
+
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
         if (!Operations.isSuccessfulOutcome(executeRead(managementClient, extensionAddress))) {
             executeOp(managementClient, Operations.createAddOperation(extensionAddress));
+            addedExtension = true;
         }
 
         if (!Operations.isSuccessfulOutcome(executeRead(managementClient, subsystemAddress))) {
             executeOp(managementClient, Operations.createAddOperation(subsystemAddress));
+            addedSubsystem = true;
         }
 
         executeOp(managementClient, writeAttribute(SUBSYSTEM_NAME, "batch-delay", "1"));
@@ -43,8 +48,12 @@ public class OpenTelemetrySetupTask extends AbstractSetupTask {
     public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
         otelCollectorContainer.stop();
 
-        executeOp(managementClient, Operations.createRemoveOperation(subsystemAddress));
-        executeOp(managementClient, Operations.createRemoveOperation(extensionAddress));
+        if (addedSubsystem) {
+            executeOp(managementClient, Operations.createRemoveOperation(subsystemAddress));
+        }
+        if (addedExtension) {
+            executeOp(managementClient, Operations.createRemoveOperation(extensionAddress));
+        }
 
         ServerReload.reloadIfRequired(managementClient);
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19938

Modify ServerSetupTask