### PR TITLE
[WFLY-20069] Upgrade WildFly Core to 27.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>4.0.5.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Beta3</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20069

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.0.Beta5
Diff: https://github.com/yersan/wildfly-core/compare/27.0.0.Beta4...27.0.0.Beta5

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7077'>WFCORE-7077</a>] -         SuspendController relies on blocking ServiceActivity behavior for ordering
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7083'>WFCORE-7083</a>] -         ModuleNameValidator fails if module name contains a dash
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7050'>WFCORE-7050</a>] -         Remove MetaspaceSize settings
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7056'>WFCORE-7056</a>] -         Upgrade SSHD from 2.13.2 to 2.14.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7071'>WFCORE-7071</a>] -         Upgrade Elytron EE to 3.1.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7084'>WFCORE-7084</a>] -         Upgrade Installation Manager API to 1.1.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7072'>WFCORE-7072</a>] -         Switch to using PolicyUtil from Elytron EE to access java.security.Policy
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7082'>WFCORE-7082</a>] -         Provide utilities to produce canonical representations of module names
</li>
</ul>

</details>


