### PR TITLE
[WFLY-20160] Upgrade Hibernate to 7.0.0.Beta3 in WildFly Preview. Upd…

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -53,6 +53,7 @@
         <version.org.jboss.resteasy>7.0.0.Alpha4</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
+        <version.org.hibernate>7.0.0.Beta3</version.org.hibernate>
         <version.org.hibernate.validator>9.0.0.CR1</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
@@ -305,6 +306,29 @@
                 <groupId>org.glassfish.expressly</groupId>
                 <artifactId>expressly</artifactId>
                 <version>${version.org.glassfish.expressly}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${version.org.hibernate}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-envers</artifactId>
+                <version>${version.org.hibernate}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
@@ -132,11 +132,10 @@ public class Hibernate2LCacheStatsTestCase {
         try {
             Set<Satellite> satellites1 = new HashSet<Satellite>();
             Satellite sat = new Satellite();
-            sat.setId(new Integer(1));
             sat.setName("MOON");
             satellites1.add(sat);
 
-            Planet s1 = sfsb.prepareData("EARTH", "MILKY WAY", "SUN", satellites1, new Integer(1));
+            Planet s1 = sfsb.prepareData("EARTH", "MILKY WAY", "SUN", satellites1);
             Planet s2 = sfsb.getPlanet(s1.getPlanetId());
 
             DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
@@ -114,8 +114,8 @@ public class Hibernate4NativeAPIProviderTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide");
             Student st = sfsb.getStudent(s1.getStudentId());
             assertTrue("name read from hibernate session is MADHUMITA", "MADHUMITA".equals(st.getFirstName()));
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
@@ -114,8 +114,8 @@ public class HibernateNativeAPITransactionTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", false);
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", false);
             assertTrue("address read from hibernate session associated with hibernate transaction is 99 Purkynova REDHAT BRNO CZ",
                     "99 Purkynova REDHAT BRNO CZ".equals(s1.getAddress()));
             // update Student
@@ -136,9 +136,9 @@ public class HibernateNativeAPITransactionTestCase {
         // setup Configuration and SessionFactory
         try {
             sfsb.setupConfig();
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
-            // force creation of student with same Id to ensure RollBack
-            Student s3 = sfsb.createStudent("Hibernate", "ORM", "JavaWorld", s2.getStudentId());
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", false);
+            // Force the rollback
+            Student s3 = sfsb.createStudent("Hibernate", "ORM", "JavaWorld", true);
             Student st = sfsb.getStudentNoTx(s2.getStudentId());
             assertTrue("name read from hibernate session associated with hibernate transaction after rollback is REDHAT",
                     "REDHAT".equals(st.getFirstName()));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernate2LcacheStats.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernate2LcacheStats.java
@@ -73,31 +73,30 @@ public class SFSBHibernate2LcacheStats {
     }
 
     // create planet
-    public Planet prepareData(String planetName, String galaxyName, String starName, Set<Satellite> satellites, Integer id) {
+    public Planet prepareData(String planetName, String galaxyName, String starName, Set<Satellite> satellites) {
 
         Session session = sessionFactory.openSession();
         Planet planet = new Planet();
-        planet.setPlanetId(id);
         planet.setPlanetName(planetName);
         planet.setGalaxy(galaxyName);
         planet.setStar(starName);
         // Transaction trans = session.beginTransaction();
         try {
 
-            session.save(planet);
+            session.persist(planet);
 
             if (satellites != null && satellites.size() > 0) {
                 Iterator<Satellite> itrSat = satellites.iterator();
                 while (itrSat.hasNext()) {
                     Satellite sat = itrSat.next();
-                    session.save(sat);
+                    session.persist(sat);
                 }
                 planet.setSatellites(new HashSet<Satellite>());
                 planet.getSatellites().addAll(satellites);
 
             }
 
-            session.saveOrUpdate(planet);
+            session.persist(planet);
             SessionStatistics stats = session.getStatistics();
             assertEquals(2, stats.getEntityKeys().size());
             assertEquals(2, stats.getEntityCount());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
@@ -63,10 +63,9 @@ public class SFSBHibernateSessionFactory {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address) {
 
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -75,7 +74,7 @@ public class SFSBHibernateSessionFactory {
             // We are not explicitly initializing a Transaction as Hibernate is expected to invoke the Jakarta Transactions TransactionManager
             // implicitly
             Session session = sessionFactory.openSession();
-            session.save(student);
+            session.persist(student);
             session.flush();
             session.close();
         } catch (Exception e) {
@@ -87,7 +86,7 @@ public class SFSBHibernateSessionFactory {
 
     // fetch student
     public Student getStudent(int id) {
-        Student emp = sessionFactory.openSession().load(Student.class, id);
+        Student emp = sessionFactory.openSession().get(Student.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
@@ -59,11 +59,10 @@ public class SFSBHibernateTransaction {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address, boolean rollback) {
 
         // setupConfig();
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -71,8 +70,12 @@ public class SFSBHibernateTransaction {
 
         try {
             Transaction trans = session.beginTransaction();
-            session.save(student);
-            trans.commit();
+            session.persist(student);
+            if (rollback) {
+                trans.rollback();
+            } else {
+                trans.commit();
+            }
         } catch (Exception e) {
             throw new RuntimeException("transactional failure while persisting student entity", e);
         }
@@ -85,13 +88,13 @@ public class SFSBHibernateTransaction {
     public Student updateStudent(String address, int id) {
 
         Session session = sessionFactory.openSession();
-        Student student = session.load(Student.class, id);
+        Student student = session.get(Student.class, id);
         student.setAddress(address);
 
         try {
             // invoking the Hibernate transaction
             Transaction trans = session.beginTransaction();
-            session.save(student);
+            student = session.merge(student);
             trans.commit();
         } catch (Exception e) {
             throw new RuntimeException("transactional failure while persisting student entity", e);
@@ -104,7 +107,7 @@ public class SFSBHibernateTransaction {
     // fetch student
     public Student getStudentNoTx(int id) {
         // Transaction trans = sessionFactory.openSession().beginTransaction();
-        Student emp = sessionFactory.openSession().load(Student.class, id);
+        Student emp = sessionFactory.openSession().get(Student.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
@@ -114,7 +114,7 @@ public class Hibernate4NativeAPIEnversTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            StudentAudited s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
+            StudentAudited s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
             StudentAudited s2 = sfsb.updateStudent("REDHAT Brisbane,Australia", 1);
             StudentAudited st = sfsb.retrieveOldStudentVersion(s2.getStudentId());
             assertTrue("address read from audit tables after envers implementation is 99 Purkynova REDHAT BRNO CZ",

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/SFSBHibernateEnversSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/SFSBHibernateEnversSessionFactory.java
@@ -57,11 +57,10 @@ public class SFSBHibernateEnversSessionFactory {
     }
 
     // create student
-    public StudentAudited createStudent(String firstName, String lastName, String address, int id) {
+    public StudentAudited createStudent(String firstName, String lastName, String address) {
 
         // setupConfig();
         StudentAudited student = new StudentAudited();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -69,7 +68,7 @@ public class SFSBHibernateEnversSessionFactory {
         try {
             Session session = sessionFactory.openSession();
             Transaction trans = session.beginTransaction();
-            session.save(student);
+            session.persist(student);
             session.flush();
             trans.commit();
             session.close();
@@ -86,9 +85,9 @@ public class SFSBHibernateEnversSessionFactory {
         try {
             Session session = sessionFactory.openSession();
             Transaction trans = session.beginTransaction();
-            student = session.load(StudentAudited.class, id);
+            student = session.get(StudentAudited.class, id);
             student.setAddress(address);
-            session.save(student);
+            student = session.merge(student);
             session.flush();
             trans.commit();
             session.close();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
@@ -118,8 +118,8 @@ public class HibernateNativeAPINaturalIdTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Person s1 = sfsb.createPerson("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 123, 1);
-            Person s2 = sfsb.createPerson("REDHAT", "LINUX", "Worldwide", 435, 3);
+            Person s1 = sfsb.createPerson("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 123);
+            Person s2 = sfsb.createPerson("REDHAT", "LINUX", "Worldwide", 435);
             Person p1 = sfsb.getPersonReference("REDHAT", 435);
             Person p2 = sfsb.loadPerson("MADHUMITA", 123);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
@@ -53,10 +53,9 @@ public class SFSBHibernateSFNaturalId {
     }
 
     // create person
-    public Person createPerson(String firstName, String lastName, String address, int voterId, int id) {
+    public Person createPerson(String firstName, String lastName, String address, int voterId) {
 
         Person per = new Person();
-        per.setPersonId(id);
         per.setAddress(address);
         per.setPersonVoterId(voterId);
         per.setFirstName(firstName);
@@ -66,7 +65,7 @@ public class SFSBHibernateSFNaturalId {
             // We are not explicitly initializing a Transaction as Hibernate is expected to invoke the JTA TransactionManager
             // implicitly
             Session session = sessionFactory.openSession();
-            session.save(per);
+            session.persist(per);
             session.flush();
             session.close();
         } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
@@ -126,7 +126,7 @@ public class HibernateSecondLevelCacheTestCase {
         sfsb.setupConfig();
         DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
             Student s2 = sfsb.getStudent(1);
 
             Connection conn = ds.getConnection();
@@ -162,7 +162,7 @@ public class HibernateSecondLevelCacheTestCase {
         sfsb.setupConfig();
         DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);
         try {
-            Student s1 = sfsb.createStudent("Hope", "Solo", "6415 NE 138th Pl. Kirkland, WA 98034 USA", 1);
+            Student s1 = sfsb.createStudent("Hope", "Solo", "6415 NE 138th Pl. Kirkland, WA 98034 USA");
             Student s2 = sfsb.getStudent(1);
 
             Connection conn = ds.getConnection();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/SFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/SFSB.java
@@ -59,10 +59,9 @@ public class SFSB {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address) {
         // setupConfig();
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -78,7 +77,7 @@ public class SFSB {
             //    throw new RuntimeException("Hibernate Transaction is not active after joining Hibernate to Jakarta Transactions transaction: " + status.name());
             //}
 
-            session.save(student);
+            session.persist(student);
             // trans.commit();
             session.close();
         } catch (Exception e) {
@@ -104,7 +103,7 @@ public class SFSB {
             // if(status.isNotOneOf(TransactionStatus.ACTIVE)) {
             //    throw new RuntimeException("Hibernate Transaction is not active after joining Hibernate to Jakarta Transactions transaction: " + status.name());
             // }
-            student = session.load(Student.class, id);
+            student = session.get(Student.class, id);
             session.close();
 
         } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
@@ -40,7 +40,7 @@ public class EntityTest {
         t.setCustomer(c);
         c.setTickets(tickets);
 
-        session.save(c);
+        session.persist(c);
 
         return c;
     }
@@ -48,13 +48,12 @@ public class EntityTest {
     public Flight manyToOneCreate() throws Exception {
         Flight f = new Flight();
         f.setName("Flight number one");
-        f.setId(new Long(1));
 
         Company comp = new Company();
         comp.setName("Airline 1");
         f.setCompany(comp);
 
-        session.save(f);
+        session.persist(f);
 
         return f;
     }
@@ -64,7 +63,6 @@ public class EntityTest {
         Flight f1 = findFlightById(new Long(1));
         Flight f2 = new Flight();
 
-        f2.setId(new Long(2));
         f2.setName("Flight two");
 
         Company us = new Company();
@@ -89,55 +87,55 @@ public class EntityTest {
         f1.setCustomers(customers1);
         f2.setCustomers(customers2);
 
-        session.save(c1);
-        session.save(c2);
-        session.save(c3);
-        session.save(f2);
+        session.persist(c1);
+        session.persist(c2);
+        session.persist(c3);
+        session.persist(f2);
     }
 
     public int testAllCustomersQuery() {
 
         //session.flush();
-        return session.getNamedQuery("allCustomers").list().size();
+        return session.createNamedQuery("allCustomers", Customer.class).list().size();
     }
 
     public Customer testCustomerByIdQuery() {
         Customer c = new Customer();
         c.setName("Peter");
 
-        session.save(c);
+        session.persist(c);
         session.flush();
 
-        return (Customer) session.getNamedQuery("customerById").setParameter("id", c.getId()).uniqueResult();
+        return session.createNamedQuery("customerById", Customer.class).setParameter("id", c.getId()).uniqueResult();
 
     }
 
     public Customer createCustomer(String name) {
         Customer c = new Customer();
         c.setName(name);
-        session.save(c);
+        session.persist(c);
         return c;
     }
 
     public void changeCustomer(Long id, String name) {
-        Customer c = session.load(Customer.class, id);
+        Customer c = session.get(Customer.class, id);
         c.setName(name);
     }
 
 
     public Flight findFlightById(Long id) {
 
-        return session.load(Flight.class, id);
+        return session.get(Flight.class, id);
     }
 
     public Company findCompanyById(Long id) {
 
-        return session.load(Company.class, id);
+        return session.get(Company.class, id);
     }
 
     public Customer findCustomerById(Long id) {
 
-        return session.load(Customer.class, id);
+        return session.get(Customer.class, id);
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
@@ -30,7 +30,7 @@ public class SFSBHibernateSession {
     }
 
     public Employee getEmployee(int id) {
-        Employee emp = session.load(Employee.class, id);
+        Employee emp = session.get(Employee.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSessionFactory.java
@@ -41,7 +41,7 @@ public class SFSBHibernateSessionFactory {
     }
 
     public Employee getEmployee(int id) {
-        Employee emp = sessionFactory.openSession().load(Employee.class, id);
+        Employee emp = sessionFactory.openSession().get(Employee.class, id);
         return emp;
     }
 


### PR DESCRIPTION
…ated tests that were using removed methods which were previously deprecated in Hibernate 6.0.

https://issues.redhat.com/browse/WFLY-20160

Note for the test changes. Some of the deprecated methods from Hibernate 6.0 have been removed. These changes only affect WildFly Preview and Hibernate 7.0+, see https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html#cleanup.

The changes to setting the ID's was done because the `persist` method does not allow generated id's to, rightfully IMO, be set.
