### PR TITLE
[WFLY-20186] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in JMS

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/MessagingDependencyProcessor.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/deployment/MessagingDependencyProcessor.java
@@ -55,8 +55,7 @@ public class MessagingDependencyProcessor implements DeploymentUnitProcessor {
         }
     }
 
-    private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
-                               String moduleIdentifier) {
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+    private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader, String moduleIdentifier) {
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier).setImportServices(true).build());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20186