### PR TITLE
[WFLY-20017] Remove all non-breaking uses of ModuleIdentifier in IIOP Subsystem

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/deployment/IIOPDependencyProcessor.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/deployment/IIOPDependencyProcessor.java
@@ -12,16 +12,15 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 /**
  * @author Stuart Douglas
  */
 public class IIOPDependencyProcessor implements DeploymentUnitProcessor {
-    public static final ModuleIdentifier CORBA_ID = ModuleIdentifier.create("org.omg.api");
-    public static final ModuleIdentifier JAVAX_RMI_API_ID = ModuleIdentifier.create("javax.rmi.api");
-    public static final ModuleIdentifier IIOP_OPENJDK_ID = ModuleIdentifier.create("javax.orb.api");
+    public static final String CORBA_ID = "org.omg.api";
+    public static final String JAVAX_RMI_API_ID = "javax.rmi.api";
+    public static final String IIOP_OPENJDK_ID = "javax.orb.api";
 
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20017

[WFLY-20017] Remove all non-breaking uses of ModuleIdentifier in IIOP Subsystem

