### PR TITLE
Fix for WFLY-19989, h2-driver layer rule for jakarta DataSourceDefinition annotation continuing, add test

### DIFF
--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/H2DriverLayerMetaDataTestCase.java
@@ -49,6 +49,11 @@ public class H2DriverLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase
         testWarWithClass(JakartaDataSourceDefinitionAnnotationUsage.class);
     }
 
+    @Test
+    public void testJakartaDataSourceDefinitionAnnotationURLUsage() throws Exception {
+        testWarWithClass(JakartaDataSourceDefinitionAnnotationURLUsage.class);
+    }
+
     private void testWarWithClass(Class<?> clazz) {
         Path p = createArchiveBuilder(ArchiveType.WAR)
                 .addClasses(clazz)

--- a/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/JakartaDataSourceDefinitionAnnotationURLUsage.java
+++ b/ee-feature-pack/layer-metadata-tests/src/test/java/org/wildfly/ee/feature/pack/layer/tests/h2/driver/JakartaDataSourceDefinitionAnnotationURLUsage.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.ee.feature.pack.layer.tests.h2.driver;
+
+import jakarta.annotation.sql.DataSourceDefinition;
+
+@DataSourceDefinition(name = "x", className = "org.example.MyClass", url = "jdbc:h2:some_content")
+public class JakartaDataSourceDefinitionAnnotationURLUsage {
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19989

Added missing test.
