### PR TITLE
WFLY-20334 Unable to build with -Dno.expansion.build

### DIFF
--- a/boms/preview-expansion/pom.xml
+++ b/boms/preview-expansion/pom.xml
@@ -47,9 +47,9 @@
                 Re-expose the standard-expansion deps.
              -->
             <dependency>
-                <groupId>${ee.maven.groupId}</groupId>
+                <groupId>${full.maven.groupId}</groupId>
                 <artifactId>wildfly-standard-expansion-bom</artifactId>
-                <version>${ee.maven.version}</version>
+                <version>${full.maven.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/boms/user/server/ee/pom.xml
+++ b/boms/user/server/ee/pom.xml
@@ -436,7 +436,7 @@
             <id>skip.preview</id>
             <activation>
                 <property>
-                    <name>!quickly</name>
+                    <name>!no.preview.build</name>
                 </property>
             </activation>
             <modules>

--- a/boms/user/server/expansion/pom.xml
+++ b/boms/user/server/expansion/pom.xml
@@ -152,7 +152,7 @@
             <id>skip.preview</id>
             <activation>
                 <property>
-                    <name>!quickly</name>
+                    <name>!no.preview.build</name>
                 </property>
             </activation>
             <modules>

--- a/boms/user/server/pom.xml
+++ b/boms/user/server/pom.xml
@@ -93,11 +93,6 @@
         </pluginManagement>
     </build>
 
-    <modules>
-        <module>ee</module>
-        <module>expansion</module>
-    </modules>
-
     <profiles>
         <profile>
             <id>base-feature-pack-build</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1440,7 +1440,6 @@
                 <module>mail</module>
                 <module>legacy/jsr77</module>
                 <module>legacy/keycloak</module>
-                <module>legacy/opentracing-extension</module>
                 <module>legacy/picketlink</module>
                 <module>legacy/security</module>
                 <module>metrics</module>
@@ -1480,6 +1479,7 @@
                 <module>build</module>
                 <module>dist</module>
                 <module>galleon-pack</module>
+                <module>legacy/opentracing-extension</module>
                 <module>microprofile</module>
                 <module>observability</module>
                 <module>release</module>

--- a/preview/pom.xml
+++ b/preview/pom.xml
@@ -31,6 +31,13 @@
         <preview.dist.product.release.version>${full.dist.product.release.version}</preview.dist.product.release.version>
     </properties>
 
+    <modules>
+        <module>channel</module>
+        <module>feature-pack</module>
+        <module>galleon-local</module>
+        <module>product-conf</module>
+    </modules>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -98,11 +105,7 @@
             </activation>
             <modules>
                 <module>build</module>
-                <module>channel</module>
                 <module>dist</module>
-                <module>feature-pack</module>
-                <module>galleon-local</module>
-                <module>product-conf</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
With these changes, it is now possible to use following parameters to skip the expansion build (both preview and expansion have to be skipped):

-Dno.expansion.build -Dno.preview.build -Dtestsuite.ee.galleon.pack.artifactId=wildfly-ee-galleon-pack -P-expansion-server-tests

https://issues.redhat.com/browse/WFLY-20334