### PR TITLE
Update maintainer emails for wildfly-github-bot.

### DIFF
--- a/.github/wildfly-bot.yml
+++ b/.github/wildfly-bot.yml
@@ -234,7 +234,8 @@ wildfly:
   emails:
     - mstefank@redhat.com
     - pberan@redhat.com
-    - rbudinsk@redhat.com
+    - khermano@redhat.com
+    - mjusko@redhat.com
     - brian.stansberry@redhat.com
   
   format:


### PR DESCRIPTION
Updating the emails in wildfly-github-bot config to current maintainers and relevant users.