### PR TITLE
WFLY-20045 Upgrade OpenTelemetry from 1.39.1 to 1.42.1 and SR OpenTelemetry to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,9 +440,9 @@
         <version.io.grpc>1.58.0</version.io.grpc>
         <version.io.micrometer>1.14.1</version.io.micrometer>
         <version.io.netty>4.1.115.Final</version.io.netty>
-        <version.io.opentelemetry.instrumentation>2.5.0</version.io.opentelemetry.instrumentation>
+        <version.io.opentelemetry.instrumentation>2.8.0</version.io.opentelemetry.instrumentation>
         <version.io.opentelemetry.opentelemetry-semconv>1.25.0-alpha</version.io.opentelemetry.opentelemetry-semconv>
-        <version.io.opentelemetry.opentelemetry>1.39.0</version.io.opentelemetry.opentelemetry>
+        <version.io.opentelemetry.opentelemetry>1.42.1</version.io.opentelemetry.opentelemetry>
         <version.io.opentelemetry.proto>1.3.2-alpha</version.io.opentelemetry.proto>
         <version.io.perfmark>0.23.0</version.io.perfmark>
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
@@ -457,7 +457,7 @@
         <version.io.smallrye.smallrye-mutiny>2.6.2</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>3.13.2</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.0</version.io.smallrye.smallrye-mutiny-zero>
-        <version.io.smallrye.smallrye-opentelemetry>2.8.0</version.io.smallrye.smallrye-opentelemetry>
+        <version.io.smallrye.smallrye-opentelemetry>2.9.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-reactive-messaging>4.24.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.10</version.io.vertx.vertx>
@@ -525,7 +525,7 @@
         <version.org.eclipse.microprofile.reactive-messaging.api>3.0.1</version.org.eclipse.microprofile.reactive-messaging.api>
         <version.org.eclipse.microprofile.reactive-streams-operators.api>3.0.1</version.org.eclipse.microprofile.reactive-streams-operators.api>
         <version.org.eclipse.microprofile.rest.client.api>4.0</version.org.eclipse.microprofile.rest.client.api>
-        <version.org.eclipse.microprofile.telemetry>2.0</version.org.eclipse.microprofile.telemetry>
+        <version.org.eclipse.microprofile.telemetry>2.0.1</version.org.eclipse.microprofile.telemetry>
         <version.org.eclipse.persistence.eclipselink>4.0.4</version.org.eclipse.persistence.eclipselink>
         <version.org.eclipse.yasson>3.0.4</version.org.eclipse.yasson>
         <version.org.elasticsearch.client.rest-client>8.15.4</version.org.elasticsearch.client.rest-client>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -6,11 +6,8 @@ package org.wildfly.extension.microprofile.faulttolerance.tck;
 
 import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
-import java.io.FilePermission;
-import java.lang.management.ManagementPermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.PropertyPermission;
-import java.util.logging.LoggingPermission;
 
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -64,18 +61,10 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
                     new PropertyPermission("*", "read,write"),
                     new RuntimePermission("getenv.*"),
                     new RuntimePermission("modifyThread"),
+                    new RuntimePermission("accessDeclaredMembers"),
                     // Permissions required by test instrumentation - awaitility.jar
                     new RuntimePermission("setDefaultUncaughtExceptionHandler"),
-                    new RuntimePermission("modifyThread"),
-                    // Permissions required by io.vertx.core / opentelemetry-sdk-extension-autoconfigure.jar
-                    new FilePermission("<<ALL FILES>>", "read,write,delete"),
-                    new RuntimePermission("getClassLoader"),
-                    new RuntimePermission("shutdownHooks"),
-                    new RuntimePermission("accessDeclaredMembers"),
-                    new LoggingPermission("control", null),
-                    new ManagementPermission("monitor"),
-                    new RuntimePermission("getStackTrace"),
-                    new RuntimePermission("setContextClassLoader")
+                    new RuntimePermission("modifyThread")
             ), "permissions.xml");
         }
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsynchronousRequestContextTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/context/asynchronous/AsynchronousRequestContextTestCase.java
@@ -4,15 +4,10 @@
  */
 package org.wildfly.test.integration.microprofile.faulttolerance.context.asynchronous;
 
-import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.FilePermission;
-import java.lang.management.ManagementPermission;
-import java.util.PropertyPermission;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.LoggingPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,19 +31,7 @@ public class AsynchronousRequestContextTestCase {
         return ShrinkWrap.create(WebArchive.class, AsynchronousRequestContextTestCase.class.getSimpleName() + ".war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addPackage(AsynchronousRequestContextTestCase.class.getPackage())
-                .addAsManifestResource(createPermissionsXmlAsset(
-                        // Permissions required by io.vertx.core / opentelemetry-sdk-extension-autoconfigure.jar
-                        new FilePermission("<<ALL FILES>>", "read,write,delete"),
-                        new LoggingPermission("control", null),
-                        new ManagementPermission("monitor"),
-                        new PropertyPermission("*", "read,write"),
-                        new RuntimePermission("accessDeclaredMembers"),
-                        new RuntimePermission("getClassLoader"),
-                        new RuntimePermission("getStackTrace"),
-                        new RuntimePermission("getenv.*"),
-                        new RuntimePermission("setContextClassLoader"),
-                        new RuntimePermission("shutdownHooks")
-                ), "permissions.xml");
+                ;
     }
 
     @Test

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -5,12 +5,7 @@
 
 package org.wildfly.test.integration.observability.opentelemetry;
 
-import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
-
-import java.lang.reflect.ReflectPermission;
 import java.net.MalformedURLException;
-import java.net.NetPermission;
-import java.util.PropertyPermission;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
@@ -50,17 +45,7 @@ public abstract class BaseOpenTelemetryTest {
             .addPackage(JaegerResponse.class.getPackage())
             .addAsManifestResource(new StringAsset(MP_CONFIG), "microprofile-config.properties")
             .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml")
-            // Some of the classes used in testing do things that break when the Security Manager is installed
-            .addAsManifestResource(createPermissionsXmlAsset(
-                    new RuntimePermission("getClassLoader"),
-                    new RuntimePermission("getProtectionDomain"),
-                    new RuntimePermission("getenv.*"),
-                    new RuntimePermission("setDefaultUncaughtExceptionHandler"),
-                    new RuntimePermission("modifyThread"),
-                    new ReflectPermission("suppressAccessChecks"),
-                    new NetPermission("getProxySelector"),
-                    new PropertyPermission("*", "read, write")),
-                "permissions.xml");
+            ;
     }
 
     protected String getDeploymentUrl(String deploymentName) throws MalformedURLException {


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20045 Upgrade OpenTelemetry from 1.39.1 to 1.42.1 and SR OpenTelemetry to 2.8.2
https://issues.redhat.com/browse/WFLY-20043 SR OpenTelemetry doesn't work with security manager
https://issues.redhat.com/browse/WFLY-20044 SR OpenTelemetry leaks anyone access to Thread.currentThread().getContextClassLoader()