### PR TITLE
WFLY-20057 Fix invalid PersistentResourceXMLDescription usage.

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_1.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser_1.java
@@ -27,7 +27,7 @@ class IIOPSubsystemParser_1 extends PersistentResourceXMLParser {
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return builder(IIOPExtension.PATH_SUBSYSTEM)
+        return builder(IIOPExtension.PATH_SUBSYSTEM, Namespace.IIOP_OPENJDK_1_0.getUriString())
                 .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .setAdditionalOperationsGenerator((address, addOperation, operations) -> {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20057

Fixes errors exposed by wildfly-core integration CI runs using new parser implementation: wildfly/wildfly-core#6261