### PR TITLE
[WFLY-20348] Remove uses of deprecated ModuleDependency.getIdentifier()

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientDependencyProcessor.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientDependencyProcessor.java
@@ -56,7 +56,7 @@ public class ApplicationClientDependencyProcessor implements DeploymentUnitProce
         }
 
         moduleSpecification.removeUserDependencies(dep -> {
-            final String identifier = dep.getIdentifier().toString();
+            final String identifier = dep.getDependencyModule();
             return identifier.startsWith(ServiceModuleLoader.MODULE_PREFIX)
                     && !identifier.startsWith(ExtensionIndexService.MODULE_PREFIX)
                     && !moduleIdentifiers.contains(identifier);

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
@@ -121,10 +121,10 @@ public class JaxrsIntegrationProcessor implements DeploymentUnitProcessor {
             final Set<String> identifiers = new HashSet<>();
             for (ModuleDependency dep : moduleSpec.getAllDependencies()) {
                 //make sure we don't double up
-                if (!identifiers.contains(dep.getIdentifier().toString())) {
-                    identifiers.add(dep.getIdentifier().toString());
-                    if (attachmentMap.containsKey(dep.getIdentifier().toString())) {
-                        additionalData.add(attachmentMap.get(dep.getIdentifier().toString()));
+                if (!identifiers.contains(dep.getDependencyModule())) {
+                    identifiers.add(dep.getDependencyModule());
+                    if (attachmentMap.containsKey(dep.getDependencyModule())) {
+                        additionalData.add(attachmentMap.get(dep.getDependencyModule()));
                     }
                 }
             }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletContainerInitializerDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletContainerInitializerDeploymentProcessor.java
@@ -95,7 +95,7 @@ public class ServletContainerInitializerDeploymentProcessor implements Deploymen
                 continue;
             }
             try {
-                Module depModule = loader.loadModule(dependency.getIdentifier());
+                Module depModule = loader.loadModule(dependency.getDependencyModule());
                 ServiceLoader<ServletContainerInitializer> serviceLoader = depModule.loadService(ServletContainerInitializer.class);
                 for (ServletContainerInitializer service : serviceLoader) {
                     if(sciClasses.add(service.getClass())) {
@@ -104,7 +104,7 @@ public class ServletContainerInitializerDeploymentProcessor implements Deploymen
                 }
             } catch (ModuleLoadException e) {
                 if (!dependency.isOptional()) {
-                    throw UndertowLogger.ROOT_LOGGER.errorLoadingSCIFromModule(dependency.getIdentifier().toString(), e);
+                    throw UndertowLogger.ROOT_LOGGER.errorLoadingSCIFromModule(dependency.getDependencyModule(), e);
                 }
             }
         }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessor.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessor.java
@@ -104,7 +104,7 @@ public class WSClassVerificationProcessor implements DeploymentUnitProcessor {
     static boolean hasCxfModuleDependency(DeploymentUnit unit) {
         final ModuleSpecification moduleSpec = unit.getAttachment(Attachments.MODULE_SPECIFICATION);
         for (ModuleDependency dep : moduleSpec.getUserDependenciesSet()) {
-            final String id = dep.getIdentifier().getName();
+            final String id = dep.getDependencyModule();
             if (cxfExportingModules.contains(id)) {
                 return true;
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20348
