### PR TITLE
[WFLY-20323] Upgrade openjdk-orb to 10.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
         <version.org.jboss.mod_cluster>2.1.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.1.0.Final</version.org.jboss.narayana>
         <version.org.jboss.narayana.lra>0.0.9.Final</version.org.jboss.narayana.lra>
-        <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>10.1.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.11.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.jboss.resteasy.microprofile>3.0.0.Final</version.org.jboss.resteasy.microprofile>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20323
Upgrade because of:
https://issues.redhat.com/browse/WFLY-20283

Upstream: #18702 
