### PR TITLE
WFLY-19976 LRA participant module should declare Weld dependencies for proper bean proxy creation

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
@@ -31,5 +31,10 @@
     <module name="org.eclipse.microprofile.config.api"/>
     <module name="io.smallrye.config"/>
 
+    <!-- Required for proper creation of proxies for CDI beans originating from this module -->    
+    <module name="org.jboss.weld.api"/>
+    <module name="org.jboss.weld.core"/>
+    <module name="org.jboss.weld.spi"/>
+
   </dependencies>
 </module>


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WFLY-19976

The LRA module registers a synthetic bean ([here](https://github.com/jbosstm/lra/blob/main/proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRACDIExtension.java#L79)) which will be housed inside this module. In order to work properly, the module should have dependencies on Weld.