### PR TITLE
[WFLY-9634] Enable MixedDomainDeploymentTest.testExplodedDeployment()

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
@@ -50,7 +50,6 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -207,8 +206,6 @@ public abstract class MixedDomainDeploymentTest {
 
     @Test
     public void testExplodedDeployment() throws Exception {
-        // TODO WFLY-9634
-        Assume.assumeFalse(supportManagedExplodedDeployment());
 
         ModelNode composite = createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
         ModelNode steps = composite.get(STEPS);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-9634

@kabir @ehsavoie @yersan FYI. I stumbled across this when looking at something else and gave removing the 'ignore' a try. It worked locally.