### PR TITLE
[WFLY-20008] Remove another ModuleIdentifier use now that core's API …

### DIFF
--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/ModuleConfig.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/ModuleConfig.java
@@ -7,7 +7,6 @@ package org.jboss.as.pojo.descriptor;
 
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
 
@@ -27,16 +26,15 @@ public class ModuleConfig extends AbstractConfigVisitorNode implements Serializa
     @Override
     public void visit(ConfigVisitor visitor) {
         if (moduleName != null) {
-            ModuleIdentifier identifier = ModuleIdentifier.fromString(moduleName);
             if (moduleName.startsWith(ServiceModuleLoader.MODULE_PREFIX)) {
-                ServiceName serviceName = ServiceModuleLoader.moduleServiceName(identifier);
+                ServiceName serviceName = ServiceModuleLoader.moduleServiceName(moduleName);
                 visitor.addDependency(serviceName, getInjectedModule());
             } else {
                 Module dm = visitor.loadModule(moduleName);
                 getInjectedModule().setValue(() -> dm);
             }
         } else {
-            getInjectedModule().setValue(() -> visitor.getModule());
+            getInjectedModule().setValue(visitor::getModule);
         }
         // no children, no need to visit
     }


### PR DESCRIPTION
…lets us

https://issues.redhat.com/browse/WFLY-20008

The latest core upgrade lets us get rid of one more use, the last one in this subsystem.

If this doesn't get into WF 35 I'll change the JIRA as WFLY-20008 is Fix Version 35.0.0.Final.

@soul2zimate @ropalka FYI.
