### PR TITLE
Add a workaround for WFLY-20030 ReactiveMessaging* tests fail with podman-machine (macOS/Windows)

### DIFF
--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -503,6 +503,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- TODO Remove workaround for https://issues.redhat.com/browse/WFLY-20030 *ReactiveMessaging* tests fail with podman -->
+                    <reuseForks>false</reuseForks>
                     <environmentVariables>
                         <!-- dummy env property for MicroProfile Config testing -->
                         <MPCONFIG_TEST_ENV_VAR>integ-basicmpconfig-test-env-var-value</MPCONFIG_TEST_ENV_VAR>


### PR DESCRIPTION
Workaround for https://issues.redhat.com/browse/WFLY-20030 until we find a proper solution.