### PR TITLE
[WFLY-20290] Add missing dependency on java.xml in Artemis commons module

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/commons/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/commons/main/module.xml
@@ -16,6 +16,7 @@
         <module name="org.apache.commons.beanutils" />
         <module name="org.slf4j"/>
         <module name="java.desktop"/>
+        <module name="java.xml"/>
         <module name="io.netty.netty-buffer"/>
         <module name="io.netty.netty-transport"/>
         <module name="io.netty.netty-handler"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20290 CLI command "server=name:import-journal" for messaging subsystem throws "NoClassDefFoundError:" in Java 17

Add missing dependency on java.xml in Artemis commons module