### PR TITLE
WFLY-19689 - Micrometer extension keeps pushing metrics after removal and reload

### DIFF
--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerSubsystemRegistrar.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerSubsystemRegistrar.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.wildfly.common.function.Functions;
 import org.wildfly.extension.micrometer.jmx.JmxMicrometerCollector;
 import org.wildfly.extension.micrometer.metrics.MicrometerCollector;
 import org.wildfly.extension.micrometer.registry.NoOpRegistry;
@@ -170,7 +171,6 @@ class MicrometerSubsystemRegistrar implements SubsystemResourceDefinitionRegistr
             }
         });
 
-
         AtomicReference<MicrometerCollector> captor = new AtomicReference<>();
 
         context.addStep((operationContext, modelNode) -> {
@@ -187,10 +187,11 @@ class MicrometerSubsystemRegistrar implements SubsystemResourceDefinitionRegistr
         }, OperationContext.Stage.VERIFY);
 
         return CapabilityServiceInstaller.builder(MICROMETER_COLLECTOR_RUNTIME_CAPABILITY, collectorSupplier)
-                .requires(List.of(mccf, executor, processStateNotifier))
-                .withCaptor(captor::set) // capture the provided value
-                .asActive() // Start actively
-                .build();
+            .requires(List.of(mccf, executor, processStateNotifier))
+            .withCaptor(captor::set) // capture the provided value
+            .onStop(Functions.closingConsumer())
+            .asActive() // Start actively
+            .build();
     }
 
     public interface MicrometerDeploymentConfiguration {

--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/metrics/MicrometerCollector.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/metrics/MicrometerCollector.java
@@ -33,7 +33,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.micrometer.registry.WildFlyRegistry;
 
-public class MicrometerCollector {
+public class MicrometerCollector implements AutoCloseable {
     private final LocalModelControllerClient modelControllerClient;
     private final ProcessStateNotifier processStateNotifier;
     private final WildFlyRegistry micrometerRegistry;
@@ -77,6 +77,11 @@ public class MicrometerCollector {
         }
 
         return registration;
+    }
+
+    @Override
+    public void close() throws Exception {
+        micrometerRegistry.close();
     }
 
     private void queueMetricRegistration(final Resource current,

--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/registry/WildFlyRegistry.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/registry/WildFlyRegistry.java
@@ -20,7 +20,7 @@ import org.wildfly.extension.micrometer.MicrometerExtensionLogger;
 import org.wildfly.extension.micrometer.metrics.MetricMetadata;
 import org.wildfly.extension.micrometer.metrics.WildFlyMetric;
 
-public interface WildFlyRegistry {
+public interface WildFlyRegistry extends AutoCloseable {
     Meter remove(Meter.Id mappedId);
 
     default Meter.Id addMeter(WildFlyMetric metric, MetricMetadata metadata) {
@@ -34,9 +34,7 @@ public interface WildFlyRegistry {
         }
     }
 
-    default void close() {
-
-    }
+    void close();
 
     private Meter.Id addCounter(WildFlyMetric metric, MetricMetadata metadata) {
         return FunctionCounter.builder(metadata.getMetricName(), metric,

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerRemovalTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerRemovalTestCase.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.micrometer;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.input.Tailer;
+import org.apache.commons.io.input.TailerListener;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.plugin.tools.OperationExecutionException;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MicrometerRemovalTestCase {
+    private static final ModelNode micrometerExtension = Operations.createAddress("extension", "org.wildfly.extension.micrometer");
+    private static final ModelNode micrometerSubsystem = Operations.createAddress("subsystem", "micrometer");
+    private static final ModelNode ADDRESS_SERVER_LOG_DIR = Operations.createAddress("path", "jboss.server.log.dir");
+    private static final String ERROR_MESSAGE = "Failed to publish metrics to OTLP receiver";
+
+    @ContainerResource
+    private ServerManager serverManager;
+    private String logFilePath;
+
+    @Before
+    public void getLogLocation() throws IOException {
+        ModelNode op = Operations.createReadAttributeOperation(ADDRESS_SERVER_LOG_DIR, "path");
+        logFilePath = serverManager.executeOperation(op).asString();
+    }
+
+    @Test
+    public void testRemoval() throws Exception {
+        ServerLogTailerListener listener = new ServerLogTailerListener();
+        try (Tailer ignored = Tailer.builder()
+            .setFile(new File(logFilePath, "server.log"))
+            .setTailerListener(listener)
+            .setDelayDuration(Duration.ofMillis(500))
+            .get()) {
+            enableMicrometer();
+            Thread.sleep(TimeoutUtil.adjust(1000));
+            disableMicrometer();
+            // Micrometer will push one last time while the registry is shutting down. Sleep long enough to allow that to
+            // happen, then clear the log, wait, then check again. The server is configured to push every millisecond, so
+            // 500 should be sufficient to give that time without slowing down the test suite more than necessary.
+            Thread.sleep(TimeoutUtil.adjust(1000));
+            listener.logs.clear();
+            Thread.sleep(TimeoutUtil.adjust(1000));
+            Assert.assertTrue("Micrometer has been removed, but errors are still being logged.",
+                listener.logs.stream().noneMatch(l -> l.contains(ERROR_MESSAGE)));
+        } finally {
+            disableMicrometer();
+        }
+    }
+
+    protected void enableMicrometer() throws IOException {
+        try {
+            if (!resourceExists(micrometerExtension)) {
+                serverManager.executeOperation(Operations.createAddOperation(micrometerExtension));
+            }
+            if (!resourceExists(micrometerSubsystem)) {
+                ModelNode addOp = Operations.createAddOperation(micrometerSubsystem);
+                addOp.get("endpoint").set("http://localhost:4318/v1/metrics/v1/metrics");
+                addOp.get("step").set("1");
+                serverManager.executeOperation(addOp);
+            }
+        } finally {
+            serverManager.reloadIfRequired();
+        }
+    }
+
+    protected void disableMicrometer() throws IOException {
+        try {
+            if (resourceExists(micrometerSubsystem)) {
+                serverManager.executeOperation(Operations.createRemoveOperation(micrometerSubsystem));
+            }
+            if (resourceExists(micrometerExtension)) {
+                serverManager.executeOperation(Operations.createRemoveOperation(micrometerExtension));
+            }
+        } finally {
+            serverManager.reloadIfRequired();
+        }
+    }
+
+    private boolean resourceExists(ModelNode resourceAddress) throws IOException {
+        try {
+            serverManager.executeOperation(Operations.createReadResourceOperation(resourceAddress));
+            return true;
+        } catch (OperationExecutionException e) {
+            return false;
+        }
+    }
+
+    private static class ServerLogTailerListener implements TailerListener {
+        List<String> logs = new ArrayList<>();
+
+        @Override
+        public void fileNotFound() {
+            throw new RuntimeException("Log file not found.");
+        }
+
+        @Override
+        public void fileRotated() {
+            logs.clear();
+        }
+
+        @Override
+        public void handle(Exception ex) {
+            throw new RuntimeException(ex);
+        }
+
+        @Override
+        public void handle(String line) {
+            logs.add(line);
+        }
+
+        @Override
+        public void init(Tailer tailer) {
+
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19689

- Add .onRemove() to Micrometer ResourceServiceInstaller to close registry when subsystem is remove 
- Remove default implementation in WildFlyRegister to prevent hiding method in superclass 
- Add test to verify that registry is shut down when micrometer subsystem is removed