### PR TITLE
[WFLY-20355] Upgrade WildFly Core to 27.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>5.0.4.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>27.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>27.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20355

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/27.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/27.0.0.Final...27.0.1.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7153'>WFCORE-7153</a>] -         CVE-2025-23367 org.wildfly.core/wildfly-server: Wildfly improper RBAC permission
</li>
</ul>
                                                                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7131'>WFCORE-7131</a>] -         Upgrade JBoss Marshalling to 2.2.2.Final
</li>
</ul>
</details>
