### PR TITLE
[WFLY-20172] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in CLUSTERING

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/deployment/ClusteringDependencyProcessor.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/deployment/ClusteringDependencyProcessor.java
@@ -26,12 +26,11 @@ public class ClusteringDependencyProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, API, true, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, MARSHALLING_API, true, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, SINGLETON_API, true, false, false, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, API).setOptional(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, MARSHALLING_API).setOptional(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, SINGLETON_API).setOptional(true).build());
     }
 }

--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/deployment/DistributableWebDeploymentProcessor.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/deployment/DistributableWebDeploymentProcessor.java
@@ -50,35 +50,35 @@ public class DistributableWebDeploymentProcessor implements DeploymentUnitProces
             ModuleSpecification specification = unit.getAttachment(Attachments.MODULE_SPECIFICATION);
             ModuleLoader loader = Module.getBootModuleLoader();
 
-            specification.addSystemDependency(new ModuleDependency(loader, WEB_API, false, false, false, false));
+            specification.addSystemDependency(ModuleDependency.Builder.of(loader, WEB_API).build());
 
             if (provider.getSessionManagementConfiguration().getMarshallerFactory() == SessionMarshallerFactory.PROTOSTREAM) {
-                specification.addSystemDependency(new ModuleDependency(loader, PROTOSTREAM, false, false, false, false));
-                specification.addSystemDependency(new ModuleDependency(loader, UNDERTOW, false, false, true, false));
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, PROTOSTREAM).build());
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, UNDERTOW).setImportServices(true).build());
 
                 CapabilityServiceSupport support = unit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
                 if (support.hasCapability(Capabilities.WELD_CAPABILITY_NAME)) {
                     try {
                         WeldCapability weldCapability = support.getCapabilityRuntimeAPI(Capabilities.WELD_CAPABILITY_NAME, WeldCapability.class);
                         if (weldCapability.isPartOfWeldDeployment(unit)) {
-                            specification.addSystemDependency(new ModuleDependency(loader, EJB_CLIENT, false, false, true, false));
-                            specification.addSystemDependency(new ModuleDependency(loader, EL_EXPRESSLY, false, false, true, false));
-                            specification.addSystemDependency(new ModuleDependency(loader, WELD_CORE, false, false, true, false));
-                            specification.addSystemDependency(new ModuleDependency(loader, WELD_EJB, false, false, true, false));
-                            specification.addSystemDependency(new ModuleDependency(loader, WELD_WEB, false, false, true, false));
+                            specification.addSystemDependency(ModuleDependency.Builder.of(loader, EJB_CLIENT).setImportServices(true).build());
+                            specification.addSystemDependency(ModuleDependency.Builder.of(loader, EL_EXPRESSLY).setImportServices(true).build());
+                            specification.addSystemDependency(ModuleDependency.Builder.of(loader, WELD_CORE).setImportServices(true).build());
+                            specification.addSystemDependency(ModuleDependency.Builder.of(loader, WELD_EJB).setImportServices(true).build());
+                            specification.addSystemDependency(ModuleDependency.Builder.of(loader, WELD_WEB).setImportServices(true).build());
                         }
                     } catch (NoSuchCapabilityException e) {
                         throw new IllegalStateException(e);
                     }
                 }
             } else {
-                specification.addSystemDependency(new ModuleDependency(loader, MARSHALLING_API, false, false, false, false));
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, MARSHALLING_API).build());
             }
 
             if (JsfVersionMarker.getVersion(unit).equals(JsfVersionMarker.JSF_4_0)) {
-                specification.addSystemDependency(new ModuleDependency(loader, EL_EXPRESSLY, false, false, true, false));
-                specification.addSystemDependency(new ModuleDependency(loader, FACES_API, false, false, true, false));
-                specification.addSystemDependency(new ModuleDependency(loader, FACES_MOJARRA, false, false, true, false));
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, EL_EXPRESSLY).setImportServices(true).build());
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, FACES_API).setImportServices(true).build());
+                specification.addSystemDependency(ModuleDependency.Builder.of(loader, FACES_MOJARRA).setImportServices(true).build());
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20172