### PR TITLE
WFLY-19891 Fix deadlock when application tries to invoke a timed-out timer referenced from TimerService.getTimers() within a @Timeout method.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/distributable/DistributableTimerService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/distributable/DistributableTimerService.java
@@ -16,6 +16,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
@@ -210,8 +212,11 @@ public class DistributableTimerService<I> implements ManagedTimerService {
     }
 
     private void addTimers(Collection<jakarta.ejb.Timer> timers, Iterable<I> timerIds) {
+        ManagedTimer currentTimer = Optional.ofNullable(CurrentInvocationContext.get()).map(InterceptorContext::getTimer).filter(ManagedTimer.class::isInstance).map(ManagedTimer.class::cast).orElse(null);
         for (I timerId : timerIds) {
-            timers.add(new OOBTimer<>(this.manager, timerId, this.invoker, this.synchronizationFactory));
+            ManagedTimer timer = new OOBTimer<>(this.manager, timerId, this.invoker, this.synchronizationFactory);
+            // Use timer from interceptor context, if one exists
+            timers.add(Objects.equals(timer, currentTimer) ? currentTimer : timer);
         }
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/AbstractManualTimerBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/timer/beans/AbstractManualTimerBean.java
@@ -7,6 +7,7 @@ package org.jboss.as.test.clustering.cluster.ejb.timer.beans;
 
 import java.util.function.Function;
 
+import jakarta.ejb.EJBException;
 import jakarta.ejb.NoSuchObjectLocalException;
 import jakarta.ejb.Timeout;
 import jakarta.ejb.Timer;
@@ -48,5 +49,9 @@ public abstract class AbstractManualTimerBean extends AbstractTimerBean implemen
     @Timeout
     public void timeout(Timer timer) {
         this.record(timer);
+        // WFLY-19891 Verify that this does not deadlock
+        if (!timer.getInfo().equals(this.service.getTimers().stream().filter(timer::equals).findFirst().map(Timer::getInfo).orElse(null))) {
+            throw new EJBException();
+        }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19891