### PR TITLE
WFLY-19977 Upgrade wildfly-clustering to 1.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@
         <version.org.opensaml.opensaml>4.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>1.1.2.Final</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>1.1.3.Final</version.org.wildfly.clustering>
         <version.org.wildfly.core>27.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Beta1</version.org.wildfly.launcher>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19977

Fixes https://issues.redhat.com/browse/WFLY-19909

(Until https://github.com/wildfly/wildfly/pull/18352 is ready)