### PR TITLE
[WFLY-20105] Missing separation between G:A and V

### DIFF
--- a/datasources-agroal/pom.xml
+++ b/datasources-agroal/pom.xml
@@ -10,7 +10,10 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-parent</artifactId>
-        <!-- Maintain separation between the artifact id and the version to help prevent merge conflicts between commits changing the GA and those changing the V. -->
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
         <version>35.0.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/microprofile/lra/coordinator/pom.xml
+++ b/microprofile/lra/coordinator/pom.xml
@@ -11,6 +11,10 @@
   <parent>
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-microprofile-lra</artifactId>
+    <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+    -->
     <version>35.0.0.Final-SNAPSHOT</version>
   </parent>
 

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -11,6 +11,10 @@
   <parent>
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-microprofile-lra</artifactId>
+    <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+    -->
     <version>35.0.0.Final-SNAPSHOT</version>
   </parent>
 

--- a/testsuite/integration/microprofile-tck/jwt/pom.xml
+++ b/testsuite/integration/microprofile-tck/jwt/pom.xml
@@ -11,6 +11,10 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-ts-integ-mp</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
         <version>35.0.0.Final-SNAPSHOT</version>
     </parent>
 

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -11,6 +11,10 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-ts-integ</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
         <version>35.0.0.Final-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20105

Add missing separation between G:A and V in some pom.xml files.
Also format the one in datasources-agroal module to match all other usages.

before:
```bash
$ grep --recursive --files-without-match "Maintain separation" --include=pom.xml
microprofile/lra/coordinator/pom.xml
microprofile/lra/participant/pom.xml
testsuite/integration/microprofile-tck/jwt/pom.xml
testsuite/integration/microprofile-tck/pom.xml
$
```

after:
```bash
$ grep --recursive --files-without-match "Maintain separation" --include=pom.xml
$ 
```