### PR TITLE
WFLY-20036 Upgrade SmallRye Fault Tolerance from 6.6.3 to 6.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.5.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.9.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.6.3</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.7.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.0.4</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.6.2</version.io.smallrye.smallrye-mutiny>

--- a/testsuite/integration/microprofile-tck/telemetry/pom.xml
+++ b/testsuite/integration/microprofile-tck/telemetry/pom.xml
@@ -174,10 +174,6 @@
         <finalName>microprofile-telemetry-${project.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.wildfly.glow</groupId>
-                <artifactId>wildfly-glow-arquillian-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <dependencies>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20036

Includes a build stability fix in wildfly-ts-integ-mp-telemetry.