### PR TITLE
[WFLY-20178] Upgrade WildFly Core to 27.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>5.0.2.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20178

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.0.Beta7
Diff: https://github.com/yersan/wildfly-core/compare/27.0.0.Beta6...27.0.0.Beta7

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7104'>WFCORE-7104</a>] -         Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Elytron
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7105'>WFCORE-7105</a>] -         Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Test Suite
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7106'>WFCORE-7106</a>] -         Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Logging
</li>
</ul>
                                
<h2>        Component Upgrade Subtask
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7093'>WFCORE-7093</a>] -         Upgrade WildFly Legacy Tests to 9.0.0.Final
</li>
</ul>
                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7094'>WFCORE-7094</a>] -         Deployment exclusion processing ignores slots
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3720'>WFCORE-3720</a>] -         Update ServiceModuleLoader to use non-deprecated JBoss Modules APIs
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7090'>WFCORE-7090</a>] -         Make WildFly 31 available in ModelTestControllerVersion
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7101'>WFCORE-7101</a>] -         Upgrade WildFly Maven Plugin to 5.1.0.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7100'>WFCORE-7100</a>] -         Use a concurrent set for ModuleSpecification.userDependenciesSet
</li>
</ul>
</details>
