### PR TITLE
[WFLY-20218] Upgrade WildFly Core to 27.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
 		<version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>5.0.3.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Beta7</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20218

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/27.0.0.Beta7...27.0.0.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7117'>WFCORE-7117</a>] -         LayersTest does not takes into account JBoss Modules layers
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7095'>WFCORE-7095</a>] -         Deprecate ModuleDependency.getIdentifier() for removal
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7111'>WFCORE-7111</a>] -         Prepare org.jboss.as.server.deployment.Attachments for removal of ModuleIdentifier
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7112'>WFCORE-7112</a>] -         Deprecate PermissionsParser.parse that takes ModuleIdentifier
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7113'>WFCORE-7113</a>] -         Deprecate AdditionalModuleSpecification.getModuleIdentifier()
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7114'>WFCORE-7114</a>] -         Deprecate use of ModuleIdentifier in ModuleDefinition
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7109'>WFCORE-7109</a>] -         Upgrade Logback to 1.5.13
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7119'>WFCORE-7119</a>] -         Upgrade WildFly Maven Plugin to 5.1.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7108'>WFCORE-7108</a>] -         Add a ModuleIdentifierUtil method to parse a module identifier into name and slot and process the tuple
</li>
</ul>
</details>


