### PR TITLE
[WFLY-20021] Remove all non-breaking uses of ModuleIdentifier in Undertow Subsystem

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowHandlersDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowHandlersDeploymentProcessor.java
@@ -6,6 +6,7 @@ package org.wildfly.extension.undertow.deployment;
 
 import io.undertow.server.handlers.builder.PredicatedHandler;
 import io.undertow.server.handlers.builder.PredicatedHandlersParser;
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -18,7 +19,6 @@ import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.HttpHandlerMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.vfs.VirtualFile;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 
@@ -70,7 +70,7 @@ public class UndertowHandlersDeploymentProcessor implements DeploymentUnitProces
             try {
                 ClassLoader cl = module.getClassLoader();
                 if (hander.getModule() != null) {
-                    Module handlerModule = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER).loadModule(ModuleIdentifier.fromString(hander.getModule()));
+                    Module handlerModule = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER).loadModule(ModuleIdentifierUtil.canonicalModuleIdentifier(hander.getModule()));
                     cl = handlerModule.getClassLoader();
 
                 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ExpressionFilterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ExpressionFilterDefinition.java
@@ -15,14 +15,15 @@ import io.undertow.server.handlers.builder.PredicatedHandler;
 import io.undertow.server.handlers.builder.PredicatedHandlersParser;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModuleIdentifierUtil;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
@@ -62,7 +63,7 @@ public class ExpressionFilterDefinition extends SimpleFilterDefinition {
         if (moduleName != null) {
             try {
                 ModuleLoader moduleLoader = Module.getBootModuleLoader();
-                Module filterModule = moduleLoader.loadModule(ModuleIdentifier.fromString(moduleName));
+                Module filterModule = moduleLoader.loadModule(ModuleIdentifierUtil.canonicalModuleIdentifier(moduleName));
                 loader = filterModule.getClassLoader();
             } catch (ModuleLoadException e) {
                 throw UndertowLogger.ROOT_LOGGER.couldNotLoadHandlerFromModule(expression, moduleName, e);

--- a/web-common/src/main/java/org/jboss/as/web/common/SharedTldsMetaDataBuilder.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/SharedTldsMetaDataBuilder.java
@@ -20,7 +20,6 @@ import org.jboss.metadata.parser.util.NoopXMLResolver;
 import org.jboss.metadata.web.spec.TldMetaData;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleClassLoader;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 
 /**
@@ -48,7 +47,7 @@ public class SharedTldsMetaDataBuilder {
         final List<TldMetaData> metadata = new ArrayList<TldMetaData>();
 
         try {
-            ModuleClassLoader jstl = Module.getModuleFromCallerModuleLoader(ModuleIdentifier.create("javax.servlet.jstl.api")).getClassLoader();
+            ModuleClassLoader jstl = Module.getModuleFromCallerModuleLoader("javax.servlet.jstl.api").getClassLoader();
             for (String tld : JSTL_TAGLIBS) {
                 InputStream is = jstl.getResourceAsStream("META-INF/" + tld);
                 if (is != null) {


### PR DESCRIPTION
[WFLY-20021] Remove all non-breaking uses of ModuleIdentifier in Undertow Subsystem

issue: https://issues.redhat.com/browse/WFLY-20021