### PR TITLE
[WFLY-20019] Remove all non-breaking uses of ModuleIdentifier in EE Subsystem

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/security/SecurityActions.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/SecurityActions.java
@@ -9,9 +9,9 @@ import static java.security.AccessController.doPrivileged;
 
 import java.security.PrivilegedAction;
 
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleClassLoader;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -28,7 +28,7 @@ class SecurityActions {
 
     static ModuleClassLoader getModuleClassLoader(final String moduleSpec) throws ModuleLoadException {
         ModuleLoader loader = Module.getCallerModuleLoader();
-        final Module module = loader.loadModule(ModuleIdentifier.fromString(moduleSpec));
+        final Module module = loader.loadModule(ModuleIdentifierUtil.canonicalModuleIdentifier(moduleSpec));
         GetModuleClassLoaderAction action = new GetModuleClassLoaderAction(module);
         return WildFlySecurityManager.isChecking() ? doPrivileged(action) : action.run();
     }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/GlobalDirectoryDeploymentService.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/GlobalDirectoryDeploymentService.java
@@ -18,7 +18,6 @@ import org.jboss.as.ee.subsystem.GlobalDirectoryResourceDefinition.GlobalDirecto
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.moduleservice.ExternalModule;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceRegistry;
@@ -74,7 +73,7 @@ public class GlobalDirectoryDeploymentService implements Service {
             for (GlobalDirectory data : dataSorted) {
                 Path resolvedPath = data.getResolvedPath();
                 String moduleName = data.getModuleName();
-                ModuleIdentifier moduleIdentifier = externalModuleService.addExternalModule(moduleName, resolvedPath.toString(), serviceRegistry, serviceTarget);
+                String moduleIdentifier = externalModuleService.addExternalModule(moduleName, resolvedPath.toString(), serviceRegistry, serviceTarget).toString();
                 moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
             }
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20019

[WFLY-20019] Remove all non-breaking uses of ModuleIdentifier in EE Subsystem

