### PR TITLE
[WFLY-20209] AbstractParseAndMarshalModelsTestCase does not correctly…

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/AbstractParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/AbstractParseAndMarshalModelsTestCase.java
@@ -31,7 +31,7 @@ abstract class AbstractParseAndMarshalModelsTestCase {
 
     private static final File JBOSS_HOME = Paths.get("target", "jbossas-parse-marshal").toFile();
 
-    static final boolean altDistTest = "ee-".equals(System.getProperty("testsuite.default.build.project.prefix"));
+    static final boolean altDistTest = System.getProperty("build.output.dir", "").startsWith("ee-");
 
     protected ModelNode standaloneXmlTest(File original) throws Exception {
         return ModelParserUtils.standaloneXmlTest(original, JBOSS_HOME);


### PR DESCRIPTION
… detect if the test is running using the wildfly-ee distribution

Jira issue: https://issues.redhat.com/browse/WFLY-20209

Note: This is not very useful upstream, but it would help on the product testsuite.
