### PR TITLE
[WFLY-20193] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in TXN

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSDependenciesDeploymentProcessor.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSDependenciesDeploymentProcessor.java
@@ -68,7 +68,7 @@ public class XTSDependenciesDeploymentProcessor implements DeploymentUnitProcess
     private void addXTSModuleDependency(final DeploymentUnit unit) {
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
         final ModuleSpecification moduleSpec = unit.getAttachment(Attachments.MODULE_SPECIFICATION);
-        moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, XTS_MODULE, false, false, false, false));
+        moduleSpec.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, XTS_MODULE).build());
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20193