### PR TITLE
WFLY-20026 run an initial recovery scan when the microprofile-lra sub…

### DIFF
--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
@@ -9,6 +9,7 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.server.Services;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.tm.XAResourceRecoveryRegistry;
@@ -20,6 +21,7 @@ import org.wildfly.extension.undertow.Host;
 import org.wildfly.extension.undertow.UndertowService;
 
 import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
 import static org.wildfly.extension.microprofile.lra.coordinator.MicroProfileLRACoordinatorSubsystemDefinition.ATTRIBUTES;
@@ -63,8 +65,8 @@ class MicroProfileLRACoordinatorAdd extends AbstractBoottimeAddStepHandler {
         builder.provides(MicroProfileLRACoordinatorSubsystemDefinition.LRA_RECOVERY_SERVICE_CAPABILITY);
         // JTA is required to be loaded before the LRA recovery setup
         builder.requiresCapability(MicroProfileLRACoordinatorSubsystemDefinition.REF_JTA_RECOVERY_CAPABILITY, XAResourceRecoveryRegistry.class);
-
-        final LRARecoveryService lraRecoveryService = new LRARecoveryService();
+        Supplier<ExecutorService> executorSupplier = Services.requireServerExecutor(builder);
+        final LRARecoveryService lraRecoveryService = new LRARecoveryService(executorSupplier);
         builder.setInstance(lraRecoveryService);
         builder.setInitialMode(ServiceController.Mode.ACTIVE).install();
     }

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/_private/MicroProfileLRACoordinatorLogger.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/_private/MicroProfileLRACoordinatorLogger.java
@@ -17,6 +17,7 @@ import org.jboss.msc.service.StartException;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import java.lang.invoke.MethodHandles;
 
@@ -51,4 +52,8 @@ public interface MicroProfileLRACoordinatorLogger extends BasicLogger {
     @Message(id = 4, value = "Failed to stop Narayana MicroProfile LRA Coordinator at path %s/" + LRAConstants.COORDINATOR_PATH_NAME)
     void failedStoppingCoordinator(String path, @Cause ServletException cause);
 
+    @LogMessage(level = WARN)
+    @Message(id = 5, value = "Failed to start a recovery scan on the Narayana MicroProfile LRA Coordinator at path %s/"
+            + LRAConstants.COORDINATOR_PATH_NAME)
+    void failedToRunRecoveryScan(String path, @Cause Exception cause);
 }


### PR DESCRIPTION
…system starts so that pending LRAs are visible

https://issues.redhat.com/browse/WFLY-20026

The PR runs an initial recovery scan when the microprofile-lra subsystem starts so that any in progress LRAs are immediately visible.


