### PR TITLE
[WFLY-20011] Remove all non-breaking uses of ModuleIdentifier in Naming Subsystem

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/ExternalContextObjectFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ExternalContextObjectFactory.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.naming;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -28,7 +30,6 @@ import org.jboss.as.server.deployment.ModuleClassFactory;
 import org.jboss.invocation.proxy.ProxyConfiguration;
 import org.jboss.invocation.proxy.ProxyFactory;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -100,7 +101,7 @@ public class ExternalContextObjectFactory implements ObjectFactory {
             Constructor ctor = initialContextClass.getConstructor(Hashtable.class);
             loadedContext = (Context) ctor.newInstance(newEnvironment);
         } else {
-            Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.fromString(initialContextModule));
+            Module module = Module.getBootModuleLoader().loadModule(canonicalModuleIdentifier(initialContextModule));
             loader = module.getClassLoader();
             final ClassLoader currentClassLoader = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
             try {

--- a/naming/src/main/java/org/jboss/as/naming/context/ModularReference.java
+++ b/naming/src/main/java/org/jboss/as/naming/context/ModularReference.java
@@ -8,7 +8,6 @@ package org.jboss.as.naming.context;
 import javax.naming.RefAddr;
 import javax.naming.Reference;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 
 /**
  * Reference implementation that captures a module name and allows object factories to be loaded and created from
@@ -18,7 +17,7 @@ import org.jboss.modules.ModuleIdentifier;
  */
 public class ModularReference extends Reference {
     private static final long serialVersionUID = -4805781394834948096L;
-    private final ModuleIdentifier moduleIdentifier;
+    private final String moduleName;
 
     /**
      * Create a ModuleReference from a target type and factory class.
@@ -39,7 +38,7 @@ public class ModularReference extends Reference {
      * @return A ModularReference
      */
     public static ModularReference create(final String className, final Class<?> factoryClass) {
-        return new ModularReference(className, factoryClass.getName(), Module.forClass(factoryClass).getIdentifier());
+        return new ModularReference(className, factoryClass.getName(), Module.forClass(factoryClass).getName());
     }
 
 
@@ -64,7 +63,7 @@ public class ModularReference extends Reference {
      * @return A ModularReference
      */
     public static ModularReference create(final String className, final RefAddr addr, final Class<?> factoryClass) {
-        return new ModularReference(className, addr, factoryClass.getName(), Module.forClass(factoryClass).getIdentifier());
+        return new ModularReference(className, addr, factoryClass.getName(), Module.forClass(factoryClass).getName());
     }
 
     /**
@@ -72,11 +71,11 @@ public class ModularReference extends Reference {
      *
      * @param className The class name of the target object type
      * @param factory The object factory class name
-     * @param moduleIdentifier The module name to load the factory class
+     * @param moduleName The module name to load the factory class
      */
-    public ModularReference(final String className, final String factory, final ModuleIdentifier moduleIdentifier) {
+    private ModularReference(final String className, final String factory, final String moduleName) {
         super(className, factory, null);
-        this.moduleIdentifier = moduleIdentifier;
+        this.moduleName = moduleName;
     }
 
     /**
@@ -85,11 +84,11 @@ public class ModularReference extends Reference {
      * @param className The class name of the target object type
      * @param addr The address of the object
      * @param factory The object factory class name
-     * @param moduleIdentifier The module name to load the factory class
+     * @param moduleName The module name to load the factory class
      */
-    public ModularReference(final String className, final RefAddr addr, final String factory, final ModuleIdentifier moduleIdentifier) {
+    private ModularReference(final String className, final RefAddr addr, final String factory, final String moduleName) {
         super(className, addr, factory, null);
-        this.moduleIdentifier = moduleIdentifier;
+        this.moduleName = moduleName;
     }
 
     /**
@@ -97,7 +96,7 @@ public class ModularReference extends Reference {
      *
      * @return The module name
      */
-    public ModuleIdentifier getModuleIdentifier() {
-        return moduleIdentifier;
+    public String getModuleName() {
+        return moduleName;
     }
 }

--- a/naming/src/main/java/org/jboss/as/naming/context/ObjectFactoryBuilder.java
+++ b/naming/src/main/java/org/jboss/as/naming/context/ObjectFactoryBuilder.java
@@ -142,7 +142,7 @@ public class ObjectFactoryBuilder implements javax.naming.spi.ObjectFactoryBuild
     }
 
     private ObjectFactory factoryFromModularReference(ModularReference modularReference, final Hashtable<?, ?> environment) throws Exception {
-        final Module module = Module.getCallerModuleLoader().loadModule(modularReference.getModuleIdentifier());
+        final Module module = Module.getCallerModuleLoader().loadModule(modularReference.getModuleName());
         final ClassLoader classLoader = module.getClassLoader();
         return factoryFromReference(modularReference, classLoader, environment);
     }

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -30,7 +30,6 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 
@@ -482,7 +481,7 @@ public interface NamingLogger extends BasicLogger {
      * @return the exception
      */
     @Message(id = 52, value = "Could not load module %s")
-    OperationFailedException couldNotLoadModule(ModuleIdentifier moduleID);
+    OperationFailedException couldNotLoadModule(String moduleID);
 
     /**
      * Creates an exception indicating that a class could not be loaded from a module.
@@ -491,7 +490,7 @@ public interface NamingLogger extends BasicLogger {
      * @return the exception
      */
     @Message(id = 53, value = "Could not load class %s from module %s")
-    OperationFailedException couldNotLoadClassFromModule(String className, ModuleIdentifier moduleID);
+    OperationFailedException couldNotLoadClassFromModule(String className, String moduleID);
 
     /**
      * Creates an exception indicating that a class instance could not be instantiate, from the specified module.
@@ -500,7 +499,7 @@ public interface NamingLogger extends BasicLogger {
      * @return the exception
      */
     @Message(id = 54, value = "Could not instantiate instance of class %s from module %s")
-    OperationFailedException couldNotInstantiateClassInstanceFromModule(String className, ModuleIdentifier moduleID);
+    OperationFailedException couldNotInstantiateClassInstanceFromModule(String className, String moduleID);
 
     /**
      * Creates an exception indicating that a class is not an {@link javax.naming.spi.ObjectFactory} instance, from the specified module.
@@ -509,7 +508,7 @@ public interface NamingLogger extends BasicLogger {
      * @return the exception
      */
     @Message(id = 55, value = "Class %s from module %s is not an instance of ObjectFactory")
-    OperationFailedException notAnInstanceOfObjectFactory(String className, ModuleIdentifier moduleID);
+    OperationFailedException notAnInstanceOfObjectFactory(String className, String moduleID);
 
 //    /**
 //     * A "simple URL" binding add operation was failed by the operation transformer.
@@ -579,7 +578,7 @@ public interface NamingLogger extends BasicLogger {
     OperationFailedException cannotRebindExternalContext();
 
     @Message(id = 65, value = "Could not load module %s - the module or one of its dependencies is missing [%s]")
-    OperationFailedException moduleNotFound(ModuleIdentifier moduleID, String missingModule);
+    OperationFailedException moduleNotFound(String moduleID, String missingModule);
 
     @Message(id = 66, value = "Failed to start remote naming service")
     StartException failedToStartRemoteNamingService(@Cause Throwable cause);

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingBindingAdd.java
@@ -4,6 +4,8 @@
  */
 package org.jboss.as.naming.subsystem;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.TYPE;
 
 import java.net.MalformedURLException;
@@ -38,7 +40,6 @@ import org.jboss.as.naming.service.ExternalContextBinderService;
 import org.jboss.as.naming.service.ExternalContextsService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceBuilder;
@@ -144,7 +145,7 @@ public class NamingBindingAdd extends AbstractAddStepHandler {
     }
 
     private ObjectFactory createObjectFactory(OperationContext context, ModelNode model) throws OperationFailedException {
-        final ModuleIdentifier moduleID = ModuleIdentifier.fromString(NamingBindingResourceDefinition.MODULE.resolveModelAttribute(context, model).asString());
+        final String moduleID = canonicalModuleIdentifier(NamingBindingResourceDefinition.MODULE.resolveModelAttribute(context, model).asString());
         final String className = NamingBindingResourceDefinition.CLASS.resolveModelAttribute(context, model).asString();
         final Module module;
         try {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20011
