### PR TITLE
WFLY-19974 Update Arquillian Testcontainers to 1.0.0.Alpha3

### DIFF
--- a/boms/standard-test-expansion/pom.xml
+++ b/boms/standard-test-expansion/pom.xml
@@ -232,6 +232,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-testcontainers</artifactId>
+                <version>${version.org.jboss.arquillian.testcontainers}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
                 <version>${version.org.jboss.weld.weld}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,7 @@
         <version.org.javassist>3.29.2-GA</version.org.javassist>
         <version.org.jboss.arquillian.core>1.9.1.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.jakarta>10.0.0.Final</version.org.jboss.arquillian.jakarta>
+        <version.org.jboss.arquillian.testcontainers>1.0.0.Alpha3</version.org.jboss.arquillian.testcontainers>
         <version.org.jboss.byteman>4.0.23</version.org.jboss.byteman>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itself  -->

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -401,7 +401,6 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-testcontainers</artifactId>
-            <version>1.0.0.Alpha1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -1011,6 +1010,35 @@
                                 <phase>none</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>disable-container-tests</id>
+            <!--
+                There is currently no way to identify hosts on which Docker-based tests should not run apart from an
+                OS check. There are CI updates in the pipeline (see https://issues.redhat.com/browse/WFCI-63 and
+                https://issues.redhat.com/browse/WFCI-64, for example) that will require this to be modified. Ideally,
+                a system property or environment variable can be set to indicate that such tests should not be run. For
+                now, we'll have to live with an OS check, which addresses the immediate need.
+            -->
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <org.arquillian.testcontainers.docker.required.exception>org.junit.AssumptionViolatedException</org.arquillian.testcontainers.docker.required.exception>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deployment.FaultTolerantApplication;
@@ -46,7 +45,7 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class FaultToleranceMicrometerIntegrationTestCase {
 
     // Let's use a slightly higher number of invocations, so we can at times differentiate between stale read and other problems

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
@@ -23,7 +23,6 @@ import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.FaultToleranceMicrometerIntegrationTestCase;
@@ -38,7 +37,7 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(MicrometerSetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class MultipleDeploymentMetricsTestCase {
 
     public static final String DEPLOYMENT_1 = "deployment-1";

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
@@ -16,7 +16,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.opentelemetry.application.JaxRsActivator;
@@ -24,7 +23,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.JaxR
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class BasicMicrometerTestCase {
     @Inject
     private MeterRegistry meterRegistry;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +38,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.JaxR
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 @RunAsClient
 public class MicrometerOtelIntegrationTestCase {
     public static final int REQUEST_COUNT = 5;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMultipleTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMultipleTestCase.java
@@ -20,12 +20,11 @@ import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorC
 import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 @RunAsClient
 public abstract class BaseMultipleTestCase {
     protected static final String SERVICE_ONE = "service-one";

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
@@ -17,13 +17,12 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @ServerSetup(OpenTelemetrySetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class BasicOpenTelemetryTestCase extends BaseOpenTelemetryTest {
     @Inject
     private Tracer tracer;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -25,7 +25,6 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelService2;
@@ -38,7 +37,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({OpenTelemetrySetupTask.class})
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
@@ -22,7 +22,6 @@ import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.setuptask.ServiceNameSetupTask;
@@ -30,7 +29,7 @@ import org.wildfly.test.integration.observability.setuptask.ServiceNameSetupTask
 @RunWith(Arquillian.class)
 @ServerSetup({OpenTelemetrySetupTask.class, ServiceNameSetupTask.class})
 @RunAsClient
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/preview/microprofile/telemetry/MetricsTestCase.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/preview/microprofile/telemetry/MetricsTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.preview.microprofile.telemetry.application.JaxRsActivator;
@@ -37,7 +36,7 @@ import org.wildfly.test.preview.microprofile.telemetry.application.MetricResourc
 
 @RunWith(Arquillian.class)
 @ServerSetup(OpenTelemetrySetupTask.class)
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 @RunAsClient
 public class MetricsTestCase {
     public static final int REQUEST_COUNT = 5;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/BaseContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/BaseContainer.java
@@ -8,12 +8,11 @@ import java.time.Duration;
 import java.util.List;
 
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
-import org.junit.AssumptionViolatedException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public abstract class BaseContainer<SELF extends GenericContainer<SELF>> extends GenericContainer<SELF> {
     private final String containerName;
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/MicrometerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/MicrometerSetupTask.java
@@ -13,13 +13,12 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.dmr.ModelNode;
-import org.junit.AssumptionViolatedException;
 
 /**
  * Sets up a functioning Micrometer subsystem configuration. Requires functioning Docker environment! Tests using this
  * are expected to call AssumeTestGroupUtil.assumeDockerAvailable(); in a @BeforeClass.
  */
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class MicrometerSetupTask extends AbstractSetupTask {
     private static final ModelNode micrometerExtension = Operations.createAddress("extension", "org.wildfly.extension.micrometer");
     private static final ModelNode micrometerSubsystem = Operations.createAddress("subsystem", "micrometer");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
@@ -11,9 +11,8 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.dmr.ModelNode;
-import org.junit.AssumptionViolatedException;
 
-@DockerRequired(AssumptionViolatedException.class)
+@DockerRequired
 public class OpenTelemetrySetupTask extends AbstractSetupTask {
     private static final String SUBSYSTEM_NAME = "opentelemetry";
     private static final ModelNode extensionAddress = Operations.createAddress("extension", "org.wildfly.extension.opentelemetry");


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19974

* Bump version
* Move version info to managed property
* Remove explicit Exception use in annotation so tests will fail if the container engine is not available
* Add profile to skip tests where docker is not required