### PR TITLE
Fix for WFLY-19989, h2-driver layer rule for jakarta DataSourceDefinition annotation

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
@@ -8,6 +8,8 @@
     <props>
         <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/datasource/driver,h2"/>
         <prop name="org.wildfly.rule.xml-path-xa" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/xa-datasource/driver,h2"/>
+        <prop name="org.wildfly.rule.annotation.field.value-url" value="jakarta.annotation.sql.DataSourceDefinition,url=jdbc:h2:*"/>
+        <prop name="org.wildfly.rule.annotation.field.value-className" value="jakarta.annotation.sql.DataSourceDefinition,className=org.h2.*"/>
     </props>
     <dependencies>
         <layer name="datasources"/>

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
@@ -44,6 +44,22 @@ public class H2DriverLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase
         checkLayersForArchive(p);
     }
 
+    @Test
+    public void testJakartaDataSourceDefinitionAnnotationUsage() throws Exception {
+        testWarWithClass(JakartaDataSourceDefinitionAnnotationUsage.class);
+    }
+
+    private void testWarWithClass(Class<?> clazz) {
+        Path p = createArchiveBuilder(ArchiveType.WAR)
+                .addClasses(clazz)
+                .build();
+        ExpectedLayers el = new ExpectedLayers();
+        el.addDecorator("h2-driver");
+        el.addLayer("h2-driver");
+        el.addLayer("ee-integration");
+        checkLayersForArchive(p,  el);
+    }
+
     private void checkLayersForArchive(Path p) {
         checkLayersForArchive(p, new ExpectedLayers("h2-driver", "h2-driver"));
     }

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/JakartaDataSourceDefinitionAnnotationUsage.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/JakartaDataSourceDefinitionAnnotationUsage.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.ee.feature.pack.layer.tests.h2.driver;
+
+import jakarta.annotation.sql.DataSourceDefinition;
+
+@DataSourceDefinition(name = "x", className = "org.h2.jdbcx.JdbcDataSource")
+public class JakartaDataSourceDefinitionAnnotationUsage {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.2.1.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.glow>1.0.0.Final</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.2.0.Beta2</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.0.1.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.0.Final</version.org.wildfly.unstable.annotation.api>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1322,7 +1322,7 @@
                                 <error>ambiguous resource injection. Enable verbose output to see the locations.</error>
                                 <error>jakarta.naming.Context or InitialContext lookup. Enable verbose output to see the locations.</error>
                             </expected-errors>
-                            <expected-discovery>[bean-validation, cdi, datasources, ee-concurrency, ee-integration, ejb-lite, h2-datasource, h2-default-datasource, jpa, naming, servlet, transactions]==>ee-core-profile-server,ejb-lite,h2-default-datasource,jpa</expected-discovery>
+                            <expected-discovery>[bean-validation, cdi, datasources, ee-concurrency, ee-integration, ejb-lite, h2-datasource, h2-default-datasource, h2-driver, jpa, naming, servlet, transactions]==>ee-core-profile-server,ejb-lite,h2-default-datasource,jpa</expected-discovery>
                             <surefire-execution-for-included-classes>ejb-lite-layers.surefire</surefire-execution-for-included-classes>
                             <add-ons>
                                 <add-on>h2-database:default</add-on>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19989

* With those rules, the h2-driver will be discovered by WildFly Glow (starting 1.2.0.Beta1) based on DataSourceDefinition annotation values.
* Upgrade to WildFly Glow 1.2.0.Beta2 that includes the rule
* Added metadata test to cover the rule
* Updated integration tests with a change of discovered content

This fix is expected by quickstart: https://github.com/wildfly/quickstart/pull/973

