### PR TITLE
[WFLY-19985] Upgrade WildFly Arquillian to 5.1.0.Beta7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testcontainers>1.20.3</version.org.testcontainers>
         <version.org.testng>7.5.1</version.org.testng>
-        <version.org.wildfly.arquillian>5.1.0.Beta6</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.1.0.Beta7</version.org.wildfly.arquillian>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>
 

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -233,6 +233,11 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-naming-client</artifactId>
         </dependency>
+        <!-- This is required by the ReadCredentialServlet. -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>

--- a/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
@@ -11,7 +11,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_ENHANCED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STABILITY;
-import static org.jboss.as.server.controller.descriptions.ServerDescriptionConstants.SERVER_ENVIRONMENT;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -42,6 +41,7 @@ import org.junit.Assume;
  * the {@code teardown()} method
  */
 public abstract class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask {
+    private static final String SERVER_ENVIRONMENT ="server-environment";
 
     private final Stability desiredStability;
     private volatile Stability originalStability;

--- a/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/stabilitylevel/StabilityServerSetupSnapshotRestoreTasks.java
@@ -41,7 +41,7 @@ import org.junit.Assume;
  * the {@code teardown()} method
  */
 public abstract class StabilityServerSetupSnapshotRestoreTasks implements ServerSetupTask {
-    private static final String SERVER_ENVIRONMENT ="server-environment";
+    private static final String SERVER_ENVIRONMENT = "server-environment";
 
     private final Stability desiredStability;
     private volatile Stability originalStability;


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19985

Tag: https://github.com/wildfly/wildfly-arquillian/releases/tag/v5.1.0.Beta7
Diff: https://github.com/wildfly/wildfly-arquillian/compare/5.1.0.Beta6...v5.1.0.Beta7

This also includes a couple fixes due to https://github.com/wildfly/wildfly-arquillian/pull/508. The removal of the `org.wildfly.arquillian:wildfly-arquillian-testenricher-msc` which has a dependency on the `org.wildfly.core:wildfly-server` was causing issues with the shared testsuite module. 
