### PR TITLE
[WFLY-19212] Do not include the security manager extension / subsystem in the default configuration for WildFly Preview.

### DIFF
--- a/preview/galleon-local/src/main/resources/feature_groups/security-manager.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/security-manager.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<feature-group-spec name="security-manager" xmlns="urn:jboss:galleon:feature-group:1.0">
+</feature-group-spec>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -256,6 +256,7 @@ public abstract class LayersTestBase {
             "org.wildfly.extension.metrics",
             // Extension not included in the default config
             "org.wildfly.extension.mvc-krazo",
+            "org.wildfly.extension.security.manager",
             "jakarta.mvc.api",
             "org.eclipse.krazo.core",
             "org.eclipse.krazo.resteasy",


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19212