### PR TITLE
[WFLY-19942] io.smallrye.reactive.mutiny.vertx-core module needs to depend on io.netty.netty-transport module

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/reactive/mutiny/vertx-core/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/reactive/mutiny/vertx-core/main/module.xml
@@ -14,6 +14,7 @@
 
     <dependencies>
         <module name="io.vertx.core"/>
+        <module name="io.netty.netty-transport" />
         <module name="io.smallrye.reactive.mutiny"/>
         <module name="io.smallrye.reactive.mutiny.vertx-runtime"/>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19942 