### PR TITLE
[WFLY-20225] & [WFLY-20231] Upgrade the jboss-parent POM from 39 to 47

### DIFF
--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/_private/MessagingLogger.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/_private/MessagingLogger.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq._private;
+package org.wildfly.extension.messaging.activemq.injection._private;
 
 import java.lang.invoke.MethodHandles;
 

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/AbstractJMSContext.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/AbstractJMSContext.java
@@ -2,9 +2,9 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
-import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
+import static org.wildfly.extension.messaging.activemq.injection._private.MessagingLogger.ROOT_LOGGER;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/CDIDeploymentProcessor.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/CDIDeploymentProcessor.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/DefaultJMSConnectionFactoryBinding.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/DefaultJMSConnectionFactoryBinding.java
@@ -2,7 +2,7 @@
  * Copyright The WildFly Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.wildfly.extension.messaging.activemq.deployment;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 /**
  *

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/InjectedJMSContext.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/InjectedJMSContext.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 
 import java.io.Serializable;
@@ -23,7 +23,7 @@ import javax.naming.NamingException;
 import jakarta.transaction.Status;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 
-import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
+import static org.wildfly.extension.messaging.activemq.injection._private.MessagingLogger.ROOT_LOGGER;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2016 Red Hat inc.

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSCDIExtension.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSCDIExtension.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AnnotatedType;

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSContextWrapper.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSContextWrapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 
 import java.io.Serializable;
@@ -25,7 +25,7 @@ import jakarta.jms.TemporaryQueue;
 import jakarta.jms.TemporaryTopic;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
-import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
+import org.wildfly.extension.messaging.activemq.injection._private.MessagingLogger;
 
 
 /**

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSInfo.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/JMSInfo.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import static jakarta.jms.JMSContext.AUTO_ACKNOWLEDGE;
-import static org.wildfly.extension.messaging.activemq.deployment.DefaultJMSConnectionFactoryBinding.COMP_DEFAULT_JMS_CONNECTION_FACTORY;
+import static org.wildfly.extension.messaging.activemq.injection.deployment.DefaultJMSConnectionFactoryBinding.COMP_DEFAULT_JMS_CONNECTION_FACTORY;
 
 import jakarta.jms.JMSConnectionFactory;
 import jakarta.jms.JMSPasswordCredential;

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/RequestedJMSContext.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/RequestedJMSContext.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.RequestScoped;

--- a/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/TransactedJMSContext.java
+++ b/messaging-activemq/injection/src/main/java/org/wildfly/extension/messaging/activemq/injection/deployment/TransactedJMSContext.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import jakarta.jms.JMSContext;
 import jakarta.transaction.Synchronization;
 import jakarta.transaction.TransactionScoped;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 
-import static org.wildfly.extension.messaging.activemq._private.MessagingLogger.ROOT_LOGGER;
+import static org.wildfly.extension.messaging.activemq.injection._private.MessagingLogger.ROOT_LOGGER;
 
 
 /**

--- a/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/injection/deployment/AbstractJMSContextTestCase.java
+++ b/messaging-activemq/injection/src/test/java/org/wildfly/extension/messaging/activemq/injection/deployment/AbstractJMSContextTestCase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.wildfly.extension.messaging.activemq.deployment.injection;
+package org.wildfly.extension.messaging.activemq.injection.deployment;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
@@ -57,7 +57,7 @@ import org.wildfly.extension.messaging.activemq.deployment.JMSDestinationDefinit
 import org.wildfly.extension.messaging.activemq.deployment.MessagingDependencyProcessor;
 import org.wildfly.extension.messaging.activemq.deployment.MessagingXmlInstallDeploymentUnitProcessor;
 import org.wildfly.extension.messaging.activemq.deployment.MessagingXmlParsingDeploymentUnitProcessor;
-import org.wildfly.extension.messaging.activemq.deployment.injection.CDIDeploymentProcessor;
+import org.wildfly.extension.messaging.activemq.injection.deployment.CDIDeploymentProcessor;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 
 /**

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/DefaultJMSConnectionFactoryBindingProcessor.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/DefaultJMSConnectionFactoryBindingProcessor.java
@@ -4,7 +4,7 @@
  */
 package org.wildfly.extension.messaging.activemq.deployment;
 
-import static org.wildfly.extension.messaging.activemq.deployment.DefaultJMSConnectionFactoryBinding.DEFAULT_JMS_CONNECTION_FACTORY;
+import static org.wildfly.extension.messaging.activemq.injection.deployment.DefaultJMSConnectionFactoryBinding.DEFAULT_JMS_CONNECTION_FACTORY;
 
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.component.deployers.AbstractPlatformBindingProcessor;

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/DefaultJMSConnectionFactoryResourceReferenceProcessor.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/DefaultJMSConnectionFactoryResourceReferenceProcessor.java
@@ -4,7 +4,7 @@
  */
 package org.wildfly.extension.messaging.activemq.deployment;
 
-import static org.wildfly.extension.messaging.activemq.deployment.DefaultJMSConnectionFactoryBinding.COMP_DEFAULT_JMS_CONNECTION_FACTORY;
+import static org.wildfly.extension.messaging.activemq.injection.deployment.DefaultJMSConnectionFactoryBinding.COMP_DEFAULT_JMS_CONNECTION_FACTORY;
 
 import jakarta.jms.ConnectionFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>39</version>
+        <version>47</version>
         <!-- The empty relativePath makes Maven lookup it in the repository. Missing tag default is ../pom.xml. -->
         <relativePath/>
     </parent>

--- a/testsuite/galleon/update/pom.xml
+++ b/testsuite/galleon/update/pom.xml
@@ -77,7 +77,7 @@
                                 </goals>
                                 <phase>${wildfly-ee.update.phase}</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="./run-test.sh" failonerror="true">
                                             <env key="GALLEON_VERSION" value="${version.org.jboss.galleon}"/>
                                             <env key="BASE_DIR" value="${project.basedir}"/>
@@ -87,7 +87,7 @@
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="jaxrs-server"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                             <execution>
@@ -97,7 +97,7 @@
                                 </goals>
                                 <phase>${wildfly.update.phase}</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="./run-test.sh" failonerror="true">
                                             <env key="GALLEON_VERSION" value="${version.org.jboss.galleon}"/>
                                             <env key="BASE_DIR" value="${project.basedir}"/>
@@ -106,8 +106,8 @@
                                             <env key="WILDFLY_PRODUCER" value="wildfly"/>
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server"/>
-                                        </exec>\
-                                    </tasks>
+                                        </exec>
+                                    </target>
                                 </configuration>
                             </execution>
                             <execution>
@@ -117,7 +117,7 @@
                                 </goals>
                                 <phase>${wildfly-preview.update.phase}</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="./run-test.sh" failonerror="true">
                                             <env key="GALLEON_VERSION" value="${version.org.jboss.galleon}"/>
                                             <env key="BASE_DIR" value="${project.basedir}"/>
@@ -127,7 +127,7 @@
                                             <env key="WILDFLY_CHANNEL" value="${galleon.minor.channel}"/>
                                             <env key="GALLEON_LAYERS" value="cloud-server,microprofile-platform,-microprofile-fault-tolerance"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This also requires a rename of the packages in the messaging-activemq/injection Maven module.

https://issues.redhat.com/browse/WFLY-20225
https://issues.redhat.com/browse/WFLY-20231
