### PR TITLE
[WFLY-20166] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in NAMING

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/deployment/JdkDependenciesProcessor.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/JdkDependenciesProcessor.java
@@ -35,7 +35,7 @@ public final class JdkDependenciesProcessor implements DeploymentUnitProcessor {
         for (String moduleName : JDK_NAMING_MODULES) {
             try {
                 moduleLoader.loadModule(moduleName);
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleName, false, false, false, false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleName).build());
             } catch (ModuleLoadException ex) {
                 NamingLogger.ROOT_LOGGER.debugf("Module not found: %s", moduleName);
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20166