### PR TITLE
[WFLY-19982] Upgrade WildFly Core to 27.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>1.1.3.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Beta1</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-19982

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/27.0.0.Beta2...27.0.0.Beta3

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6935'>WFCORE-6935</a>] -         Improve systemd service units
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6981'>WFCORE-6981</a>] -         Spurious data in upload-deployment-url reply description
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7031'>WFCORE-7031</a>] -         Unstable annotations package should be provisioned only for preview stability level
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7043'>WFCORE-7043</a>] -         Subsystem-level testing of core-managment is incomplete
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7047'>WFCORE-7047</a>] -         Installation manager integration tests are not executed in the CI
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7058'>WFCORE-7058</a>] -         CachingRealm should start lazily in admin only mode
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7044'>WFCORE-7044</a>] -         Split the launcher into its own repository
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6997'>WFCORE-6997</a>] -         Upgrade snakeyaml to 2.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7046'>WFCORE-7046</a>] -         Upgrade Galleon to 6.0.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7048'>WFCORE-7048</a>] -         Upgrade licenses-plugin to 2.4.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7057'>WFCORE-7057</a>] -         Upgrade JBoss Parent to 47
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7060'>WFCORE-7060</a>] -         Upgrade Jboss Logging Tools to 3.0.3.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7039'>WFCORE-7039</a>] -         Add ServiceInstaller.Builder.onRemove(...) to accomodate ValueRegistry removal
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7049'>WFCORE-7049</a>] -         Remove MaxMetaspaceSize settings
</li>
</ul>
</details>



