### PR TITLE
[WFLY-19954] A follow up to add tests on the vertx instance usage in opentelemetry subsystem

### DIFF
--- a/testsuite/preview/expansion/pom.xml
+++ b/testsuite/preview/expansion/pom.xml
@@ -37,7 +37,6 @@
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <!-- Disable the default surefire test execution. -->
         <surefire.default-test.phase>none</surefire.default-test.phase>
-        <ts.copy-wildfly-standalone-embedded-broker.phase>process-test-resources</ts.copy-wildfly-standalone-embedded-broker.phase>
         <cloud-profile-provisioning.phase>none</cloud-profile-provisioning.phase>
         <full-provisioning.phase>generate-test-resources</full-provisioning.phase>
     </properties>
@@ -190,31 +189,6 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions combine.children="append">
-                            <!-- Copy the docs/example configs into the regulard configuration dir so
-                                 they are available for use by surefire executions that need them. -->
-                            <execution>
-                                <id>ts.copy-wildfly-standalone-embedded-broker</id>
-                                <inherited>true</inherited>
-                                <phase>${ts.copy-wildfly-standalone-embedded-broker.phase}</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${basedir}/target/wildfly/standalone/configuration/</outputDirectory>
-                                    <overwrite>true</overwrite>
-                                    <resources>
-                                        <resource>
-                                            <directory>${jbossas.project.dir}/${wildfly.build.output.dir}/docs/examples/configs/</directory>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <!-- General configuration is inherited from the surefire plugin declaration outside this profile-->
                         <!-- Here we just have executions -->
@@ -238,7 +212,7 @@
 
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables combine.children="append">
-                                        <jboss.server.config.file.name>standalone-activemq-embedded.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                         <jboss.inst>${basedir}/target/wildfly</jboss.inst>
                                         <!-- Needed for the IIOP tests-->
                                         <com.sun.CORBA.ORBUseDynamicStub>true</com.sun.CORBA.ORBUseDynamicStub>
@@ -308,7 +282,6 @@
                 <glow.cloud-profile.phase>test-compile</glow.cloud-profile.phase>
                 <full-provisioning.phase>none</full-provisioning.phase>
                 <ts.config-as.copy-mgmt-users.phase>process-test-classes</ts.config-as.copy-mgmt-users.phase>
-                <ts.copy-wildfly-standalone-embedded-broker.phase>none</ts.copy-wildfly-standalone-embedded-broker.phase>
             </properties>
             <build>
                 <plugins>
@@ -350,7 +323,6 @@
                 <extra.server.jvm.args>-Dmaven.repo.local=${settings.localRepository}</extra.server.jvm.args>
                 <full-provisioning.phase>none</full-provisioning.phase>
                 <glow.cloud-profile.phase>test-compile</glow.cloud-profile.phase>
-                <ts.copy-wildfly-standalone-embedded-broker.phase>none</ts.copy-wildfly-standalone-embedded-broker.phase>
                 <ts.bootable-jar-packaging.phase>process-test-classes</ts.bootable-jar-packaging.phase>
             </properties>
             <build>

--- a/testsuite/preview/expansion/pom.xml
+++ b/testsuite/preview/expansion/pom.xml
@@ -71,6 +71,11 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-testsuite-shared</artifactId>
             <scope>test</scope>
         </dependency>
@@ -78,7 +83,6 @@
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-testcontainers</artifactId>
-            <version>1.0.0.Alpha1</version>
             <scope>test</scope>
         </dependency>
 
@@ -90,6 +94,33 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+
+        <!-- following dependencies are needed to test opentelemetry subsystem using the vertx instance from vertx subsystem -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/JaxRsActivator.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/JaxRsActivator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+// This is copied from testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/JaxRsActivator.java
+// this will be removed once promoted to ts/integ/mp
+@ApplicationPath("/")
+public class JaxRsActivator extends Application {
+
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/AbstractOpenTelemetryIntegrationTest.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/AbstractOpenTelemetryIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+import java.net.URL;
+import java.util.stream.Collectors;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+public abstract class AbstractOpenTelemetryIntegrationTest extends BaseOpenTelemetryTest{
+
+    @ArquillianResource
+    protected ManagementClient managementClient;
+
+    @ArquillianResource
+    private URL url;
+
+    protected void requestOpenTelemetryTrace(String serviceName) throws Exception {
+        try (Client client = ClientBuilder.newClient()) {
+            final String restUrl = url.toString() + "/?name=value";
+            Response response = client.target(restUrl).request().get();
+            Assert.assertEquals(200, response.getStatus());
+        }
+        otelCollector.assertTraces(serviceName, traces -> Assert.assertFalse("Traces not found for service", traces.isEmpty()));
+    }
+
+    static String retrieveServerLog(ManagementClient managementClient, String logFileName) throws Exception {
+        PathAddress logFileAddress = PathAddress.pathAddress().append(SUBSYSTEM, "logging").append("log-file", logFileName);
+        ModelNode op = Util.createEmptyOperation("read-log-file", logFileAddress);
+        op.get("lines").set(30);
+        ModelNode result = managementClient.getControllerClient().execute(op);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        return result.get(RESULT).asList().stream().map(ModelNode::toString).collect(Collectors.joining("\n"));
+    }
+
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.as.test.shared.CdiUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
+import org.jboss.as.test.shared.observability.signals.jaeger.JaegerResponse;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.observability.JaxRsActivator;
+import org.wildfly.test.integration.observability.opentelemetry.application.OtelService1;
+
+import java.net.MalformedURLException;
+
+// This is copied from testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+// this will be removed once promoted to ts/integ/mp
+@RunWith(Arquillian.class)
+@DockerRequired
+public abstract class BaseOpenTelemetryTest {
+    @Testcontainer
+    protected OpenTelemetryCollectorContainer otelCollector;
+
+    private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
+            // Lower the interval from 60 seconds to 100 millis
+            "otel.metric.export.interval=100";
+
+    static WebArchive buildBaseArchive(String name) {
+        return ShrinkWrap
+            .create(WebArchive.class, name + ".war")
+            .addClasses(
+                BaseOpenTelemetryTest.class,
+                JaxRsActivator.class,
+                OtelService1.class
+            )
+            .addPackage(JaegerResponse.class.getPackage())
+            .addAsManifestResource(new StringAsset(MP_CONFIG), "microprofile-config.properties")
+            .addAsWebInfResource(CdiUtils.createBeansXml(), "beans.xml")
+            ;
+    }
+
+    protected String getDeploymentUrl(String deploymentName) throws MalformedURLException {
+        return TestSuiteEnvironment.getHttpUrl() + "/" + deploymentName + "/";
+    }
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/LoggingServerSetupTask.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/LoggingServerSetupTask.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+
+/**
+ * A ServerSetupTask to set up logger categories to file handlers for log messages check in the tests.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+public class LoggingServerSetupTask extends ManagementServerSetupTask {
+
+    public LoggingServerSetupTask() {
+        this(SMALLRYE_OPENTELEMETRY_LOG_FILE, VERTX_FEATURE_PACK_LOG_FILE);
+    }
+
+    static final String SMALLRYE_OPENTELEMETRY_LOG_FILE = "smallrye-opentelemetry.log";
+    static final String VERTX_FEATURE_PACK_LOG_FILE = "vertx-feature-pack.log";
+
+    public LoggingServerSetupTask(String smallryeOpentelemetryLogFile, String vertxSubsystemLogFile) {
+        super(createContainerConfigurationBuilder()
+                .setupScript(createScriptBuilder()
+                        .startBatch()
+                        .add("/subsystem=logging/file-handler=otel-exporter:add(file={relative-to=jboss.server.log.dir, path=%s}, append=false, level=DEBUG)", smallryeOpentelemetryLogFile)
+                        .add("/subsystem=logging/logger=io.smallrye.opentelemetry.implementation.exporters:add(level=DEBUG, handlers=[otel-exporter])")
+                        .add("/subsystem=logging/file-handler=vertx-extension-logger-handler:add(file={relative-to=jboss.server.log.dir, path=%s}, append=false, level=DEBUG)", vertxSubsystemLogFile)
+                        .add("/subsystem=logging/logger=org.wildfly.extension.vertx:add(level=DEBUG, handlers=[vertx-extension-logger-handler])")
+                        .endBatch()
+                        .build())
+                .tearDownScript(createScriptBuilder()
+                        .startBatch()
+                        .add("/subsystem=logging/logger=org.wildfly.extension.vertx:remove()")
+                        .add("/subsystem=logging/file-handler=vertx-extension-logger-handler:remove()")
+                        .add("/subsystem=logging/logger=io.smallrye.opentelemetry.implementation.exporters:remove()")
+                        .add("/subsystem=logging/file-handler=otel-exporter:remove()")
+                        .endBatch()
+                        .build())
+                .build());
+    }
+
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationWithVertxTestCase.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationWithVertxTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * A test on opentelemetry to use the Vertx instance defined in the vertx subsystem.
+ * There will be a server log to indicate the usage.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({OpenTelemetryWithCollectorSetupTask.class, OpenTelemetryIntegrationWithVertxTestCase.LoggingWithVertxServerSetupTask.class, VertxSubsystemSetupTask.class})
+@RunAsClient
+@DockerRequired
+public class OpenTelemetryIntegrationWithVertxTestCase extends AbstractOpenTelemetryIntegrationTest {
+
+    private static final String WITH_VERTX_SMALLRYE_OPENTELEMETRY_LOG_FILE = "smallrye-opentelemetry-with-vertx.log";
+    private static final String WITH_VERTX_VERTX_FEATURE_PACK_LOG_FILE = "vertx-feature-pack-with-vertx.log";
+    public static class LoggingWithVertxServerSetupTask extends LoggingServerSetupTask {
+        public LoggingWithVertxServerSetupTask() {
+            super(WITH_VERTX_SMALLRYE_OPENTELEMETRY_LOG_FILE, WITH_VERTX_VERTX_FEATURE_PACK_LOG_FILE);
+        }
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive getDeployment() {
+        return buildBaseArchive("otelinteg-with-vertx");
+    }
+
+    @Test
+    public void testVertxUsageInLog() throws Exception {
+        requestOpenTelemetryTrace("otelinteg-with-vertx.war");
+        String logsInSmalleRyeOpentelemetry = retrieveServerLog(managementClient, WITH_VERTX_SMALLRYE_OPENTELEMETRY_LOG_FILE);
+        Assert.assertFalse("It won't create Vertx when vertx subsystem is available", logsInSmalleRyeOpentelemetry.contains("Create a new Vertx instance"));
+        String logsInVertxSubsystem = retrieveServerLog(managementClient, WITH_VERTX_VERTX_FEATURE_PACK_LOG_FILE);
+        Assert.assertTrue("Should use Vertx instance from vertx subsystem", logsInVertxSubsystem.contains("WFLYVTX0008"));
+    }
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationWithoutVertxTestCase.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationWithoutVertxTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A test on opentelemetry that is not using the Vertx instance defined in the vertx subsystem.
+ * There will be a server log to indicate a Vertx instance is created by smallerye-opentelemetry.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({OpenTelemetryWithCollectorSetupTask.class, LoggingServerSetupTask.class})
+@RunAsClient
+@DockerRequired
+public class OpenTelemetryIntegrationWithoutVertxTestCase extends AbstractOpenTelemetryIntegrationTest {
+
+    @Deployment(testable = false)
+    public static WebArchive getDeployment() {
+        return buildBaseArchive("otelinteg-without-vertx");
+    }
+
+    @Test
+    public void testVertxUsageInLog() throws Exception {
+        requestOpenTelemetryTrace("otelinteg-without-vertx.war");
+        String logsInSmalleRyeOpentelemetry = retrieveServerLog(managementClient, LoggingServerSetupTask.SMALLRYE_OPENTELEMETRY_LOG_FILE);
+        Assert.assertTrue("It should create Vertx when vertx subsystem is not available", logsInSmalleRyeOpentelemetry.contains("Create a new Vertx instance"));
+        String logsInVertxSubsystem = retrieveServerLog(managementClient, LoggingServerSetupTask.VERTX_FEATURE_PACK_LOG_FILE);
+        Assert.assertFalse("Should not use Vertx instance from vertx subsystem", logsInVertxSubsystem.contains("WFLYVTX0008"));
+    }
+
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/VertxSubsystemSetupTask.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/VertxSubsystemSetupTask.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+
+/**
+ * A ServerSetupTask to add vertx extension and subsystem, add a Vertx instance with default options.
+ * It will clean up the configuration on tearDown.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+public class VertxSubsystemSetupTask extends ManagementServerSetupTask {
+    public VertxSubsystemSetupTask() {
+        super(createContainerConfigurationBuilder()
+                .setupScript(createScriptBuilder()
+                        .startBatch()
+                        .add("/extension=org.wildfly.extension.vertx:add()")
+                        .add("/subsystem=vertx:add()")
+                        .endBatch()
+                        .startBatch()
+                        .add("/subsystem=vertx/vertx=vertx:add()")
+                        .endBatch()
+                        .build())
+                .tearDownScript(createScriptBuilder()
+                        .startBatch()
+                        .add("/subsystem=vertx/vertx=vertx:remove()")
+                        .add("/subsystem=vertx:remove()")
+                        .add("/extension=org.wildfly.extension.vertx:remove()")
+                        .endBatch()
+                        .build())
+                .build());
+    }
+}

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry.application;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+// This is copied from testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
+// this will be removed once promoted to ts/integ/mp
+@RequestScoped
+@Path("/")
+public class OtelService1 {
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private Tracer tracer;
+
+    @GET
+    public String sayHello(@QueryParam("name") String name) {
+        final Span span = tracer.spanBuilder("Saying hello from server1").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            span.addEvent("some-event");
+            span.setAttribute("name", name);
+            span.end();
+        }
+
+        return "Hello, " + name;
+    }
+
+    @GET
+    @Path("contextProp1")
+    public Response contextProp1() throws URISyntaxException {
+        final Span span = tracer.spanBuilder("Handling contextProp1 request from server1").startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            span.setAttribute("method_called", "contextProp1");
+            span.addEvent("The method contextProp1 was called");
+
+            span.end();
+            try (Client client = ClientBuilder.newClient()) {
+                URI baseUri = uriInfo.getBaseUri();
+                URI targetUri = new URI(baseUri.getScheme() +"://" +
+                        baseUri.getHost() + ":" +
+                        baseUri.getPort() + "/service2/contextProp2");
+
+                Response response = client.target(targetUri)
+                        .request()
+                        .get();
+
+                if (response.getStatus() != 204) {
+                    throw new WebApplicationException("Second server not found.");
+                }
+
+            }
+        }
+
+
+        return Response.noContent().build();
+    }
+}


### PR DESCRIPTION
This is a follow up to add tests on the vertx instance usage in opentelemetry subsystem

Related issue is: https://issues.redhat.com/browse/WFLY-19954

If a new WFLY issue is a better, I can create one to update.