### PR TITLE
[WFLY-20192] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in WELD

### DIFF
--- a/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/WeldBeanValidationDependencyProcessor.java
+++ b/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/WeldBeanValidationDependencyProcessor.java
@@ -45,7 +45,7 @@ public class WeldBeanValidationDependencyProcessor implements DeploymentUnitProc
             return; // Skip if there are no beans.xml files in the deployment
         }
 
-        ModuleDependency cdiBeanValidationDep = new ModuleDependency(moduleLoader, CDI_BEAN_VALIDATION_ID, false, false, true, false);
+        ModuleDependency cdiBeanValidationDep = ModuleDependency.Builder.of(moduleLoader, CDI_BEAN_VALIDATION_ID).setImportServices(true).build();
         moduleSpecification.addSystemDependency(cdiBeanValidationDep);
     }
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDependencyProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDependencyProcessor.java
@@ -54,7 +54,7 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
         addDependency(moduleSpecification, moduleLoader, WELD_API_ID);
         addDependency(moduleSpecification, moduleLoader, WELD_SPI_ID);
 
-        ModuleDependency weldSubsystemDependency = new ModuleDependency(moduleLoader, JBOSS_AS_WELD_ID, false, false, false, false);
+        ModuleDependency weldSubsystemDependency = ModuleDependency.Builder.of(moduleLoader, JBOSS_AS_WELD_ID).build();
         weldSubsystemDependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
         weldSubsystemDependency.addImportFilter(PathFilters.is("org/jboss/as/weld/injection"), true);
         weldSubsystemDependency.addImportFilter(PathFilters.acceptAll(), false);
@@ -62,7 +62,7 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
         moduleSpecification.addSystemDependency(weldSubsystemDependency);
 
         // Due to serialization of Jakarta Enterprise Beans
-        ModuleDependency weldEjbDependency = new ModuleDependency(moduleLoader, JBOSS_AS_WELD_EJB_ID, true, false, false, false);
+        ModuleDependency weldEjbDependency = ModuleDependency.Builder.of(moduleLoader, JBOSS_AS_WELD_EJB_ID).setOptional(true).build();
         weldEjbDependency.addImportFilter(PathFilters.is("org/jboss/as/weld/ejb"), true);
         weldEjbDependency.addImportFilter(PathFilters.acceptAll(), false);
         moduleSpecification.addSystemDependency(weldEjbDependency);
@@ -75,6 +75,6 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
 
     private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
             String moduleIdentifier, boolean optional) {
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, optional, false, true, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, moduleIdentifier).setOptional(optional).setImportServices(true).build());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20192