### PR TITLE
[WFLY-20295] Ban the org.wildfly.security:wildfly-elytron dependency

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -4054,7 +4054,7 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.infinispan</groupId>
+                        <groupId>*</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -1093,6 +1093,8 @@
                                             <exclude>xml-apis:xml-apis</exclude>
                                             <!-- Jandex moved to SmallRye -->
                                             <exclude>org.jboss:jandex</exclude>
+                                            <!-- We don't want the shaded jar that shades external artifacts -->
+                                            <exclude>org.wildfly.security:wildfly-elytron</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                     <dependencyConvergence></dependencyConvergence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20295
