### PR TITLE
[WFLY-20008] Remove all non-breaking uses of ModuleIdentifier in Pojo Subsystem

### DIFF
--- a/pojo/src/main/java/org/jboss/as/pojo/KernelDeploymentModuleProcessor.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/KernelDeploymentModuleProcessor.java
@@ -15,7 +15,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.filter.PathFilter;
 import org.jboss.modules.filter.PathFilters;
@@ -29,7 +28,7 @@ import java.util.List;
  */
 public class KernelDeploymentModuleProcessor implements DeploymentUnitProcessor {
 
-    private ModuleIdentifier POJO_MODULE = ModuleIdentifier.create("org.jboss.as.pojo");
+    private final String POJO_MODULE = "org.jboss.as.pojo";
 
     /**
      * Add POJO module if we have any bean factories.

--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/ConfigVisitor.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/ConfigVisitor.java
@@ -9,7 +9,6 @@ import org.jboss.as.pojo.BeanState;
 import org.jboss.as.pojo.service.BeanInfo;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceName;
 
@@ -55,7 +54,7 @@ public interface ConfigVisitor {
      * @param identifier the module identifier
      * @return loaded module
      */
-    Module loadModule(ModuleIdentifier identifier);
+    Module loadModule(String identifier);
 
     /**
      * Get reflection index.

--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/DefaultConfigVisitor.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/DefaultConfigVisitor.java
@@ -9,7 +9,6 @@ import org.jboss.as.pojo.BeanState;
 import org.jboss.as.pojo.service.BeanInfo;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -50,7 +49,7 @@ public class DefaultConfigVisitor extends AbstractConfigVisitor {
     }
 
     @Override
-    public Module loadModule(ModuleIdentifier identifier) {
+    public Module loadModule(String identifier) {
         try {
             return module.getModule(identifier);
         } catch (Throwable t) {

--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/KernelDeploymentXmlDescriptorParser.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/KernelDeploymentXmlDescriptorParser.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.pojo.BeanState;
 import org.jboss.as.pojo.ParseResult;
 import org.jboss.as.pojo.logging.PojoLogger;
@@ -362,7 +363,7 @@ public class KernelDeploymentXmlDescriptorParser implements XMLElementReader<Par
 
             switch (attribute) {
                 case NAME:
-                    moduleConfig.setModuleName(attributeValue);
+                    moduleConfig.setModuleName(ModuleIdentifierUtil.canonicalModuleIdentifier(attributeValue));
                     break;
                 default:
                     throw unexpectedAttribute(reader, i);

--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/ModuleConfig.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/ModuleConfig.java
@@ -32,7 +32,7 @@ public class ModuleConfig extends AbstractConfigVisitorNode implements Serializa
                 ServiceName serviceName = ServiceModuleLoader.moduleServiceName(identifier);
                 visitor.addDependency(serviceName, getInjectedModule());
             } else {
-                Module dm = visitor.loadModule(identifier);
+                Module dm = visitor.loadModule(moduleName);
                 getInjectedModule().setValue(() -> dm);
             }
         } else {


### PR DESCRIPTION

Issue: https://issues.redhat.com/browse/WFLY-20008

[WFLY-20008] Remove all non-breaking uses of `ModuleIdentifier` in Pojo Subsystem
