### PR TITLE
WFLY-20075 - MP Telemetry Metrics (OpenTelemetry) without any rest/servlet call

### DIFF
--- a/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/OpenTelemetryCdiExtension.java
+++ b/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/OpenTelemetryCdiExtension.java
@@ -6,17 +6,19 @@
 package org.wildfly.extension.opentelemetry.api;
 
 import java.util.Map;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.smallrye.opentelemetry.api.OpenTelemetryConfig;
+import io.smallrye.opentelemetry.implementation.rest.OpenTelemetryClientFilter;
+import io.smallrye.opentelemetry.implementation.rest.OpenTelemetryServerFilter;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Singleton;
-
-import io.smallrye.opentelemetry.api.OpenTelemetryConfig;
-import io.smallrye.opentelemetry.implementation.rest.OpenTelemetryClientFilter;
-import io.smallrye.opentelemetry.implementation.rest.OpenTelemetryServerFilter;
 
 public final class OpenTelemetryCdiExtension implements Extension {
     private final boolean useServerConfig;
@@ -36,6 +38,14 @@ public final class OpenTelemetryCdiExtension implements Extension {
                 OpenTelemetryServerFilter.class.getName());
         beforeBeanDiscovery.addAnnotatedType(beanManager.createAnnotatedType(OpenTelemetryClientFilter.class),
                 OpenTelemetryClientFilter.class.getName());
+    }
+
+    // For the publication of metrics to begin, the OpenTelemetry instance must be created. Unless something like
+    // this is done, that will not happen until the first request to the application (via the OpenTelemetryServerFilter).
+    // Forcing the creation of that instance here causes that publication to begin as soon as the application is
+    // deployed/started. See https://issues.redhat.com/browse/WFLY-20075
+    void forceEagerInstantiationOfOpenTelemetry(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
+        beanManager.createInstance().select(OpenTelemetry.class).get();
     }
 
     public void registerOpenTelemetryBeans(@Observes AfterBeanDiscovery abd) {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -29,8 +29,6 @@ public abstract class BaseOpenTelemetryTest {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-//        "otel.metrics.exporter=otlp\n" +
-//        "otel.traces.exporter=otlp\n" +
         "otel.metric.export.interval=100";
 
     static WebArchive buildBaseArchive(String name) {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -39,6 +39,13 @@ public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
 
     @Test
     @InSequence(1)
+    public void metricsShouldStartPublishingImmediately() throws Exception {
+        Assert.assertFalse("Metrics should be published immediately.",
+            otelCollector.fetchMetrics("jvm_class_count").isEmpty());
+    }
+
+    @Test
+    @InSequence(2)
     public void makeRequests() throws MalformedURLException {
         final String testName = "TeamCity";
         try (Client client = ClientBuilder.newClient()) {
@@ -54,7 +61,7 @@ public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     // Request the published metrics from the OpenTelemetry Collector via the configured Prometheus exporter and check
     // a few metrics to verify there existence
     @Test
-    @InSequence(2)
+    @InSequence(3)
     public void getMetrics() throws InterruptedException {
         List<String> metricsToTest = List.of(OtelMetricResource.COUNTER_NAME);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20075

* Force eager initialization of OpenTelemetry instance so that metrics publication begins on application deployment/start
* Add test to verify