### PR TITLE
[WFLY-20127] Warning messages when playing quickstart for opentelemtry

### DIFF
--- a/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/WildFlyOpenTelemetryConfig.java
+++ b/observability/opentelemetry-api/src/main/java/org/wildfly/extension/opentelemetry/api/WildFlyOpenTelemetryConfig.java
@@ -44,7 +44,7 @@ public final class WildFlyOpenTelemetryConfig implements OpenTelemetryConfig {
     public WildFlyOpenTelemetryConfig(String serviceName, String exporter, String endpoint,
                                       Long batchDelay, Long maxQueueSize, Long maxExportBatchSize,
                                       Long exportTimeout, String spanProcessorType, String sampler, Double ratio,
-                                      boolean mpTelemetryInstalled) {
+                                      boolean mpTelemetryInstalled, boolean vertxInstalled) {
         Map<String, String> config = new HashMap<>();
         // Default to on
         addValue(config, OTEL_SDK_DISABLED, "false");
@@ -85,7 +85,9 @@ public final class WildFlyOpenTelemetryConfig implements OpenTelemetryConfig {
         }
 
 
-        addValue(config, "otel.exporter.vertx.cdi.identifier", "vertx");
+        if (vertxInstalled) {
+            addValue(config, "otel.exporter.vertx.cdi.identifier", "vertx");
+        }
         properties = Collections.unmodifiableMap(config);
         this.mpTelemetryInstalled = mpTelemetryInstalled;
     }

--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemRegistrar.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetrySubsystemRegistrar.java
@@ -215,7 +215,8 @@ class OpenTelemetrySubsystemRegistrar implements SubsystemResourceDefinitionRegi
                 OpenTelemetrySubsystemRegistrar.SPAN_PROCESSOR_TYPE.resolveModelAttribute(context, model).asStringOrNull(),
                 OpenTelemetrySubsystemRegistrar.SAMPLER.resolveModelAttribute(context, model).asStringOrNull(),
                 OpenTelemetrySubsystemRegistrar.RATIO.resolveModelAttribute(context, model).asDoubleOrNull(),
-                context.getCapabilityServiceSupport().hasCapability("org.wildfly.extension.microprofile.telemetry")
+                context.getCapabilityServiceSupport().hasCapability("org.wildfly.extension.microprofile.telemetry"),
+                context.hasOptionalCapability("org.wildfly.extension.vertx", OPENTELEMETRY_CAPABILITY, null)
         );
 
         return CapabilityServiceInstaller.builder(OPENTELEMETRY_CONFIG_CAPABILITY, config)


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20127

What this PR tries to do:

* addValue `otel.exporter.vertx.cdi.identifier` only when vertx is setup to avoid warning messages

Tested by playing https://github.com/wildfly/quickstart/tree/main/opentelemetry-tracing, the warning messages are gone with this fix.