### PR TITLE
[WFLY-20189] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in WEBSERVICES

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSDependenciesProcessor.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSDependenciesProcessor.java
@@ -22,9 +22,9 @@ import org.jboss.modules.ModuleLoader;
  */
 public final class WSDependenciesProcessor implements DeploymentUnitProcessor {
 
-    public static final String JBOSSWS_API = "org.jboss.ws.api";
-    public static final String JBOSSWS_SPI = "org.jboss.ws.spi";
-    public static final String[] JAVAEE_APIS = {
+    private static final String JBOSSWS_API = "org.jboss.ws.api";
+    private static final String JBOSSWS_SPI = "org.jboss.ws.spi";
+    private static final String[] JAVAEE_APIS = {
             "jakarta.xml.ws.api",
             "jakarta.xml.soap.api"
     };
@@ -39,12 +39,13 @@ public final class WSDependenciesProcessor implements DeploymentUnitProcessor {
         final DeploymentUnit unit = phaseContext.getDeploymentUnit();
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
         final ModuleSpecification moduleSpec = unit.getAttachment(Attachments.MODULE_SPECIFICATION);
+
         if (addJBossWSDependencies) {
-            moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, JBOSSWS_API, false, true, true, false));
-            moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, JBOSSWS_SPI, false, true, true, false));
+            moduleSpec.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JBOSSWS_API).setExport(true).setImportServices(true).build());
+            moduleSpec.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, JBOSSWS_SPI).setExport(true).setImportServices(true).build());
         }
-        for(String api : JAVAEE_APIS) {
-            moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, api, false, false, true, false));
+        for (String api : JAVAEE_APIS) {
+            moduleSpec.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, api).setImportServices(true).build());
         }
     }
 }

--- a/webservices/server-integration/src/test/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessorTestCase.java
+++ b/webservices/server-integration/src/test/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessorTestCase.java
@@ -46,14 +46,14 @@ public class WSClassVerificationProcessorTestCase {
 
     @Test
     public void testCxfModuleDependencyPresent() {
-        spec.addUserDependency(new ModuleDependency(null, "org.apache.cxf", false, false, false, false));
+        spec.addUserDependency(ModuleDependency.Builder.of(null, "org.apache.cxf").build());
 
         Assert.assertTrue(WSClassVerificationProcessor.hasCxfModuleDependency(unit));
     }
 
     @Test
     public void testRootNonExportedCxfModuleDependencyPresent() {
-        rootSpec.addUserDependency(new ModuleDependency(null, "org.apache.cxf", false, false, false, false));
+        rootSpec.addUserDependency(ModuleDependency.Builder.of(null, "org.apache.cxf").build());
 
         Assert.assertFalse(WSClassVerificationProcessor.hasCxfModuleDependency(unit)); // parent dep not exported, should return false
     }
@@ -61,7 +61,7 @@ public class WSClassVerificationProcessorTestCase {
     @Test
     public void testSiblingNonExportedCxfModuleDependencyPresent() {
         setSubDeploymentsIsolated(false);
-        siblingSpec.addUserDependency(new ModuleDependency(null, "org.apache.cxf", false, false, false, false));
+        siblingSpec.addUserDependency(ModuleDependency.Builder.of(null, "org.apache.cxf").build());
 
         Assert.assertFalse(WSClassVerificationProcessor.hasCxfModuleDependency(unit)); // parent dep not exported, should return false
     }
@@ -69,7 +69,7 @@ public class WSClassVerificationProcessorTestCase {
     @Test
     public void testSiblingCxfModuleDependencyPresentIsolatedDeploymentsTrue() {
         setSubDeploymentsIsolated(true);
-        siblingSpec.addUserDependency(new ModuleDependency(null, "org.apache.cxf", false, true, false, false));
+        siblingSpec.addUserDependency(ModuleDependency.Builder.of(null, "org.apache.cxf").setExport(true).build());
 
         Assert.assertFalse(WSClassVerificationProcessor.hasCxfModuleDependency(unit));
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20189