### PR TITLE
[WFLY-20277] Ignore persistence units in app-client container archive when deploying on server

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -61,11 +61,14 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
     private static final String WEB_PERSISTENCE_XML = "WEB-INF/classes/META-INF/persistence.xml";
     private static final String META_INF_PERSISTENCE_XML = "META-INF/persistence.xml";
+    private static final String META_INF_APPLICATION_CLIENT_XML = "META-INF/application-client.xml";
     private static final String JAR_FILE_EXTENSION = ".jar";
     private static final String LIB_FOLDER = "lib";
 
-    public PersistenceUnitParseProcessor() {
+    private final boolean appclient;
 
+    public PersistenceUnitParseProcessor(boolean appclient) {
+        this.appclient = appclient;
     }
 
     @Override
@@ -89,6 +92,12 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
             List<PersistenceUnitMetadataHolder> listPUHolders = new ArrayList<PersistenceUnitMetadataHolder>(1);
             // handle META-INF/persistence.xml
             final ResourceRoot deploymentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
+            VirtualFile appclientClientXml = deploymentRoot.getRoot().getChild(META_INF_APPLICATION_CLIENT_XML);
+            if (!appclient && appclientClientXml.exists()) {
+                // if not in appclient container, do not deploy persistence units contained in appclient container archive
+                return;
+            }
+
             VirtualFile persistence_xml = deploymentRoot.getRoot().getChild(META_INF_PERSISTENCE_XML);
             parse(persistence_xml, listPUHolders, deploymentUnit);
             PersistenceUnitMetadataHolder holder = normalize(listPUHolders);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -61,14 +61,13 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
     private static final String WEB_PERSISTENCE_XML = "WEB-INF/classes/META-INF/persistence.xml";
     private static final String META_INF_PERSISTENCE_XML = "META-INF/persistence.xml";
-    private static final String META_INF_APPLICATION_CLIENT_XML = "META-INF/application-client.xml";
     private static final String JAR_FILE_EXTENSION = ".jar";
     private static final String LIB_FOLDER = "lib";
 
-    private final boolean appclient;
+    private final boolean inAppClientContainer;
 
-    public PersistenceUnitParseProcessor(boolean appclient) {
-        this.appclient = appclient;
+    public PersistenceUnitParseProcessor(boolean inAppClientContainer) {
+        this.inAppClientContainer = inAppClientContainer;
     }
 
     @Override
@@ -92,8 +91,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
             List<PersistenceUnitMetadataHolder> listPUHolders = new ArrayList<PersistenceUnitMetadataHolder>(1);
             // handle META-INF/persistence.xml
             final ResourceRoot deploymentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
-            VirtualFile appclientClientXml = deploymentRoot.getRoot().getChild(META_INF_APPLICATION_CLIENT_XML);
-            if (!appclient && appclientClientXml.exists()) {
+            if (!inAppClientContainer && DeploymentTypeMarker.isType(DeploymentType.APPLICATION_CLIENT, deploymentUnit)) {
                 // if not in appclient container, do not deploy persistence units contained in appclient container archive
                 return;
             }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -75,7 +75,7 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
                         new JBossAllXmlParserRegisteringProcessor<>(JPAJarJBossAllParser.ROOT_ELEMENT, JpaAttachments.DEPLOYMENT_SETTINGS_KEY, new JPAJarJBossAllParser()));
 
                 // handles parsing of persistence.xml
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor());
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor(appclient));
 
                 // handles persistence unit / context annotations in components
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_PERSISTENCE_ANNOTATION, new JPAAnnotationProcessor());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/MainArchiveEntity.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/MainArchiveEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.appclient;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * @author Scott Marlow
+ */
+@Entity
+public class MainArchiveEntity {
+
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/PersistenceUnitInAppClientArchiveInServerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/PersistenceUnitInAppClientArchiveInServerTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.appclient;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Cover testing of https://issues.redhat.com/browse/WFLY-20277 change to ignore persistence units in app-client container archive when deploying on server.
+ *
+ * This test includes a client container archive that has a persistence.xml with invalid persistence provider name that would produce a deployment failure
+ * if the the persistence unit was actually started (since the invalid persistence provider class does not exist).
+ *
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class PersistenceUnitInAppClientArchiveInServerTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "PersistenceUnitInAppClientArchiveInServerTestCase.ear");
+
+        JavaArchive clientModule = ShrinkWrap.create(JavaArchive.class,"appclientcontainerarchive.jar");
+        clientModule.addAsManifestResource( PersistenceUnitInAppClientArchiveInServerTestCase.class.getPackage(), "application-client.xml","application-client.xml");
+        clientModule.addAsManifestResource(PersistenceUnitInAppClientArchiveInServerTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        ear.addAsModule(clientModule);
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jarfile.jar");
+        jar.addClass(MainArchiveEntity.class);
+        ear.addAsLibrary(jar);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "Test.war");
+        war.addClasses(HttpRequest.class, SimpleServlet.class);
+        // WEB-INF/classes is implied
+        war.addAsWebInfResource(PersistenceUnitInAppClientArchiveInServerTestCase.class.getPackage(), "web.xml", "web.xml");
+        ear.addAsModule(war);
+
+        return ear;
+    }
+
+    /**
+     * Any deployment failures for this test means the fix for WFLY-20277 has been broken.
+     * This test is expected to simply pass meaning that the test deployment succeeded with the ignored invalid persistence provider.
+     */
+    @Test
+    public void testNothing() throws NamingException {
+        assertTrue("if we don't get a deployer failure than this test has passed", true);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/PersistenceUnitInAppClientArchiveInServerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/PersistenceUnitInAppClientArchiveInServerTestCase.java
@@ -72,9 +72,7 @@ public class PersistenceUnitInAppClientArchiveInServerTestCase {
             fail("The change for WFLY-20277 has been broken likely because the appclientcontainerarchive.jar contains an invalid persistence.xml (someone needs to verify that).  " +
                     "Deployment failure message: " + deploymentProblem.getMessage());
         }
-        finally {
-            deployer.undeploy(ARCHIVE_NAME);
-        }
+        deployer.undeploy(ARCHIVE_NAME);
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/SimpleServlet.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.jpa.appclient;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+
+@WebServlet(name = "SimpleServlet", urlPatterns = {"/simple"})
+public class SimpleServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String msg = req.getParameter("input");
+
+        Writer writer = resp.getWriter();
+        writer.write("this won't be called");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/application-client.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/application-client.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <display-name>clienttest</display-name>
+</application-client>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/persistence.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="testPersistenceUnit" transaction-type="JTA">
+        <provider>org.jboss.as.test.integration.jpa.appclient.WillBeIgoredPersistenceProvider</provider>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="jboss.as.jpa.classtransformer" value="true" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/appclient/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+    <env-entry>
+        <env-entry-name>simpleString</env-entry-name>
+        <env-entry-type>java.lang.String</env-entry-type>
+        <env-entry-value>It's Friday!!!</env-entry-value>
+    </env-entry>
+
+</web-app>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20277

This helps but doesn't solve the https://hibernate.atlassian.net/browse/HHH-18901 problem (`Seeing "java.lang.annotation.AnnotationFormatError: Duplicate annotation for class: interface org.hibernate.bytecode.enhance.spi.EnhancementInfo`).