### PR TITLE
[WFLY-20084] With ts.bootable, ensure the test-feature-pack is built …

### DIFF
--- a/testsuite/aggregator-base/pom.xml
+++ b/testsuite/aggregator-base/pom.xml
@@ -289,6 +289,7 @@
                 </property>
             </activation>
             <modules>
+                <module>../test-feature-pack</module> <!-- needed by integration/basic -->
                 <module>../integration/basic</module>
                 <module>../integration/clustering</module>
                 <module>../integration/elytron</module>


### PR DESCRIPTION
…before ts/int/basic runs

Follow up work on https://issues.redhat.com/browse/WFLY-20084, the initial bit on which broke PR CI with -Dts.bootable.