### PR TITLE
WFLY-19977 Upgrade wildfly-clustering to 1.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,7 +579,7 @@
         <version.org.opensaml.opensaml>4.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>1.1.3.Final</version.org.wildfly.clustering>
         <version.org.wildfly.core>26.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19977

Fixes https://issues.redhat.com/browse/WFLY-19909