### PR TITLE
[WFLY-20168] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in BATCH

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDependencyProcessor.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDependencyProcessor.java
@@ -8,7 +8,6 @@ package org.wildfly.extension.batch.jberet.deployment;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
-import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
@@ -19,14 +18,13 @@ import org.jboss.modules.ModuleLoader;
  * Adds required batch dependencies to deployments.
  */
 public class BatchDependencyProcessor implements DeploymentUnitProcessor {
-
     @Override
-    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+    public void deploy(final DeploymentPhaseContext phaseContext) {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "jakarta.batch.api", false, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.jberet.jberet-core", false, false, true, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "jakarta.batch.api").build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.jberet.jberet-core").setImportServices(true).build());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20168