### PR TITLE
[WFLY-19968] Switch from org.wildfly.core:wildfly-launcher to org.wildfly.launcher:wildfly-launcher

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -4156,6 +4156,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wildfly.launcher</groupId>
+                <artifactId>wildfly-launcher</artifactId>
+                <version>${version.org.wildfly.launcher}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.wildfly.transaction</groupId>
                 <artifactId>wildfly-transaction-client</artifactId>
                 <version>${version.org.wildfly.transaction.client}</version>

--- a/ee-feature-pack/galleon-shared/pom.xml
+++ b/ee-feature-pack/galleon-shared/pom.xml
@@ -2997,6 +2997,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.launcher</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.wildfly-http-client</groupId>
             <artifactId>wildfly-http-client-common</artifactId>
             <exclusions>

--- a/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/packages/core-tools/pm/wildfly/tasks.xml
@@ -6,6 +6,6 @@
   -->
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.2">
-    <copy-artifact artifact="org.wildfly.core:wildfly-launcher" to-location="bin/launcher.jar"/>
+    <copy-artifact artifact="org.wildfly.launcher:wildfly-launcher" to-location="bin/launcher.jar"/>
     <assemble-shaded-artifact shaded-model-package="org.wildfly.core.wildfly-elytron-tool-wrapper.shaded" to-location="bin/wildfly-elytron-tool.jar"/>
 </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -583,6 +583,7 @@
         <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
         <version.org.wildfly.core>27.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.launcher>1.0.0.Beta1</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -97,15 +97,15 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-launcher</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-network</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.launcher</groupId>
+            <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>

--- a/testsuite/layers-expansion/pom.xml
+++ b/testsuite/layers-expansion/pom.xml
@@ -39,7 +39,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -39,7 +39,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -56,11 +56,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-model-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -79,6 +74,10 @@
                 </exclusion>
             </exclusions>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.launcher</groupId>
+            <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19968

Note: this must be merged before the WFCORE-7044 removal of the launcher module in wildfly-core; otherwise WildFly Core CI will fail.