### PR TITLE
WFLY-20254 MP OpenAPI TCK is never run with the security manager

### DIFF
--- a/testsuite/integration/microprofile-tck/openapi/src/test/java/org/wildfly/extension/microprofile/openapi/tck/DeploymentProcessor.java
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/java/org/wildfly/extension/microprofile/openapi/tck/DeploymentProcessor.java
@@ -4,6 +4,11 @@
  */
 package org.wildfly.extension.microprofile.openapi.tck;
 
+import static org.wildfly.testing.tools.deployments.DeploymentDescriptors.createPermissionsXmlAsset;
+
+import java.lang.reflect.ReflectPermission;
+import java.util.PropertyPermission;
+
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
@@ -12,14 +17,15 @@ import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArch
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class DeploymentProcessor implements ApplicationArchiveProcessor {
 
     @Override
-    public void process(Archive<?> archive, TestClass testClass) {
-        if (archive instanceof WebArchive) {
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        if (applicationArchive instanceof WebArchive) {
             JavaArchive extensionsJar = ShrinkWrap.create(JavaArchive.class, "extension.jar");
 
             extensionsJar.addPackage(Matchers.class.getPackage());
@@ -27,8 +33,20 @@ public class DeploymentProcessor implements ApplicationArchiveProcessor {
             extensionsJar.addPackage(IsEqual.class.getPackage());
             extensionsJar.addPackage(ReflectiveTypeFinder.class.getPackage());
 
-            WebArchive war = WebArchive.class.cast(archive);
+            WebArchive war = (WebArchive) applicationArchive;
             war.addAsLibraries(extensionsJar);
+        }
+
+        if (applicationArchive instanceof ManifestContainer<?>) {
+            ManifestContainer<?> manifestContainer = (ManifestContainer<?>) applicationArchive;
+
+            // Enable running the TCK with the security manager
+            manifestContainer.addAsManifestResource(createPermissionsXmlAsset(
+                    // Permissions required by test instrumentation - arquillian-core.jar and arquillian-testng.jar
+                    new ReflectPermission("suppressAccessChecks"),
+                    new PropertyPermission("*", "read"),
+                    new RuntimePermission("accessDeclaredMembers")
+            ), "permissions.xml");
         }
     }
 }

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
@@ -5,19 +5,19 @@
   -->
 
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="jmx-as7" />
+    <defaultProtocol type="jmx-as7"/>
 
     <container qualifier="jboss" default="true">
         <configuration>
+            <property name="allowConnectingToRunningServer">true</property>
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
-
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
-            <property name="allowConnectingToRunningServer">true</property>
             <property name="waitForPorts">9990</property>
             <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian.xml
@@ -7,17 +7,18 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="jboss" default="true" >
+    <container qualifier="jboss" default="true">
         <configuration>
-            <property name="jbossHome">${jboss.home}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="javaHome">${container.java.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">standalone-microprofile.xml</property>
+            <property name="jbossArguments">${jboss.args}</property>
+            <property name="jbossHome">${jboss.home}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
-            <property name="allowConnectingToRunningServer">true</property>
+            <property name="serverConfig">standalone-microprofile.xml</property>
             <property name="waitForPorts">9990</property>
             <property name="waitForPortsTimeoutInSeconds">10</property>
-            <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20254