### PR TITLE
[WFLY-20018] Remove all non-breaking uses of ModuleIdentifier in XTS Subsystem

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSDependenciesDeploymentProcessor.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSDependenciesDeploymentProcessor.java
@@ -16,7 +16,6 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 import jakarta.ejb.TransactionAttribute;
@@ -30,7 +29,7 @@ import java.util.List;
  */
 public class XTSDependenciesDeploymentProcessor implements DeploymentUnitProcessor {
 
-    private static final ModuleIdentifier XTS_MODULE = ModuleIdentifier.create("org.jboss.xts");
+    private static final String XTS_MODULE = "org.jboss.xts";
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20018

[WFLY-20018] Remove all non-breaking uses of ModuleIdentifier in XTS Subsystem

