### PR TITLE
WFLY-20139 Upgrade otel/opentelemetry-collector image to 0.115.1 and jaegertracing/all-in-one to 1.64.0

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -6,6 +6,7 @@
 package org.wildfly.test.integration.microprofile.faulttolerance.opentelemetry;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -50,7 +51,8 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-            "otel.metric.export.interval=10";
+            // Lower the interval from 60 seconds to 100 millis
+            "otel.metric.export.interval=100";
 
     @Deployment
     public static Archive<?> deploy() {
@@ -100,7 +102,7 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
                     .findFirst();
             Assert.assertTrue(prometheusMetric.isPresent());
             Assert.assertEquals(0, Integer.parseInt(prometheusMetric.get().getValue()), 0);
-        });
+        }, Duration.ofSeconds(70)); // n.b. this in ~2% of cases needs slightly more time on our CI given the asynchronicity
     }
 
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -29,7 +29,8 @@ public abstract class BaseOpenTelemetryTest {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-        "otel.metric.export.interval=100";
+            // Lower the interval from 60 seconds to 100 millis
+            "otel.metric.export.interval=100";
 
     static WebArchive buildBaseArchive(String name) {
         return ShrinkWrap

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
@@ -17,7 +17,7 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
  */
 class JaegerContainer extends BaseContainer<JaegerContainer> {
     public static final String IMAGE_NAME = "jaegertracing/all-in-one";
-    public static final String IMAGE_VERSION = "1.53.0";
+    public static final String IMAGE_VERSION = "1.64.0";
     public static final int PORT_JAEGER_QUERY = 16686;
     public static final int PORT_JAEGER_OTLP = 4317;
 
@@ -47,30 +47,4 @@ class JaegerContainer extends BaseContainer<JaegerContainer> {
     private String getJaegerEndpoint() {
         return "http://localhost:" + getMappedPort(PORT_JAEGER_QUERY);
     }
-
-    /*
-    private void waitForDataToAppear(String serviceName) {
-        try (Client client = ClientBuilder.newClient()) {
-            boolean found = false;
-            int count = 0;
-            while (count < 30) {
-                String response = client.target(getJaegerEndpoint() + "/api/services").request()
-                        .get()
-                        .readEntity(String.class);
-                if (response.contains(serviceName)) {
-                    found = true;
-                    break;
-                }
-                count++;
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    //
-                }
-            }
-
-            Assert.assertTrue("Expected service name not found", found);
-        }
-    }
-    */
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -33,7 +33,7 @@ import org.testcontainers.utility.MountableFile;
  */
 public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetryCollectorContainer> {
     public static final String IMAGE_NAME = "otel/opentelemetry-collector";
-    public static final String IMAGE_VERSION = "0.103.1";
+    public static final String IMAGE_VERSION = "0.115.1";
     public static final int OTLP_GRPC_PORT = 4317;
     public static final int OTLP_HTTP_PORT = 4318;
     public static final int PROMETHEUS_PORT = 1234;
@@ -42,7 +42,7 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
 
     private final JaegerContainer jaegerContainer;
     private final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(
-        TimeoutUtil.adjust(Integer.parseInt(System.getProperty("testsuite.integration.container.timeout", "30"))));
+            TimeoutUtil.adjust(Integer.parseInt(System.getProperty("testsuite.integration.container.timeout", "30"))));
 
     public OpenTelemetryCollectorContainer() {
         super("OpenTelemetryCollector", IMAGE_NAME, IMAGE_VERSION,
@@ -99,7 +99,7 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
      *                          {@link AssertionError#AssertionError()}s if the state obtained from the Jaeger endpoint
      *                          does not match the expected state
      * @return list of Jaeger traces; typically ignored.
-     * @throws AssertionError if
+     * @throws AssertionError       last {@link AssertionError} thrown by the provided {@code assertionConsumer} before timeout elapsed
      * @throws InterruptedException if interrupted
      */
     public List<JaegerTrace> assertTraces(String serviceName, Consumer<List<JaegerTrace>> assertionConsumer) throws InterruptedException {
@@ -135,12 +135,14 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
      * Continually evaluates assertions provided in a consumer until the state obtained from the Prometheus endpoint
      * matches the expected state or until a timeout elapses.
      * By default, polls the collector every second for 30 seconds.
+     * Typically {@code otel.metric.export.interval} must be adjusted to lower values since the default is attempting
+     * to push every 60 seconds, which is well above the default timeout of this method.
      * Returns snapshot of the prometheus registry that passed the assertions; typically ignored.
      *
      * @param assertionConsumer consumer implementation that contains {@link Assert}ions throwing {@link AssertionError#AssertionError()}s
      *                          if the state obtained from the Prometheus endpoint does not match the expected state
      * @return list of prometheus metrics; typically ignored.
-     * @throws AssertionError if
+     * @throws AssertionError       last {@link AssertionError} thrown by the provided {@code assertionConsumer} before timeout elapsed
      * @throws InterruptedException if interrupted
      */
     public List<PrometheusMetric> assertMetrics(Consumer<List<PrometheusMetric>> assertionConsumer) throws AssertionError, InterruptedException {

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/shared/observability/containers/otel-collector-config.yaml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/shared/observability/containers/otel-collector-config.yaml
@@ -1,19 +1,23 @@
 receivers:
   otlp:
     protocols:
+      # Explicitly set endpoints to 0.0.0.0 to avoid issues in containerized environments
+      # Reference: https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#v1110v01040
       grpc:
+        endpoint: "0.0.0.0:4317"
       http:
+        endpoint: "0.0.0.0:4318"
 
 processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   prometheus:
     endpoint: "0.0.0.0:1234"
   otlp:
-    endpoint: jaeger:4317
+    endpoint: "jaeger:4317"
     tls:
       insecure: true
 
@@ -25,13 +29,13 @@ service:
   pipelines:
     traces:
       receivers: [ otlp ]
-      processors: [ ]
-      exporters: [ logging, otlp ]
+      processors: [ batch ]
+      exporters: [ debug, otlp ]
     metrics:
       receivers: [ otlp ]
-      processors: [ ]
-      exporters: [ logging, prometheus ]
+      processors: [ batch ]
+      exporters: [ debug, prometheus ]
     logs:
       receivers: [ otlp ]
-      processors: [ ]
-      exporters: [ logging ]
+      processors: [ batch ]
+      exporters: [ debug ]


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20139

Another chuck of work to stabilize our OpenTelemetry testing, cleanup and improve javadoc/comments.