### PR TITLE
[WFLY-20054] Use the galleon-pack/pom.xml as the parent for the 'build' and 'dist'…

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -12,12 +12,13 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-feature-pack-parent</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>35.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../galleon-pack/pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-build</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -12,12 +12,13 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-feature-pack-parent</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>35.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../galleon-pack/pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-dist</artifactId>


### PR DESCRIPTION
… modules.

Make it easier to use a different groupId and version scheme for these downstream.

Ideally these modules would move under "galleon-pack", and ee-build and ee-dist would be under ee-galleon-pack. Both being similar to the 'preview' structure. But that can be disruptive for so late in WF 35 development as external code may expect the current decade+ old filesystem structure.

https://issues.redhat.com/browse/WFLY-20054