### PR TITLE
[WFLY-20171] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in BEAN VALIDATION

### DIFF
--- a/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationDeploymentDependenciesProcessor.java
+++ b/bean-validation/src/main/java/org/jboss/as/ee/beanvalidation/BeanValidationDeploymentDependenciesProcessor.java
@@ -32,9 +32,9 @@ public class BeanValidationDeploymentDependenciesProcessor implements Deployment
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
-        //
-        for (final String moduleIdentifier : DEPENDENCIES) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, true, false, true, false));
+
+        for (String moduleIdentifier : DEPENDENCIES) {
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier).setOptional(true).setImportServices(true).build());
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20171