### PR TITLE
WFLY-19995 Upgrade to Hibernate Search 7.2.2.Final / WFLY-19996 Upgrade to Elasticsearch client 8.15.4 / WFLY-19997 Upgrade to com.carrotsearch:hppc 0.10.0 / WFLY-20013 Upgrade to Hibernate ORM 6.6.3.Final

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -28,6 +28,5 @@
         <module name="java.xml"/>
         <module name="jdk.management"/>
         <module name="jdk.unsupported"/>
-        <module name="com.carrotsearch.hppc" />
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.6.2.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.3.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
             Properties for dependencies that solely relate to tests go in the test code section above.
          -->
         <version.antlr>4.13.0</version.antlr>
-        <version.com.carrotsearch.hppc>0.8.1</version.com.carrotsearch.hppc>
+        <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.17.3</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.6.2.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.2.1.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.2.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.9.Final</version.org.hornetq>
         <version.org.infinispan>14.0.32.Final</version.org.infinispan>

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
         <version.org.eclipse.microprofile.telemetry>1.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.4</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.4</version.org.eclipse.yasson>
-        <version.org.elasticsearch.client.rest-client>8.15.0</version.org.elasticsearch.client.rest-client>
+        <version.org.elasticsearch.client.rest-client>8.15.4</version.org.elasticsearch.client.rest-client>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.enterprise.concurrent>3.0.0</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.jaxb>4.0.5</version.org.glassfish.jaxb>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/search/backend/elasticsearch/util/ElasticsearchServerSetupObserver.java
@@ -14,7 +14,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ElasticsearchServerSetupObserver {
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.15.0";
+    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.15.4";
 
     private static final AtomicReference<String> httpHostAddress = new AtomicReference<>();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19995
https://issues.redhat.com/browse/WFLY-19996
https://issues.redhat.com/browse/WFLY-19997
https://issues.redhat.com/browse/WFLY-20013

Hibernate Search 7.2.2 brings a few bug fixes and dependency updates. 

I noticed that the last time we did a Lucene upgrade, I completely missed the hppc dependency, hence the changes in the Lucene module. 

While Hibernate Search also bumped Hibernate ORM to 6.6.3, I'm leaving out that update from this PR as I think @scottmarlow was planning on doing some other changes related to bytecode enhancement.