### PR TITLE
[WFLY-19953] Upgrade Jackson to 2.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.antlr>4.13.0</version.antlr>
         <version.com.carrotsearch.hppc>0.8.1</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.17.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.18.1</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.com.fasterxml.jackson.jr.jackson-jr-objects>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.jr.jackson-jr-objects>
         <version.com.github.ben-manes.caffeine>3.1.8</version.com.github.ben-manes.caffeine>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19953

This was originally part of #18325 but Emmanuel withdrew it as off-topic. But many affected folks already signed off on it so it seems reasonable to move it forward.