### PR TITLE
[WFLY-20204] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in MP TELEMETRY

### DIFF
--- a/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryDependencyProcessor.java
+++ b/microprofile/telemetry-smallrye/extension/src/main/java/org/wildfly/extension/microprofile/telemetry/MicroProfileTelemetryDependencyProcessor.java
@@ -35,8 +35,7 @@ class MicroProfileTelemetryDependencyProcessor implements DeploymentUnitProcesso
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
         for (String module : EXPORTED_MODULES) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, true,
-                    true, false));
+            moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, module).setExport(true).setImportServices(true).build());
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20204