### PR TITLE
[WFLY-20170] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in EE

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -60,12 +60,12 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
         //add jboss-invocation classes needed by the proxies
-        ModuleDependency invocation = new ModuleDependency(moduleLoader, JBOSS_INVOCATION_ID, false, false, false, false);
+        ModuleDependency invocation = ModuleDependency.Builder.of(moduleLoader, JBOSS_INVOCATION_ID).build();
         invocation.addImportFilter(PathFilters.is("org/jboss/invocation/proxy/classloading"), true);
         invocation.addImportFilter(PathFilters.acceptAll(), false);
         moduleSpecification.addSystemDependency(invocation);
 
-        ModuleDependency ee = new ModuleDependency(moduleLoader, JBOSS_AS_EE, false, false, false, false);
+        ModuleDependency ee = ModuleDependency.Builder.of(moduleLoader, JBOSS_AS_EE).build();
         ee.addImportFilter(PathFilters.is("org/jboss/as/ee/component/serialization"), true);
         ee.addImportFilter(PathFilters.is("org/jboss/as/ee/concurrent"), true);
         ee.addImportFilter(PathFilters.is("org/jboss/as/ee/concurrent/handle"), true);
@@ -73,13 +73,13 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
         moduleSpecification.addSystemDependency(ee);
 
         // add dep for naming permission
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, WILDFLY_NAMING, false, false, false, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, WILDFLY_NAMING).build());
 
         //we always add all Jakarta EE API modules, as the platform spec requires them to always be available
         //we do not just add the javaee.api module, as this breaks excludes
 
-        for (final String moduleIdentifier : JAVA_EE_API_MODULES) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, true, false, true, false));
+        for (String moduleName : JAVA_EE_API_MODULES) {
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleName).setOptional(true).setImportServices(true).build());
         }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/structure/GlobalModuleDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/GlobalModuleDependencyProcessor.java
@@ -36,11 +36,10 @@ public class GlobalModuleDependencyProcessor implements DeploymentUnitProcessor 
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
-
         final List<GlobalModule> globalMods = this.globalModules;
 
             for (final GlobalModule module : globalMods) {
-                final ModuleDependency dependency = new ModuleDependency(Module.getBootModuleLoader(), module.getModuleName(), false, false, module.isServices(), false);
+                final ModuleDependency dependency = ModuleDependency.Builder.of(Module.getBootModuleLoader(), module.getModuleName()).setImportServices(module.isServices()).build();
 
                 if (module.isMetaInf()) {
                     dependency.addImportFilter(PathFilters.getMetaInfSubdirectoriesFilter(), true);

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/GlobalDirectoryDeploymentService.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/GlobalDirectoryDeploymentService.java
@@ -74,7 +74,7 @@ public class GlobalDirectoryDeploymentService implements Service {
                 Path resolvedPath = data.getResolvedPath();
                 String moduleName = data.getModuleName();
                 String moduleIdentifier = externalModuleService.addExternalModule(moduleName, resolvedPath.toString(), serviceRegistry, serviceTarget).toString();
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier).setImportServices(true).build());
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20170