### PR TITLE
[WFLY-20125] Don't run testsuite/integration/secman tests on SE 24+

### DIFF
--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -131,6 +131,16 @@
                 </plugins>
             </build>
         </profile>
+        <!-- SecurityManager can't work on SE 24+ so turn of test execution -->
+        <profile>
+            <id>secman.integration.unsupported.profile</id>
+            <activation>
+                <jdk>[24,)</jdk>
+            </activation>
+            <properties>
+                <surefire.default-test.phase>none</surefire.default-test.phase>
+            </properties>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20125