### PR TITLE
WFLY-20076 Intermittent failures in OpenTelemetry integration test cases

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
@@ -4,6 +4,8 @@
  */
 package org.wildfly.test.integration.observability.micrometer.multiple;
 
+import static org.junit.Assert.*;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -17,7 +19,6 @@ import org.jboss.as.test.shared.CdiUtils;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.test.integration.observability.JaxRsActivator;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
@@ -47,11 +48,12 @@ public class MultipleWarTestCase extends BaseMultipleTestCase {
         makeRequests(new URI(String.format("%s/%s", serviceOne, DuplicateMetricResource1.TAG)));
         makeRequests(new URI(String.format("%s/%s", serviceTwo, DuplicateMetricResource2.TAG)));
 
-        List<PrometheusMetric> results = getMetricsByName(
-                otelCollector.fetchMetrics(DuplicateMetricResource1.METER_NAME),
-                DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
+        otelCollector.assertMetrics(prometheusMetrics -> {
+            List<PrometheusMetric> results = getMetricsByName(prometheusMetrics,
+                    DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
 
-        Assert.assertEquals(2, results.size());
-        results.forEach(r -> Assert.assertEquals("" + REQUEST_COUNT, r.getValue()));
+            assertEquals(2, results.size());
+            results.forEach(r -> assertEquals("" + REQUEST_COUNT, r.getValue()));
+        });
     }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -18,7 +18,6 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
-import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,16 +56,9 @@ public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     @Test
     @InSequence(2)
     public void getMetrics() throws InterruptedException {
-        List<String> metricsToTest = List.of(
-                OtelMetricResource.COUNTER_NAME
-        );
+        List<String> metricsToTest = List.of(OtelMetricResource.COUNTER_NAME);
 
-        final List<PrometheusMetric> metrics = otelCollector.fetchMetrics(metricsToTest.get(0));
-        System.err.println("**************\nPrometheus metrics:");
-        System.err.println(metrics);
-        System.err.println("**************");
-
-        metricsToTest.forEach(n -> Assert.assertTrue("Missing metric: " + n,
-                metrics.stream().anyMatch(m -> m.getKey().startsWith(n))));
+        otelCollector.assertMetrics(prometheusMetrics -> metricsToTest.forEach(n -> Assert.assertTrue("Missing metric: " + n,
+                prometheusMetrics.stream().anyMatch(m -> m.getKey().startsWith(n)))));
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -4,21 +4,34 @@
  */
 package org.jboss.as.test.shared.observability.containers;
 
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
+
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
+import org.junit.Assert;
 import org.testcontainers.utility.MountableFile;
 
+/**
+ * @author Jason Lee
+ * @author Radoslav Husar
+ */
 public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetryCollectorContainer> {
     public static final String IMAGE_NAME = "otel/opentelemetry-collector";
     public static final String IMAGE_VERSION = "0.103.1";
@@ -28,7 +41,7 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     public static final int HEALTH_CHECK_PORT = 13133;
     public static final String OTEL_COLLECTOR_CONFIG_YAML = "/etc/otel-collector-config.yaml";
 
-    private JaegerContainer jaegerContainer;
+    private final JaegerContainer jaegerContainer;
 
     public OpenTelemetryCollectorContainer() {
         super("OpenTelemetryCollector", IMAGE_NAME, IMAGE_VERSION,
@@ -76,26 +89,76 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
         return (jaegerContainer != null ? jaegerContainer.getTraces(serviceName) : Collections.emptyList());
     }
 
-    public List<PrometheusMetric> fetchMetrics(String nameToMonitor) throws InterruptedException {
-        String body = "";
-        try (Client client = ClientBuilder.newClient()) {
-            WebTarget target = client.target(getPrometheusUrl());
+    Duration DEFAULT_TIMEOUT = Duration.ofSeconds(TimeoutUtil.adjust(30));
 
-            int attemptCount = 0;
-            boolean found = false;
+    /**
+     * Continually evaluates assertions provided in a consumer until the state obtained from the Prometheus endpoint
+     * matches the expected state or until a timeout elapses.
+     * By default, polls the collector every second for 30 seconds.
+     * Returns snapshot of the prometheus registry that passed the assertions; typically ignored.
+     *
+     * @param assertionConsumer consumer implementation that contains {@link Assert}ions throwing {@link AssertionError#AssertionError()}s
+     *                          if the state obtained from the Prometheus endpoint does not match the expected state
+     * @return list of prometheus metrics; typically ignored.
+     * @throws AssertionError if
+     * @throws InterruptedException if interrupted
+     */
+    public List<PrometheusMetric> assertMetrics(Consumer<List<PrometheusMetric>> assertionConsumer) throws AssertionError, InterruptedException {
+        return this.assertMetrics(assertionConsumer, DEFAULT_TIMEOUT);
+    }
 
-            // Request counts can vary. Setting high to help ensure test stability
-            while (!found && attemptCount < 30) {
-                // Wait to give Micrometer time to export
+    /**
+     * Variant of {@link OpenTelemetryCollectorContainer#assertMetrics(Consumer)} that can be configured with a timeout duration.
+     */
+    public List<PrometheusMetric> assertMetrics(Consumer<List<PrometheusMetric>> assertionConsumer, Duration timeout) throws AssertionError, InterruptedException {
+        debugLog("assertMetrics(..) validation starting.");
+
+        Instant endTime = Instant.now().plus(timeout);
+
+        AssertionError lastAssertionError = null;
+
+        while (Instant.now().isBefore(endTime)) {
+            try {
+                List<PrometheusMetric> prometheusMetrics = fetchMetrics();
+
+                assertionConsumer.accept(prometheusMetrics);
+
+                debugLog("assertMetrics(..) validation passed.");
+
+                return prometheusMetrics;
+            } catch (AssertionError assertionError) {
+                debugLog("assertMetrics(..) validation failed - retrying.");
+                lastAssertionError = assertionError;
                 Thread.sleep(1000);
-
-                body = target.request().get().readEntity(String.class);
-                found = body.contains(nameToMonitor);
-                attemptCount++;
             }
         }
 
-        return buildPrometheusMetrics(body);
+        throw Objects.requireNonNullElseGet(lastAssertionError, AssertionError::new);
+    }
+
+    /**
+     * Fetches a current snapshot of the metrics from the Prometheus endpoint.
+     *
+     * @return list of prometheus metrics
+     */
+    public List<PrometheusMetric> fetchMetrics() {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(getPrometheusUrl());
+            return buildPrometheusMetrics(target.request().get().readEntity(String.class));
+        }
+    }
+
+    /**
+     * @deprecated Use {@link OpenTelemetryCollectorContainer#assertMetrics(Consumer)} instead.
+     */
+    @Deprecated
+    public List<PrometheusMetric> fetchMetrics(String nameToMonitor) throws InterruptedException {
+        return assertMetrics(prometheusMetrics -> {
+            assertTrue(
+                    String.format("Metric %s not seen in Prometheus within timeout.", nameToMonitor),
+                    prometheusMetrics.stream().anyMatch(x -> x.getKey().contains(nameToMonitor))
+            );
+        });
     }
 
     private List<PrometheusMetric> buildPrometheusMetrics(String body) {


### PR DESCRIPTION
Fixes all intermittent otel test cases.

Introduces org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer#assertMetrics(java.util.function.Consumer<java.util.List<org.jboss.as.test.shared.observability.signals.PrometheusMetric>>) that continually evaluates assertions provided in a consumer until the state obtained from the Prometheus endpoint matches the expected state or until a timeout elapses.  By default, polls the collector every second for 30 seconds. Returns snapshot of the prometheus registry that passed the assertions; typically ignored.

Resolves https://issues.redhat.com/browse/WFLY-20076
