### PR TITLE
[WFLY-20157] Remove all non-breaking uses of ModuleIdentifier in Connector subsystem

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/driver/InstalledDriver.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/driver/InstalledDriver.java
@@ -4,8 +4,6 @@
  */
 package org.jboss.as.connector.services.driver;
 
-import org.jboss.modules.ModuleIdentifier;
-
 /**
  * Metadata describing a JDBC driver that has been installed as a service in the
  * runtime.
@@ -14,7 +12,7 @@ import org.jboss.modules.ModuleIdentifier;
 public final class InstalledDriver {
 
     private final String driverName;
-    private final ModuleIdentifier moduleName;
+    private final String moduleName;
     private final String deploymentUnitName;
     private final String driverClassName;
     private final String dataSourceClassName;
@@ -38,7 +36,7 @@ public final class InstalledDriver {
      * @param minorVersion the driver minor version
      * @param jdbcCompliant whether the driver is JDBC compliant
      */
-    public InstalledDriver(final String driverName, final ModuleIdentifier moduleName, final String driverClassName,
+    public InstalledDriver(final String driverName, final String moduleName, final String driverClassName,
                            final String dataSourceClassName, final String xaDataSourceClassName,
                            final int majorVersion, final int minorVersion, final boolean jdbcCompliant) {
         this.deploymentUnitName = null;
@@ -88,7 +86,7 @@ public final class InstalledDriver {
      * @return the module name, or {@code null} if {@link #isFromDeployment()}
      *         returns {@code true}
      */
-    public ModuleIdentifier getModuleName() {
+    public String getModuleName() {
         return moduleName;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -359,8 +359,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                     String driverName = dataSourceConfig.getDriver();
                     InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName);
                     if (installedDriver != null) {
-                        String moduleName = installedDriver.getModuleName() != null ? installedDriver.getModuleName().getName()
-                                : null;
+                        String moduleName = installedDriver.getModuleName();
                         org.jboss.jca.common.api.metadata.ds.Driver driver = new DriverImpl(installedDriver.getDriverName(),
                                 installedDriver.getMajorVersion(), installedDriver.getMinorVersion(),
                                 moduleName, installedDriver.getDriverClassName(),
@@ -386,8 +385,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                     String driverName = xaDataSourceConfig.getDriver();
                     InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName);
                     if (installedDriver != null) {
-                        String moduleName = installedDriver.getModuleName() != null ? installedDriver.getModuleName().getName()
-                                : null;
+                        String moduleName = installedDriver.getModuleName();
                         org.jboss.jca.common.api.metadata.ds.Driver driver = new DriverImpl(installedDriver.getDriverName(),
                                 installedDriver.getMajorVersion(), installedDriver.getMinorVersion(), moduleName,
                                 installedDriver.getDriverClassName(),

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetDataSourceClassInfoOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetDataSourceClassInfoOperationHandler.java
@@ -26,7 +26,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
 import org.jboss.dmr.ModelNode;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.msc.service.ServiceRegistry;
 
@@ -71,7 +70,7 @@ public class GetDataSourceClassInfoOperationHandler implements OperationStepHand
         }
     }
 
-    static ModelNode dsClsInfoNode(ServiceModuleLoader serviceModuleLoader, ModuleIdentifier mid, String dsClsName, String xaDSClsName)
+    static ModelNode dsClsInfoNode(ServiceModuleLoader serviceModuleLoader, String mid, String dsClsName, String xaDSClsName)
             throws OperationFailedException {
         ModelNode result = new ModelNode();
         if (dsClsName != null) {
@@ -87,11 +86,11 @@ public class GetDataSourceClassInfoOperationHandler implements OperationStepHand
         return result;
     }
 
-    private static ModelNode findPropsFromCls(ServiceModuleLoader serviceModuleLoader, ModuleIdentifier mid, String clsName) throws OperationFailedException {
+    private static ModelNode findPropsFromCls(ServiceModuleLoader serviceModuleLoader, String mid, String clsName) throws OperationFailedException {
         Class<?> cls = null;
         if (mid != null) {
             try {
-                cls = Class.forName(clsName, true, serviceModuleLoader.loadModule(mid.toString()).getClassLoader());
+                cls = Class.forName(clsName, true, serviceModuleLoader.loadModule(mid).getClassLoader());
             } catch (ModuleLoadException | ClassNotFoundException e) {
                 throw ConnectorLogger.SUBSYSTEM_DATASOURCES_LOGGER.failedToLoadDataSourceClass(clsName, e);
             }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
@@ -71,9 +71,12 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
                         driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName());
                         driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName());
                     } else {
+                        final int commaIndex = driver.getModuleName() != null ? driver.getModuleName().indexOf(":") : -1;
+                        final String moduleName = commaIndex != -1 ? driver.getModuleName().substring(0, commaIndex) : driver.getModuleName();
+                        final String moduleSlot = commaIndex != -1 ? driver.getModuleName().substring(commaIndex + 1) : "";
                         driverNode.get(DEPLOYMENT_NAME.getName());
-                        driverNode.get(DRIVER_MODULE_NAME.getName()).set(driver.getModuleName().getName());
-                        driverNode.get(MODULE_SLOT.getName()).set(driver.getModuleName() != null ? driver.getModuleName().getSlot() : "");
+                        driverNode.get(DRIVER_MODULE_NAME.getName()).set(moduleName);
+                        driverNode.get(MODULE_SLOT.getName()).set(moduleSlot);
                         driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName()).set(
                                 driver.getDataSourceClassName() != null ? driver.getDataSourceClassName() : "");
                         driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).set(driver.getXaDataSourceClassName() != null ? driver.getXaDataSourceClassName() : "");

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
@@ -70,10 +70,12 @@ public class InstalledDriversListOperationHandler implements OperationStepHandle
                             driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName());
 
                         } else {
+                            final int commaIndex = driver.getModuleName() != null ? driver.getModuleName().indexOf(":") : -1;
+                            final String moduleName = commaIndex != -1 ? driver.getModuleName().substring(0, commaIndex) : driver.getModuleName();
+                            final String moduleSlot = commaIndex != -1 ? driver.getModuleName().substring(commaIndex + 1) : "";
                             driverNode.get(DEPLOYMENT_NAME.getName());
-                            driverNode.get(DRIVER_MODULE_NAME.getName()).set(driver.getModuleName().getName());
-                            driverNode.get(MODULE_SLOT.getName()).set(
-                                    driver.getModuleName() != null ? driver.getModuleName().getSlot() : "");
+                            driverNode.get(DRIVER_MODULE_NAME.getName()).set(moduleName);
+                            driverNode.get(MODULE_SLOT.getName()).set(moduleSlot);
                             driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName()).set(
                                     driver.getDataSourceClassName() != null ? driver.getDataSourceClassName() : "");
                             driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).set(

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
@@ -15,6 +15,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_NAM
 import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_XA_DATASOURCE_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER_ATTRIBUTES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.lang.reflect.Constructor;
@@ -41,7 +42,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceBuilder;
@@ -77,12 +77,12 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
 
         final ServiceTarget target = context.getServiceTarget();
 
-        final ModuleIdentifier moduleId;
+        final String moduleId;
         final Module module;
         String slot = model.hasDefined(MODULE_SLOT.getName()) ? MODULE_SLOT.resolveModelAttribute(context, model).asString() : null;
 
         try {
-            moduleId = ModuleIdentifier.create(moduleName, slot);
+            moduleId = canonicalModuleIdentifier(moduleName, slot);
             module = Module.getCallerModuleLoader().loadModule(moduleId);
         } catch (ModuleNotFoundException e) {
             throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.missingDependencyInModuleDriver(moduleName, e.getMessage()), e);
@@ -153,7 +153,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
         }
     }
 
-    public static void startDriverServices(final ServiceTarget target, final ModuleIdentifier moduleId, Driver driver, final String driverName, final Integer majorVersion,
+    public static void startDriverServices(final ServiceTarget target, final String moduleId, Driver driver, final String driverName, final Integer majorVersion,
                                            final Integer minorVersion, final String dataSourceClassName, final String xaDataSourceClassName) throws IllegalStateException {
         final int majorVer = driver.getMajorVersion();
         final int minorVer = driver.getMinorVersion();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.connector.subsystems.resourceadapters;
 
+import static org.jboss.as.controller.ModuleIdentifierUtil.canonicalModuleIdentifier;
 import static org.jboss.as.connector._private.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 import static org.jboss.as.connector._private.Capabilities.ELYTRON_SECURITY_DOMAIN_CAPABILITY;
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_RA_LOGGER;
@@ -125,7 +126,6 @@ import org.jboss.jca.common.metadata.common.ValidationImpl;
 import org.jboss.jca.common.metadata.common.XaPoolImpl;
 import org.jboss.jca.common.metadata.resourceadapter.WorkManagerImpl;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.LifecycleEvent;
@@ -449,7 +449,7 @@ public class RaOperationUtil {
 
         Module module;
         try {
-            ModuleIdentifier moduleId = ModuleIdentifier.create(moduleName, slot);
+            String moduleId = canonicalModuleIdentifier(moduleName, slot);
             module = Module.getCallerModuleLoader().loadModule(moduleId);
         } catch (ModuleNotFoundException e) {
             throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.raModuleNotFound(moduleName, e.getMessage()), e);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20157