### PR TITLE
WFLY-20311 Fix memory leak when SFSB is created, but never invoked, and thus never scheduled for expiration.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentSessionIdGeneratingInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentSessionIdGeneratingInterceptor.java
@@ -37,7 +37,7 @@ public class StatefulComponentSessionIdGeneratingInterceptor implements Intercep
         } else {
             StatefulSessionComponent statefulComponent = (StatefulSessionComponent) component;
             statefulComponent.waitForComponentStart();
-            clientInstance.setViewInstanceData(SessionID.class, statefulComponent.getCache().createStatefulSessionBean());
+            clientInstance.setViewInstanceData(SessionID.class, statefulComponent.createSession());
         }
 
         // move to the next interceptor in chain

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCache.java
@@ -23,9 +23,9 @@ public interface StatefulSessionBeanCache<K, V extends StatefulSessionBeanInstan
 
     /**
      * Creates and caches a stateful bean using a generated identifier.
-     * @return the identifier of the created session bean
+     * @return the newly created session bean
      */
-    K createStatefulSessionBean();
+    StatefulSessionBean<K, V> createStatefulSessionBean();
 
     /**
      * Returns the stateful bean with the specified identifier, or null if no such bean exists.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/simple/SimpleStatefulSessionBeanCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/simple/SimpleStatefulSessionBeanCache.java
@@ -144,7 +144,7 @@ public class SimpleStatefulSessionBeanCache<K, V extends StatefulSessionBeanInst
     }
 
     @Override
-    public K createStatefulSessionBean() {
+    public StatefulSessionBean<K, V> createStatefulSessionBean() {
         if (CURRENT_GROUP.get() != null) {
             // An SFSB that uses a distributable cache cannot contain an SFSB that uses a simple cache
             throw EjbLogger.ROOT_LOGGER.incompatibleCaches();
@@ -152,7 +152,7 @@ public class SimpleStatefulSessionBeanCache<K, V extends StatefulSessionBeanInst
         V instance = this.factory.createInstance();
         K id = instance.getId();
         this.instances.put(id, instance);
-        return id;
+        return new SimpleStatefulSessionBean<>(instance, this.remover, this);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/DefaultStatefulTimeout0TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/DefaultStatefulTimeout0TestCase.java
@@ -80,8 +80,6 @@ public class DefaultStatefulTimeout0TestCase extends StatefulTimeoutTestBase2 {
         Assert.assertEquals(CONFIGURED_TIMEOUT, readAttribute().asLong());
 
         TimeoutNotConfiguredBean timeoutNotConfiguredBean = lookup(TimeoutNotConfiguredBean.class);
-        timeoutNotConfiguredBean.doStuff();
-        Thread.sleep(2000);
         try {
             timeoutNotConfiguredBean.doStuff();
             throw new RuntimeException("Expecting NoSuchEJBException");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
@@ -73,13 +73,31 @@ public class StatefulTimeoutTestCase extends StatefulTimeoutTestBase1 {
     }
 
     /**
-     * Verifies that a stateful bean with timeout value 0 is eligible for removal immediately, and its
+     * Verifies that a stateful bean with timeout value 0 is eligible for removal immediately after creation and its
      * preDestroy method is invoked.
      */
     @Test
     public void testStatefulTimeout0() throws Exception {
         Annotated0TimeoutBean timeout0 = lookup(Annotated0TimeoutBean.class);
+        try {
+            timeout0.doStuff();
+            throw new RuntimeException("Expecting NoSuchEJBException");
+        } catch (NoSuchEJBException expected) {
+        }
+        Assert.assertTrue(Annotated0TimeoutBean.preDestroy);
+    }
+
+    /**
+     * Verifies that a stateful bean with timeout value 0 is eligible for removal immediately and its
+     * preDestroy method is invoked, but not during an active transaction.
+     */
+    @Test
+    public void testTxStatefulTimeout0() throws Exception {
+        this.userTransaction.begin();
+        Annotated0TimeoutBean timeout0 = lookup(Annotated0TimeoutBean.class);
+        // Invocation should succeed, since bean was created within an active transaction
         timeout0.doStuff();
+        this.userTransaction.commit();
         try {
             timeout0.doStuff();
             throw new RuntimeException("Expecting NoSuchEJBException");


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20311

SFSBs will now be scheduled for expiration following creation, instead of upon initial invocation.

N.B. This change requires changes to some test assumptions, where a SFSB with a @StatefulTimeout of 0 is assumed to be invokable once.
With this change, such a bean is considered expired immediately following creation, i.e. *before* the 1st invocation, unless created within an active transaction.