### PR TITLE
[WFLY-20198] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in MP FAULT

### DIFF
--- a/microprofile/fault-tolerance-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/faulttolerance/deployment/MicroProfileFaultToleranceDependenciesProcessor.java
+++ b/microprofile/fault-tolerance-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/faulttolerance/deployment/MicroProfileFaultToleranceDependenciesProcessor.java
@@ -38,8 +38,8 @@ public class MicroProfileFaultToleranceDependenciesProcessor implements Deployme
 
             ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
             ModuleLoader moduleLoader = Module.getBootModuleLoader();
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.eclipse.microprofile.fault-tolerance.api", false, false, false, false));
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.wildfly.microprofile.fault-tolerance-smallrye.deployment", false, false, true, false));
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.eclipse.microprofile.fault-tolerance.api").build());
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.wildfly.microprofile.fault-tolerance-smallrye.deployment").setImportServices(true).build());
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20198