### PR TITLE
[WFLY-20228] Upgrade the WildFly Arquillian to 5.1.0.Beta8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
              on the dependency on the MicroProfile REST Client TCK POM.
          -->
         <version.org.testng.mp.rest.client>7.10.2</version.org.testng.mp.rest.client>
-        <version.org.wildfly.arquillian>5.1.0.Beta7</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.1.0.Beta8</version.org.wildfly.arquillian>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>
 


### PR DESCRIPTION
* https://issues.redhat.com/browse/WFLY-20228
* https://issues.redhat.com/browse/WFLY-20219

This fixes [WFLY-20219](https://issues.redhat.com/browse/WFLY-20219) by upgrading the `org.wildfly.plugins:wildfly-plugin-tools` in Arquillian to [1.2.1.Final](https://github.com/wildfly/wildfly-plugin-tools/releases/tag/v1.2.1.Final).
