### PR TITLE
[WFLY-20196] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in OPENTELEMETRY

### DIFF
--- a/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetryDependencyProcessor.java
+++ b/observability/opentelemetry/src/main/java/org/wildfly/extension/opentelemetry/OpenTelemetryDependencyProcessor.java
@@ -47,14 +47,12 @@ class OpenTelemetryDependencyProcessor implements DeploymentUnitProcessor {
                 .getCapabilityRuntimeAPI(Capabilities.WELD_CAPABILITY_NAME, WeldCapability.class);
             if (weldCapability.isPartOfWeldDeployment(deploymentUnit)) {
                 // Export the -api module only if CDI is available
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, API_MODULE,
-                        false, true, true, false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, API_MODULE).setExport(true).setImportServices(true).build());
             }
 
             // Export all other modules regardless of CDI availability
             for (String module : EXPORTED_MODULES) {
-                moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, true,
-                        true, false));
+                moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, module).setExport(true).setImportServices(true).build());
             }
         } catch (CapabilityServiceSupport.NoSuchCapabilityException e) {
             throw new IllegalStateException();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20196