### PR TITLE
WFLY-20022 Remove all non-breaking uses of ModuleIdentifier in JSF Subsystem

### DIFF
--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
@@ -21,7 +21,6 @@ import org.jboss.as.web.common.WarMetaData;
 import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.filter.PathFilters;
@@ -33,7 +32,7 @@ import org.jboss.modules.filter.PathFilters;
 public class JSFDependencyProcessor implements DeploymentUnitProcessor {
     public static final String IS_CDI_PARAM = "org.jboss.jbossfaces.IS_CDI";
 
-    private static final ModuleIdentifier JSF_SUBSYSTEM = ModuleIdentifier.create("org.jboss.as.jsf");
+    private static final String JSF_SUBSYSTEM = "org.jboss.as.jsf";
     // We use . instead of / on this stream as a workaround to get it transformed correctly by Batavia into a Jakarta namespace
     private static final String JAVAX_FACES_EVENT_NAMEDEVENT_class = "/jakarta.faces.event.NamedEvent".replaceAll("\\.", "/") + ".class";
 
@@ -93,7 +92,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
     private void addJSFAPI(String jsfVersion, ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
         if (jsfVersion.equals(JsfVersionMarker.WAR_BUNDLES_JSF_IMPL)) return;
 
-        ModuleIdentifier jsfModule = moduleIdFactory.getApiModId(jsfVersion);
+        String jsfModule = moduleIdFactory.getApiModId(jsfVersion);
         ModuleDependency jsfAPI = new ModuleDependency(moduleLoader, jsfModule, false, false, false, false);
         moduleSpecification.addSystemDependency(jsfAPI);
     }
@@ -103,7 +102,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
             ModuleLoader moduleLoader) {
         if (jsfVersion.equals(JsfVersionMarker.WAR_BUNDLES_JSF_IMPL)) return;
 
-        ModuleIdentifier jsfModule = moduleIdFactory.getImplModId(jsfVersion);
+        String jsfModule = moduleIdFactory.getImplModId(jsfVersion);
         ModuleDependency jsfImpl = new ModuleDependency(moduleLoader, jsfModule, false, false, true, false);
         jsfImpl.addImportFilter(PathFilters.getMetaInfFilter(), true);
         moduleSpecification.addSystemDependency(jsfImpl);
@@ -113,7 +112,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
             throws DeploymentUnitProcessingException {
         if (jsfVersion.equals(JsfVersionMarker.WAR_BUNDLES_JSF_IMPL)) return;
 
-        ModuleIdentifier jsfInjectionModule = moduleIdFactory.getInjectionModId(jsfVersion);
+        String jsfInjectionModule = moduleIdFactory.getInjectionModId(jsfVersion);
         ModuleDependency jsfInjectionDependency = new ModuleDependency(moduleLoader, jsfInjectionModule, false, true, true, false);
 
         try {

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFModuleIdFactory.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFModuleIdFactory.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import org.jboss.as.jsf.logging.JSFLogger;
 import org.jboss.as.jsf.subsystem.JSFResourceDefinition;
-import org.jboss.modules.ModuleIdentifier;
+import org.jboss.as.controller.ModuleIdentifierUtil;
 
 /**
  * This class finds all the installed Jakarta Server Faces implementations and provides their ModuleId's.
@@ -34,9 +34,9 @@ public class JSFModuleIdFactory {
     // The default JSF impl slot.  This can be overridden by the management layer.
     private String defaultSlot = JSFResourceDefinition.DEFAULT_SLOT;
 
-    private Map<String, ModuleIdentifier> apiIds = new HashMap<>();
-    private Map<String, ModuleIdentifier> implIds = new HashMap<>();
-    private Map<String, ModuleIdentifier> injectionIds = new HashMap<>();
+    private Map<String, String> apiIds = new HashMap<>();
+    private Map<String, String> implIds = new HashMap<>();
+    private Map<String, String> injectionIds = new HashMap<>();
 
     private Set<String> allVersions = new HashSet<>();
     private List<String> activeVersions = new ArrayList<>();
@@ -79,9 +79,9 @@ public class JSFModuleIdFactory {
 
     // just provide the default implementations
     private void loadIdsManually() {
-        implIds.put("main", ModuleIdentifier.create(IMPL_MODULE));
-        apiIds.put("main", ModuleIdentifier.create(API_MODULE));
-        injectionIds.put("main", ModuleIdentifier.create(INJECTION_MODULE));
+        implIds.put("main", ModuleIdentifierUtil.canonicalModuleIdentifier(IMPL_MODULE, "main"));
+        apiIds.put("main", ModuleIdentifierUtil.canonicalModuleIdentifier(API_MODULE, "main"));
+        injectionIds.put("main", ModuleIdentifierUtil.canonicalModuleIdentifier(INJECTION_MODULE, "main"));
 
         allVersions.add("main");
 
@@ -97,7 +97,7 @@ public class JSFModuleIdFactory {
         checkVersionIntegrity();
     }
 
-    private void loadIds(String moduleRootDir, Map<String, ModuleIdentifier> idMap, String moduleName) {
+    private void loadIds(String moduleRootDir, Map<String, String> idMap, String moduleName) {
         StringBuilder baseDirBuilder = new StringBuilder(moduleRootDir);
         baseDirBuilder.append(File.separator);
         baseDirBuilder.append(moduleName.replace(".", File.separator));
@@ -116,7 +116,7 @@ public class JSFModuleIdFactory {
             if (!new File(slot, "module.xml").exists()) continue; // make sure directory represents a real module
             String slotName = slot.getName();
             allVersions.add(slotName);
-            idMap.put(slotName, ModuleIdentifier.create(moduleName, slotName));
+            idMap.put(slotName, ModuleIdentifierUtil.canonicalModuleIdentifier(moduleName, slotName));
         }
     }
 
@@ -154,15 +154,15 @@ public class JSFModuleIdFactory {
         return jsfVersion;
     }
 
-    ModuleIdentifier getApiModId(String jsfVersion) {
+    String getApiModId(String jsfVersion) {
         return this.apiIds.get(computeSlot(jsfVersion));
     }
 
-    ModuleIdentifier getImplModId(String jsfVersion) {
+    String getImplModId(String jsfVersion) {
         return this.implIds.get(computeSlot(jsfVersion));
     }
 
-    ModuleIdentifier getInjectionModId(String jsfVersion) {
+    String getInjectionModId(String jsfVersion) {
         return this.injectionIds.get(computeSlot(jsfVersion));
     }
 

--- a/jsf/subsystem/src/test/java/org/jboss/as/jsf/deployment/JSFModuleIdFactoryTestCase.java
+++ b/jsf/subsystem/src/test/java/org/jboss/as/jsf/deployment/JSFModuleIdFactoryTestCase.java
@@ -4,10 +4,11 @@
  */
 package org.jboss.as.jsf.deployment;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
+
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -50,27 +51,30 @@ public class JSFModuleIdFactoryTestCase {
    }
 
     @Test
-    @Ignore("Depends on https://issues.redhat.com/browse/WFLY-17405")
     public void modIdsTest() {
-        Assert.assertEquals(API_MODULE, factory.getApiModId("main").getName());
-        Assert.assertEquals("main", factory.getApiModId("main").getSlot());
-        Assert.assertEquals(IMPL_MODULE, factory.getImplModId("main").getName());
-        Assert.assertEquals("main", factory.getImplModId("main").getSlot());
-        Assert.assertEquals(INJECTION_MODULE, factory.getInjectionModId("main").getName());
-        Assert.assertEquals("main", factory.getInjectionModId("main").getSlot());
+        String apiModIdMain = factory.getApiModId("main");
+        String implModIdMain = factory.getImplModId("main");
+        String injectionModIdMain = factory.getInjectionModId("main");
 
-        Assert.assertEquals(API_MODULE, factory.getApiModId("myfaces").getName());
-        Assert.assertEquals("myfaces", factory.getApiModId("myfaces").getSlot());
-        Assert.assertEquals(IMPL_MODULE, factory.getImplModId("myfaces").getName());
-        Assert.assertEquals("myfaces", factory.getImplModId("myfaces").getSlot());
-        Assert.assertEquals(INJECTION_MODULE, factory.getInjectionModId("myfaces").getName());
-        Assert.assertEquals("myfaces", factory.getInjectionModId("myfaces").getSlot());
 
-        Assert.assertEquals(API_MODULE, factory.getApiModId("myfaces2").getName());
-        Assert.assertEquals("myfaces2", factory.getApiModId("myfaces2").getSlot());
-        Assert.assertEquals(IMPL_MODULE, factory.getImplModId("myfaces2").getName());
-        Assert.assertEquals("myfaces2", factory.getImplModId("myfaces2").getSlot());
-        Assert.assertEquals(INJECTION_MODULE, factory.getInjectionModId("myfaces2").getName());
-        Assert.assertEquals("myfaces2", factory.getInjectionModId("myfaces2").getSlot());
+        Assert.assertEquals(canonicalModuleIdentifier(API_MODULE, "main"), apiModIdMain);
+        Assert.assertEquals(canonicalModuleIdentifier(IMPL_MODULE, "main"), implModIdMain);
+        Assert.assertEquals(canonicalModuleIdentifier(INJECTION_MODULE, "main"), injectionModIdMain);
+
+        String apiModIdMyfaces = factory.getApiModId("myfaces");
+        String implModIdMyfaces = factory.getImplModId("myfaces");
+        String injectionModIdMyfaces = factory.getInjectionModId("myfaces");
+
+        Assert.assertEquals(canonicalModuleIdentifier(API_MODULE, "myfaces"), apiModIdMyfaces);
+        Assert.assertEquals(canonicalModuleIdentifier(IMPL_MODULE, "myfaces"), implModIdMyfaces);
+        Assert.assertEquals(canonicalModuleIdentifier(INJECTION_MODULE, "myfaces"), injectionModIdMyfaces);
+
+        String apiModIdMyfaces2 = factory.getApiModId("myfaces2");
+        String implModIdMyfaces2 = factory.getImplModId("myfaces2");
+        String injectionModIdMyfaces2 = factory.getInjectionModId("myfaces2");
+
+        Assert.assertEquals(canonicalModuleIdentifier(API_MODULE, "myfaces2"), apiModIdMyfaces2);
+        Assert.assertEquals(canonicalModuleIdentifier(IMPL_MODULE, "myfaces2"), implModIdMyfaces2);
+        Assert.assertEquals(canonicalModuleIdentifier(INJECTION_MODULE, "myfaces2"), injectionModIdMyfaces2);
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20022
