### PR TITLE
[WFLY-19924] - OpenTelemetry quickstart application logs warning with NoClassDefFoundError exceptionafter URL request

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
@@ -17,6 +17,7 @@
 
     <dependencies>
         <module name="org.wildfly.extension.opentelemetry-api"/>
+        <module name="io.netty.netty-common"/>
         <module name="io.opentelemetry.api" />
         <module name="io.opentelemetry.sdk" />
         <module name="io.opentelemetry.context" />

--- a/legacy/opentracing-extension/pom.xml
+++ b/legacy/opentracing-extension/pom.xml
@@ -77,6 +77,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <!-- This is only required for the extension to initialize Netty's InternalLoggerFactory -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/observability/opentelemetry/pom.xml
+++ b/observability/opentelemetry/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>smallrye-opentelemetry-propagation</artifactId>
         </dependency>
 
+        <!-- This is only required for the extension to initialize Netty's InternalLoggerFactory -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+
         <!-- ======================================================= -->
 
         <dependency>

--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.opentelemetry;
 
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.JdkLoggerFactory;
 import org.wildfly.subsystem.SubsystemConfiguration;
 import org.wildfly.subsystem.SubsystemExtension;
 import org.wildfly.subsystem.SubsystemPersistence;
@@ -18,5 +20,8 @@ public class OpenTelemetrySubsystemExtension extends SubsystemExtension<OpenTele
                 OpenTelemetrySubsystemModel.CURRENT,
                 OpenTelemetrySubsystemRegistrar::new),
                 SubsystemPersistence.of(OpenTelemetrySubsystemSchema.CURRENT));
+
+        // Initialize the Netty logger factory
+        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19924

Add netty module dep
Set netty default logger factory
