### PR TITLE
[WFLY-20160] Upgrade Hibernate to 7.0.0.Beta3 in WildFly Preview. Upd…

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -48,11 +48,17 @@
         <version.jakarta.validation.jakarta-validation-api>3.1.0</version.jakarta.validation.jakarta-validation-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.2.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
+        <!-- Required for Hibernate Search -->
+        <version.org.apache.lucene>9.12.1</version.org.apache.lucene>
+        <version.org.bytebuddy>1.15.11</version.org.bytebuddy>
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.0</version.org.glassfish.jakarta.faces>
         <version.org.jboss.resteasy>7.0.0.Alpha4</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.0.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
+        <version.org.hibernate>7.0.0.Beta3</version.org.hibernate>
+        <version.org.hibernate.models>0.9.3</version.org.hibernate.models>
+        <version.org.hibernate.search>8.0.0.Alpha1</version.org.hibernate.search>
         <version.org.hibernate.validator>9.0.0.CR1</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
@@ -72,6 +78,17 @@
             </dependency>
 
             <!-- Bom-specific dependencies. Keep sorted -->
+            <dependency>
+                <groupId>${ee.maven.groupId}</groupId>
+                <artifactId>jipijapa-hibernate7</artifactId>
+                <version>${ee.maven.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>jakarta.annotation</groupId>
@@ -277,10 +294,90 @@
                 </exclusions>
             </dependency>
 
+            <!-- Used by Hibernate -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.org.bytebuddy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
                 <version>${version.org.apache.avro}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analysis-common</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-facet</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-join</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queries</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${version.org.apache.lucene}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -314,9 +411,157 @@
             </dependency>
 
             <dependency>
+                <groupId>org.hibernate.models</groupId>
+                <artifactId>hibernate-models</artifactId>
+                <version>${version.org.hibernate.models}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.models</groupId>
+                <artifactId>hibernate-models-jandex</artifactId>
+                <version>${version.org.hibernate.models}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${version.org.hibernate}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-envers</artifactId>
+                <version>${version.org.hibernate}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-scan-jandex</artifactId>
+                <version>${version.org.hibernate}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-lucene</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-engine</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>
                 <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-common</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
+                <version>${version.org.hibernate.search}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:jipijapa-hibernate6}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.annotation.api"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
+        <module name="jakarta.xml.bind.api"/>
+
+        <module name="org.hibernate" services="import"/>
+        <module name="org.hibernate.commons-annotations"/>
+        <module name="org.infinispan.core" services="import"/>
+        <module name="org.infinispan.protostream"/>
+        <module name="org.infinispan.hibernate-cache" services="import"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="io.smallrye.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
+        <module name="org.wildfly.common"/>
+    </dependencies>
+</module>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate6/main/module.xml
@@ -4,35 +4,4 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-
-<module xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate6">
-
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
-    <resources>
-        <artifact name="${org.wildfly:jipijapa-hibernate6}"/>
-    </resources>
-
-    <dependencies>
-        <module name="jakarta.annotation.api"/>
-        <module name="jakarta.enterprise.api"/>
-        <module name="jakarta.persistence.api"/>
-        <module name="jakarta.transaction.api"/>
-        <module name="jakarta.validation.api"/>
-        <module name="jakarta.xml.bind.api"/>
-
-        <module name="org.hibernate" services="import"/>
-        <module name="org.hibernate.commons-annotations"/>
-        <module name="org.infinispan.core" services="import"/>
-        <module name="org.infinispan.protostream"/>
-        <module name="org.infinispan.hibernate-cache" services="import"/>
-        <module name="org.jboss.as.jpa.spi"/>
-        <module name="io.smallrye.jandex"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
-        <module name="org.wildfly.clustering.marshalling.protostream"/>
-        <module name="org.wildfly.common"/>
-    </dependencies>
-</module>
+<module-alias xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate6" target-name="org.hibernate.jipijapa-hibernate"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -38,7 +38,7 @@
         <module name="io.smallrye.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.hibernate.commons-annotations"/>
-        <module name="org.hibernate.jipijapa-hibernate6" services="import"/>
+        <module name="org.hibernate.jipijapa-hibernate" services="import"/>
         <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
         <module name="net.bytebuddy"/>
         <module name="java.xml"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
@@ -24,7 +24,7 @@
         <module name="jakarta.transaction.api"/>
 
         <module name="org.hibernate"/>
-        <module name="org.hibernate.jipijapa-hibernate6" services="import"/>
+        <module name="org.hibernate.jipijapa-hibernate" services="import"/>
         <module name="org.infinispan.commons"/>
         <module name="org.infinispan.core" services="import"/>
         <module name="org.jboss.as.jpa.spi"/>

--- a/jpa/hibernate7/pom.xml
+++ b/jpa/hibernate7/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-jpa-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>36.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jipijapa-hibernate7</artifactId>
+
+    <name>WildFly: Jipijapa Hibernate 7 (JPA 3.2) integration</name>
+
+    <properties>
+        <!-- Use the standard WildFly dependency set -->
+        <dependency.management.pom.artifactId>wildfly-preview-ee-bom</dependency.management.pom.artifactId>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>wildfly-preview-test-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Internal -->
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jipijapa-spi</artifactId>
+        </dependency>
+
+        <!-- External -->
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.common</groupId>
+            <artifactId>hibernate-commons-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-scan-jandex</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-hibernate-cache-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-component-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-vfs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+    
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.clustering</groupId>
+            <artifactId>wildfly-clustering-marshalling-protostream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateArchiveScanner.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateArchiveScanner.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+
+import org.hibernate.archive.scan.spi.AbstractScannerImpl;
+import org.hibernate.boot.archive.scan.spi.Scanner;
+
+/**
+ * Annotation scanner for Hibernate.  Essentially just passes along the VFS-based ArchiveDescriptorFactory
+ *
+ * @author Steve Ebersole
+ */
+public class HibernateArchiveScanner extends AbstractScannerImpl implements Scanner {
+    public HibernateArchiveScanner() {
+        super(VirtualFileSystemArchiveDescriptorFactory.INSTANCE);
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateExtendedBeanManager.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateExtendedBeanManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.util.ArrayList;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+/**
+ * HibernateExtendedBeanManager helps defer the registering of entity listeners, with the Jakarta Contexts and Dependency Injection BeanManager until
+ * after the persistence unit is available for lookup by Jakarta Contexts and Dependency Injection bean(s).
+ * This solves the WFLY-2387 issue of Jakarta Persistence entity listeners referencing the Jakarta Contexts and Dependency Injection bean, when the bean cycles back
+ * to the persistence unit, or a different persistence unit.
+ *
+ * @author Scott Marlow
+ */
+public class HibernateExtendedBeanManager implements ExtendedBeanManager {
+    private final BeanManager beanManager;
+    private final ArrayList<LifecycleListener> lifecycleListeners = new ArrayList<>();
+
+    public HibernateExtendedBeanManager(BeanManager beanManager) {
+        this.beanManager = beanManager;
+    }
+
+    /**
+     * Hibernate calls registerLifecycleListener to register callback to be notified
+     * when the Jakarta Contexts and Dependency Injection BeanManager can safely be used.
+     * The Jakarta Contexts and Dependency Injection BeanManager can safely be used
+     * when the Jakarta Contexts and Dependency Injection AfterDeploymentValidation event is reached.
+     * <p>
+     * Note: Caller (BeanManagerAfterDeploymentValidation) is expected to synchronize calls to
+     * registerLifecycleListener() + beanManagerIsAvailableForUse(), which protects
+     * HibernateExtendedBeanManager.lifecycleListeners from being read/written from multiple concurrent threads.
+     * There are many writer threads (one per deployed persistence unit) and one reader/writer thread expected
+     * to be triggered by one AfterDeploymentValidation event per deployment.
+     */
+    public void beanManagerIsAvailableForUse() {
+        if (lifecycleListeners.isEmpty()) {
+            throw JpaLogger.JPA_LOGGER.HibernateORMDidNotRegisterLifeCycleListener();
+        }
+        for (LifecycleListener hibernateCallback : lifecycleListeners) {
+            hibernateCallback.beanManagerInitialized(beanManager);
+        }
+    }
+
+    @Override
+    public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+        lifecycleListeners.add(lifecycleListener);
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.persistence.SharedCacheMode;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import org.hibernate.cfg.AvailableSettings;
+import org.jipijapa.cache.spi.Classification;
+import org.jipijapa.event.impl.internal.Notification;
+import org.jipijapa.plugin.spi.EntityManagerFactoryBuilder;
+import org.jipijapa.plugin.spi.JtaManager;
+import org.jipijapa.plugin.spi.ManagementAdaptor;
+import org.jipijapa.plugin.spi.PersistenceProviderAdaptor;
+import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
+import org.jipijapa.plugin.spi.Platform;
+import org.jipijapa.plugin.spi.TwoPhaseBootstrapCapable;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.persistence.jipijapa.hibernate7.management.HibernateManagementAdaptor;
+import org.wildfly.persistence.jipijapa.hibernate7.service.WildFlyCustomJtaPlatform;
+
+/**
+ * Implements the PersistenceProviderAdaptor for Hibernate
+ *
+ * @author Scott Marlow
+ */
+@MetaInfServices(PersistenceProviderAdaptor.class)
+public class HibernatePersistenceProviderAdaptor implements PersistenceProviderAdaptor, TwoPhaseBootstrapCapable {
+
+    public static final String NAMING_STRATEGY_JPA_COMPLIANT_IMPL = "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl";
+    private volatile Platform platform;
+    private static final String SHARED_CACHE_MODE = "jakarta.persistence.sharedCache.mode";
+    private static final String NONE = SharedCacheMode.NONE.name();
+    private static final String UNSPECIFIED = SharedCacheMode.UNSPECIFIED.name();
+
+    // Hibernate ORM 5.3 setting which if false, the old IdentifierGenerator were used for AUTO, TABLE and SEQUENCE id generation.
+    // Hibernate ORM 6.0 does not support AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS
+    private static final String USE_NEW_ID_GENERATOR_MAPPINGS = "hibernate.id.new_generator_mappings";
+
+    @Override
+    public void injectJtaManager(JtaManager jtaManager) {
+        WildFlyCustomJtaPlatform.setTransactionSynchronizationRegistry(jtaManager.getSynchronizationRegistry());
+    }
+
+    @Override
+    public void injectPlatform(Platform platform) {
+        if (this.platform != platform) {
+            this.platform = platform;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void addProviderProperties(Map properties, PersistenceUnitMetadata pu) {
+        putPropertyIfAbsent(pu, properties, AvailableSettings.JPAQL_STRICT_COMPLIANCE, "true"); // JIPI-24 ignore jpql aliases case
+
+        failOnIncompatibleSetting(pu, properties);  // fail application deployment if application sets hibernate.id.new_generator_mappings to false
+        // applications that set new_generator_mappings to false need to be migrated to Hibernate ORM 6+,
+        // the database may need changes as well to deal with ensuring the "next id" counter is represented
+        // correctly in the database to match what the application is changed to instead use when inserting
+        // new database table rows.
+
+        putPropertyIfAbsent(pu, properties, AvailableSettings.KEYWORD_AUTO_QUOTING_ENABLED, "false");
+        putPropertyIfAbsent(pu, properties, AvailableSettings.IMPLICIT_NAMING_STRATEGY, NAMING_STRATEGY_JPA_COMPLIANT_IMPL);
+        putPropertyIfAbsent(pu, properties, AvailableSettings.SCANNER, HibernateArchiveScanner.class);
+        properties.put(AvailableSettings.CLASSLOADERS, pu.getClassLoader());
+        // Only set SESSION_FACTORY_NAME_IS_JNDI to false if application didn't override Hibernate ORM session factory name.
+        if (!pu.getProperties().containsKey(AvailableSettings.SESSION_FACTORY_NAME)) {
+            putPropertyIfAbsent(pu, properties, AvailableSettings.SESSION_FACTORY_NAME_IS_JNDI, Boolean.FALSE);
+        }
+        putPropertyIfAbsent(pu, properties, AvailableSettings.SESSION_FACTORY_NAME, pu.getScopedPersistenceUnitName());
+
+        putPropertyIfAbsent(pu, properties, AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, false);
+
+        // Enable JPA Compliance mode
+        putPropertyIfAbsent(pu, properties, AvailableSettings.JPA_COMPLIANCE, true);
+    }
+
+    private void failOnIncompatibleSetting(PersistenceUnitMetadata pu, Map properties) {
+        if ("false".equals(pu.getProperties().getProperty(USE_NEW_ID_GENERATOR_MAPPINGS))) {
+            throw JpaLogger.JPA_LOGGER.failOnIncompatibleSetting();
+        }
+    }
+
+    @Override
+    public void addProviderDependencies(PersistenceUnitMetadata pu) {
+        final Properties properties = pu.getProperties();
+        final String sharedCacheMode = properties.getProperty(SHARED_CACHE_MODE);
+
+        if (Classification.NONE.equals(platform.defaultCacheClassification())) {
+            JpaLogger.JPA_LOGGER.tracef("second level cache is not supported in platform, ignoring shared cache mode");
+            pu.setSharedCacheMode(SharedCacheMode.NONE);
+        }
+        // precedence order of cache settings (1 overrides other settings and 3 is lowest precedence level):
+        // 1 - SharedCacheMode.NONE
+        // 2 - AvailableSettings.USE_SECOND_LEVEL_CACHE
+        // 2 - AvailableSettings.USE_QUERY_CACHE
+        // 3 - SharedCacheMode.UNSPECIFIED
+        // 3 - SharedCacheMode.ENABLE_SELECTIVE
+        // 3 - SharedCacheMode.DISABLE_SELECTIVE
+
+        // if SharedCacheMode.NONE, set cacheDisabled to true.
+        boolean cacheDisabled = noneCacheMode(pu)
+                // Or if Hibernate cache settings are specified and Hibernate settings indicate cache is disabled, set cacheDisabled to true.
+                || (haveHibernateCachePropertyDefined(pu) && !hibernateCacheEnabled(pu));
+
+        if (!cacheDisabled) {
+            HibernateSecondLevelCache.addSecondLevelCacheDependencies(pu.getProperties(), pu.getScopedPersistenceUnitName());
+            JpaLogger.JPA_LOGGER.secondLevelCacheIsEnabled(pu.getScopedPersistenceUnitName());
+            // for SharedCacheMode.UNSPECIFIED, enable the cache and enable caching for entities marked with Cacheable
+            if (unspecifiedCacheMode(pu)) {
+                pu.setSharedCacheMode(SharedCacheMode.ENABLE_SELECTIVE);
+            }
+
+        } else {
+            JpaLogger.JPA_LOGGER.tracef("second level cache disabled for %s, pu %s property = %s, pu.getSharedCacheMode = %s",
+                    pu.getScopedPersistenceUnitName(),
+                    SHARED_CACHE_MODE,
+                    sharedCacheMode,
+                    pu.getSharedCacheMode().toString());
+            pu.setSharedCacheMode(SharedCacheMode.NONE);  // ensure that Hibernate doesn't try to use the 2lc
+        }
+    }
+
+    /**
+     * Determine if Hibernate cache properties are specified.
+     *
+     * @param pu
+     *
+     * @return true if Hibernate cache setting are specified.
+     */
+    private boolean haveHibernateCachePropertyDefined(PersistenceUnitMetadata pu) {
+        return (pu.getProperties().getProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE) != null ||
+                pu.getProperties().getProperty(AvailableSettings.USE_QUERY_CACHE) != null);
+    }
+
+    /**
+     * Determine if Hibernate cache properties are enabling or disabling cache.
+     *
+     * @param pu
+     *
+     * @return true if cache enabled, false if cache disabled.
+     */
+    private boolean hibernateCacheEnabled(PersistenceUnitMetadata pu) {
+        return (Boolean.parseBoolean(pu.getProperties().getProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE))
+                || Boolean.parseBoolean(pu.getProperties().getProperty(AvailableSettings.USE_QUERY_CACHE))
+        );
+
+    }
+
+    private boolean unspecifiedCacheMode(PersistenceUnitMetadata pu) {
+        return SharedCacheMode.UNSPECIFIED.equals(pu.getSharedCacheMode()) ||
+                UNSPECIFIED.equals(pu.getProperties().getProperty(SHARED_CACHE_MODE));
+    }
+
+    private boolean noneCacheMode(PersistenceUnitMetadata pu) {
+        return SharedCacheMode.NONE.equals(pu.getSharedCacheMode()) ||
+                NONE.equals(pu.getProperties().getProperty(SHARED_CACHE_MODE));
+    }
+
+    private void putPropertyIfAbsent(PersistenceUnitMetadata pu, Map properties, String property, Object value) {
+        if (!pu.getProperties().containsKey(property)) {
+            properties.put(property, value);
+        }
+    }
+
+    @Override
+    public void beforeCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        Notification.beforeEntityManagerFactoryCreate(Classification.INFINISPAN, pu);
+    }
+
+    @Override
+    public void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        Notification.afterEntityManagerFactoryCreate(Classification.INFINISPAN, pu);
+    }
+
+    @Override
+    public ManagementAdaptor getManagementAdaptor() {
+        return HibernateManagementAdaptor.getInstance();
+    }
+
+    /**
+     * determine if management console can display the second level cache entries
+     *
+     * @param pu
+     *
+     * @return false if a custom AvailableSettings.CACHE_REGION_PREFIX property is specified.
+     * true if the scoped persistence unit name is used to prefix cache entries.
+     */
+    @Override
+    public boolean doesScopedPersistenceUnitNameIdentifyCacheRegionName(PersistenceUnitMetadata pu) {
+        String cacheRegionPrefix = pu.getProperties().getProperty(AvailableSettings.CACHE_REGION_PREFIX);
+
+        return cacheRegionPrefix == null || cacheRegionPrefix.equals(pu.getScopedPersistenceUnitName());
+    }
+
+    @Override
+    public void cleanup(PersistenceUnitMetadata pu) {
+
+    }
+
+    @Override
+    public Object beanManagerLifeCycle(BeanManager beanManager) {
+        return new HibernateExtendedBeanManager(beanManager);
+    }
+
+    @Override
+    public void markPersistenceUnitAvailable(Object wrapperBeanManagerLifeCycle) {
+
+        HibernateExtendedBeanManager hibernateExtendedBeanManager = (HibernateExtendedBeanManager) wrapperBeanManagerLifeCycle;
+        // notify Hibernate ORM ExtendedBeanManager extension that the entity listener(s) can now be registered.
+        hibernateExtendedBeanManager.beanManagerIsAvailableForUse();
+    }
+
+    /* start of TwoPhaseBootstrapCapable methods */
+
+    public EntityManagerFactoryBuilder getBootstrap(final PersistenceUnitInfo info, final Map map) {
+        return new TwoPhaseBootstrapImpl(info, map);
+    }
+
+    /* end of TwoPhaseBootstrapCapable methods */
+}
+

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateSecondLevelCache.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernateSecondLevelCache.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.COLLECTION_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.DEF_ENTITY_RESOURCE;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.DEF_PENDING_PUTS_RESOURCE;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.DEF_QUERY_RESOURCE;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.DEF_TIMESTAMPS_RESOURCE;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.ENTITY_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.IMMUTABLE_ENTITY_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.INFINISPAN_CONFIG_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.NATURAL_ID_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.PENDING_PUTS_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.QUERY_CACHE_RESOURCE_PROP;
+import static org.infinispan.hibernate.cache.spi.InfinispanProperties.TIMESTAMPS_CACHE_RESOURCE_PROP;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.jipijapa.cache.spi.Classification;
+import org.jipijapa.event.impl.internal.Notification;
+
+/**
+ * Second level cache setup.
+ *
+ * @author Scott Marlow
+ */
+public class HibernateSecondLevelCache {
+
+    private static final String DEFAULT_REGION_FACTORY = "org.infinispan.hibernate.cache.v62.InfinispanRegionFactory";
+
+    public static final String CACHE_TYPE = "cachetype";    // shared (Jakarta Persistence) or private (for native applications)
+    public static final String CACHE_PRIVATE = "private";
+    public static final String CONTAINER = "container";
+    public static final String NAME = "name";
+    public static final String CACHES = "caches";
+
+    public static void addSecondLevelCacheDependencies(Properties mutableProperties, String scopedPersistenceUnitName) {
+
+        if (mutableProperties.getProperty(AvailableSettings.CACHE_REGION_PREFIX) == null
+                && scopedPersistenceUnitName != null) {
+            // cache entries for this PU will be identified by scoped pu name + Entity class name
+            mutableProperties.setProperty(AvailableSettings.CACHE_REGION_PREFIX, scopedPersistenceUnitName);
+        }
+        String regionFactory = mutableProperties.getProperty(AvailableSettings.CACHE_REGION_FACTORY);
+        if (regionFactory == null) {
+            regionFactory = DEFAULT_REGION_FACTORY;
+            mutableProperties.setProperty(AvailableSettings.CACHE_REGION_FACTORY, regionFactory);
+        }
+        if (Boolean.parseBoolean(mutableProperties.getProperty(ManagedEmbeddedCacheManagerProvider.SHARED, ManagedEmbeddedCacheManagerProvider.DEFAULT_SHARED))) {
+            // Set infinispan defaults
+            String container = mutableProperties.getProperty(ManagedEmbeddedCacheManagerProvider.CACHE_CONTAINER);
+            if (container == null) {
+                container = ManagedEmbeddedCacheManagerProvider.DEFAULT_CACHE_CONTAINER;
+                mutableProperties.setProperty(ManagedEmbeddedCacheManagerProvider.CACHE_CONTAINER, container);
+            }
+
+            /**
+             * AS will need the ServiceBuilder<?> builder that used to be passed to PersistenceProviderAdaptor.addProviderDependencies
+             */
+            Properties cacheSettings = new Properties();
+            cacheSettings.setProperty(CONTAINER, container);
+            cacheSettings.setProperty(CACHES, String.join(" ", findCaches(mutableProperties)));
+
+            Notification.addCacheDependencies(Classification.INFINISPAN, cacheSettings);
+        }
+    }
+
+    public static Set<String> findCaches(Properties properties) {
+        Set<String> caches = new HashSet<>();
+
+        caches.add(properties.getProperty(ENTITY_CACHE_RESOURCE_PROP, DEF_ENTITY_RESOURCE));
+        caches.add(properties.getProperty(IMMUTABLE_ENTITY_CACHE_RESOURCE_PROP, DEF_ENTITY_RESOURCE));
+        caches.add(properties.getProperty(COLLECTION_CACHE_RESOURCE_PROP, DEF_ENTITY_RESOURCE));
+        caches.add(properties.getProperty(NATURAL_ID_CACHE_RESOURCE_PROP, DEF_ENTITY_RESOURCE));
+        caches.add(properties.getProperty(PENDING_PUTS_CACHE_RESOURCE_PROP, DEF_PENDING_PUTS_RESOURCE));
+
+        if (Boolean.parseBoolean(properties.getProperty(AvailableSettings.USE_QUERY_CACHE))) {
+            caches.add(properties.getProperty(QUERY_CACHE_RESOURCE_PROP, DEF_QUERY_RESOURCE));
+            caches.add(properties.getProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, DEF_TIMESTAMPS_RESOURCE));
+        }
+
+        int length = INFINISPAN_CONFIG_RESOURCE_PROP.length();
+        String customRegionPrefix = INFINISPAN_CONFIG_RESOURCE_PROP.substring(0, length - 3) + properties.getProperty(AvailableSettings.CACHE_REGION_PREFIX, "");
+        String customRegionSuffix = INFINISPAN_CONFIG_RESOURCE_PROP.substring(length - 4, length);
+
+        for (String propertyName : properties.stringPropertyNames()) {
+            if (propertyName.startsWith(customRegionPrefix) && propertyName.endsWith(customRegionSuffix)) {
+                caches.add(properties.getProperty(propertyName));
+            }
+        }
+
+        return caches;
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/JpaLogger.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/JpaLogger.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.boot.archive.spi.ArchiveException;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * JipiJapa message range is 20200-20299
+ * note: keep duplicate messages in sync between different sub-projects that use the same messages
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @author Scott Marlow
+ */
+@MessageLogger(projectCode = "JIPIORMV7")
+public interface JpaLogger extends BasicLogger {
+
+    /**
+     * A logger with the category {@code org.jipijapa}.
+     */
+    JpaLogger JPA_LOGGER = Logger.getMessageLogger(MethodHandles.lookup(), JpaLogger.class, "org.jipijapa");
+
+    /**
+     * Inform that the Hibernate second level cache is enabled.
+     *
+     * @param puUnitName the persistence unit name
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 20260, value = "Second level cache enabled for %s")
+    void secondLevelCacheIsEnabled(Object puUnitName);
+
+    /**
+     * Creates an exception indicating that Hibernate ORM did not register the expected LifeCycleListener
+     *
+     * @return an {@link IllegalStateException} for the error.
+     */
+    @Message(id = 20261, value = "Hibernate ORM did not register LifeCycleListener")
+    IllegalStateException HibernateORMDidNotRegisterLifeCycleListener();
+
+    @LogMessage(level = WARN)
+    @Message(id = 20262, value = "Application custom cache region setting is ignored %s=%s")
+    void ignoredCacheRegionSetting(String propertyName, String setting );
+
+    /**
+     * Creates an exception indicating application is setting persistence unit property "hibernate.id.new_generator_mappings" to
+     * false which indicates that the old ID generator should be used, however Hibernate ORM 6 does not include the old ID generator.
+     *
+     * @return an {@link IllegalStateException} for the error.
+     */
+    @Message(id = 20263, value = "hibernate.id.new_generator_mappings set to false is not supported" +
+            ", remove the setting or set to true.  "+
+            "Refer to Hibernate ORM migration documentation for how to update the next id state in the application database.")
+    IllegalStateException failOnIncompatibleSetting();
+
+    @Message(id = 20264, value = "Unable to open VirtualFile-based InputStream")
+    ArchiveException unableOpenInputStream(@Cause Throwable cause);
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/ManagedEmbeddedCacheManagerProvider.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/ManagedEmbeddedCacheManagerProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.util.Properties;
+
+import org.hibernate.cache.CacheException;
+import org.hibernate.cfg.AvailableSettings;
+import org.infinispan.hibernate.cache.spi.EmbeddedCacheManagerProvider;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.manager.impl.AbstractDelegatingEmbeddedCacheManager;
+import org.jipijapa.cache.spi.Classification;
+import org.jipijapa.cache.spi.Wrapper;
+import org.jipijapa.event.impl.internal.Notification;
+import org.kohsuke.MetaInfServices;
+
+/**
+ * Provides a managed {@link EmbeddedCacheManager} instance to Infinispan's region factory implementation.
+ * @author Paul Ferraro
+ */
+@MetaInfServices(EmbeddedCacheManagerProvider.class)
+public class ManagedEmbeddedCacheManagerProvider implements EmbeddedCacheManagerProvider {
+    public static final String CACHE_CONTAINER = "hibernate.cache.infinispan.container";
+    public static final String DEFAULT_CACHE_CONTAINER = "hibernate";
+    public static final String SHARED = "hibernate.cache.infinispan.shared";
+    public static final String DEFAULT_SHARED = "true";
+    public static final String STATISTICS = "hibernate.cache.infinispan.statistics";
+
+    @Override
+    public EmbeddedCacheManager getEmbeddedCacheManager(Properties properties) {
+
+        Properties settings = new Properties();
+        String container = properties.getProperty(CACHE_CONTAINER, DEFAULT_CACHE_CONTAINER);
+        settings.setProperty(HibernateSecondLevelCache.CONTAINER, container);
+
+        if (!Boolean.parseBoolean(properties.getProperty(SHARED, DEFAULT_SHARED))) {
+            HibernateSecondLevelCache.addSecondLevelCacheDependencies(properties, null);
+
+            settings.setProperty(HibernateSecondLevelCache.CACHE_TYPE, HibernateSecondLevelCache.CACHE_PRIVATE);
+
+            // Find a suitable service name to represent this session factory instance
+            String name = properties.getProperty(AvailableSettings.SESSION_FACTORY_NAME);
+            if (name != null) {
+                settings.setProperty(HibernateSecondLevelCache.NAME, name);
+            }
+
+            settings.setProperty(HibernateSecondLevelCache.CACHES, String.join(" ", HibernateSecondLevelCache.findCaches(properties)));
+        }
+
+        try {
+            EmbeddedCacheManager manager = new JipiJapaCacheManager(Notification.startCache(Classification.INFINISPAN, settings));
+            if (manager.getCacheManagerConfiguration().statistics()) {
+                settings.setProperty(STATISTICS, Boolean.TRUE.toString());
+            }
+            return manager;
+        } catch (CacheException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+
+    private static class JipiJapaCacheManager extends AbstractDelegatingEmbeddedCacheManager {
+        private final Wrapper wrapper;
+
+        JipiJapaCacheManager(Wrapper wrapper) {
+            super((EmbeddedCacheManager) wrapper.getValue());
+            this.wrapper = wrapper;
+        }
+
+        @Override
+        public void stop() {
+            Notification.stopCache(Classification.INFINISPAN, this.wrapper);
+        }
+
+        @Override
+        public void close() {
+            this.stop();
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/TwoPhaseBootstrapImpl.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/TwoPhaseBootstrapImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.util.Map;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import org.hibernate.jpa.boot.spi.Bootstrap;
+import org.jipijapa.plugin.spi.EntityManagerFactoryBuilder;
+
+/**
+ * TwoPhaseBootstrapImpl
+ *
+ * @author Scott Marlow
+ */
+public class TwoPhaseBootstrapImpl implements EntityManagerFactoryBuilder {
+
+    final org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder entityManagerFactoryBuilder;
+
+    public TwoPhaseBootstrapImpl(final PersistenceUnitInfo info, final Map map) {
+        entityManagerFactoryBuilder =
+                    Bootstrap.getEntityManagerFactoryBuilder(info, map);
+    }
+
+    @Override
+    public EntityManagerFactory build() {
+        return entityManagerFactoryBuilder.build();
+    }
+
+    @Override
+    public void cancel() {
+        entityManagerFactoryBuilder.cancel();
+    }
+
+    @Override
+    public EntityManagerFactoryBuilder withValidatorFactory(Object validatorFactory) {
+        entityManagerFactoryBuilder.withValidatorFactory(validatorFactory);
+        return this;
+    }
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileInputStreamAccess.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileInputStreamAccess.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.hibernate.boot.archive.spi.InputStreamAccess;
+import org.jboss.vfs.VirtualFile;
+
+
+/**
+ * InputStreamAccess provides Hibernate with lazy, on-demand access to InputStreams for the various
+ * types of resources found during archive scanning.
+ *
+ * @author Steve Ebersole
+ */
+public class VirtualFileInputStreamAccess implements InputStreamAccess {
+    private final String name;
+    private final VirtualFile virtualFile;
+
+    public VirtualFileInputStreamAccess(String name, VirtualFile virtualFile) {
+        this.name = name;
+        this.virtualFile = virtualFile;
+    }
+
+    @Override
+    public String getStreamName() {
+        return name;
+    }
+
+    @Override
+    public InputStream accessInputStream() {
+        try {
+            return virtualFile.openStream();
+        } catch (IOException e) {
+            throw JpaLogger.JPA_LOGGER.unableOpenInputStream(e);
+        }
+    }
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileSystemArchiveDescriptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileSystemArchiveDescriptor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import org.hibernate.boot.archive.spi.ArchiveContext;
+import org.hibernate.boot.archive.spi.ArchiveDescriptor;
+import org.hibernate.boot.archive.spi.ArchiveEntry;
+import org.hibernate.boot.archive.spi.InputStreamAccess;
+import org.jboss.vfs.VirtualFile;
+
+
+/**
+ * Representation of an archive in the JBoss VirtualFileSystem API in terms of how to walk entries.
+ *
+ * @author Steve Ebersole
+ */
+public class VirtualFileSystemArchiveDescriptor implements ArchiveDescriptor {
+    private final VirtualFile root;
+
+    public VirtualFileSystemArchiveDescriptor(VirtualFile archiveRoot, String entryBase) {
+        if ( entryBase != null && entryBase.length() > 0 && ! "/".equals( entryBase ) ) {
+            this.root = archiveRoot.getChild( entryBase );
+        }
+        else {
+            this.root = archiveRoot;
+        }
+    }
+
+    public VirtualFile getRoot() {
+        return root;
+    }
+
+    @Override
+    public void visitArchive(ArchiveContext archiveContext) {
+        processVirtualFile( root, null, archiveContext );
+    }
+
+    private void processVirtualFile(VirtualFile virtualFile, String path, ArchiveContext archiveContext) {
+        if ( path == null ) {
+            path = "";
+        }
+        else {
+            if ( !path.endsWith( "/'" ) ) {
+                path = path + "/";
+            }
+        }
+
+        for ( VirtualFile child : virtualFile.getChildren() ) {
+            if ( !child.exists() ) {
+                // should never happen conceptually, but...
+                continue;
+            }
+
+            if ( child.isDirectory() ) {
+                processVirtualFile( child, path + child.getName(), archiveContext );
+                continue;
+            }
+
+            final String name = child.getPathName();
+            final String relativeName = path + child.getName();
+            final InputStreamAccess inputStreamAccess = new VirtualFileInputStreamAccess( name, child );
+
+            final ArchiveEntry entry = new ArchiveEntry() {
+                @Override
+                public String getName() {
+                    return name;
+                }
+
+                @Override
+                public String getNameWithinArchive() {
+                    return relativeName;
+                }
+
+                @Override
+                public InputStreamAccess getStreamAccess() {
+                    return inputStreamAccess;
+                }
+            };
+
+            archiveContext.obtainArchiveEntryHandler( entry ).handleEntry( entry, archiveContext );
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileSystemArchiveDescriptorFactory.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/VirtualFileSystemArchiveDescriptorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.hibernate.boot.archive.internal.StandardArchiveDescriptorFactory;
+import org.hibernate.boot.archive.spi.ArchiveDescriptor;
+import org.jboss.vfs.VFS;
+
+
+/**
+ * In Hibernate terms, the ArchiveDescriptorFactory contract is used to plug in handling for how to deal
+ * with archives in various systems.  For JBoss, that means its VirtualFileSystem API.
+ *
+ * @author Steve Ebersole
+ */
+public class VirtualFileSystemArchiveDescriptorFactory extends StandardArchiveDescriptorFactory {
+    static final VirtualFileSystemArchiveDescriptorFactory INSTANCE = new VirtualFileSystemArchiveDescriptorFactory();
+
+    private VirtualFileSystemArchiveDescriptorFactory() {
+    }
+
+    @Override
+    public ArchiveDescriptor buildArchiveDescriptor(URL url, String entryBase) {
+        try {
+            return new VirtualFileSystemArchiveDescriptor( VFS.getChild( url.toURI() ), entryBase );
+        }
+        catch (URISyntaxException e) {
+            throw new IllegalArgumentException( e );
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/BasicCacheKeyImplementationMarshaller.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/BasicCacheKeyImplementationMarshaller.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.cache;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.BasicCacheKeyImplementation;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link BasicCacheKeyImplementation}.
+ * @author Paul Ferraro
+ */
+public class BasicCacheKeyImplementationMarshaller implements ProtoStreamMarshaller<BasicCacheKeyImplementation> {
+
+    private static final int ID_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int HASH_CODE_INDEX = 3;
+
+    @Override
+    public Class<? extends BasicCacheKeyImplementation> getJavaClass() {
+        return BasicCacheKeyImplementation.class;
+    }
+
+    @Override
+    public BasicCacheKeyImplementation readFrom(ProtoStreamReader reader) throws IOException {
+        Serializable id = null;
+        String entity = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case ID_INDEX:
+                    id = reader.readAny(Serializable.class);
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new BasicCacheKeyImplementation(id, entity, hashCode.orElse(Objects.hashCode(id)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, BasicCacheKeyImplementation key) throws IOException {
+        Object id = key.getId();
+        if (id != null) {
+            writer.writeAny(ID_INDEX, id);
+        }
+        String entity = key.getEntityOrRoleName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(id)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/CacheKeyImplementationMarshaller.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/CacheKeyImplementationMarshaller.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.cache;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.CacheKeyImplementation;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link CacheKeyImplementation}.
+ * @author Paul Ferraro
+ */
+public class CacheKeyImplementationMarshaller implements ProtoStreamMarshaller<CacheKeyImplementation> {
+
+    private static final int ID_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int TENANT_INDEX = 3;
+    private static final int HASH_CODE_INDEX = 4;
+
+    @Override
+    public Class<? extends CacheKeyImplementation> getJavaClass() {
+        return CacheKeyImplementation.class;
+    }
+
+    @Override
+    public CacheKeyImplementation readFrom(ProtoStreamReader reader) throws IOException {
+        Object id = null;
+        String entity = null;
+        String tenant = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case ID_INDEX:
+                    id = reader.readAny();
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case TENANT_INDEX:
+                    tenant = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+                default:
+                    reader.skipField(tag);
+            }
+        }
+        return new CacheKeyImplementation(id, entity, tenant, hashCode.orElse(Objects.hashCode(id)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, CacheKeyImplementation key) throws IOException {
+        Object id = key.getId();
+        if (id != null) {
+            writer.writeAny(ID_INDEX, id);
+        }
+        String entity = key.getEntityOrRoleName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        String tenant = key.getTenantId();
+        if (tenant != null) {
+            writer.writeString(TENANT_INDEX, tenant);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(id)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/HibernateCacheInternalSerializationContextInitializer.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/HibernateCacheInternalSerializationContextInitializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.cache;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.marshalling.protostream.AbstractSerializationContextInitializer;
+import org.wildfly.clustering.marshalling.protostream.SerializationContext;
+import org.wildfly.clustering.marshalling.protostream.SerializationContextInitializer;
+
+/**
+ * {@link SerializationContextInitializer} for the {@link org.hibernate.cache.internal} package.
+ * @author Paul Ferraro
+ */
+@MetaInfServices(SerializationContextInitializer.class)
+public class HibernateCacheInternalSerializationContextInitializer extends AbstractSerializationContextInitializer {
+
+    public HibernateCacheInternalSerializationContextInitializer() {
+        super("org.hibernate.cache.internal.proto");
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext context) {
+        context.registerMarshaller(new BasicCacheKeyImplementationMarshaller());
+        context.registerMarshaller(new CacheKeyImplementationMarshaller());
+        context.registerMarshaller(new NaturalIdCacheKeyMarshaller());
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/NaturalIdCacheKeyMarshaller.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/cache/NaturalIdCacheKeyMarshaller.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.cache;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import org.hibernate.cache.internal.NaturalIdCacheKey;
+import org.infinispan.protostream.descriptors.WireType;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamMarshaller;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamReader;
+import org.wildfly.clustering.marshalling.protostream.ProtoStreamWriter;
+
+/**
+ * ProtoStream marshaller for {@link NaturalIdCacheKey}.
+ * @author Paul Ferraro
+ */
+public class NaturalIdCacheKeyMarshaller implements ProtoStreamMarshaller<NaturalIdCacheKey> {
+
+    private static final int VALUES_INDEX = 1;
+    private static final int ENTITY_INDEX = 2;
+    private static final int TENANT_INDEX = 3;
+    private static final int HASH_CODE_INDEX = 4;
+
+    @Override
+    public Class<? extends NaturalIdCacheKey> getJavaClass() {
+        return NaturalIdCacheKey.class;
+    }
+
+    @Override
+    public NaturalIdCacheKey readFrom(ProtoStreamReader reader) throws IOException {
+        Object values = null;
+        String entity = null;
+        String tenant = null;
+        OptionalInt hashCode = OptionalInt.empty();
+        while (!reader.isAtEnd()) {
+            int tag = reader.readTag();
+            switch (WireType.getTagFieldNumber(tag)) {
+                case VALUES_INDEX:
+                    values = reader.readAny();
+                    break;
+                case ENTITY_INDEX:
+                    entity = reader.readString();
+                    break;
+                case TENANT_INDEX:
+                    tenant = reader.readString();
+                    break;
+                case HASH_CODE_INDEX:
+                    hashCode = OptionalInt.of(reader.readSFixed32());
+                    break;
+            }
+        }
+        return new NaturalIdCacheKey(values, entity, tenant, hashCode.orElse(Objects.hashCode(values)));
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, NaturalIdCacheKey key) throws IOException {
+        Object values = key.getNaturalIdValues();
+        if (values != null) {
+            writer.writeAny(VALUES_INDEX, values);
+        }
+        String entity = key.getEntityName();
+        if (entity != null) {
+            writer.writeString(ENTITY_INDEX, entity);
+        }
+        String tenant = key.getTenantId();
+        if (tenant != null) {
+            writer.writeString(TENANT_INDEX, tenant);
+        }
+        int hashCode = key.hashCode();
+        if (hashCode != Objects.hashCode(values)) {
+            writer.writeSFixed32(HASH_CODE_INDEX, hashCode);
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateAbstractStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateAbstractStatistics.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+import org.jipijapa.management.spi.StatisticName;
+import org.jipijapa.management.spi.Statistics;
+
+/**
+ * HibernateAbstractStatistics
+ *
+ * @author Scott Marlow
+ */
+public abstract class HibernateAbstractStatistics implements Statistics {
+
+    private static final String RESOURCE_BUNDLE = HibernateAbstractStatistics.class.getPackage().getName() + ".LocalDescriptions";
+    private static final String RESOURCE_BUNDLE_KEY_PREFIX = "hibernate";
+    protected Map<String,Operation> operations = new HashMap<String, Operation>();
+    protected Set<String> childrenNames = new HashSet<String>();
+    protected Set<String> writeableNames = new HashSet<String>();
+    protected Map<String, Class> types = new HashMap<String, Class>();
+    protected Map<Locale, ResourceBundle> rbs = new HashMap<Locale, ResourceBundle>();
+
+    @Override
+    public String getResourceBundleName() {
+        return RESOURCE_BUNDLE;
+    }
+
+    @Override
+    public String getResourceBundleKeyPrefix() {
+        return RESOURCE_BUNDLE_KEY_PREFIX;
+    }
+
+    protected EntityManagerFactory getEntityManagerFactory(Object[] args) {
+        PathAddress pathAddress = getPathAddress(args);
+        for(Object arg :args) {
+            if (arg instanceof EntityManagerFactoryAccess) {
+                EntityManagerFactoryAccess entityManagerFactoryAccess = (EntityManagerFactoryAccess)arg;
+                return entityManagerFactoryAccess.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getNames() {
+        return Collections.unmodifiableSet(operations.keySet());
+    }
+
+    @Override
+    public Class getType(String name) {
+        return types.get(name);
+    }
+
+    @Override
+    public boolean isOperation(String name) {
+        return Operation.class.equals(getType(name));
+    }
+
+    @Override
+    public boolean isAttribute(String name) {
+        return ! isOperation(name);
+    }
+
+    @Override
+    public boolean isWriteable(String name) {
+        return writeableNames.contains(name);
+    }
+
+    @Override
+    public Object getValue(String name, EntityManagerFactoryAccess entityManagerFactoryAccess, StatisticName statisticName, PathAddress pathAddress) {
+        return operations.get(name).invoke(entityManagerFactoryAccess, statisticName, pathAddress);
+    }
+
+    @Override
+    public void setValue(String name, Object newValue, EntityManagerFactoryAccess entityManagerFactoryAccess, StatisticName statisticName, PathAddress pathAddress) {
+        operations.get(name).invoke(newValue, entityManagerFactoryAccess, statisticName, pathAddress);
+    }
+
+    protected EntityManagerFactoryAccess getEntityManagerFactoryAccess(Object[] args) {
+        for(Object arg :args) {
+            if (arg instanceof EntityManagerFactoryAccess) {
+                EntityManagerFactoryAccess entityManagerFactoryAccess = (EntityManagerFactoryAccess)arg;
+                return entityManagerFactoryAccess;
+            }
+        }
+        return null;
+    }
+
+    protected PathAddress getPathAddress(Object[] args) {
+        for(Object arg :args) {
+            if (arg instanceof PathAddress) {
+                return (PathAddress)arg;
+            }
+        }
+        return null;
+    }
+
+    protected String getStatisticName(Object[] args) {
+        for(Object arg :args) {
+            if (arg instanceof StatisticName) {
+                StatisticName name = (StatisticName)arg;
+                return name.getName();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getChildrenNames() {
+        return Collections.unmodifiableSet(childrenNames);
+    }
+
+    @Override
+    public Statistics getChild(String childName) {
+        return null;
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateCollectionStatistics.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.CollectionStatistics;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+
+/**
+ * Hibernate collection statistics
+ *
+ * @author Scott Marlow
+ */
+public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
+
+    private static final String ATTRIBUTE_COLLECTION_NAME = "collection-name";
+    public static final String OPERATION_COLLECTION_LOAD_COUNT = "collection-load-count";
+    public static final String OPERATION_COLLECTION_FETCH_COUNT = "collection-fetch-count";
+    public static final String OPERATION_COLLECTION_UPDATE_COUNT = "collection-update-count";
+    public static final String OPERATION_COLLECTION_REMOVE_COUNT = "collection-remove-count";
+    public static final String OPERATION_COLLECTION_RECREATED_COUNT = "collection-recreated-count";
+
+    public HibernateCollectionStatistics() {
+        /**
+         * specify the different operations
+         */
+        operations.put(ATTRIBUTE_COLLECTION_NAME, showCollectionName);
+        types.put(ATTRIBUTE_COLLECTION_NAME,String.class);
+
+        operations.put(OPERATION_COLLECTION_LOAD_COUNT, collectionLoadCount);
+        types.put(OPERATION_COLLECTION_LOAD_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_FETCH_COUNT, collectionFetchCount);
+        types.put(OPERATION_COLLECTION_FETCH_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_UPDATE_COUNT, collectionUpdateCount);
+        types.put(OPERATION_COLLECTION_UPDATE_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_REMOVE_COUNT, collectionRemoveCount);
+        types.put(OPERATION_COLLECTION_REMOVE_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_RECREATED_COUNT, collectionRecreatedCount);
+        types.put(OPERATION_COLLECTION_RECREATED_COUNT, Long.class);
+    }
+
+    @Override
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
+    }
+
+    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
+    private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics().getCollectionStatistics(pathAddress.getValue(HibernateStatistics.COLLECTION));
+        }
+        return null;
+    }
+
+    private Operation showCollectionName = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            return getStatisticName(args);
+        }
+    };
+
+    private Operation collectionUpdateCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getUpdateCount() : 0);
+        }
+    };
+
+    private Operation collectionRemoveCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getRemoveCount() : 0);
+        }
+    };
+
+    private Operation collectionRecreatedCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getRemoveCount() : 0);
+        }
+    };
+
+    private Operation collectionLoadCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getLoadCount() : 0);
+        }
+    };
+
+    private Operation collectionFetchCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getFetchCount() : 0);
+        }
+    };
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityCacheStatistics.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+
+/**
+ * Hibernate entity cache (SecondLevelCacheStatistics) statistics
+ *
+ * @author Scott Marlow
+ */
+public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics {
+
+    public static final String ATTRIBUTE_ENTITY_CACHE_REGION_NAME = "entity-cache-region-name";
+    public static final String OPERATION_SECOND_LEVEL_CACHE_HIT_COUNT = "second-level-cache-hit-count";
+    public static final String OPERATION_SECOND_LEVEL_CACHE_MISS_COUNT = "second-level-cache-miss-count";
+    public static final String OPERATION_SECOND_LEVEL_CACHE_PUT_COUNT = "second-level-cache-put-count";
+    public static final String OPERATION_SECOND_LEVEL_CACHE_COUNT_IN_MEMORY = "second-level-cache-count-in-memory";
+    public static final String OPERATION_SECOND_LEVEL_CACHE_SIZE_IN_MEMORY = "second-level-cache-size-in-memory";
+
+    public HibernateEntityCacheStatistics() {
+        /**
+         * specify the different operations
+         */
+        operations.put(ATTRIBUTE_ENTITY_CACHE_REGION_NAME, getEntityCacheRegionName);
+        types.put(ATTRIBUTE_ENTITY_CACHE_REGION_NAME,String.class);
+
+        operations.put(OPERATION_SECOND_LEVEL_CACHE_HIT_COUNT, entityCacheHitCount);
+        types.put(OPERATION_SECOND_LEVEL_CACHE_HIT_COUNT, Long.class);
+
+        operations.put(OPERATION_SECOND_LEVEL_CACHE_MISS_COUNT, entityCacheMissCount);
+        types.put(OPERATION_SECOND_LEVEL_CACHE_MISS_COUNT, Long.class);
+
+        operations.put(OPERATION_SECOND_LEVEL_CACHE_PUT_COUNT, entityCachePutCount);
+        types.put(OPERATION_SECOND_LEVEL_CACHE_PUT_COUNT, Long.class);
+
+        operations.put(OPERATION_SECOND_LEVEL_CACHE_COUNT_IN_MEMORY, entityCacheCountInMemory);
+        types.put(OPERATION_SECOND_LEVEL_CACHE_COUNT_IN_MEMORY, Long.class);
+
+        operations.put(OPERATION_SECOND_LEVEL_CACHE_SIZE_IN_MEMORY, entityCacheSizeInMemory);
+        types.put(OPERATION_SECOND_LEVEL_CACHE_SIZE_IN_MEMORY, Long.class);
+
+    }
+
+    @Override
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
+    }
+
+    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
+    org.hibernate.stat.CacheRegionStatistics getStatistics(EntityManagerFactoryAccess entityManagerFactoryaccess, PathAddress pathAddress) {
+        String scopedPersistenceUnitName = pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL);
+        SessionFactory sessionFactory = entityManagerFactoryaccess.entityManagerFactory(scopedPersistenceUnitName).unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            // Statistics#getCacheRegionStatistics() only expects the entity class name to be specified.
+            return sessionFactory.getStatistics().getCacheRegionStatistics(pathAddress.getValue(HibernateStatistics.ENTITYCACHE));
+        }
+        return null;
+    }
+    private Operation getEntityCacheRegionName = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            return getStatisticName(args);
+        }
+    };
+
+
+    private Operation entityCacheHitCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.CacheRegionStatistics statistics = getStatistics(getEntityManagerFactoryAccess(args),  getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getHitCount() : 0);
+        }
+    };
+
+    private Operation entityCacheMissCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.CacheRegionStatistics statistics = getStatistics(getEntityManagerFactoryAccess(args),  getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getMissCount() : 0);
+        }
+    };
+
+    private Operation entityCachePutCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.CacheRegionStatistics statistics = getStatistics(getEntityManagerFactoryAccess(args),  getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getPutCount() : 0);
+        }
+    };
+
+    private Operation entityCacheSizeInMemory = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.CacheRegionStatistics statistics = getStatistics(getEntityManagerFactoryAccess(args),  getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getSizeInMemory() : 0);
+        }
+    };
+
+    private Operation entityCacheCountInMemory = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.CacheRegionStatistics statistics = getStatistics(getEntityManagerFactoryAccess(args),  getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getElementCountInMemory() : 0);
+        }
+    };
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateEntityStatistics.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+
+/**
+ * Hibernate entity statistics
+ *
+ * @author Scott Marlow
+ */
+public class HibernateEntityStatistics extends HibernateAbstractStatistics {
+
+    public static final String OPERATION_ENTITY_DELETE_COUNT = "entity-delete-count";
+    public static final String OPERATION_ENTITY_INSERT_COUNT = "entity-insert-count";
+    public static final String OPERATION_ENTITY_LOAD_COUNT = "entity-load-count";
+    public static final String OPERATION_ENTITY_FETCH_COUNT = "entity-fetch-count";
+    public static final String OPERATION_ENTITY_UPDATE_COUNT = "entity-update-count";
+    public static final String OPERATION_OPTIMISTIC_FAILURE_COUNT = "optimistic-failure-count";
+
+    public HibernateEntityStatistics() {
+        /**
+         * specify the different operations
+         */
+        operations.put(OPERATION_ENTITY_DELETE_COUNT, entityDeleteCount);
+        types.put(OPERATION_ENTITY_DELETE_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_INSERT_COUNT, entityInsertCount);
+        types.put(OPERATION_ENTITY_INSERT_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_LOAD_COUNT, entityLoadCount);
+        types.put(OPERATION_ENTITY_LOAD_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_FETCH_COUNT, entityFetchCount);
+        types.put(OPERATION_ENTITY_FETCH_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_UPDATE_COUNT, entityUpdateCount);
+        types.put(OPERATION_ENTITY_UPDATE_COUNT, Long.class);
+
+        operations.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, optimisticFailureCount);
+        types.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, Long.class);
+    }
+
+    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
+    private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics().getEntityStatistics(pathAddress.getValue(HibernateStatistics.ENTITY));
+        }
+        return null;
+    }
+
+    private Operation entityDeleteCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getDeleteCount() : 0);
+        }
+    };
+
+    private Operation entityFetchCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getFetchCount() : 0);
+        }
+    };
+
+    private Operation entityInsertCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getInsertCount() : 0);
+        }
+    };
+
+    private Operation entityLoadCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getLoadCount() : 0);
+        }
+    };
+
+    private Operation entityUpdateCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getUpdateCount() : 0);
+        }
+    };
+
+    private Operation optimisticFailureCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
+            return Long.valueOf(statistics != null ? statistics.getOptimisticFailureCount() : 0);
+        }
+    };
+
+    @Override
+    public Set<String> getNames() {
+
+        return Collections.unmodifiableSet(operations.keySet());
+    }
+
+    @Override
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        org.hibernate.stat.Statistics statistics = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        return statistics != null ?
+            Collections.unmodifiableCollection(Arrays.asList( statistics.getEntityNames())) :
+                Collections.EMPTY_LIST;
+
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateManagementAdaptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateManagementAdaptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import org.jboss.as.jpa.spi.ManagementAdaptor;
+import org.jipijapa.management.spi.Statistics;
+
+/**
+ * Contains management support for Hibernate
+ *
+ * @author Scott Marlow
+ */
+public class HibernateManagementAdaptor implements ManagementAdaptor {
+
+    // shared (per classloader) instance for all Hibernate 4.3 Jakarta Persistence deployments
+    private static final HibernateManagementAdaptor INSTANCE = new HibernateManagementAdaptor();
+
+    private final Statistics statistics = new HibernateStatistics();
+
+    private static final String PROVIDER_LABEL = "hibernate-persistence-unit";
+    private static final String VERSION = "Hibernate ORM 4.3.x";
+
+    private HibernateManagementAdaptor() {
+
+    }
+
+    /**
+     * The management statistics are shared across all Hibernate 4 Jakarta Persistence deployments
+     * @return shared instance for all Hibernate 4 Jakarta Persistence deployments
+     */
+    public static HibernateManagementAdaptor getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getIdentificationLabel() {
+        return PROVIDER_LABEL;
+    }
+
+    @Override
+    public String getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public Statistics getStatistics() {
+        return statistics;
+    }
+
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateQueryCacheStatistics.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+
+/**
+ * Hibernate query cache statistics
+ *
+ * @author Scott Marlow
+ */
+public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
+
+    public static final String ATTRIBUTE_QUERY_NAME = "query-name";
+    public static final String OPERATION_QUERY_EXECUTION_COUNT = "query-execution-count";
+    public static final String OPERATION_QUERY_EXECUTION_ROW_COUNT = "query-execution-row-count";
+    public static final String OPERATION_QUERY_EXECUTION_AVG_TIME = "query-execution-average-time";
+    public static final String OPERATION_QUERY_EXECUTION_MAX_TIME = "query-execution-max-time";
+    public static final String OPERATION_QUERY_EXECUTION_MIN_TIME = "query-execution-min-time";
+    public static final String OPERATION_QUERY_CACHE_HIT_COUNT = "query-cache-hit-count";
+    public static final String OPERATION_QUERY_CACHE_MISS_COUNT = "query-cache-miss-count";
+    public static final String OPERATION_QUERY_CACHE_PUT_COUNT = "query-cache-put-count";
+
+    public HibernateQueryCacheStatistics() {
+        /**
+         * specify the different operations
+         */
+        operations.put(ATTRIBUTE_QUERY_NAME, showQueryName);
+        types.put(ATTRIBUTE_QUERY_NAME,String.class);
+
+        operations.put(OPERATION_QUERY_EXECUTION_COUNT, queryExecutionCount);
+        types.put(OPERATION_QUERY_EXECUTION_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERY_EXECUTION_ROW_COUNT, queryExecutionRowCount);
+        types.put(OPERATION_QUERY_EXECUTION_ROW_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERY_EXECUTION_AVG_TIME, queryExecutionAverageTime);
+        types.put(OPERATION_QUERY_EXECUTION_AVG_TIME, Long.class);
+
+        operations.put(OPERATION_QUERY_EXECUTION_MAX_TIME, queryExecutionMaximumTime);
+        types.put(OPERATION_QUERY_EXECUTION_MAX_TIME, Long.class);
+
+        operations.put(OPERATION_QUERY_EXECUTION_MIN_TIME, queryExecutionMinimumTime);
+        types.put(OPERATION_QUERY_EXECUTION_MIN_TIME, Long.class);
+
+        operations.put(OPERATION_QUERY_CACHE_HIT_COUNT, queryCacheHitCount);
+        types.put(OPERATION_QUERY_CACHE_HIT_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERY_CACHE_MISS_COUNT, queryCacheMissCount);
+        types.put(OPERATION_QUERY_CACHE_MISS_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERY_CACHE_PUT_COUNT, queryCachePutCount);
+        types.put(OPERATION_QUERY_CACHE_PUT_COUNT, Long.class);
+   }
+
+    @Override
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+        Set<String> result = new HashSet<>();
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats != null) {
+            String[] queries = stats.getQueries();
+            if (queries != null) {
+                for (String query : queries) {
+                    result.add(QueryName.queryName(query).getDisplayName());
+                }
+            }
+        }
+        return result;
+    }
+
+    private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
+    private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        // convert displayed (transformed by QueryNames) query name to original query name to look up query statistics
+        if (sessionFactory != null) {
+            String[] originalQueryNames = sessionFactory.getStatistics().getQueries();
+            if (originalQueryNames != null) {
+                for (String originalQueryName : originalQueryNames) {
+                    if (QueryName.queryName(originalQueryName).getDisplayName().equals(displayQueryName)) {
+                        return sessionFactory.getStatistics().getQueryStatistics(originalQueryName);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private Operation queryExecutionCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getExecutionCount() : 0);
+        }
+    };
+
+    private Operation queryExecutionMaximumTime = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getExecutionMaxTime() : 0);
+        }
+    };
+
+    private Operation queryExecutionRowCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getExecutionRowCount() : 0);
+        }
+    };
+
+    private Operation queryExecutionAverageTime = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getExecutionAvgTime() : 0);
+        }
+    };
+
+    private Operation queryExecutionMinimumTime = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getExecutionMinTime() : 0);
+        }
+    };
+
+    private Operation queryCacheHitCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getCacheHitCount() : 0);
+        }
+    };
+
+    private Operation queryCacheMissCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getCacheMissCount() : 0);
+        }
+    };
+
+    private Operation queryCachePutCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.QueryStatistics statistics = getStatistics(getEntityManagerFactory(args), getQueryName(args));
+            return Long.valueOf(statistics != null ? statistics.getCachePutCount() : 0);
+        }
+    };
+
+    private Operation showQueryName = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            String displayQueryName = getQueryName(args);
+            EntityManagerFactory entityManagerFactory = getEntityManagerFactory(args);
+            if (displayQueryName != null && entityManagerFactory != null) {
+                SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+                // convert displayed (transformed by QueryNames) query name to original query name
+                if (sessionFactory != null) {
+                    String[] originalQueryNames = sessionFactory.getStatistics().getQueries();
+                    if (originalQueryNames != null) {
+                        for (String originalQueryName : originalQueryNames) {
+                            if (QueryName.queryName(originalQueryName).getDisplayName().equals(displayQueryName)) {
+                                return originalQueryName;
+                            }
+                        }
+                    }
+                }
+
+            }
+            return null;
+        }
+    };
+
+    private String getQueryName(Object... args) {
+        PathAddress pathAddress = getPathAddress(args);
+        if (pathAddress != null) {
+            return pathAddress.getValue(HibernateStatistics.QUERYCACHE);
+        }
+        return null;
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatistics.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/HibernateStatistics.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.Cache;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.jipijapa.management.spi.EntityManagerFactoryAccess;
+import org.jipijapa.management.spi.Operation;
+import org.jipijapa.management.spi.PathAddress;
+import org.jipijapa.management.spi.Statistics;
+
+/**
+ * HibernateStatistics
+ *
+ * @author Scott Marlow
+ */
+public class HibernateStatistics extends HibernateAbstractStatistics {
+
+    public static final String PROVIDER_LABEL = "hibernate-persistence-unit";
+    public static final String OPERATION_CLEAR = "clear";
+    public static final String OPERATION_EVICTALL = "evict-all";
+    public static final String OPERATION_SUMMARY = "summary";
+    public static final String OPERATION_STATISTICS_ENABLED_DEPRECATED = "enabled";    // deprecated by JIPI-28
+    public static final String OPERATION_STATISTICS_ENABLED = "statistics-enabled";
+    public static final String OPERATION_ENTITY_DELETE_COUNT = "entity-delete-count";
+    public static final String OPERATION_ENTITY_INSERT_COUNT = "entity-insert-count";
+    public static final String OPERATION_ENTITY_LOAD_COUNT = "entity-load-count";
+    public static final String OPERATION_ENTITY_FETCH_COUNT = "entity-fetch-count";
+    public static final String OPERATION_ENTITY_UPDATE_COUNT = "entity-update-count";
+    public static final String OPERATION_COLLECTION_FETCH_COUNT = "collection-fetch-count";
+    public static final String OPERATION_COLLECTION_LOAD_COUNT = "collection-load-count";
+    public static final String OPERATION_COLLECTION_RECREATED_COUNT = "collection-recreated-count";
+    public static final String OPERATION_COLLECTION_REMOVE_COUNT = "collection-remove-count";
+    public static final String OPERATION_COLLECTION_UPDATE_COUNT = "collection-update-count";
+    public static final String OPERATION_QUERYCACHE_HIT_COUNT = "query-cache-hit-count";
+    public static final String OPERATION_QUERYCACHE_MISS_COUNT ="query-cache-miss-count";
+    public static final String OPERATION_QUERYQUERYCACHE_PUT_COUNT ="query-cache-put-count";
+    public static final String OPERATION_QUERYEXECUTION_COUNT ="query-execution-count";
+    public static final String OPERATION_QUERYEXECUTION_MAX_TIME ="query-execution-max-time";
+    public static final String OPERATION_QUERYEXECUTION_MAX_TIME_STRING ="query-execution-max-time-query-string";
+    public static final String OPERATION_SECONDLEVELCACHE_HIT_COUNT= "second-level-cache-hit-count";
+    public static final String OPERATION_SECONDLEVELCACHE_MISS_COUNT="second-level-cache-miss-count";
+    public static final String OPERATION_SECONDLEVELCACHE_PUT_COUNT="second-level-cache-put-count";
+
+    public static final String OPERATION_FLUSH_COUNT = "flush-count";
+    public static final String OPERATION_CONNECT_COUNT = "connect-count";
+    public static final String OPERATION_SESSION_CLOSE_COUNT = "session-close-count";
+    public static final String OPERATION_SESSION_OPEN_COUNT = "session-open-count";
+    public static final String OPERATION_SUCCESSFUL_TRANSACTION_COUNT = "successful-transaction-count";
+    public static final String OPERATION_COMPLETED_TRANSACTION_COUNT = "completed-transaction-count";
+    public static final String OPERATION_PREPARED_STATEMENT_COUNT = "prepared-statement-count";
+    public static final String OPERATION_CLOSE_STATEMENT_COUNT = "close-statement-count";
+    public static final String OPERATION_OPTIMISTIC_FAILURE_COUNT = "optimistic-failure-count";
+    public static final String ENTITYCACHE = "entity-cache";
+    public static final String COLLECTION = "collection";
+    public static final String ENTITY = "entity";
+    public static final String QUERYCACHE = "query-cache";
+
+    private final Map<String, Statistics> childrenStatistics = new HashMap<String,Statistics>();
+    public HibernateStatistics() {
+
+        /**
+         * specify the different operations
+         */
+        operations.put(PROVIDER_LABEL, label);
+        types.put(PROVIDER_LABEL,String.class);
+
+        operations.put(OPERATION_CLEAR, clear);
+        types.put(OPERATION_CLEAR, Operation.class);
+
+        operations.put(OPERATION_EVICTALL, evictAll);
+        types.put(OPERATION_EVICTALL, Operation.class);
+
+        operations.put(OPERATION_SUMMARY, summary);
+        types.put(OPERATION_SUMMARY, Operation.class);
+
+        operations.put(OPERATION_STATISTICS_ENABLED, statisticsEnabled);
+        types.put(OPERATION_STATISTICS_ENABLED, Boolean.class);
+        writeableNames.add(OPERATION_STATISTICS_ENABLED);   // make 'enabled' writeable
+
+        operations.put(OPERATION_STATISTICS_ENABLED_DEPRECATED, statisticsEnabled);
+        types.put(OPERATION_STATISTICS_ENABLED_DEPRECATED, Boolean.class);
+        writeableNames.add(OPERATION_STATISTICS_ENABLED_DEPRECATED);   // make 'enabled' writeable
+
+        operations.put(OPERATION_ENTITY_DELETE_COUNT, entityDeleteCount);
+        types.put(OPERATION_ENTITY_DELETE_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_FETCH_COUNT, collectionFetchCount);
+        types.put(OPERATION_COLLECTION_FETCH_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_LOAD_COUNT, collectionLoadCount);
+        types.put(OPERATION_COLLECTION_LOAD_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_RECREATED_COUNT, collectionRecreatedCount);
+        types.put(OPERATION_COLLECTION_RECREATED_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_REMOVE_COUNT, collectionRemoveCount);
+        types.put(OPERATION_COLLECTION_REMOVE_COUNT, Long.class);
+
+        operations.put(OPERATION_COLLECTION_UPDATE_COUNT, collectionUpdateCount);
+        types.put(OPERATION_COLLECTION_UPDATE_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERYCACHE_HIT_COUNT, queryCacheHitCount);
+        types.put(OPERATION_QUERYCACHE_HIT_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERYCACHE_MISS_COUNT, queryCacheMissCount);
+        types.put(OPERATION_QUERYCACHE_MISS_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERYQUERYCACHE_PUT_COUNT, queryCachePutCount);
+        types.put(OPERATION_QUERYQUERYCACHE_PUT_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERYEXECUTION_COUNT, queryExecutionCount);
+        types.put(OPERATION_QUERYEXECUTION_COUNT, Long.class);
+
+        operations.put(OPERATION_QUERYEXECUTION_MAX_TIME, queryExecutionMaxTime);
+        types.put(OPERATION_QUERYEXECUTION_MAX_TIME, Long.class);
+
+        operations.put(OPERATION_QUERYEXECUTION_MAX_TIME_STRING, queryExecutionMaxTimeString);
+        types.put(OPERATION_QUERYEXECUTION_MAX_TIME_STRING, String.class);
+
+        operations.put(OPERATION_ENTITY_INSERT_COUNT, entityInsertCount);
+        types.put(OPERATION_ENTITY_INSERT_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_LOAD_COUNT, entityLoadCount);
+        types.put(OPERATION_ENTITY_LOAD_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_FETCH_COUNT, entityFetchCount);
+        types.put(OPERATION_ENTITY_FETCH_COUNT, Long.class);
+
+        operations.put(OPERATION_ENTITY_UPDATE_COUNT, entityUpdateCount);
+        types.put(OPERATION_ENTITY_UPDATE_COUNT, Long.class);
+
+        operations.put(OPERATION_FLUSH_COUNT, flushCount);
+        types.put(OPERATION_FLUSH_COUNT, Long.class);
+
+        operations.put(OPERATION_CONNECT_COUNT, connectCount);
+        types.put(OPERATION_CONNECT_COUNT, Long.class);
+
+        operations.put(OPERATION_SESSION_CLOSE_COUNT, sessionCloseCount);
+        types.put(OPERATION_SESSION_CLOSE_COUNT, Long.class);
+
+        operations.put(OPERATION_SESSION_OPEN_COUNT, sessionOpenCount);
+        types.put(OPERATION_SESSION_OPEN_COUNT, Long.class);
+
+        operations.put(OPERATION_SUCCESSFUL_TRANSACTION_COUNT, transactionCount);
+        types.put(OPERATION_SUCCESSFUL_TRANSACTION_COUNT, Long.class);
+
+        operations.put(OPERATION_COMPLETED_TRANSACTION_COUNT, transactionCompletedCount);
+        types.put(OPERATION_COMPLETED_TRANSACTION_COUNT, Long.class);
+
+        operations.put(OPERATION_PREPARED_STATEMENT_COUNT, preparedStatementCount);
+        types.put(OPERATION_PREPARED_STATEMENT_COUNT, Long.class);
+
+        operations.put(OPERATION_CLOSE_STATEMENT_COUNT, closedStatementCount);
+        types.put(OPERATION_CLOSE_STATEMENT_COUNT, Long.class);
+
+        operations.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, optimisticFailureCount);
+        types.put(OPERATION_OPTIMISTIC_FAILURE_COUNT, Long.class);
+
+        operations.put(OPERATION_SECONDLEVELCACHE_HIT_COUNT, secondLevelCacheHitCount);
+        types.put(OPERATION_SECONDLEVELCACHE_HIT_COUNT, Long.class);
+
+        operations.put(OPERATION_SECONDLEVELCACHE_MISS_COUNT, secondLevelCacheMissCount);
+        types.put(OPERATION_SECONDLEVELCACHE_MISS_COUNT, Long.class);
+
+        operations.put(OPERATION_SECONDLEVELCACHE_PUT_COUNT, secondLevelCachePutCount);
+        types.put(OPERATION_SECONDLEVELCACHE_PUT_COUNT, Long.class);
+
+        /**
+         * Specify the children statistics
+         */
+        childrenNames.add(ENTITY);
+        childrenStatistics.put(ENTITY, new HibernateEntityStatistics());
+
+        childrenNames.add(ENTITYCACHE);
+        childrenStatistics.put(ENTITYCACHE, new HibernateEntityCacheStatistics());
+
+        childrenNames.add(COLLECTION);
+        childrenStatistics.put(COLLECTION, new HibernateCollectionStatistics());
+
+        childrenNames.add(QUERYCACHE);
+        childrenStatistics.put(QUERYCACHE , new HibernateQueryCacheStatistics());
+
+    }
+
+    @Override
+    public Statistics getChild(String childName) {
+        return childrenStatistics.get(childName);
+    }
+
+    static final org.hibernate.stat.Statistics getStatistics(final EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        if (sessionFactory != null) {
+            return sessionFactory.getStatistics();
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
+
+        return Collections.EMPTY_LIST;
+    }
+
+    private Operation clear = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            getStatistics(getEntityManagerFactory(args)).clear();
+            return null;
+        }
+    };
+
+    private Operation label = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            PathAddress pathAddress = getPathAddress(args);
+            if (pathAddress != null) {
+                return pathAddress.getValue(PROVIDER_LABEL);
+            }
+            return "";
+        }
+    };
+
+    private Operation evictAll = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            Cache secondLevelCache = getEntityManagerFactory(args).getCache();
+            if (secondLevelCache != null) {
+                secondLevelCache.evictAll();
+            }
+            return null;
+        }
+    };
+
+    private Operation summary = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            getStatistics(getEntityManagerFactory(args)).logSummary();
+            return null;
+        }
+    };
+
+    private Operation statisticsEnabled = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            if (statistics != null) {
+                if (args.length > 0 && args[0] instanceof Boolean) {
+                    Boolean newValue = (Boolean) args[0];
+                    statistics.setStatisticsEnabled(newValue.booleanValue());
+                }
+            return Boolean.valueOf(statistics.isStatisticsEnabled());
+            }
+         return null;
+        }
+    };
+
+    private Operation entityDeleteCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getEntityDeleteCount() : 0);
+        }
+    };
+
+    private Operation collectionLoadCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCollectionLoadCount() : 0);
+        }
+    };
+
+    private Operation collectionFetchCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCollectionFetchCount() : 0);
+        }
+    };
+
+    private Operation collectionRecreatedCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCollectionRecreateCount() : 0);
+        }
+    };
+
+    private Operation collectionRemoveCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCollectionRemoveCount() : 0);
+        }
+    };
+
+    private Operation collectionUpdateCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCollectionUpdateCount() : 0);
+        }
+    };
+
+    private Operation queryCacheHitCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getQueryCacheHitCount() : 0);
+        }
+    };
+    private Operation queryCacheMissCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getQueryCacheMissCount() : 0);
+        }
+    };
+    private Operation queryCachePutCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getQueryCachePutCount() : 0);
+        }
+    };
+    private Operation queryExecutionCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getQueryExecutionCount() : 0);
+        }
+    };
+    private Operation queryExecutionMaxTime = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getQueryExecutionMaxTime() : 0);
+        }
+    };
+    private Operation queryExecutionMaxTimeString = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return String.valueOf(statistics != null ? statistics.getQueryExecutionMaxTimeQueryString() : 0);
+        }
+    };
+
+    private Operation entityFetchCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getEntityFetchCount() : 0);
+        }
+    };
+
+    private Operation entityInsertCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getEntityInsertCount() : 0);
+        }
+    };
+
+    private Operation entityLoadCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getEntityLoadCount() : 0);
+        }
+    };
+
+    private Operation entityUpdateCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getEntityUpdateCount() : 0);
+        }
+    };
+
+    private Operation flushCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getFlushCount() : 0);
+        }
+    };
+
+    private Operation connectCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getConnectCount() : 0);
+        }
+    };
+
+    private Operation sessionCloseCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSessionCloseCount() : 0);
+        }
+    };
+
+    private Operation sessionOpenCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSessionOpenCount() : 0);
+        }
+    };
+
+    private Operation transactionCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getTransactionCount() : 0);
+        }
+    };
+
+    private Operation transactionCompletedCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSuccessfulTransactionCount() : 0);
+        }
+    };
+
+    private Operation preparedStatementCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getPrepareStatementCount() : 0);
+        }
+    };
+
+    private Operation closedStatementCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getCloseStatementCount() : 0);
+        }
+    };
+
+    private Operation optimisticFailureCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getOptimisticFailureCount() : 0);
+        }
+    };
+
+    private Operation secondLevelCacheHitCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSecondLevelCacheHitCount() : 0);
+        }
+    };
+
+    private Operation secondLevelCacheMissCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSecondLevelCacheMissCount() : 0);
+        }
+    };
+
+    private Operation secondLevelCachePutCount = new Operation() {
+        @Override
+        public Object invoke(Object... args) {
+            org.hibernate.stat.Statistics statistics = getStatistics(getEntityManagerFactory(args));
+            return Long.valueOf(statistics != null ? statistics.getSecondLevelCachePutCount() : 0);
+        }
+    };
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/QueryName.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/management/QueryName.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.persistence.jipijapa.hibernate7.management;
+
+/**
+ * Represents the Hibernate query name which is passed in as a parameter.  The displayQuery can be obtained which
+ * has spaces and other symbols replaced with a textual description (which shouldn't be changed or localized.
+ * The localization rule is so that one set of admin scripts will work against any back end system.  If it becomes
+ * more important to localize the textual descriptions, care should be taken to avoid duplicate values when doing so.
+ *
+ * @author Scott Marlow
+ */
+public class QueryName {
+
+    // query name as returned from hibernate Statistics.getQueries()
+    private final String hibernateQuery;
+
+    // query name transformed for display use (allowed to be ugly but should be unique)
+    private final String displayQuery;
+
+    // HQL symbol or operators
+    private static final String SQL_NE = "<>";
+    private static final String NE_BANG = "!=";
+    private static final String NE_HAT = "^=";
+    private static final String LE = "<=";
+    private static final String GE = ">=";
+    private static final String CONCAT = "||";
+    private static final String LT = "<";
+    private static final String EQ = "=";
+    private static final String GT = ">";
+    private static final String OPEN = "(";
+    private static final String CLOSE = ")";
+    private static final String OPEN_BRACKET = "[";
+    private static final String CLOSE_BRACKET = "]";
+    private static final String PLUS = "+";
+    private static final String MINUS = "-";
+    private static final String STAR = "*";
+    private static final String DIV = "/";
+    private static final String MOD = "%";
+    private static final String COLON = ":";
+    private static final String PARAM = "?";
+    private static final String COMMA = ",";
+    private static final String SPACE = " ";
+    private static final String TAB = "\t";
+    private static final String NEWLINE = "\n";
+    private static final String LINEFEED = "\r";
+    private static final String QUOTE = "'";
+    private static final String DQUOTE = "\"";
+    private static final String TICK = "`";
+    private static final String OPEN_BRACE = "{";
+    private static final String CLOSE_BRACE = "}";
+    private static final String HAT = "^";
+    private static final String AMPERSAND = "&";
+
+    // textual representation (not to be localized as we don't won't duplication between any of the values)
+    private static final String NOT_EQUAL__ = "_not_equal_";
+    private static final String BANG_NOT_EQUAL__ = "_bang_not_equal_";
+    private static final String HAT_NOT_EQUAL__ = "_hat_not_equal_";
+    private static final String LESS_THAN_EQUAL__ = "_less_than_equal_";
+    private static final String GREATER_THAN_EQUAL__ = "_greater_than_equal_";
+    private static final String CONCAT__ = "_concat_";
+    private static final String LESS_THAN__ = "_less_than_";
+    private static final String EQUAL__ = "_equal_";
+    private static final String GREATER__ = "_greater_";
+    private static final String LEFT_PAREN__ = "_left_paren_";
+    private static final String RIGHT_PAREN__ = "_right_paren_";
+    private static final String LEFT_BRACKET__ = "_left_bracket_";
+    private static final String RIGHT_BRACKET__ = "_right_bracket_";
+    private static final String PLUS__ = "_plus_";
+    private static final String MINUS__ = "_minus_";
+    private static final String STAR__ = "_star_";
+    private static final String DIVIDE__ = "_divide_";
+    private static final String MODULUS__ = "_modulus_";
+    private static final String COLON__ = "_colon_";
+    private static final String PARAM__ = "_param_";
+    private static final String COMMA__ = "_comma_";
+    private static final String SPACE__ = "_space_";
+    private static final String TAB__ = "_tab_";
+    private static final String NEWLINE__ = "_newline_";
+    private static final String LINEFEED__ = "_linefeed_";
+    private static final String QUOTE__ = "_quote_";
+    private static final String DQUOTE__ = "_double_quote_";
+    private static final String TICK__ = "_tick_";
+    private static final String OPEN_BRACE__ = "_left_brace_";
+    private static final String CLOSE_BRACE__ = "_right_brace_";
+    private static final String HAT__ = "_hat_";
+    private static final String AMPERSAND__ = "_ampersand_";
+
+    public static QueryName queryName(String query) {
+        return new QueryName(query);
+    }
+
+    /**
+     * Construct
+     *
+     * @param query
+     */
+    private QueryName(String query) {
+        hibernateQuery = query;
+        displayQuery = displayable(query);
+
+    }
+
+    public String getDisplayName() {
+        return displayQuery;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryName queryName = (QueryName) o;
+
+        if (displayQuery != null ? !displayQuery.equals(queryName.displayQuery) : queryName.displayQuery != null)
+            return false;
+        if (hibernateQuery != null ? !hibernateQuery.equals(queryName.hibernateQuery) : queryName.hibernateQuery != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hibernateQuery != null ? hibernateQuery.hashCode() : 0;
+        result = 31 * result + (displayQuery != null ? displayQuery.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * transform a Hibernate HQL query into something that can be displayed/used for management operations
+     *
+     * @param query
+     * @return
+     */
+    private String displayable(String query) {
+        if (query == null ||
+            query.length() == 0) {
+            return query;
+        }
+
+        StringBuilder buff = new StringBuilder(query);
+
+        // handle two character transforms first
+        subst(buff, SQL_NE, NOT_EQUAL__);
+        subst(buff, NE_BANG, BANG_NOT_EQUAL__);
+        subst(buff, NE_HAT, HAT_NOT_EQUAL__);
+        subst(buff, LE, LESS_THAN_EQUAL__);
+        subst(buff, GE, GREATER_THAN_EQUAL__);
+        subst(buff, CONCAT, CONCAT__);
+        subst(buff, LT, LESS_THAN__);
+        subst(buff, EQ, EQUAL__);
+        subst(buff, GT, GREATER__);
+        subst(buff, OPEN, LEFT_PAREN__);
+        subst(buff, CLOSE, RIGHT_PAREN__);
+        subst(buff, OPEN_BRACKET, LEFT_BRACKET__);
+        subst(buff, CLOSE_BRACKET, RIGHT_BRACKET__);
+        subst(buff, PLUS, PLUS__);
+        subst(buff, MINUS, MINUS__);
+        subst(buff, STAR, STAR__);
+        subst(buff, DIV, DIVIDE__);
+        subst(buff, MOD, MODULUS__);
+        subst(buff, COLON, COLON__);
+        subst(buff, PARAM, PARAM__);
+        subst(buff, COMMA, COMMA__);
+        subst(buff, SPACE, SPACE__);
+        subst(buff, TAB, TAB__);
+        subst(buff, NEWLINE, NEWLINE__);
+        subst(buff, LINEFEED, LINEFEED__);
+        subst(buff, QUOTE, QUOTE__);
+        subst(buff, DQUOTE, DQUOTE__);
+        subst(buff, TICK, TICK__);
+        subst(buff, OPEN_BRACE, OPEN_BRACE__);
+        subst(buff, CLOSE_BRACE, CLOSE_BRACE__);
+        subst(buff, HAT, HAT__);
+        subst(buff, AMPERSAND, AMPERSAND__);
+        return buff.toString();
+    }
+
+    /**
+     * Substitute sub-strings inside of a string.
+     *
+     * @param stringBuilder String buffer to use for substitution (buffer is not reset)
+     * @param from String to substitute from
+     * @param to   String to substitute to
+     */
+    private static void subst(final StringBuilder stringBuilder, final String from, final String to) {
+        int begin = 0, end = 0;
+
+        while ((end = stringBuilder.indexOf(from, end)) != -1) {
+            stringBuilder.delete(end, end + from.length());
+            stringBuilder.insert(end, to);
+
+            // update positions
+            begin = end + to.length();
+            end = begin;
+        }
+    }
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/ServiceContributorImpl.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/ServiceContributorImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import static org.wildfly.persistence.jipijapa.hibernate7.JpaLogger.JPA_LOGGER;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.spi.ServiceContributor;
+import org.kohsuke.MetaInfServices;
+
+/**
+ * Contribute specialized Hibernate Service impls
+ *
+ * @author Steve Ebersole
+ * @author Scott Marlow
+ */
+@MetaInfServices
+public class ServiceContributorImpl implements ServiceContributor {
+    private static final String CONTROLJTAINTEGRATION = "wildfly.jpa.jtaplatform"; // these properties are documented in org.jboss.as.jpa.config.Configuration
+    private static final String CONTROL2LCINTEGRATION = "wildfly.jpa.regionfactory";
+    private static final String TRANSACTION_PLATFORM = "hibernate.transaction.jta.platform";
+    private static final String EHCACHE = "ehcache";
+    private static final String HIBERNATE_REGION_FACTORY_CLASS = "hibernate.cache.region.factory_class";
+    private static final String DEFAULT_REGION_FACTORY = "org.infinispan.hibernate.cache.v62.InfinispanRegionFactory";
+
+    @Override
+    public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+        // note that the following deprecated getSettings() is agreed to be replaced with method that returns immutable copy of configuration settings.
+        final Object jtaPlatformInitiatorEnabled = serviceRegistryBuilder.getSettings().getOrDefault(CONTROLJTAINTEGRATION, true);
+
+        if (serviceRegistryBuilder.getSettings().get(TRANSACTION_PLATFORM) != null) {
+            // applications that already specify the transaction platform property which will override the WildFlyCustomJtaPlatform.
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute application configured the Jakarta Transactions Platform to be used instead of WildFlyCustomJtaPlatform (%s=%s)",
+                    TRANSACTION_PLATFORM, serviceRegistryBuilder.getSettings().get(TRANSACTION_PLATFORM));
+        } else if (jtaPlatformInitiatorEnabled == null ||
+                (jtaPlatformInitiatorEnabled instanceof Boolean && ((Boolean) jtaPlatformInitiatorEnabled).booleanValue()) ||
+                Boolean.parseBoolean(jtaPlatformInitiatorEnabled.toString())) {
+            // use WildFlyCustomJtaPlatform unless they explicitly set wildfly.jpa.jtaplatform to false.
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute application will use WildFlyCustomJtaPlatform");
+            serviceRegistryBuilder.addInitiator(new WildFlyCustomJtaPlatformInitiator());
+        }
+
+        final Object regionFactoryInitiatorEnabled = serviceRegistryBuilder.getSettings().getOrDefault(CONTROL2LCINTEGRATION, true);
+        final Object regionFactory = serviceRegistryBuilder.getSettings().get(HIBERNATE_REGION_FACTORY_CLASS);
+        if ((regionFactory instanceof String)) {
+            String cacheRegionFactory = (String) regionFactory;
+            if (cacheRegionFactory.contains(EHCACHE)) {
+                JPA_LOGGER.tracef("ServiceContributorImpl#contribute application is using Ehcache via %s=%s",
+                        HIBERNATE_REGION_FACTORY_CLASS, cacheRegionFactory);
+                return;
+            } else if (!DEFAULT_REGION_FACTORY.equals(cacheRegionFactory)) {
+                // warn and ignore application cache region setting
+                JPA_LOGGER.ignoredCacheRegionSetting(HIBERNATE_REGION_FACTORY_CLASS, cacheRegionFactory);
+            }
+        }
+        if (regionFactoryInitiatorEnabled == null ||
+                (regionFactoryInitiatorEnabled instanceof Boolean && ((Boolean) regionFactoryInitiatorEnabled).booleanValue()) ||
+                Boolean.parseBoolean(regionFactoryInitiatorEnabled.toString())) {
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute adding ORM initiator for 2lc region factory");
+            serviceRegistryBuilder.addInitiator(new WildFlyCustomRegionFactoryInitiator());
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomJtaPlatform.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomJtaPlatform.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import org.hibernate.engine.transaction.jta.platform.internal.JBossAppServerJtaPlatform;
+import org.hibernate.engine.transaction.jta.platform.internal.JtaSynchronizationStrategy;
+import org.wildfly.common.Assert;
+
+/**
+ * WildFlyCustomJtaPlatform can obtain the Jakarta Transactions TransactionSynchronizationRegistry to be used by
+ * Hibernate ORM Jakarta Persistence + native applications.
+ * For Jakarta Persistence applications, we could of passed the TransactionSynchronizationRegistry into the
+ * constructor but Hibernate native apps wouldn't be able to do that, so this covers all app types.
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyCustomJtaPlatform extends JBossAppServerJtaPlatform implements JtaSynchronizationStrategy {
+
+    // The 'transactionSynchronizationRegistry' used by Jakarta Persistence container managed applications,
+    // is reset every time the Transaction Manager service is restarted,
+    // as (application deployment) Jakarta Persistence persistence unit service depends on the TM service.
+    // For this reason, the static 'transactionSynchronizationRegistry' can be updated.
+    // Note that Hibernate native applications currently have to be (manually) restarted when the TM
+    // service restarts, as native applications do not have WildFly service dependencies set for them.
+    private static volatile TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+    private static final String TSR_NAME = "java:jboss/TransactionSynchronizationRegistry";
+
+    // JtaSynchronizationStrategy
+    @Override
+    public void registerSynchronization(Synchronization synchronization) {
+        locateTransactionSynchronizationRegistry().
+                registerInterposedSynchronization(synchronization);
+    }
+
+    // JtaSynchronizationStrategy
+    @Override
+    public boolean canRegisterSynchronization() {
+        return locateTransactionSynchronizationRegistry().
+                getTransactionStatus() == Status.STATUS_ACTIVE;
+    }
+
+    @Override
+    protected JtaSynchronizationStrategy getSynchronizationStrategy() {
+        return this;
+    }
+
+    private TransactionSynchronizationRegistry locateTransactionSynchronizationRegistry() {
+        TransactionSynchronizationRegistry curTsr = transactionSynchronizationRegistry;
+        if (curTsr != null) {
+            return curTsr;
+        }
+        synchronized (WildFlyCustomJtaPlatform.class) {
+            curTsr = transactionSynchronizationRegistry;
+            if (curTsr != null) {
+                return curTsr;
+            }
+            return transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) jndiService().locate(TSR_NAME);
+        }
+    }
+
+    /**
+     * Hibernate native applications cannot know when the TransactionManaTransactionManagerSerger + TransactionSynchronizationRegistry
+     * services are stopped but Jakarta Persistence container managed applications can and will call setTransactionSynchronizationRegistry
+     * with the new (global) TransactionSynchronizationRegistry to use.
+     *
+     * @param tsr
+     */
+    public static void setTransactionSynchronizationRegistry(TransactionSynchronizationRegistry tsr) {
+
+        if ((Assert.checkNotNullParam("tsr", tsr)) != transactionSynchronizationRegistry) {
+            synchronized (WildFlyCustomJtaPlatform.class) {
+                if (tsr != transactionSynchronizationRegistry) {
+                    transactionSynchronizationRegistry = tsr;
+                }
+            }
+        }
+    }
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomJtaPlatformInitiator.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomJtaPlatformInitiator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import java.util.Map;
+
+import org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * Custom JtaPlatform initiator for use inside WildFly picking an appropriate
+ * fallback JtaPlatform.
+ *
+ * @author Steve Ebersole
+ */
+public class WildFlyCustomJtaPlatformInitiator extends JtaPlatformInitiator {
+    @Override
+    public JtaPlatform initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        return new WildFlyCustomJtaPlatform();
+    }
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomRegionFactoryInitiator.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomRegionFactoryInitiator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_FACTORY;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_MODE;
+import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
+import static org.wildfly.persistence.jipijapa.hibernate7.JpaLogger.JPA_LOGGER;
+
+import java.util.Map;
+
+import org.hibernate.cache.internal.NoCachingRegionFactory;
+import org.hibernate.cache.internal.RegionFactoryInitiator;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * @author Steve Ebersole
+ * @author Scott Marlow
+ */
+public class WildFlyCustomRegionFactoryInitiator extends RegionFactoryInitiator {
+
+    private static final String INFINISPAN_REGION_FACTORY = "org.infinispan.hibernate.cache.v62.InfinispanRegionFactory";
+    private static final String UNSPECIFIED = "UNSPECIFIED";
+    private static final String NONE = "NONE";
+
+    @Override
+    protected RegionFactory resolveRegionFactory(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
+        final Object useSecondLevelCache = configurationValues.get(USE_SECOND_LEVEL_CACHE);
+        final String jpaSharedCodeModeValue = configurationValues.get(JAKARTA_SHARED_CACHE_MODE) != null ? configurationValues.get(JAKARTA_SHARED_CACHE_MODE).toString() : UNSPECIFIED;
+        final Object regionFactory = configurationValues.get(CACHE_REGION_FACTORY);
+
+        // treat Hibernate 2lc as off, if not specified.
+        // Note that Hibernate 2lc in 5.1.x, defaults to disabled, so this code is only needed in 5.3.x+.
+        if(Boolean.parseBoolean((String)useSecondLevelCache)) {
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory using %s for 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    INFINISPAN_REGION_FACTORY, useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
+            configurationValues.put(CACHE_REGION_FACTORY, INFINISPAN_REGION_FACTORY);
+            return super.resolveRegionFactory(configurationValues, registry);
+        } else if(UNSPECIFIED.equals(jpaSharedCodeModeValue)
+             || NONE.equals(jpaSharedCodeModeValue)) {
+            // explicitly disable 2lc cache
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory not using a 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
+            return NoCachingRegionFactory.INSTANCE;
+        }
+        else {
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory using %s for 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    INFINISPAN_REGION_FACTORY, useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
+            configurationValues.put(CACHE_REGION_FACTORY, INFINISPAN_REGION_FACTORY);
+            return super.resolveRegionFactory(configurationValues, registry);
+        }
+    }
+}

--- a/jpa/hibernate7/src/main/resources/org.hibernate.cache.internal.proto
+++ b/jpa/hibernate7/src/main/resources/org.hibernate.cache.internal.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package org.hibernate.cache.internal;
+
+import "org.wildfly.clustering.marshalling.protostream.proto";
+
+// IDs: 350-359
+
+/**
+ * @TypeId(350)
+ */
+message BasicCacheKeyImplementation {
+	org.wildfly.clustering.marshalling.protostream.Any	id	 = 1;
+	string	entity	 = 2;
+	sfixed32	hashCode	 = 4;
+}
+
+/**
+ * @TypeId(351)
+ */
+message CacheKeyImplementation {
+	org.wildfly.clustering.marshalling.protostream.Any	id	 = 1;
+	string	entity	 = 2;
+	string	tenant	 = 3;
+	sfixed32	hashCode	 = 4;
+}
+
+/**
+ * @TypeId(352)
+ */
+message NaturalIdCacheKey {
+	org.wildfly.clustering.marshalling.protostream.Any	value	 = 1;
+	string	entity	 = 2;
+	string	tenant	 = 3;
+	sfixed32	hashCode	 = 4;
+}

--- a/jpa/hibernate7/src/main/resources/org/wildfly/persistence/jipijapa/hibernate7/management/LocalDescriptions.properties
+++ b/jpa/hibernate7/src/main/resources/org/wildfly/persistence/jipijapa/hibernate7/management/LocalDescriptions.properties
@@ -1,0 +1,110 @@
+#
+# Copyright The WildFly Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+hibernate=Contains Hibernate statistics
+
+#
+# top-level Hibernate statistics
+#
+hibernate.hibernate-persistence-unit=Contains Hibernate statistics
+hibernate.statistics.collection=Statistics for individual collections.
+hibernate.clear.clear=Clear statistics.
+hibernate.evict-all.evict-all=Evict all entities from second level cache.
+hibernate.summary.summary=Log the statistics.
+hibernate.flush-count=Get the number of flushes executed by sessions (either implicit or explicit).
+hibernate.connect-count=Get the number of connections asked for by the sessions.
+hibernate.session-close-count=Number of sessions closed.
+hibernate.session-open-count=Number of sessions opened.
+hibernate.enabled=Determine if statistics are enabled.
+hibernate.enabled.deprecated=Use statistics-enabled.
+hibernate.statistics-enabled=Determine if statistics are enabled.
+hibernate.successful-transaction-count=Number of successful transactions.
+hibernate.completed-transaction-count=Number of completed transactions.
+hibernate.prepared-statement-count=Number of acquired prepared statements.
+hibernate.close-statement-count=Number of released prepared statements.
+hibernate.optimistic-failure-count=Number of optimistic lock exceptions.
+hibernate.clear=Clear statistics.
+hibernate.evict-all=Evict all entities from second level cache.
+hibernate.statistics.enable=Enable the statistics.
+hibernate.statistics.enable.enable=True will enable the statistics.
+hibernate.statistics.enable.reply=Return whether statistics were previously enabled.
+hibernate.summary=Log the statistics.
+hibernate.entity-delete-count=Get number of entity deletes.
+hibernate.entity-insert-count=Get number of entity inserts.
+hibernate.entity-load-count=Get number of entity loads.
+hibernate.entity-fetch-count=Get number of entity fetches.
+hibernate.entity-update-count=Get number of entity updates.
+hibernate.collection-load-count=Number of times collection was loaded.
+hibernate.collection-fetch-count=Number of times collection was fetched.
+hibernate.collection-recreated-count=Number of times collection was recreated.
+hibernate.collection-remove-count=Number of times collection was removed.
+hibernate.collection-update-count=Number of times collection was updated.
+hibernate.query-cache-hit-count=Get the number of times query was retrieved from cache.
+hibernate.query-cache-miss-count=Get the number of times query was not found in cache.
+hibernate.query-cache-put-count=Get the number of times query was put in cache.
+hibernate.query-execution-max-time-query-string=Longest running query.
+hibernate.query=Statistics for individual queries.
+hibernate.query-execution-count=Get number of times query has been executed.
+hibernate.query-execution-row-count=Get number of rows returned from executions of query.
+hibernate.query-execution-max-time=Get the time in milliseconds of the query.
+hibernate.query-execution-min-time=Get the minimum time in milliseconds of the query.
+hibernate.query-execution-average-time=Get the average time in milliseconds of the query.
+hibernate.query-name=Query name.
+hibernate.second-level-cache-hit-count=Number of cacheable entities/collections successfully retrieved from the cache.
+hibernate.second-level-cache-miss-count=Number of cacheable entities/collections not found in the cache and loaded.
+hibernate.second-level-cache-put-count=Number of cacheable entities/collections put in the cache.
+
+#
+#  per entity class statistics
+#
+hibernate.entity=Per entity class statistics.
+entity=Statistics for individual entities.
+entity.entity-delete-count=Get number of entity deletes.
+entity.entity-insert-count=Get number of entity inserts.
+entity.entity-load-count=Get number of entity loads.
+entity.entity-fetch-count=Get number of entity fetches.
+entity.entity-update-count=Get number of entity updates.
+entity.optimistic-failure-count=Number of optimistic lock exceptions.
+
+#
+# query cache statistics
+#
+hibernate.query-cache=Query cache.
+query-cache=Query cache.
+query-cache.query-cache-hit-count=Get the number of times query was retrieved from cache.
+query-cache.query-cache-miss-count=Get the number of times query was not found in cache.
+query-cache.query-cache-put-count=Get the number of times query was put in cache.
+query-cache.query-execution-count=Get number of times query has been executed.
+query-cache.query-execution-row-count=Get number of rows returned from executions of query.
+query-cache.query-execution-max-time=Get the time in milliseconds of the query.
+query-cache.query-execution-min-time=Get the minimum time in milliseconds of the query.
+query-cache.query-execution-average-time=Get the average time in milliseconds of the query.
+query-cache.query-name=Query name.
+
+#
+# collection statistics
+#
+collection=Statistics for individual collections.
+collection.collection-name=Name of collection.
+hibernate.collection=Statistics for individual collections.
+collection.collection-load-count=Number of times collection was loaded.
+collection.collection-fetch-count=Number of times collection was fetched.
+collection.collection-recreated-count=Number of times collection was recreated.
+collection.collection-remove-count=Number of times collection was removed.
+collection.collection-update-count=Number of times collection was updated.
+
+#
+# second level entity cache statistics
+#
+entity-cache=Statistics for a Hibernate Second Level Cache region.
+hibernate.entity-cache=Statistics for a Hibernate Second Level Cache region.
+hibernate.entity-cache-region-name=Region name used to identity the cached entity class.
+entity-cache.entity-cache-region-name=Region name used to identity the cached entity class.
+entity-cache.second-level-cache-hit-count=Number of cacheable entities/collections successfully retrieved from the cache.
+entity-cache.second-level-cache-miss-count=Number of cacheable entities/collections not found in the cache and loaded.
+entity-cache.second-level-cache-put-count=Number of cacheable entities/collections put in the cache.
+entity-cache.second-level-cache-size-in-memory=Memory size of cacheable entities.
+entity-cache.second-level-cache-count-in-memory=Number of cacheable entities/collections currently stored in memory.
+

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -44,6 +44,7 @@
 
     <modules>
         <module>hibernate6</module>
+        <module>hibernate7</module>
         <module>hibernatesearch</module>
         <module>subsystem</module>
         <module>spi</module>

--- a/preview/galleon-local/pom.xml
+++ b/preview/galleon-local/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>jipijapa-hibernate7</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
@@ -41,6 +45,20 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.models</groupId>
+            <artifactId>hibernate-models</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.models</groupId>
+            <artifactId>hibernate-models-jandex</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-scan-jandex</artifactId>
         </dependency>
 
         <dependency>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.jipijapa-hibernate">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:jipijapa-hibernate7}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.annotation.api"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
+
+        <module name="org.hibernate" services="import"/>
+        <module name="org.hibernate.models.hibernate-models" services="import"/>
+        <module name="org.hibernate.orm.hibernate-scan-jandex"/>
+        <module name="org.infinispan.core" services="import"/>
+        <module name="org.infinispan.protostream"/>
+        <module name="org.infinispan.hibernate-cache" services="import"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.clustering.marshalling.protostream"/>
+        <module name="org.wildfly.common"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Represents Hibernate ORM 6  -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate">
+
+    <resources>
+        <artifact name="${org.hibernate.orm:hibernate-core}"/>
+        <artifact name="${org.hibernate.orm:hibernate-envers}"/>
+    </resources>
+
+    <dependencies>
+        <!-- Java SE dependencies -->
+        <module name="java.desktop"/>
+        <module name="java.instrument"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
+
+        <!-- Jakarta Dependencies -->
+        <module name="jakarta.annotation.api"/>
+        <!-- If Jakarta Data is provisioned, depend on it -->
+        <module name="jakarta.data.api" optional="true"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.json.bind.api"/>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.transaction.api"/>
+        <module name="jakarta.validation.api"/>
+        <module name="jakarta.xml.bind.api"/>
+
+        <!-- Other dependencies -->
+        <module name="com.fasterxml.classmate"/>
+        <module name="com.fasterxml.jackson.core.jackson-core" optional="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind" optional="true"/>
+        <!-- If the Oracle JDBC driver classes are accessible, Hibernate ORM will use them to tailor OracleDialect behavior -->
+        <module name="com.oracle.ojdbc" optional="true"/>
+        <module name="io.smallrye.jandex" export="true"/>
+        <module name="net.bytebuddy"/>
+        <module name="org.antlr"/>
+        <module name="org.eclipse.yasson" optional="true"/>
+        <module name="org.glassfish.jaxb"/>
+        <module name="org.hibernate.jipijapa-hibernate" services="import"/>
+        <module name="org.hibernate.models.hibernate-models" services="import"/>
+        <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.logging"/>
+        <!-- If the PostgreSQL JDBC driver classes are accessible, Hibernate ORM will use them to tailor PostgresDialect and CockroachDialect behavior -->
+        <module name="org.postgresql.jdbc" optional="true"/>
+    </dependencies>
+
+    <provides>
+        <service name="org.hibernate.bytecode.spi.BytecodeProvider">
+            <with-class name="org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl"/>
+        </service>
+    </provides>
+
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/models/hibernate-models/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/models/hibernate-models/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.models.hibernate-models">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.hibernate.models:hibernate-models}"/>
+        <artifact name="${org.hibernate.models:hibernate-models-jandex}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.sql"/>
+
+        <module name="io.smallrye.jandex"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/orm/hibernate-scan-jandex/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/orm/hibernate-scan-jandex/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.orm.hibernate-scan-jandex">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.hibernate.orm:hibernate-scan-jandex}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.persistence.api"/>
+
+        <module name="io.smallrye.jandex"/>
+        <module name="org.apache.logging.log4j.api"/>
+        <module name="org.hibernate" services="import"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/main/module.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Hibernate Search ORM Mapper: integrates org.hibernate.search.engine with
+     Hibernate ORM to provide Hibernate Search functionality to
+     JPA Applications -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.orm">
+
+    <resources>
+        <artifact name="${org.hibernate.search:hibernate-search-mapper-orm}"/>
+    </resources>
+
+    <dependencies>
+        <module name="jakarta.persistence.api"/>
+        <module name="jakarta.enterprise.api"/>
+        <module name="jakarta.transaction.api"/>
+
+        <module name="io.smallrye.jandex"/>
+        <module name="org.hibernate" />
+        <module name="org.hibernate.models.hibernate-models" services="import"/>
+        <module name="org.hibernate.search.engine" export="true" />
+        <module name="org.hibernate.search.mapper.pojo" export="true" />
+        <module name="org.hibernate.search.jipijapa-hibernatesearch" services="import" />
+        <module name="org.jboss.logging" />
+    </dependencies>
+</module>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/outboxpolling/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/orm/outboxpolling/main/module.xml
@@ -19,6 +19,7 @@
         <module name="jakarta.xml.bind.api"/>
         <module name="org.jboss.logging" />
         <module name="org.hibernate" />
+        <module name="org.hibernate.models.hibernate-models" services="import"/>
         <module name="org.hibernate.search.engine" export="true" />
         <module name="org.hibernate.search.mapper.pojo" export="true" />
         <module name="org.hibernate.search.mapper.orm" export="true" />

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/search/mapper/pojo/main/module.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!-- Hibernate Search Pojo-base Mapper: base code for mappers such as org.hibernate.search.mapper.orm -->
+<module xmlns="urn:jboss:module:1.9" name="org.hibernate.search.mapper.pojo">
+
+    <resources>
+        <artifact name="${org.hibernate.search:hibernate-search-mapper-pojo-base}"/>
+    </resources>
+
+    <dependencies>
+        <module name="java.sql" export="true" /> <!-- For java.sql.Date, etc. -->
+
+        <module name="io.smallrye.jandex"/>
+        <module name="org.hibernate.models.hibernate-models" services="import"/>
+        <module name="org.hibernate.search.engine" export="true" />
+        <module name="org.jboss.logging" />
+    </dependencies>
+</module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
@@ -132,11 +132,10 @@ public class Hibernate2LCacheStatsTestCase {
         try {
             Set<Satellite> satellites1 = new HashSet<Satellite>();
             Satellite sat = new Satellite();
-            sat.setId(new Integer(1));
             sat.setName("MOON");
             satellites1.add(sat);
 
-            Planet s1 = sfsb.prepareData("EARTH", "MILKY WAY", "SUN", satellites1, new Integer(1));
+            Planet s1 = sfsb.prepareData("EARTH", "MILKY WAY", "SUN", satellites1);
             Planet s2 = sfsb.getPlanet(s1.getPlanetId());
 
             DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
@@ -114,8 +114,8 @@ public class Hibernate4NativeAPIProviderTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide");
             Student st = sfsb.getStudent(s1.getStudentId());
             assertTrue("name read from hibernate session is MADHUMITA", "MADHUMITA".equals(st.getFirstName()));
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
@@ -114,8 +114,8 @@ public class HibernateNativeAPITransactionTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", false);
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", false);
             assertTrue("address read from hibernate session associated with hibernate transaction is 99 Purkynova REDHAT BRNO CZ",
                     "99 Purkynova REDHAT BRNO CZ".equals(s1.getAddress()));
             // update Student
@@ -136,9 +136,9 @@ public class HibernateNativeAPITransactionTestCase {
         // setup Configuration and SessionFactory
         try {
             sfsb.setupConfig();
-            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
-            // force creation of student with same Id to ensure RollBack
-            Student s3 = sfsb.createStudent("Hibernate", "ORM", "JavaWorld", s2.getStudentId());
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", false);
+            // Force the rollback
+            Student s3 = sfsb.createStudent("Hibernate", "ORM", "JavaWorld", true);
             Student st = sfsb.getStudentNoTx(s2.getStudentId());
             assertTrue("name read from hibernate session associated with hibernate transaction after rollback is REDHAT",
                     "REDHAT".equals(st.getFirstName()));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernate2LcacheStats.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernate2LcacheStats.java
@@ -73,31 +73,30 @@ public class SFSBHibernate2LcacheStats {
     }
 
     // create planet
-    public Planet prepareData(String planetName, String galaxyName, String starName, Set<Satellite> satellites, Integer id) {
+    public Planet prepareData(String planetName, String galaxyName, String starName, Set<Satellite> satellites) {
 
         Session session = sessionFactory.openSession();
         Planet planet = new Planet();
-        planet.setPlanetId(id);
         planet.setPlanetName(planetName);
         planet.setGalaxy(galaxyName);
         planet.setStar(starName);
         // Transaction trans = session.beginTransaction();
         try {
 
-            session.save(planet);
+            session.persist(planet);
 
             if (satellites != null && satellites.size() > 0) {
                 Iterator<Satellite> itrSat = satellites.iterator();
                 while (itrSat.hasNext()) {
                     Satellite sat = itrSat.next();
-                    session.save(sat);
+                    session.persist(sat);
                 }
                 planet.setSatellites(new HashSet<Satellite>());
                 planet.getSatellites().addAll(satellites);
 
             }
 
-            session.saveOrUpdate(planet);
+            session.persist(planet);
             SessionStatistics stats = session.getStatistics();
             assertEquals(2, stats.getEntityKeys().size());
             assertEquals(2, stats.getEntityCount());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
@@ -63,10 +63,9 @@ public class SFSBHibernateSessionFactory {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address) {
 
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -75,7 +74,7 @@ public class SFSBHibernateSessionFactory {
             // We are not explicitly initializing a Transaction as Hibernate is expected to invoke the Jakarta Transactions TransactionManager
             // implicitly
             Session session = sessionFactory.openSession();
-            session.save(student);
+            session.persist(student);
             session.flush();
             session.close();
         } catch (Exception e) {
@@ -87,7 +86,7 @@ public class SFSBHibernateSessionFactory {
 
     // fetch student
     public Student getStudent(int id) {
-        Student emp = sessionFactory.openSession().load(Student.class, id);
+        Student emp = sessionFactory.openSession().get(Student.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
@@ -59,11 +59,10 @@ public class SFSBHibernateTransaction {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address, boolean rollback) {
 
         // setupConfig();
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -71,8 +70,12 @@ public class SFSBHibernateTransaction {
 
         try {
             Transaction trans = session.beginTransaction();
-            session.save(student);
-            trans.commit();
+            session.persist(student);
+            if (rollback) {
+                trans.rollback();
+            } else {
+                trans.commit();
+            }
         } catch (Exception e) {
             throw new RuntimeException("transactional failure while persisting student entity", e);
         }
@@ -85,13 +88,13 @@ public class SFSBHibernateTransaction {
     public Student updateStudent(String address, int id) {
 
         Session session = sessionFactory.openSession();
-        Student student = session.load(Student.class, id);
+        Student student = session.get(Student.class, id);
         student.setAddress(address);
 
         try {
             // invoking the Hibernate transaction
             Transaction trans = session.beginTransaction();
-            session.save(student);
+            student = session.merge(student);
             trans.commit();
         } catch (Exception e) {
             throw new RuntimeException("transactional failure while persisting student entity", e);
@@ -104,7 +107,7 @@ public class SFSBHibernateTransaction {
     // fetch student
     public Student getStudentNoTx(int id) {
         // Transaction trans = sessionFactory.openSession().beginTransaction();
-        Student emp = sessionFactory.openSession().load(Student.class, id);
+        Student emp = sessionFactory.openSession().get(Student.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
@@ -114,7 +114,7 @@ public class Hibernate4NativeAPIEnversTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            StudentAudited s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
+            StudentAudited s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
             StudentAudited s2 = sfsb.updateStudent("REDHAT Brisbane,Australia", 1);
             StudentAudited st = sfsb.retrieveOldStudentVersion(s2.getStudentId());
             assertTrue("address read from audit tables after envers implementation is 99 Purkynova REDHAT BRNO CZ",

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/SFSBHibernateEnversSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/SFSBHibernateEnversSessionFactory.java
@@ -57,11 +57,10 @@ public class SFSBHibernateEnversSessionFactory {
     }
 
     // create student
-    public StudentAudited createStudent(String firstName, String lastName, String address, int id) {
+    public StudentAudited createStudent(String firstName, String lastName, String address) {
 
         // setupConfig();
         StudentAudited student = new StudentAudited();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -69,7 +68,7 @@ public class SFSBHibernateEnversSessionFactory {
         try {
             Session session = sessionFactory.openSession();
             Transaction trans = session.beginTransaction();
-            session.save(student);
+            session.persist(student);
             session.flush();
             trans.commit();
             session.close();
@@ -86,9 +85,9 @@ public class SFSBHibernateEnversSessionFactory {
         try {
             Session session = sessionFactory.openSession();
             Transaction trans = session.beginTransaction();
-            student = session.load(StudentAudited.class, id);
+            student = session.get(StudentAudited.class, id);
             student.setAddress(address);
-            session.save(student);
+            student = session.merge(student);
             session.flush();
             trans.commit();
             session.close();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
@@ -118,8 +118,8 @@ public class HibernateNativeAPINaturalIdTestCase {
         // setup Configuration and SessionFactory
         sfsb.setupConfig();
         try {
-            Person s1 = sfsb.createPerson("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 123, 1);
-            Person s2 = sfsb.createPerson("REDHAT", "LINUX", "Worldwide", 435, 3);
+            Person s1 = sfsb.createPerson("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 123);
+            Person s2 = sfsb.createPerson("REDHAT", "LINUX", "Worldwide", 435);
             Person p1 = sfsb.getPersonReference("REDHAT", 435);
             Person p2 = sfsb.loadPerson("MADHUMITA", 123);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
@@ -53,10 +53,9 @@ public class SFSBHibernateSFNaturalId {
     }
 
     // create person
-    public Person createPerson(String firstName, String lastName, String address, int voterId, int id) {
+    public Person createPerson(String firstName, String lastName, String address, int voterId) {
 
         Person per = new Person();
-        per.setPersonId(id);
         per.setAddress(address);
         per.setPersonVoterId(voterId);
         per.setFirstName(firstName);
@@ -66,7 +65,7 @@ public class SFSBHibernateSFNaturalId {
             // We are not explicitly initializing a Transaction as Hibernate is expected to invoke the JTA TransactionManager
             // implicitly
             Session session = sessionFactory.openSession();
-            session.save(per);
+            session.persist(per);
             session.flush();
             session.close();
         } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
@@ -126,7 +126,7 @@ public class HibernateSecondLevelCacheTestCase {
         sfsb.setupConfig();
         DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);
         try {
-            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ");
             Student s2 = sfsb.getStudent(1);
 
             Connection conn = ds.getConnection();
@@ -162,7 +162,7 @@ public class HibernateSecondLevelCacheTestCase {
         sfsb.setupConfig();
         DataSource ds = rawLookup("java:jboss/datasources/ExampleDS", DataSource.class);
         try {
-            Student s1 = sfsb.createStudent("Hope", "Solo", "6415 NE 138th Pl. Kirkland, WA 98034 USA", 1);
+            Student s1 = sfsb.createStudent("Hope", "Solo", "6415 NE 138th Pl. Kirkland, WA 98034 USA");
             Student s2 = sfsb.getStudent(1);
 
             Connection conn = ds.getConnection();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/SFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/SFSB.java
@@ -59,10 +59,9 @@ public class SFSB {
     }
 
     // create student
-    public Student createStudent(String firstName, String lastName, String address, int id) {
+    public Student createStudent(String firstName, String lastName, String address) {
         // setupConfig();
         Student student = new Student();
-        student.setStudentId(id);
         student.setAddress(address);
         student.setFirstName(firstName);
         student.setLastName(lastName);
@@ -78,7 +77,7 @@ public class SFSB {
             //    throw new RuntimeException("Hibernate Transaction is not active after joining Hibernate to Jakarta Transactions transaction: " + status.name());
             //}
 
-            session.save(student);
+            session.persist(student);
             // trans.commit();
             session.close();
         } catch (Exception e) {
@@ -104,7 +103,7 @@ public class SFSB {
             // if(status.isNotOneOf(TransactionStatus.ACTIVE)) {
             //    throw new RuntimeException("Hibernate Transaction is not active after joining Hibernate to Jakarta Transactions transaction: " + status.name());
             // }
-            student = session.load(Student.class, id);
+            student = session.get(Student.class, id);
             session.close();
 
         } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
@@ -40,7 +40,7 @@ public class EntityTest {
         t.setCustomer(c);
         c.setTickets(tickets);
 
-        session.save(c);
+        session.persist(c);
 
         return c;
     }
@@ -48,13 +48,12 @@ public class EntityTest {
     public Flight manyToOneCreate() throws Exception {
         Flight f = new Flight();
         f.setName("Flight number one");
-        f.setId(new Long(1));
 
         Company comp = new Company();
         comp.setName("Airline 1");
         f.setCompany(comp);
 
-        session.save(f);
+        session.persist(f);
 
         return f;
     }
@@ -64,7 +63,6 @@ public class EntityTest {
         Flight f1 = findFlightById(new Long(1));
         Flight f2 = new Flight();
 
-        f2.setId(new Long(2));
         f2.setName("Flight two");
 
         Company us = new Company();
@@ -89,55 +87,55 @@ public class EntityTest {
         f1.setCustomers(customers1);
         f2.setCustomers(customers2);
 
-        session.save(c1);
-        session.save(c2);
-        session.save(c3);
-        session.save(f2);
+        session.persist(c1);
+        session.persist(c2);
+        session.persist(c3);
+        session.persist(f2);
     }
 
     public int testAllCustomersQuery() {
 
         //session.flush();
-        return session.getNamedQuery("allCustomers").list().size();
+        return session.createNamedQuery("allCustomers", Customer.class).list().size();
     }
 
     public Customer testCustomerByIdQuery() {
         Customer c = new Customer();
         c.setName("Peter");
 
-        session.save(c);
+        session.persist(c);
         session.flush();
 
-        return (Customer) session.getNamedQuery("customerById").setParameter("id", c.getId()).uniqueResult();
+        return session.createNamedQuery("customerById", Customer.class).setParameter("id", c.getId()).uniqueResult();
 
     }
 
     public Customer createCustomer(String name) {
         Customer c = new Customer();
         c.setName(name);
-        session.save(c);
+        session.persist(c);
         return c;
     }
 
     public void changeCustomer(Long id, String name) {
-        Customer c = session.load(Customer.class, id);
+        Customer c = session.get(Customer.class, id);
         c.setName(name);
     }
 
 
     public Flight findFlightById(Long id) {
 
-        return session.load(Flight.class, id);
+        return session.get(Flight.class, id);
     }
 
     public Company findCompanyById(Long id) {
 
-        return session.load(Company.class, id);
+        return session.get(Company.class, id);
     }
 
     public Customer findCustomerById(Long id) {
 
-        return session.load(Customer.class, id);
+        return session.get(Customer.class, id);
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
@@ -30,7 +30,7 @@ public class SFSBHibernateSession {
     }
 
     public Employee getEmployee(int id) {
-        Employee emp = session.load(Employee.class, id);
+        Employee emp = session.get(Employee.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSessionFactory.java
@@ -41,7 +41,7 @@ public class SFSBHibernateSessionFactory {
     }
 
     public Employee getEmployee(int id) {
-        Employee emp = sessionFactory.openSession().load(Employee.class, id);
+        Employee emp = sessionFactory.openSession().get(Employee.class, id);
         return emp;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/sessionfactorytest/persistence.xml
@@ -12,6 +12,12 @@
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
             <property name="hibernate.session_factory_name" value="modelSessionFactory"/>
+            <!-- There is a bug, HHH-19072, where the above property is being overlooked in Hibernate 7.0. This is
+                 likely to be resolved. However, the below property works around the issue to get the test passing
+                 for the 7.0 upgrade. Once the bug is fixed, this comment and the hibernate.session_factory_jndi_name
+                 can be removed.
+            -->
+            <property name="hibernate.session_factory_jndi_name" value="modelSessionFactory"/>
             <!-- Hibernate 5.2+ (see https://hibernate.atlassian.net/browse/HHH-10877 +
                  https://hibernate.atlassian.net/browse/HHH-12665) no longer defaults
                  to allowing a DML operation outside of a started transaction.

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -259,6 +259,8 @@ public abstract class LayersTestBase {
             "jakarta.mvc.api",
             "org.eclipse.krazo.core",
             "org.eclipse.krazo.resteasy",
+            // Not needed for WildFly as this module is effectively replaced by org.hibernate.models.hibernate-models
+            "org.hibernate.commons-annotations",
             "org.wildfly.extension.vertx"
     };
 


### PR DESCRIPTION
…ated tests that were using removed methods which were previously deprecated in Hibernate 6.0.

[WFLY-20326] Upgrade Hibernate Search to work with Hibernate 7.0. This also required an upgrade of Apache Lucene.

https://issues.redhat.com/browse/WFLY-20160
https://issues.redhat.com/browse/WFLY-20326

This replaces #17934 with the exception is it does not add the new Jakarta Batch integration module.

Note for the test changes. Some of the deprecated methods from Hibernate 6.0 have been removed. These changes only affect WildFly Preview and Hibernate 7.0+, see https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html#cleanup.

The changes to setting the ID's was done because the `persist` method does not allow generated id's to, rightfully IMO, be set.

There was also a bug found, [HHH-19072](https://hibernate.atlassian.net/browse/HHH-19072). which requires a temporary workaround of using the `hibernate.session_factory_jndi_name` property in a tests `persistence.xml`.

cc @marko-bekhta and @yrodiere 
