### PR TITLE
[WFLY-20058]: "netty-common" should depend on "org.apache.logging.log4j.api".

### DIFF
--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -112,11 +112,6 @@
         </dependency>
 
         <!-- External dependencies -->
-        <!-- This is only required for the InfinispanExtension to initialize Netty's InternalLoggerFactory -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -4,8 +4,6 @@
  */
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.JdkLoggerFactory;
 
 import org.jboss.as.clustering.controller.SubsystemExtension;
 import org.jboss.as.controller.Extension;
@@ -27,8 +25,5 @@ public class InfinispanExtension extends SubsystemExtension<InfinispanSubsystemS
 
     public InfinispanExtension() {
         super(SUBSYSTEM_NAME, InfinispanSubsystemModel.CURRENT, InfinispanSubsystemResourceDefinition::new, InfinispanSubsystemSchema.CURRENT, new InfinispanSubsystemXMLWriter());
-
-        // Initialize the Netty logger factory
-        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
     }
 }

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/netty/netty-common/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/netty/netty-common/main/module.xml
@@ -20,5 +20,15 @@
         <module name="io.netty.netty-transport-native-unix-common"/>
         <module name="io.netty.netty-transport-native-epoll"/>
         <module name="io.netty.netty-transport-native-kqueue"/>
+        <!-- 
+            There is no requirement for this in Netty. This avoids a warning from
+            JBoss Modules which gets logged when checking the InternalLoggerFactory
+            for which logging framework to bind to. Netty isn't aggressive enough
+            when attempting to see if log4j 2 is available and JBoss Modules
+            is a bit too aggressive with logging the warning. For this reason
+            it is best to just process through log4j 2.
+            @see https://issues.redhat.com/browse/WFLY-20058
+        -->
+        <module name="org.apache.logging.log4j.api"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -25,9 +25,6 @@
         <module name="java.transaction.xa"/>
         <module name="java.xml"/>
         <module name="jakarta.transaction.api"/>
-
-        <!-- The netty-common module is only require to initialize Netty's InternalLoggingFactory -->
-        <module name="io.netty.netty-common"/>
         <module name="io.netty.netty-transport-native-epoll"/>
         <module name="io.netty.netty-transport-native-kqueue"/>
         <module name="io.reactivex.rxjava3.rxjava"/>

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -86,8 +86,6 @@ import org.wildfly.extension.messaging.activemq.jms.JMSTopicDefinition;
 import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.JdkLoggerFactory;
 
 /**
  * Domain extension that integrates Apache ActiveMQ Artemis 2.x.
@@ -348,8 +346,6 @@ public class MessagingExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
-        // Initialize the Netty logger factory
-        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
         final SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
         subsystemRegistration.registerXMLElementWriter(CURRENT_PARSER);
 

--- a/microprofile/reactive-messaging-smallrye/extension/pom.xml
+++ b/microprofile/reactive-messaging-smallrye/extension/pom.xml
@@ -70,10 +70,6 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/MicroProfileReactiveMessagingExtension.java
+++ b/microprofile/reactive-messaging-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/reactive/messaging/MicroProfileReactiveMessagingExtension.java
@@ -8,13 +8,11 @@ package org.wildfly.extension.microprofile.reactive.messaging;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import io.vertx.core.logging.LoggerFactory;
 import java.util.EnumSet;
 import java.util.List;
 
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.JdkLoggerFactory;
 
-import io.vertx.core.logging.LoggerFactory;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
@@ -65,12 +63,6 @@ public class MicroProfileReactiveMessagingExtension implements Extension {
         ClassLoader cl = WildFlySecurityManager.getClassLoaderPrivileged(this.getClass());
         if (cl instanceof ModuleClassLoader) {
             ModuleLoader loader = ((ModuleClassLoader) cl).getModule().getModuleLoader();
-            try {
-                loader.loadModule("io.netty");
-                InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
-            } catch (ModuleLoadException e) {
-                // The netty module is not there so don't do anything
-            }
             try {
                 loader.loadModule("io.vertx.core");
                 //noinspection deprecation

--- a/observability/opentelemetry/pom.xml
+++ b/observability/opentelemetry/pom.xml
@@ -104,12 +104,6 @@
             <artifactId>smallrye-opentelemetry-propagation</artifactId>
         </dependency>
 
-        <!-- This is only required for the extension to initialize Netty's InternalLoggerFactory -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
-
         <!-- This is only required for the extension to initialize Vert.x's LoggerFactory -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemExtension.java
@@ -5,8 +5,6 @@
 
 package org.wildfly.extension.opentelemetry;
 
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.util.internal.logging.JdkLoggerFactory;
 import io.vertx.core.logging.LoggerFactory;
 import org.wildfly.subsystem.SubsystemConfiguration;
 import org.wildfly.subsystem.SubsystemExtension;
@@ -21,9 +19,6 @@ public class OpenTelemetrySubsystemExtension extends SubsystemExtension<OpenTele
                 OpenTelemetrySubsystemModel.CURRENT,
                 OpenTelemetrySubsystemRegistrar::new),
                 SubsystemPersistence.of(OpenTelemetrySubsystemSchema.CURRENT));
-
-        // Initialize the Netty logger factory
-        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
         // Initialize the Vert.x logger factory
         //noinspection deprecation
         LoggerFactory.initialise();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -166,7 +166,7 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.mod_cluster",
             "org.wildfly.mod_cluster.undertow",
             // Brought by galleon ServerRootResourceDefinition
-            "wildflyee.api"
+            "wildflyee.api",
     };
 
 
@@ -176,8 +176,6 @@ public abstract class LayersTestBase {
      */
     public static final String[] NOT_REFERENCED_WILDFLY_EE = {
             // Only injected by logging in 'wildfly-ee', but referenced in 'wildfly' and 'wildfly-preview'
-            "org.apache.logging.log4j.api",
-            "org.jboss.logmanager.log4j2",
     };
 
 


### PR DESCRIPTION
* Updating the netty-common module.
* removing the infinispan workaround.
* removing the messaging workaround.

Jira: https://issues.redhat.com/browse/WFLY-20058