### PR TITLE
[WFLY-20173] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in JCA

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/JdbcDriverDeploymentProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/JdbcDriverDeploymentProcessor.java
@@ -51,7 +51,7 @@ public final class JdbcDriverDeploymentProcessor implements DeploymentUnitProces
         }
 
         if (javaSqlDriverDetected) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JDK_SECURITY_JGSS_ID, false, false, false, false));
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JDK_SECURITY_JGSS_ID).build());
         }
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
@@ -43,18 +43,18 @@ public class RarDependencyProcessor implements DeploymentUnitProcessor {
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, RESOURCE_API_ID, false, false, false, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, RESOURCE_API_ID).build());
         if (phaseContext.getDeploymentUnit().getAttachment(ConnectorXmlDescriptor.ATTACHMENT_KEY) == null) {
             return;  // Skip non ra deployments
         }
 
         //if a module depends on a rar it also needs a dep on all the rar's "local dependencies"
         moduleSpecification.setLocalDependenciesTransitive(true);
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JMS_ID, false, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, VALIDATION_ID, false, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, IRON_JACAMAR_ID, false, false, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, IRON_JACAMAR_IMPL_ID, false, true, false, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, HIBERNATE_VALIDATOR_ID, false, false, true, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JMS_ID).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, VALIDATION_ID).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, IRON_JACAMAR_ID).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, IRON_JACAMAR_IMPL_ID).setExport(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, HIBERNATE_VALIDATOR_ID).setImportServices(true).build());
         if (support.hasCapability(Capabilities.RESOURCE_ADAPTERS_SUBSYSTEM_CAPABILITY_NAME)) {
             phaseContext.addDeploymentDependency(ConnectorServices.RESOURCEADAPTERS_SUBSYSTEM_SERVICE, ResourceAdaptersSubsystemService.ATTACHMENT_KEY);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20173