### PR TITLE
WFLY-20141 Multiple @Deployment-s in microprofile test suite are attaching unnecessary classes to deployments, e.g. test class itself

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
@@ -42,10 +42,10 @@ import org.wildfly.test.integration.microprofile.config.smallrye.SubsystemConfig
 @ServerSetup(SubsystemConfigSourceTask.class)
 public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileConfigTestCase.war")
-                .addClasses(TestApplication.class, AbstractMicroProfileConfigTestCase.class)
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(MicroProfileConfigTestCase.class.getPackage(),
                         "microprofile-config.properties", "microprofile-config.properties")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_class/ConfigSourceFromClassTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_class/ConfigSourceFromClassTestCase.java
@@ -37,10 +37,10 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @ServerSetup(SetupTask.class)
 public class ConfigSourceFromClassTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromClassTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsWebInfResource(ConfigSourceFromClassTestCase.class.getPackage(), "jboss-deployment-structure.xml",
                         "jboss-deployment-structure.xml");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/ConfigSourceFromDirTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_dir/ConfigSourceFromDirTestCase.java
@@ -46,12 +46,11 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @ServerSetup(SetupTask.class)
 public class ConfigSourceFromDirTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromDirTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+        return ShrinkWrap.create(WebArchive.class, "ConfigSourceFromDirTestCase.war")
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        return war;
     }
 
     @ArquillianResource

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_properties/ConfigSourceFromPropertiesTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_properties/ConfigSourceFromPropertiesTestCase.java
@@ -43,12 +43,11 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @ServerSetup(SetupTask.class)
 public class ConfigSourceFromPropertiesTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromPropertiesTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+        return ShrinkWrap.create(WebArchive.class, "ConfigSourceFromPropertiesTestCase.war")
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        return war;
     }
 
     @ArquillianResource

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/from_root_dir/ConfigSourceRootTestCase.java
@@ -47,10 +47,10 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @ServerSetup(SetupTask.class)
 public class ConfigSourceRootTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromDirTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/ConfigSourceProviderFromClassTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/ConfigSourceProviderFromClassTestCase.java
@@ -38,12 +38,11 @@ import org.wildfly.test.integration.microprofile.config.smallrye.management.conf
 @ServerSetup(SetupTask.class)
 public class ConfigSourceProviderFromClassTestCase extends AbstractMicroProfileConfigTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceProviderFromClassTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+        return ShrinkWrap.create(WebArchive.class, "ConfigSourceProviderFromClassTestCase.war")
+                .addClasses(TestApplication.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        return war;
     }
 
     @ArquillianResource

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
@@ -43,12 +43,12 @@ public class MultipleDeploymentMetricsTestCase {
     public static final String DEPLOYMENT_1 = "deployment-1";
     public static final String DEPLOYMENT_2 = "deployment-2";
 
-    @Deployment(name = DEPLOYMENT_1)
+    @Deployment(name = DEPLOYMENT_1, testable = false)
     public static Archive<?> deployment1() {
         return deployment(1);
     }
 
-    @Deployment(name = DEPLOYMENT_2)
+    @Deployment(name = DEPLOYMENT_2, testable = false)
     public static Archive<?> deployment2() {
         return deployment(2);
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -16,7 +16,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
@@ -52,11 +51,10 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
             "otel.metric.export.interval=10";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, FaultToleranceMicrometerIntegrationTestCase.class.getSimpleName() + ".war")
                 .addAsManifestResource(new StringAsset(MP_CONFIG), "microprofile-config.properties")
-                .addClasses(ServerSetupTask.class)
                 .addPackage(FaultTolerantApplication.class.getPackage())
                 .addAsWebInfResource(FaultToleranceMicrometerIntegrationTestCase.class.getPackage(), "web.xml", "web.xml")
                 .addAsWebInfResource(FaultToleranceMicrometerIntegrationTestCase.class.getPackage(), "beans.xml", "beans.xml");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessTestBase.java
@@ -38,7 +38,7 @@ public abstract class MicroProfileHealthApplicationWithoutReadinessTestBase {
 
     abstract void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException;
 
-    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBaseSetup")
+    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBaseSetup", testable = false)
     public static Archive<?> deploySetup() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutReadinessTestBaseSetup.war")
                 .addClass(MicroProfileHealthApplicationReadySetupTask.class);
@@ -46,7 +46,7 @@ public abstract class MicroProfileHealthApplicationWithoutReadinessTestBase {
     }
 
     // deployment does not define any readiness probe
-    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBase", managed = false)
+    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBase", managed = false, testable = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutReadinessTestBase.war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutStartupTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutStartupTestBase.java
@@ -37,7 +37,7 @@ public abstract class MicroProfileHealthApplicationWithoutStartupTestBase {
 
     abstract void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException;
 
-    @Deployment(name = "MicroProfileHealthApplicationWithoutStartupTestBaseSetup")
+    @Deployment(name = "MicroProfileHealthApplicationWithoutStartupTestBaseSetup", testable = false)
     public static Archive<?> deploySetup() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutStartupTestBaseSetup.war")
                 .addClass(MicroProfileHealthApplicationStartupSetupTask.class);
@@ -45,7 +45,7 @@ public abstract class MicroProfileHealthApplicationWithoutStartupTestBase {
     }
 
     // deployment does not define any startup probe
-    @Deployment(name = "MicroProfileHealthApplicationWithoutStartupTestBase", managed = false)
+    @Deployment(name = "MicroProfileHealthApplicationWithoutStartupTestBase", managed = false, testable = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutStartupTestBase.war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresMultiWarTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresMultiWarTestBase.java
@@ -22,7 +22,7 @@ public abstract class MicroProfileHealthDisabledDefaultProceduresMultiWarTestBas
     abstract void checkGlobalOutcome(final ManagementClient managementClient, final String operation, final boolean mustBeUP,
                                      final String probeName, final Integer expectedChecksCount) throws IOException;
 
-    @Deployment(name = SERVICE_ONE, order = 1)
+    @Deployment(name = SERVICE_ONE, order = 1, testable = false)
     public static WebArchive createDeployment1() {
         return ShrinkWrap.create(WebArchive.class, SERVICE_ONE + ".war")
                 // no deployment health checks provided, we want for WildFly to automatically add readiness + startup checks here
@@ -30,7 +30,7 @@ public abstract class MicroProfileHealthDisabledDefaultProceduresMultiWarTestBas
                 .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml");
     }
 
-    @Deployment(name = SERVICE_TWO, order = 2)
+    @Deployment(name = SERVICE_TWO, order = 2, testable = false)
     public static WebArchive createDeployment2() {
         return ShrinkWrap.create(WebArchive.class, SERVICE_TWO + ".war")
                 // we want the deployment to provide ready and startup checks here

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresTestBase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthDisabledDefaultProceduresTestBase.java
@@ -30,7 +30,7 @@ public abstract class MicroProfileHealthDisabledDefaultProceduresTestBase {
     abstract void checkGlobalOutcome(final ManagementClient managementClient, final String operation, final boolean mustBeUP,
                                      final String probeName, final Integer expectedChecksCount) throws IOException;
 
-    @Deployment(name = "MicroProfileHealthDisabledDefaultProceduresTestBase")
+    @Deployment(name = "MicroProfileHealthDisabledDefaultProceduresTestBase", testable = false)
     public static Archive<?> deployDisabledDefaultProcedures() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "DisabledProcedures.war")
                 .addClass(MyReadyProbe.class)

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.java
@@ -19,6 +19,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,11 +32,11 @@ public class MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase {
     @ContainerResource
     ManagementClient managementClient;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deployment() {
-        final Archive<?> deployment = ShrinkWrap.create(JavaArchive.class, "MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.jar")
-                .addClasses(MicroProfileHealthSecuredHTTPEndpointSetupTask.class, EmptyMgmtUsersSetupTask.class);
-        return deployment;
+        // Dummy deployment to trigger @ServerSetup
+        return ShrinkWrap.create(JavaArchive.class, "MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.jar")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointTestCase.java
@@ -38,7 +38,7 @@ public class MicroProfileHealthSecuredHTTPEndpointTestCase {
     @ContainerResource
     ManagementClient managementClient;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deployment() {
         final Archive<?> deployment = ShrinkWrap.create(JavaArchive.class, "MicroProfileHealthSecuredHTTPEndpointTestCase.jar")
                 .addClasses(MicroProfileHealthSecuredHTTPEndpointSetupTask.class);

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/ClockSkewTest.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/ClockSkewTest.java
@@ -52,7 +52,7 @@ public class ClockSkewTest {
     public static WebArchive createDeployment() {
         return ShrinkWrap
                 .create(WebArchive.class, "ClockSkewTest.war")
-                .addClasses(App.class, SampleEndPoint.class, BaseJWTCase.class)
+                .addClasses(App.class, SampleEndPoint.class)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
                 .addAsManifestResource(ClockSkewTest.class.getPackage(), "microprofile-config-with-clock-skew.properties", "microprofile-config.properties")
                 .addAsManifestResource(ClockSkewTest.class.getPackage(), "public.pem", "public.pem");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/ejb/JWTEJBTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/ejb/JWTEJBTestCase.java
@@ -41,11 +41,10 @@ public class JWTEJBTestCase {
 
     private static final String DEPLOYMENT_NAME = JWTEJBTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
-                .addClasses(JWTEJBTestCase.class)
                 .addClasses(App.class, BeanEndPoint.class, TargetBean.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/norealm/JWTNoRealmTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/norealm/JWTNoRealmTestCase.java
@@ -27,11 +27,10 @@ public class JWTNoRealmTestCase extends BaseJWTCase {
 
     private static final String DEPLOYMENT_NAME = JWTNoRealmTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
-                .addClasses(BaseJWTCase.class, JWTNoRealmTestCase.class)
                 .addClasses(App.class, SampleEndPoint.class)
                 .addAsWebInfResource(BaseJWTCase.class.getPackage(), "web.xml", "web.xml")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(),"microprofile-config.properties", "microprofile-config.properties")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/propagation/JWTIdentityPropagationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/propagation/JWTIdentityPropagationTestCase.java
@@ -88,12 +88,10 @@ public class JWTIdentityPropagationTestCase {
     @ArquillianResource
     private URL deploymentUrl;
 
-    @Deployment(name= SINGLE_DEPLOYMENT, order = 1)
+    @Deployment(name = SINGLE_DEPLOYMENT, order = 1, testable = false)
     public static Archive<?> singleDeploymentLocal() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, SINGLE_DEPLOYMENT + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, BeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem");
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, SINGLE_DEPLOYMENT + "-ejb.jar")
@@ -105,12 +103,10 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= ANOTHER_SINGLE_DEPLOYMENT, order = 2)
+    @Deployment(name = ANOTHER_SINGLE_DEPLOYMENT, order = 2, testable = false)
     public static Archive<?> anotherSingleDeploymentLocal() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, ANOTHER_SINGLE_DEPLOYMENT + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, AnotherBeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem");
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ANOTHER_SINGLE_DEPLOYMENT + "-ejb.jar")
@@ -122,12 +118,10 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= NO_OUTFLOW_CONFIG, order = 3)
+    @Deployment(name = NO_OUTFLOW_CONFIG, order = 3, testable = false)
     public static Archive<?> noOutflowConfig() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, NO_OUTFLOW_CONFIG + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, BeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem");
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, NO_OUTFLOW_CONFIG + "-ejb.jar")
@@ -139,12 +133,10 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= OUTFLOW_ANONYMOUS_CONFIG, order = 4)
+    @Deployment(name = OUTFLOW_ANONYMOUS_CONFIG, order = 4, testable = false)
     public static Archive<?> outflowAnonymousConfig() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, OUTFLOW_ANONYMOUS_CONFIG + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, BeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem");
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, OUTFLOW_ANONYMOUS_CONFIG + "-ejb.jar")
@@ -156,7 +148,7 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= EAR_DEPLOYMENT_WITH_EJB, order = 5)
+    @Deployment(name = EAR_DEPLOYMENT_WITH_EJB, order = 5, testable = false)
     public static Archive<?> earDeploymentWithEJB() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_EJB + "-ejb.jar")
                 .addClasses(WhoAmIRemote.class)
@@ -167,12 +159,10 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= EAR_DEPLOYMENT_WITH_MP_JWT, order = 6)
+    @Deployment(name = EAR_DEPLOYMENT_WITH_MP_JWT, order = 6, testable = false)
     public static Archive<?> earDeploymentWithMPJWT() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_MP_JWT + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, RemoteBeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem")
                 .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB + "-ejb.jar"), "MANIFEST.MF");
@@ -181,7 +171,7 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= EAR_DEPLOYMENT_WITH_EJB_SAME_DOMAIN, order = 7)
+    @Deployment(name = EAR_DEPLOYMENT_WITH_EJB_SAME_DOMAIN, order = 7, testable = false)
     public static Archive<?> earDeploymentWithEJBSameDomain() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EAR_DEPLOYMENT_WITH_EJB_SAME_DOMAIN + "-ejb.jar")
                 .addClasses(org.wildfly.test.integration.microprofile.jwt.propagation.sameVirtualDomain.WhoAmIRemote.class)
@@ -192,12 +182,10 @@ public class JWTIdentityPropagationTestCase {
         return ear;
     }
 
-    @Deployment(name= EAR_DEPLOYMENT_WITH_MP_JWT_SAME_DOMAIN, order = 8)
+    @Deployment(name = EAR_DEPLOYMENT_WITH_MP_JWT_SAME_DOMAIN, order = 8, testable = false)
     public static Archive<?> earDeploymentWithMPJWTSameDomain() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, EAR_DEPLOYMENT_WITH_MP_JWT_SAME_DOMAIN + "-web.war")
-                .addClasses(JWTIdentityPropagationTestCase.class)
                 .addClasses(App.class, org.wildfly.test.integration.microprofile.jwt.propagation.sameVirtualDomain.RemoteBeanEndPoint.class)
-                .addClasses(PropagationSetup.class)
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "public.pem", "public.pem")
                 .addAsManifestResource(new StringAsset("Dependencies: deployment." + EAR_DEPLOYMENT_WITH_EJB_SAME_DOMAIN + ".ear" + "." + EAR_DEPLOYMENT_WITH_EJB_SAME_DOMAIN + "-ejb.jar"), "MANIFEST.MF");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/smoke/JWTSmokeTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/jwt/smoke/JWTSmokeTestCase.java
@@ -27,12 +27,11 @@ public class JWTSmokeTestCase extends BaseJWTCase {
 
     private static final String DEPLOYMENT_NAME = JWTSmokeTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
 
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")
-                .addClasses(BaseJWTCase.class, JWTSmokeTestCase.class)
                 .addClasses(App.class, SampleEndPoint.class)
                 .addAsWebInfResource(BaseJWTCase.class.getPackage(), "web.xml", "web.xml")
                 .addAsManifestResource(BaseJWTCase.class.getPackage(), "microprofile-config.properties", "microprofile-config.properties")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIAbsoluteServersTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIAbsoluteServersTestCase.java
@@ -48,7 +48,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class OpenAPIAbsoluteServersTestCase {
     private static final String DEPLOYMENT_NAME = OpenAPIAbsoluteServersTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIAltPathTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIAltPathTestCase.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class OpenAPIAltPathTestCase {
     private static final String DEPLOYMENT_NAME = OpenAPIAltPathTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIDisabledTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIDisabledTestCase.java
@@ -37,7 +37,7 @@ import org.wildfly.test.integration.microprofile.openapi.service.TestApplication
 @RunAsClient
 public class OpenAPIDisabledTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "openapi-disabled.war")
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIFormatTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIFormatTestCase.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class OpenAPIFormatTestCase {
     private static final String DEPLOYMENT_NAME = OpenAPIFormatTestCase.class.getSimpleName() + ".war";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .addPackage(TestApplication.class.getPackage())

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentIndexTestCase.java
@@ -50,7 +50,7 @@ public class OpenAPIMultiModuleDeploymentIndexTestCase {
     private static final String PARENT_DEPLOYMENT_NAME =
             OpenAPIMultiModuleDeploymentIndexTestCase.class.getSimpleName() + ".ear";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() throws Exception {
         WebArchive jaxrs = ShrinkWrap.create(WebArchive.class, "rest.war")
                                      .addAsResource(TestResource.class.getResource("beans.xml"), "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIMultiModuleDeploymentTestCase.java
@@ -47,7 +47,7 @@ public class OpenAPIMultiModuleDeploymentTestCase {
     private static final String DEPLOYMENT_NAME = OpenAPIMultiModuleDeploymentTestCase.class.getSimpleName() + ".war";
     private static final String PARENT_DEPLOYMENT_NAME = OpenAPIMultiModuleDeploymentTestCase.class.getSimpleName() + ".ear";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         WebArchive jaxrs = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIRESTlessTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIRESTlessTestCase.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class OpenAPIRESTlessTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "openapi-RESTless.war")
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
@@ -17,7 +17,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.CLIServerSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -33,16 +32,16 @@ import io.restassured.RestAssured;
 @RunAsClient
 @ServerSetup({RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 public class AnonymousAmqpTestCase {
+
     @ArquillianResource
     URL url;
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive createDeployment() {
         final WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "reactive-messaging-anonymous-amqp.war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .setWebXML(AnonymousAmqpTestCase.class.getPackage(), "web.xml")
                 .addClasses(ConsumingBean.class, ProducingBean.class, TestResource.class)
-                .addClasses(RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class, CLIServerSetupTask.class)
                 .addAsWebInfResource(AnonymousAmqpTestCase.class.getPackage(), "microprofile-config-no-ssl.properties", "classes/META-INF/microprofile-config.properties")
                 .addClass(TimeoutUtil.class)
                 .addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
@@ -83,7 +83,7 @@ public class MultiDeploymentReactiveMessagingTestCase extends AbstractCliTestBas
         closeCLI();
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> getDeployment() {
         // Empty deployment to satisfy Arquillian
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
@@ -65,7 +65,7 @@ public class MultiEarModuleReactiveMessagingTestCase {
     @ArquillianResource
     URL url;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         WebArchive jaxrs = ShrinkWrap.create(WebArchive.class, BASE_NAME + ".war")
                 .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml")

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelConfigTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelConfigTestCase.java
@@ -23,7 +23,7 @@ public class AmqpReactiveMessagingAndOtelConfigTestCase extends BaseReactiveMess
         super("mp.messaging.connector.smallrye-amqp.tracing-enabled", "amqp-connector");
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive getDeployment() {
         return createDeployment("mp-rm-amqp-otel-config.war");
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
@@ -31,7 +31,7 @@ public class AmqpReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingA
         super("amqp");
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive createDeployment() {
         return BaseReactiveMessagingAndOtelTest.createDeployment(
                 "mp-rm-amqp-otel.war",

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelConfigTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelConfigTestCase.java
@@ -23,7 +23,7 @@ public class KafkaReactiveMessagingAndOtelConfigTestCase extends BaseReactiveMes
         super("mp.messaging.connector.smallrye-kafka.tracing-enabled", "kafka-connector");
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive getDeployment() {
         return createDeployment("mp-rm-kafka-otel-config.war");
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
@@ -32,7 +32,7 @@ public class KafkaReactiveMessagingAndOtelTestCase extends BaseReactiveMessaging
         super("kafka");
     }
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive createDeployment() {
         return BaseReactiveMessagingAndOtelTest.createDeployment(
                 "mp-rm-kafka-otel.war",

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.CLIServerSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -54,13 +53,12 @@ public class ReactiveMessagingChannelsTestCase {
     @ArquillianResource
     URL url;
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive getDeployment() {
         final WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "rm-channels-client.war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .setWebXML(ReactiveMessagingChannelsTestCase.class.getPackage(), "web.xml")
                 .addAsWebInfResource(ReactiveMessagingChannelsTestCase.class.getPackage(), "microprofile-config.properties", "classes/META-INF/microprofile-config.properties")
-                .addClasses(EnableReactiveExtensionsSetupTask.class, CLIServerSetupTask.class, RunKafkaSetupTask.class)
                 .addClasses(
                         PublisherToChannelPublisherEndpoint.class,
                         EmitterToSubscriberEndpoint.class,

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/restclient/HeaderPropagationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/restclient/HeaderPropagationTestCase.java
@@ -39,7 +39,7 @@ public class HeaderPropagationTestCase {
     @ArquillianResource
     private URI uri;
 
-    @Deployment
+    @Deployment(testable = false)
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class, HeaderPropagationTestCase.class.getSimpleName() + ".war")
                 .addClasses(

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -52,7 +52,7 @@ public class MicrometerOtelIntegrationTestCase {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
                 .addClasses(JaxRsActivator.class, MicrometerMetricResource.class)

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
@@ -24,7 +24,7 @@ import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 public class EarDeploymentTestCase extends BaseMultipleTestCase {
     protected static final String ENTERPRISE_APP = "enterprise-app";
 
-    @Deployment(name = ENTERPRISE_APP)
+    @Deployment(name = ENTERPRISE_APP, testable = false)
     public static EnterpriseArchive createDeployment() {
         return ShrinkWrap.create(EnterpriseArchive.class, ENTERPRISE_APP + ".ear")
                 .addAsModule(MultipleWarTestCase.createDeployment1())

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -41,12 +41,12 @@ public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
     @ArquillianResource
     private Deployer deployer;
 
-    @Deployment(name = DEPLOYMENT_SERVICE1, managed = false)
+    @Deployment(name = DEPLOYMENT_SERVICE1, managed = false, testable = false)
     public static WebArchive getDeployment1() {
         return buildBaseArchive(DEPLOYMENT_SERVICE1);
     }
 
-    @Deployment(name = DEPLOYMENT_SERVICE2, managed = false)
+    @Deployment(name = DEPLOYMENT_SERVICE2, managed = false, testable = false)
     public static WebArchive getDeployment2() {
         return buildBaseArchive(DEPLOYMENT_SERVICE2).addClass(OtelService2.class);
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -32,7 +32,7 @@ public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     @ArquillianResource
     private URL url;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> getDeployment() {
         return buildBaseArchive(DEPLOYMENT_NAME);
     }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
@@ -1,13 +1,12 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.wildfly.test.integration.observability.opentelemetry;
 
 import java.net.URL;
 
-import io.opentelemetry.instrumentation.annotations.WithSpan;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
@@ -22,6 +21,7 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.wildfly.test.integration.observability.opentelemetry.span.AppScopedBean;
 
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
@@ -32,10 +32,10 @@ public class WithSpanTestCase extends BaseOpenTelemetryTest {
     @ArquillianResource
     private URL url;
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> getDeployment() {
         return buildBaseArchive(DEPLOYMENT_NAME)
-            .addClasses(AppScopedBean.class, RequestScopedBean.class);
+            .addPackage(AppScopedBean.class.getPackage());
     }
 
     @Test
@@ -56,23 +56,4 @@ public class WithSpanTestCase extends BaseOpenTelemetryTest {
         }
     }
 
-    @ApplicationScoped
-    public static class AppScopedBean {
-        @WithSpan
-        public String getString() {
-            return "greeting";
-        }
-    }
-
-    @RequestScoped
-    @Path("/span")
-    public static class RequestScopedBean {
-        @Inject
-        AppScopedBean bean;
-
-        @GET
-        public String getString() {
-            return bean.getString();
-        }
-    }
 }

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/span/AppScopedBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/span/AppScopedBean.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.observability.opentelemetry.span;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
+@ApplicationScoped
+public class AppScopedBean {
+    @WithSpan
+    public String getString() {
+        return "greeting";
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/span/RequestScopedBean.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/observability/opentelemetry/span/RequestScopedBean.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.observability.opentelemetry.span;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@RequestScoped
+@Path("/span")
+public class RequestScopedBean {
+    @Inject
+    AppScopedBean bean;
+
+    @GET
+    public String getString() {
+        return bean.getString();
+    }
+}


### PR DESCRIPTION
Eliminates "WELD-000119: Not generating any bean definitions from ... because of underlying class loading error: Type org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer" logging

Resolve
https://issues.redhat.com/browse/WFLY-20141