### PR TITLE
[WFLY-20007] Remove all non-breaking uses of ModuleIdentifier in Messaging Subsystem

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -4,6 +4,8 @@
  */
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -150,7 +152,6 @@ import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.Mode;
@@ -717,8 +718,7 @@ class ServerAdd extends AbstractAddStepHandler {
             String className = classModel.get(NAME).asString();
             String moduleName = classModel.get(MODULE).asString();
             try {
-                ModuleIdentifier moduleID = ModuleIdentifier.fromString(moduleName);
-                Module module = Module.getCallerModuleLoader().loadModule(moduleID);
+                Module module = Module.getCallerModuleLoader().loadModule(canonicalModuleIdentifier(moduleName));
                 Class<?> clazz = module.getClassLoader().loadClass(className);
                 return clazz;
             } catch (Exception e) {

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeFactory.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeFactory.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.messaging.activemq.jms.bridge;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import java.util.Properties;
 import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
 import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
@@ -18,7 +20,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
@@ -66,7 +67,7 @@ public class JMSBridgeFactory {
             // if a module is specified, use it to instantiate the JMSBridge to ensure its ExecutorService
             // will use the correct class loader to execute its threads
             if (moduleName != null) {
-                org.jboss.modules.Module module = org.jboss.modules.Module.getCallerModuleLoader().loadModule(ModuleIdentifier.fromString(moduleName));
+                org.jboss.modules.Module module = org.jboss.modules.Module.getCallerModuleLoader().loadModule(canonicalModuleIdentifier(moduleName));
                 WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
             }
             return new JMSBridgeImpl(sourceCff,

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.messaging.activemq.jms.bridge;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
@@ -12,7 +14,6 @@ import java.util.function.Supplier;
 
 import org.apache.activemq.artemis.jms.bridge.JMSBridge;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -80,8 +81,7 @@ class JMSBridgeService implements Service<JMSBridge> {
     public void startBridge() throws Exception {
         final Module module;
         if (moduleName != null) {
-            ModuleIdentifier moduleID = ModuleIdentifier.fromString(moduleName);
-            module =  Module.getContextModuleLoader().loadModule(moduleID);
+            module =  Module.getContextModuleLoader().loadModule(canonicalModuleIdentifier(moduleName));
         } else {
             module = Module.forClass(JMSBridgeService.class);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20007

[WFLY-20007] Remove all non-breaking uses of `ModuleIdentifier` in Messaging Subsystem

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-17539](https://issues.redhat.com/browse/WFLY-17539)
> * [WFLY-19988](https://issues.redhat.com/browse/WFLY-19988)
> * [WFLY-19985](https://issues.redhat.com/browse/WFLY-19985)
> * [WFLY-19994](https://issues.redhat.com/browse/WFLY-19994)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)