### PR TITLE
[WFLY-20009] Remove all non-breaking uses of ModuleIdentifier in MP Config Subsystem

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceDefinition.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.microprofile.config.smallrye;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILESYSTEM_PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
@@ -36,7 +38,6 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
@@ -120,8 +121,7 @@ class ConfigSourceDefinition extends PersistentResourceDefinition {
         String className = classModel.get(NAME).asString();
         String moduleName = classModel.get(MODULE).asString();
         try {
-            ModuleIdentifier moduleID = ModuleIdentifier.fromString(moduleName);
-            Module module = Module.getCallerModuleLoader().loadModule(moduleID);
+            Module module = Module.getCallerModuleLoader().loadModule(canonicalModuleIdentifier(moduleName));
             Class<?> clazz = module.getClassLoader().loadClass(className);
             return clazz;
         } catch (Exception e) {

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigSourceProviderDefinition.java
@@ -5,6 +5,8 @@
 
 package org.wildfly.extension.microprofile.config.smallrye;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
@@ -26,7 +28,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
@@ -63,8 +64,7 @@ class ConfigSourceProviderDefinition extends PersistentResourceDefinition {
         String className = classModel.get(NAME).asString();
         String moduleName = classModel.get(MODULE).asString();
         try {
-            ModuleIdentifier moduleID = ModuleIdentifier.fromString(moduleName);
-            Module module = Module.getCallerModuleLoader().loadModule(moduleID);
+            Module module = Module.getCallerModuleLoader().loadModule(canonicalModuleIdentifier(moduleName));
             Class<?> clazz = module.getClassLoader().loadClass(className);
             return clazz;
         } catch (Exception e) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20009

[WFLY-20009] Remove all non-breaking uses of ModuleIdentifier in MP Config Subsystem
