### PR TITLE
Fix for WFLY-20149, Upgrade WildFly Glow to 1.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.glow>1.2.0.Beta2</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.2.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Alpha2</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.0.Final</version.org.wildfly.unstable.annotation.api>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20149
