### PR TITLE
[WFLY-20199] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in MP HEALTH

### DIFF
--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DependencyProcessor.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DependencyProcessor.java
@@ -30,7 +30,7 @@ public class DependencyProcessor implements DeploymentUnitProcessor {
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.eclipse.microprofile.health.api", false, false, false, false));
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.eclipse.microprofile.health.api").build());
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20199