### PR TITLE
[WFLY-20202] Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in MP OPENAPI

### DIFF
--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIDependencyProcessor.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIDependencyProcessor.java
@@ -31,7 +31,7 @@ public class OpenAPIDependencyProcessor implements DeploymentUnitProcessor {
             ModuleSpecification specification = unit.getAttachment(Attachments.MODULE_SPECIFICATION);
             ModuleLoader loader = Module.getBootModuleLoader();
 
-            specification.addSystemDependency(new ModuleDependency(loader, "org.eclipse.microprofile.openapi.api", false, false, false, false));
+            specification.addSystemDependency(ModuleDependency.Builder.of(loader, "org.eclipse.microprofile.openapi.api").build());
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20202