### PR TITLE
[WFLY-20236] Don't test whether irrelevant queues are still around

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/prefix/ExternalJMSDestinationDefinitionMessagingDeploymentTestCase.java
@@ -266,10 +266,10 @@ public class ExternalJMSDestinationDefinitionMessagingDeploymentTestCase {
             op.get("child-type").set("runtime-queue");
             List<ModelNode> runtimeQueues = Operations.readResult(managementClient.getControllerClient().execute(op)).asList();
             Set<String> queues = runtimeQueues.stream().map(ModelNode::asString).collect(Collectors.toSet());
-            Assert.assertEquals(initialQueues.size() + 2, queues.size());
-            Assert.assertTrue("We should have myExternalQueue queue", queues.contains("myExternalQueue"));
+            Assert.assertTrue("We should have myExternalQueue queue in " + queues, queues.contains("myExternalQueue"));
             queues.removeAll(initialQueues);
             queues.remove("myExternalQueue");
+            Assert.assertEquals("Too many queues in " + queues, 1, queues.size());
             String topicId = queues.iterator().next();
             checkRuntimeQueue(ops, "myExternalQueue", "ANYCAST", "myExternalQueue");
             checkRuntimeQueue(ops, topicId, "MULTICAST", "myExternalTopic");


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20236

Upstream: #18617

@darranl This doesn't actually need to be merged for 35.0.1, although it adds no risk to include it as it's just test hardening. I filed it to test the pull player against the 35.x branch.