### PR TITLE
[WFLY-20106] For any testsuite/integration/* modules always include a…

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -399,6 +399,7 @@
             <modules>
                 <module>build-demander-base</module> <!-- Ensure base server build/dist modules used by tests are built -->
                 <module>aggregator-base</module>
+                <module>integration</module>
             </modules>
         </profile>
         <profile>
@@ -408,6 +409,7 @@
             <modules>
                 <module>build-demander-expansion</module> <!-- Ensure expansion server build/dist modules used by tests are built -->
                 <module>aggregator-expansion</module>
+                <module>integration</module>
             </modules>
         </profile>
         <profile>
@@ -416,6 +418,7 @@
             <modules>
                 <module>build-demander-preview</module> <!-- Ensure preview server build/dist modules used by tests are built -->
                 <module>aggregator-preview</module>
+                <module>integration</module>
             </modules>
         </profile>
         <!-- These execute in all feature pack contexts, so declare them here instead


### PR DESCRIPTION
…lso its parent

This was previously always the case (before WFLY-20084) since the testsuite/integration module was aggregator module (containing <modules>..</modules>) and we directly included this module (see previous state at
https://github.com/wildfly/wildfly/pull/18467/files#diff-1bf02fff15a7bfe6d93918dc600f864c1d82c4c656e0643a7ccd7e79797f64b5L412, look for `<module>integration</module`>).

After WFLY-20084, the set of executed testsuite/integration/* modules is managed by aggregator modules so testsuite/integration was left out. Thus we should explicitly add it back whenever we try to execute any module under testsuite/integration wrapper module. To do so without adding more complexity, we need to add this module at the testsuite module level and also we need to add it to the reactor regardless whether there is actually any integration submodule being executed.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-20106](https://issues.redhat.com/browse/WFLY-20106)
> * [WFLY-20084](https://issues.redhat.com/browse/WFLY-20084)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)