### PR TITLE
WFLY-20223 Fix mocking in Mockito 5.14.2 on JDK24.

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -114,6 +114,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -379,6 +379,11 @@ projects that depend on this project.-->
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/elytron-oidc-client/pom.xml
+++ b/elytron-oidc-client/pom.xml
@@ -165,6 +165,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem</artifactId>
         </dependency>

--- a/messaging-activemq/injection/pom.xml
+++ b/messaging-activemq/injection/pom.xml
@@ -133,5 +133,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -372,6 +372,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- javax dependencies required to bootstrap the legacy controllers for transformer tests -->
         <dependency>

--- a/mod_cluster/undertow/pom.xml
+++ b/mod_cluster/undertow/pom.xml
@@ -82,5 +82,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -181,6 +181,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -152,6 +152,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -207,6 +207,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-subclass</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
             <type>pom</type>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20223