### PR TITLE
WFLY-20133 Upgrade Hibernate Validator to 9.0.0.CR1 in WildFly preview / WFLY-20132 Upgrade Hibernate Validator to 8.0.2.Final

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -53,7 +53,7 @@
         <version.org.jboss.resteasy>7.0.0.Alpha4</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
-        <version.org.hibernate.validator>9.0.0.Beta2</version.org.hibernate.validator>
+        <version.org.hibernate.validator>9.0.0.CR1</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.6.3.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.2.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>8.0.1.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>8.0.2.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>15.0.11.Final</version.org.infinispan>
         <version.org.infinispan.protostream>5.0.12.Final</version.org.infinispan.protostream>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Car.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Car.java
@@ -9,9 +9,9 @@ import java.util.List;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
-import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.hibernate.validator.group.GroupSequenceProvider;
 
 /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Employee.java
@@ -4,7 +4,7 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
-import org.hibernate.validator.constraints.Email;
+import jakarta.validation.constraints.Email;
 
 /**
  * @author Madhumita Sadhukhan

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/UserBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/UserBean.java
@@ -4,9 +4,9 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
-import org.hibernate.validator.constraints.Email;
-import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * @author Madhumita Sadhukhan

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidAdminObjectImpl1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ra/ValidAdminObjectImpl1.java
@@ -10,8 +10,7 @@ import javax.naming.Reference;
 import jakarta.resource.Referenceable;
 import jakarta.resource.spi.ResourceAdapter;
 import jakarta.resource.spi.ResourceAdapterAssociation;
-
-import org.hibernate.validator.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * Admin object implementation

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/Player.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/Player.java
@@ -12,11 +12,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
-import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.constraints.NotEmpty;
 
 /**
  * @author Madhumita Sadhukhan

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/SoccerPlayer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/SoccerPlayer.java
@@ -7,9 +7,9 @@ package org.jboss.as.test.integration.jpa.beanvalidation;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 
 import org.hibernate.envers.Audited;
-import org.hibernate.validator.constraints.NotBlank;
 
 /**
  * @author Madhumita Sadhukhan

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/beanvalidationinheritancetest/BeanValidationJPAInheritanceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/beanvalidation/beanvalidationinheritancetest/BeanValidationJPAInheritanceTestCase.java
@@ -83,7 +83,7 @@ public class BeanValidationJPAInheritanceTestCase {
             String stacktrace = w.toString();
 
             if (Locale.getDefault().getLanguage().equals("en")) {
-                Assert.assertTrue(stacktrace.contains("interpolatedMessage='may not be empty', propertyPath=lastName, rootBeanClass=class org.jboss.as.test.integration.jpa.beanvalidation.SoccerPlayer"));
+                Assert.assertTrue(stacktrace.contains("interpolatedMessage='must not be empty', propertyPath=lastName, rootBeanClass=class org.jboss.as.test.integration.jpa.beanvalidation.SoccerPlayer"));
             } else {
                 Assert.assertTrue(stacktrace.contains("propertyPath=lastName, rootBeanClass=class org.jboss.as.test.integration.jpa.beanvalidation.SoccerPlayer"));
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20132
https://issues.redhat.com/browse/WFLY-20133

- 8.0 update has a couple of fixes for `UUID` and `TituloEleitoral` constraints: https://in.relation.to/2024/12/13/hibernate-validator-8-0-2-Final/ (or https://hibernate.atlassian.net/projects/HV/versions/32167/tab/release-report-all-issues)
- 9.0 has a bit more; all changes are listed here https://in.relation.to/2024/12/13/hibernate-validator-9-0-0-CR1 (or https://hibernate.atlassian.net/projects/HV/versions/32349/tab/release-report-all-issues)