### PR TITLE
[WFLY-20194] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in MICROMETER

### DIFF
--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerDependencyProcessor.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/MicrometerDependencyProcessor.java
@@ -30,7 +30,7 @@ class MicrometerDependencyProcessor implements DeploymentUnitProcessor {
         ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         ModuleLoader moduleLoader = Module.getBootModuleLoader();
         for (String module : EXPORTED_MODULES) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, true, true, false));
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, module).setExport(true).setImportServices(true).build());
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20194