### PR TITLE
[WFLY-20035] Initialize the Vert.x LoggerFactory in the WF Extension classes that use Vert.x

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/reactive-messaging-smallrye/main/module.xml
@@ -15,6 +15,8 @@
     <dependencies>
         <!-- Needed to initialise the netty logger if the module is present -->
         <module name="io.netty" optional="true"/>
+        <!-- Needed to initialise the vert.x logger if the module is present -->
+        <module name="io.vertx.core" optional="true"/>
 
         <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.jboss.as.controller"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/opentelemetry/main/module.xml
@@ -23,6 +23,8 @@
         <module name="io.opentelemetry.context" />
         <module name="io.opentelemetry.exporter" />
         <module name="io.smallrye.opentelemetry" services="import"/>
+        <!-- Needed to initialise the vert.x logger if the module is present -->
+        <module name="io.vertx.core"/>
 
         <module name="java.logging"/>
         <module name="jakarta.enterprise.api" />

--- a/legacy/opentracing-extension/pom.xml
+++ b/legacy/opentracing-extension/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>netty-common</artifactId>
         </dependency>
 
+        <!-- This is only required for the extension to initialize Vert.x's LoggerFactory -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.smallrye.opentelemetry</groupId>

--- a/microprofile/reactive-messaging-smallrye/extension/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/extension/pom.xml
@@ -89,6 +89,10 @@
             <artifactId>netty-codec-http</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
         </dependency>

--- a/observability/opentelemetry/pom.xml
+++ b/observability/opentelemetry/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>netty-common</artifactId>
         </dependency>
 
+        <!-- This is only required for the extension to initialize Vert.x's LoggerFactory -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+
         <!-- ======================================================= -->
 
         <dependency>

--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
@@ -7,6 +7,7 @@ package org.wildfly.extension.opentelemetry;
 
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.JdkLoggerFactory;
+import io.vertx.core.logging.LoggerFactory;
 import org.wildfly.subsystem.SubsystemConfiguration;
 import org.wildfly.subsystem.SubsystemExtension;
 import org.wildfly.subsystem.SubsystemPersistence;
@@ -23,5 +24,8 @@ public class OpenTelemetrySubsystemExtension extends SubsystemExtension<OpenTele
 
         // Initialize the Netty logger factory
         InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
+        // Initialize the Vert.x logger factory
+        //noinspection deprecation
+        LoggerFactory.initialise();
     }
 }

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -503,6 +503,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- TODO Remove workaround for https://issues.redhat.com/browse/WFLY-20030 *ReactiveMessaging* tests fail with podman -->
+                    <reuseForks>false</reuseForks>
                     <environmentVariables>
                         <!-- dummy env property for MicroProfile Config testing -->
                         <MPCONFIG_TEST_ENV_VAR>integ-basicmpconfig-test-env-var-value</MPCONFIG_TEST_ENV_VAR>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20035

This also merges in @rhusar 's branch from #18452 as that branch seems to reveal the bug this attempts to fix.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-20030](https://issues.redhat.com/browse/WFLY-20030)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)