### PR TITLE
[WFLY-20053] Upgrade JBeret to 3.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
         <version.org.infinispan>14.0.32.Final</version.org.infinispan>
         <version.org.infinispan.protostream>4.6.5.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
-        <version.org.jberet>3.0.0.Final</version.org.jberet>
+        <version.org.jberet>3.1.0.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>2.0.3.Final</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>5.0.8.Final</version.org.jboss.ejb-client>


### PR DESCRIPTION
- https://issues.redhat.com/browse/WFLY-20053

Tag: https://github.com/jberet/jsr352/releases/tag/3.1.0.Final
Diff: https://github.com/jberet/jsr352/compare/3.0.0.Final...3.1.0.Final

In this release, the major change is that the `MongoRepository` and `InfinispanRepository` are moved out of `jberet-core`, so the `mongodb` and `infinispan` dependencies are removed from `jberet-core`.

