### PR TITLE
WFLY-20259, WFLY-20306 and WFLY-20309 - Upgrade RESTEasy MicroProfile and Wiremock. Allow testing of the MP REST Client with the security manger enabled 

### DIFF
--- a/boms/standard-test-expansion/pom.xml
+++ b/boms/standard-test-expansion/pom.xml
@@ -245,6 +245,23 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Used for the MP REST Client test to add the required permissions when running with the security manager
+                 enabled.
+             -->
+            <dependency>
+                <groupId>org.jboss.resteasy.microprofile</groupId>
+                <artifactId>microprofile-rest-client-tck</artifactId>
+                <version>${version.org.jboss.resteasy.microprofile}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.container</groupId>
+                        <artifactId>arquillian-container-test-spi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- End MP RES Client requirement -->
+
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
             Properties for dependencies that relate to production code go in the production code section below.
          -->
         <version.com.beust>1.78</version.com.beust>
-        <version.org.wiremock>3.9.2</version.org.wiremock>
+        <version.org.wiremock>3.10.0</version.org.wiremock>
         <version.dom4j>2.1.4</version.dom4j>
         <version.httpunit>1.7.3</version.httpunit>
         <legacy.version.io.netty>4.0.19.Final</legacy.version.io.netty>

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
         <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.11.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
-        <version.org.jboss.resteasy.microprofile>3.0.0.Final</version.org.jboss.resteasy.microprofile>
+        <version.org.jboss.resteasy.microprofile>3.0.1.Final</version.org.jboss.resteasy.microprofile>
         <version.org.jboss.resteasy.spring>3.2.0.Final</version.org.jboss.resteasy.spring>
         <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.1.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
         <version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>1.0.0.Final</version.org.jboss.spec.jakarta.xml.soap.saaj-api_3.0_spec>

--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -144,6 +144,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Used for the MP REST Client test to add the required permissions when running with the security manager
+             enabled.
+         -->
+        <dependency>
+            <groupId>org.jboss.resteasy.microprofile</groupId>
+            <artifactId>microprofile-rest-client-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- End permission requirement -->
+
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>

--- a/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian-bootable.xml
@@ -7,14 +7,15 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="jboss" default="true" >
+    <container qualifier="jboss" default="true">
         <configuration>
+            <property name="allowConnectingToRunningServer">true</property>
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
-            <property name="allowConnectingToRunningServer">true</property>
             <property name="waitForPorts">9990</property>
             <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>

--- a/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/src/test/resources/arquillian.xml
@@ -7,17 +7,18 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="jboss" default="true" >
+    <container qualifier="jboss" default="true">
         <configuration>
-            <property name="jbossHome">${jboss.home}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="javaHome">${container.java.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
-            <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="jbossArguments">${jboss.args}</property>
+            <property name="jbossHome">${jboss.home}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
-            <property name="allowConnectingToRunningServer">true</property>
+            <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="waitForPorts">9990</property>
             <property name="waitForPortsTimeoutInSeconds">10</property>
-            <property name="javaHome">${container.java.home}</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
* https://issues.redhat.com/browse/WFLY-20259
* https://issues.redhat.com/browse/WFLY-20306
* https://issues.redhat.com/browse/WFLY-20309

The 3.0.1.Final release of the RESTEasy MicroProfile project includes an Arquillian extension which adds a `permissions.xml` file to the deployment to allow running with the security manager enabled.

The upgrade to Wiremock 3.10 also includes a fix for running with the security manager enabled.

Upstream #18686