### PR TITLE
[WFLY-20091] Provide distributed deployment repository functionality

### DIFF
--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbResourceDefinition.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbResourceDefinition.java
@@ -86,6 +86,10 @@ public class DistributableEjbResourceDefinition extends SubsystemResourceDefinit
         new LocalClientMappingsRegistryProviderResourceDefinition().register(registration);
         new InfinispanClientMappingsRegistryProviderResourceDefinition().register(registration);
 
+        // register the child resources for module-availability-registrar-provider
+        new LocalModuleAvailabilityRegistrarProviderResourceDefinition().register(registration);
+        new InfinispanModuleAvailabilityRegistrarProviderResourceDefinition().register(registration);
+
         new InfinispanTimerManagementResourceDefinition().register(registration);
     }
 

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbSubsystemSchema.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbSubsystemSchema.java
@@ -18,8 +18,8 @@ import org.jboss.staxmapper.IntVersion;
 public enum DistributableEjbSubsystemSchema implements PersistentSubsystemSchema<DistributableEjbSubsystemSchema> {
 
     VERSION_1_0(1, 0), // WildFly 27
-    ;
-    static final DistributableEjbSubsystemSchema CURRENT = VERSION_1_0;
+    VERSION_2_0(2, 0); // WildFly 36   ;
+    static final DistributableEjbSubsystemSchema CURRENT = VERSION_2_0;
 
     private final VersionedNamespace<IntVersion, DistributableEjbSubsystemSchema> namespace;
 

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbXMLDescriptionFactory.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/DistributableEjbXMLDescriptionFactory.java
@@ -26,6 +26,8 @@ public enum DistributableEjbXMLDescriptionFactory implements Function<Distributa
                 .addChild(builder(InfinispanBeanManagementResourceDefinition.WILDCARD_PATH).addAttributes(Stream.concat(Attribute.stream(BeanManagementResourceDefinition.Attribute.class), Attribute.stream(InfinispanBeanManagementResourceDefinition.Attribute.class))))
                 .addChild(builder(LocalClientMappingsRegistryProviderResourceDefinition.PATH).setXmlElementName("local-client-mappings-registry"))
                 .addChild(builder(InfinispanClientMappingsRegistryProviderResourceDefinition.PATH).addAttributes(Attribute.stream(InfinispanClientMappingsRegistryProviderResourceDefinition.Attribute.class)).setXmlElementName("infinispan-client-mappings-registry"))
+                .addChild(builder(LocalModuleAvailabilityRegistrarProviderResourceDefinition.PATH).setXmlElementName("local-module-availability-registrar"))
+                .addChild(builder(InfinispanModuleAvailabilityRegistrarProviderResourceDefinition.PATH).addAttributes(Attribute.stream(InfinispanModuleAvailabilityRegistrarProviderResourceDefinition.Attribute.class)).setXmlElementName("infinispan-module-availability-registrar"))
                 .addChild(builder(InfinispanTimerManagementResourceDefinition.WILDCARD_PATH).addAttributes(Attribute.stream(InfinispanTimerManagementResourceDefinition.Attribute.class)).setXmlElementName("infinispan-timer-management"))
                 .build();
     }

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanModuleAvailabilityRegistrarProviderResourceDefinition.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/InfinispanModuleAvailabilityRegistrarProviderResourceDefinition.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.clustering.ejb;
+
+import org.jboss.as.clustering.controller.SimpleResourceDescriptorConfigurator;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.clustering.ejb.infinispan.remote.InfinispanModuleAvailabilityRegistrarProvider;
+import org.wildfly.clustering.infinispan.service.InfinispanServiceDescriptor;
+import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
+import org.wildfly.subsystem.resource.ResourceModelResolver;
+import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
+import org.wildfly.subsystem.service.ResourceServiceInstaller;
+import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Definition of the /subsystem=distributable-ejb/module-availability-registrar=infinispan resource.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public class InfinispanModuleAvailabilityRegistrarProviderResourceDefinition extends ModuleAvailabilityRegistrarProviderResourceDefinition {
+
+    static final PathElement PATH = pathElement("infinispan");
+
+    enum Attribute implements org.jboss.as.clustering.controller.Attribute, UnaryOperator<SimpleAttributeDefinitionBuilder> {
+        CACHE_CONTAINER("cache-container", ModelType.STRING) {
+            @Override
+            public SimpleAttributeDefinitionBuilder apply(SimpleAttributeDefinitionBuilder builder) {
+                return builder.setRequired(true)
+                        .setCapabilityReference(CapabilityReferenceRecorder.builder(CAPABILITY, InfinispanServiceDescriptor.DEFAULT_CACHE_CONFIGURATION).build())
+                        ;
+            }
+        },
+        CACHE("cache", ModelType.STRING) {
+            @Override
+            public SimpleAttributeDefinitionBuilder apply(SimpleAttributeDefinitionBuilder builder) {
+                return builder.setRequired(false)
+                        .setCapabilityReference(CapabilityReferenceRecorder.builder(CAPABILITY, InfinispanServiceDescriptor.CACHE_CONFIGURATION).withParentAttribute(CACHE_CONTAINER.getDefinition()).build());
+            }
+        }
+        ;
+
+        private final AttributeDefinition definition ;
+
+        Attribute(String name, ModelType type) {
+            this.definition = this.apply(new SimpleAttributeDefinitionBuilder(name, type)
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    ).build();
+        }
+
+        @Override
+        public AttributeDefinition getDefinition() {
+            return this.definition;
+        }
+    }
+
+    private final ResourceModelResolver<BinaryServiceConfiguration> resolver = BinaryServiceConfiguration.resolver(Attribute.CACHE_CONTAINER.getDefinition(), Attribute.CACHE.getDefinition());
+
+    InfinispanModuleAvailabilityRegistrarProviderResourceDefinition() {
+        super(PATH, new SimpleResourceDescriptorConfigurator<>(Attribute.class));
+    }
+
+    @Override
+    public ResourceServiceInstaller configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        return CapabilityServiceInstaller.builder(CAPABILITY, new InfinispanModuleAvailabilityRegistrarProvider(this.resolver.resolve(context, model))).build();
+    }
+}

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.clustering.ejb;
+
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
+import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
+import org.wildfly.clustering.server.service.ClusteringServiceDescriptor;
+import org.wildfly.clustering.server.service.FilteredBinaryServiceInstallerProvider;
+import org.wildfly.subsystem.service.ServiceInstaller;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A local module availability registrar provider implementation.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public enum LocalModuleAvailabilityRegistrarProvider implements ModuleAvailabilityRegistrarProvider {
+    INSTANCE;
+
+    @Override
+    public Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support) {
+        BinaryServiceConfiguration configuration = BinaryServiceConfiguration.of(ModelDescriptionConstants.LOCAL, "module-availability");
+        List<ServiceInstaller> installers = new LinkedList<>();
+        // install an instance of ServiceProviderRegistrar to hold module availability information
+        new FilteredBinaryServiceInstallerProvider(Set.of(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR)).apply(support, configuration).forEach(installers::add);
+        return installers;
+    }
+}

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
@@ -38,14 +38,16 @@ public enum LocalModuleAvailabilityRegistrarProvider implements ModuleAvailabili
      */
     @Override
     public Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support) {
+        System.out.println("LocalModuleAvailabilityRegistrar: getServiceInstallers()");
         List<ServiceInstaller> installers = new LinkedList<>();
         // install an instance of ServiceProviderRegistrar to hold module availability information
         BinaryServiceConfiguration configuration = BinaryServiceConfiguration.of(ModelDescriptionConstants.LOCAL, "module-availability");
         new FilteredBinaryServiceInstallerProvider(Set.of(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR)).apply(support, configuration).forEach(installers::add);
         // add an alias service to a well-known name
-        ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
+        //ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
+        ServiceName aliasServiceName = support.getCapabilityServiceName(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
         ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistry = configuration.getServiceDependency(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR);
-        installers.add(ServiceInstaller.builder(serviceProviderRegistry).provides(aliasServiceName).build());
+        installers.add(ServiceInstaller.builder(serviceProviderRegistry).asActive().provides(aliasServiceName).build());
         return installers;
     }
 }

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
@@ -7,10 +7,14 @@ package org.wildfly.extension.clustering.ejb;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
 import org.wildfly.clustering.server.service.ClusteringServiceDescriptor;
 import org.wildfly.clustering.server.service.FilteredBinaryServiceInstallerProvider;
+import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.ServiceInstaller;
 
 import java.util.LinkedList;
@@ -26,12 +30,22 @@ import java.util.Set;
 public enum LocalModuleAvailabilityRegistrarProvider implements ModuleAvailabilityRegistrarProvider {
     INSTANCE;
 
+    /**
+     * This method aliases the ServiceProviderRegistry defined for the default local cache for the "ejb" container
+     * to the capability for the ServiceProviderRegistry used by the ModuleAvailabilityRegistrar instance.
+     * @param support
+     * @return
+     */
     @Override
     public Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support) {
-        BinaryServiceConfiguration configuration = BinaryServiceConfiguration.of(ModelDescriptionConstants.LOCAL, "module-availability");
         List<ServiceInstaller> installers = new LinkedList<>();
         // install an instance of ServiceProviderRegistrar to hold module availability information
+        BinaryServiceConfiguration configuration = BinaryServiceConfiguration.of(ModelDescriptionConstants.LOCAL, "module-availability");
         new FilteredBinaryServiceInstallerProvider(Set.of(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR)).apply(support, configuration).forEach(installers::add);
+        // add an alias service to a well-known name
+        ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
+        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistry = configuration.getServiceDependency(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR);
+        installers.add(ServiceInstaller.builder(serviceProviderRegistry).provides(aliasServiceName).build());
         return installers;
     }
 }

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProvider.java
@@ -38,16 +38,15 @@ public enum LocalModuleAvailabilityRegistrarProvider implements ModuleAvailabili
      */
     @Override
     public Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support) {
-        System.out.println("LocalModuleAvailabilityRegistrar: getServiceInstallers()");
         List<ServiceInstaller> installers = new LinkedList<>();
         // install an instance of ServiceProviderRegistrar to hold module availability information
         BinaryServiceConfiguration configuration = BinaryServiceConfiguration.of(ModelDescriptionConstants.LOCAL, "module-availability");
         new FilteredBinaryServiceInstallerProvider(Set.of(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR)).apply(support, configuration).forEach(installers::add);
         // add an alias service to a well-known name
-        //ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
         ServiceName aliasServiceName = support.getCapabilityServiceName(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
-        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistry = configuration.getServiceDependency(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR);
-        installers.add(ServiceInstaller.builder(serviceProviderRegistry).asActive().provides(aliasServiceName).build());
+        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = configuration.getServiceDependency(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR);
+        // this starts as PASSIVE by default
+        installers.add(ServiceInstaller.builder(serviceProviderRegistrar).provides(aliasServiceName).build());
         return installers;
     }
 }

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProviderResourceDefinition.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/LocalModuleAvailabilityRegistrarProviderResourceDefinition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.clustering.ejb;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.subsystem.service.ResourceServiceInstaller;
+import org.wildfly.subsystem.service.capability.CapabilityServiceInstaller;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Definition of the /subsystem=distributable-ejb/module-availability-registrar=local resource.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public class LocalModuleAvailabilityRegistrarProviderResourceDefinition extends ModuleAvailabilityRegistrarProviderResourceDefinition {
+
+    static final PathElement PATH = pathElement("local");
+
+    LocalModuleAvailabilityRegistrarProviderResourceDefinition() {
+        super(PATH, UnaryOperator.identity());
+    }
+
+    @Override
+    public ResourceServiceInstaller configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        return CapabilityServiceInstaller.builder(CAPABILITY, LocalModuleAvailabilityRegistrarProvider.INSTANCE).build();
+    }
+}

--- a/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/ModuleAvailabilityRegistrarProviderResourceDefinition.java
+++ b/clustering/ejb/extension/src/main/java/org/wildfly/extension/clustering/ejb/ModuleAvailabilityRegistrarProviderResourceDefinition.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.clustering.ejb;
+
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
+import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.controller.SimpleResourceRegistrar;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
+import org.wildfly.subsystem.resource.operation.ResourceOperationRuntimeHandler;
+import org.wildfly.subsystem.service.ResourceServiceConfigurator;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+/**
+ * Base class definition of the /subsystem=distributable-ejb/module-availability-registrar=* resource.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public abstract class ModuleAvailabilityRegistrarProviderResourceDefinition extends ChildResourceDefinition<ManagementResourceRegistration> implements ResourceServiceConfigurator {
+
+    static PathElement pathElement(String value) {
+        return PathElement.pathElement("module-availability-registrar", value);
+    }
+
+    static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of(ModuleAvailabilityRegistrarProvider.SERVICE_DESCRIPTOR).setAllowMultipleRegistrations(true).build();
+
+    private final UnaryOperator<ResourceDescriptor> configurator;
+
+    ModuleAvailabilityRegistrarProviderResourceDefinition(PathElement path, UnaryOperator<ResourceDescriptor> configurator) {
+        super(path, DistributableEjbExtension.SUBSYSTEM_RESOLVER.createChildResolver(path));
+        this.configurator = configurator;
+    }
+
+    @Override
+    public ManagementResourceRegistration register(ManagementResourceRegistration parent) {
+        ManagementResourceRegistration registration = parent.registerSubModel(this);
+        ResourceDescriptor descriptor = this.configurator.apply(new ResourceDescriptor(this.getResourceDescriptionResolver()))
+                .addCapabilities(List.of(CAPABILITY))
+                ;
+        ResourceOperationRuntimeHandler handler = ResourceOperationRuntimeHandler.configureService(this);
+        new SimpleResourceRegistrar(descriptor, ResourceServiceHandler.of(handler)).register(registration);
+        return registration;
+    }
+}

--- a/clustering/ejb/extension/src/main/resources/org/wildfly/extension/clustering/ejb/LocalDescriptions.properties
+++ b/clustering/ejb/extension/src/main/resources/org/wildfly/extension/clustering/ejb/LocalDescriptions.properties
@@ -25,6 +25,17 @@ distributable-ejb.client-mappings-registry.infinispan=The Infinispan client mapp
 distributable-ejb.client-mappings-registry.infinispan.cache-container=The name of the cache container associated this provider
 distributable-ejb.client-mappings-registry.infinispan.cache=The name of the cache associated this provider
 
+distributable-ejb.module-availability-registrar=A module availability registrar provider
+distributable-ejb.module-availability-registrar.add=Adds a module availability registrar provider
+distributable-ejb.module-availability-registrar.remove=Removes a module availability registrar provider
+
+distributable-ejb.module-availability-registrar.local=The local module availability registrar provider, used to generate local service provider registrars for module availability.
+
+distributable-ejb.module-availability-registrar.infinispan=The Infinispan module availability registrar provider, used to generate non-local service provider registrars for module availability.
+distributable-ejb.module-availability-registrar.infinispan.cache-container=The name of the cache container associated this provider
+distributable-ejb.module-availability-registrar.infinispan.cache=The name of the cache associated this provider
+
+
 distributable-ejb.infinispan-timer-management=An Infinispan-based timer management provider
 distributable-ejb.infinispan-timer-management.add=Adds an Infinispan-based timer management provider
 distributable-ejb.infinispan-timer-management.remove=Removes an Infinispan-based timer management provider

--- a/clustering/ejb/extension/src/main/resources/schema/wildfly-distributable-ejb_2_0.xsd
+++ b/clustering/ejb/extension/src/main/resources/schema/wildfly-distributable-ejb_2_0.xsd
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<xs:schema targetNamespace="urn:jboss:domain:distributable-ejb:2.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:jboss:domain:distributable-ejb:2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="2.0">
+
+    <xs:element name="subsystem" type="tns:subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="infinispan-bean-management" type="tns:infinispan-bean-management">
+                    <xs:annotation>
+                        <xs:documentation>An Infinispan-based bean management provider</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="local-client-mappings-registry" type="tns:empty">
+                    <xs:annotation>
+                        <xs:documentation>Configures support for local client mappings registry</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="infinispan-client-mappings-registry" type="tns:infinispan-client-mappings-registry">
+                    <xs:annotation>
+                        <xs:documentation>Configures support for cluster-aware client mappings registry</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="local-module-availability-registrar" type="tns:empty">
+                    <xs:annotation>
+                        <xs:documentation>Configures support for local module availability registrar</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="infinispan-module-availability-registrar" type="tns:infinispan-module-availability-registrar">
+                    <xs:annotation>
+                        <xs:documentation>Configures support for cluster-aware module availability registrar</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="infinispan-timer-management" type="tns:infinispan-timer-management">
+                    <xs:annotation>
+                        <xs:documentation>References an existing timer management provider</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="default-bean-management" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Identifies the default bean management provider for ejb applications.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="infinispan-bean-management">
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of this bean management provider</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attributeGroup ref="tns:infinispan"/>
+        <xs:attribute name="max-active-beans" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The maximum number active beans to retain in memory at a time, after which the least recently used will passivate.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="infinispan-client-mappings-registry">
+        <xs:attributeGroup ref="tns:infinispan"/>
+    </xs:complexType>
+
+    <xs:complexType name="infinispan-module-availability-registrar">
+        <xs:attributeGroup ref="tns:infinispan"/>
+    </xs:complexType>
+
+    <xs:attributeGroup name="infinispan">
+        <xs:attribute name="cache-container" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>References a cache-container defined by the Infinispan subsystem.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cache" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    References a cache within the associated cache-container.
+                    If unspecified, the default cache of the associated cache-container is assumed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="infinispan-timer-management">
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>References the name of an existing bean management provider</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attributeGroup ref="tns:infinispan"/>
+        <xs:attribute name="max-active-timers" type="xs:integer">
+            <xs:annotation>
+                <xs:documentation>The maximum number active timers to retain in memory at a time, after which the least recently used will passivate.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="marshaller" type="tns:marshaller" default="JBOSS">
+            <xs:annotation>
+                <xs:documentation>Indicates the marshalling implementation used for serializing the timeout context of a timer.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="empty">
+        <xs:sequence/>
+    </xs:complexType>
+
+    <xs:simpleType name="marshaller">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="JBOSS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Marshaller based on JBoss Marshalling.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PROTOSTREAM">
+                <xs:annotation>
+                    <xs:documentation>
+                        Marshaller based on ProtoStream.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/clustering/ejb/extension/src/test/resources/org/wildfly/extension/clustering/ejb/distributable-ejb-2.0.xml
+++ b/clustering/ejb/extension/src/test/resources/org/wildfly/extension/clustering/ejb/distributable-ejb-2.0.xml
@@ -1,0 +1,12 @@
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<subsystem xmlns="urn:jboss:domain:distributable-ejb:2.0" default-bean-management="default">
+    <infinispan-bean-management name="default" cache-container="foo" cache="bar" max-active-beans="${exp.max-active-beans:10000}"/>
+    <local-client-mappings-registry/>
+    <local-module-availability-registrar/>
+    <infinispan-timer-management name="distributed" cache-container="foo" cache="bar" max-active-timers="${exp.max-active-distributed-timers:100}"/>
+    <infinispan-timer-management name="transient" cache-container="foo" cache="bar" max-active-timers="${exp.max-active-transient-timers:1000}"/>
+</subsystem>

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/InfinispanModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/InfinispanModuleAvailabilityRegistrarProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.clustering.ejb.infinispan.remote;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
+import org.wildfly.clustering.infinispan.service.CacheServiceInstallerFactory;
+import org.wildfly.clustering.infinispan.service.TemplateConfigurationServiceInstallerFactory;
+import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
+import org.wildfly.clustering.server.service.ClusteringServiceDescriptor;
+import org.wildfly.clustering.server.service.FilteredBinaryServiceInstallerProvider;
+import org.wildfly.common.function.Functions;
+import org.wildfly.subsystem.service.ServiceInstaller;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * The non-legacy version of the module availability registrar provider, used when the distributable-ejb subsystem is present.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public class InfinispanModuleAvailabilityRegistrarProvider implements ModuleAvailabilityRegistrarProvider {
+
+    private final BinaryServiceConfiguration configuration;
+    private final Consumer<ConfigurationBuilder> configurator;
+
+    /**
+     * Creates an instance of the Infinispan-based service provider registrar provider.
+     * @param configuration a cache configuration
+     */
+    public InfinispanModuleAvailabilityRegistrarProvider(BinaryServiceConfiguration configuration) {
+        this(configuration, Functions.discardingConsumer());
+    }
+
+    InfinispanModuleAvailabilityRegistrarProvider(BinaryServiceConfiguration configuration, Consumer<ConfigurationBuilder> configurator) {
+        this.configuration = configuration;
+        this.configurator = configurator;
+    }
+
+    @Override
+    public Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support) {
+        BinaryServiceConfiguration configuration = this.configuration.withChildName("module-availability");
+        List<ServiceInstaller> installers = new LinkedList<>();
+        // add in installers for cache service
+        installers.add(new TemplateConfigurationServiceInstallerFactory(this.configurator).apply(this.configuration, configuration));
+        installers.add(CacheServiceInstallerFactory.INSTANCE.apply(configuration));
+        // add in installer for service provider registry
+        new FilteredBinaryServiceInstallerProvider(Set.of(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR)).apply(support, configuration).forEach(installers::add);
+        return installers;
+    }
+}

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/InfinispanModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/InfinispanModuleAvailabilityRegistrarProvider.java
@@ -58,7 +58,8 @@ public class InfinispanModuleAvailabilityRegistrarProvider implements ModuleAvai
         ServiceName serviceProviderRegistrarServiceName = configuration.resolveServiceName(ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR);
         ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = ServiceDependency.on(serviceProviderRegistrarServiceName);
         // create an installer to install a well-known alias to that SPR
-        ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
+        // ServiceName aliasServiceName = ServiceName.of(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR.getName());
+        ServiceName aliasServiceName = support.getCapabilityServiceName(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
         installers.add(ServiceInstaller.builder(serviceProviderRegistrar).provides(aliasServiceName).build());
         return installers;
     }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/LegacyInfinispanModuleAvailabilityRegistrarProviderFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/remote/LegacyInfinispanModuleAvailabilityRegistrarProviderFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.clustering.ejb.infinispan.remote;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ClusteringConfigurationBuilder;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.eviction.EvictionStrategy;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.cache.infinispan.embedded.container.DataContainerConfigurationBuilder;
+import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
+import org.wildfly.clustering.ejb.remote.LegacyModuleAvailabilityRegistrarProviderFactory;
+import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
+
+import java.util.function.Consumer;
+
+/**
+ * Factory for creating legacy version of the InfinispanModuleAvailabilityRegistrarProvider
+ *
+ * @author Richard Achmatowicz
+ */
+@Deprecated
+@MetaInfServices(LegacyModuleAvailabilityRegistrarProviderFactory.class)
+public class LegacyInfinispanModuleAvailabilityRegistrarProviderFactory implements LegacyModuleAvailabilityRegistrarProviderFactory, Consumer<ConfigurationBuilder> {
+
+    @Override
+    public ModuleAvailabilityRegistrarProvider createModuleAvailabilityRegistrarProvider(String clusterName) {
+        return new InfinispanModuleAvailabilityRegistrarProvider(BinaryServiceConfiguration.of(clusterName, null), this);
+    }
+
+    @Override
+    public void accept(ConfigurationBuilder builder) {
+        ClusteringConfigurationBuilder clustering = builder.clustering();
+        CacheMode mode = clustering.cacheMode();
+        clustering.cacheMode(mode.needsStateTransfer() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
+        clustering.l1().disable();
+        // Ensure we use the default data container
+        builder.addModule(DataContainerConfigurationBuilder.class).evictable(null);
+        // Disable expiration
+        builder.expiration().lifespan(-1).maxIdle(-1);
+        // Disable eviction
+        builder.memory().storage(StorageType.HEAP).maxCount(-1).whenFull(EvictionStrategy.NONE);
+        builder.persistence().clearStores();
+        clustering.stateTransfer().fetchInMemoryState(mode.needsStateTransfer()).awaitInitialTransfer(mode.needsStateTransfer());
+    }
+}

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/LegacyModuleAvailabilityRegistrarProviderFactory.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/LegacyModuleAvailabilityRegistrarProviderFactory.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.clustering.ejb.remote;
+
+/**
+ * interface for obtaining ModuleAvailabilityRegistrarProvider instances in the legacy case where no distributable-ejb subsystem is present.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+@Deprecated
+public interface LegacyModuleAvailabilityRegistrarProviderFactory {
+    ModuleAvailabilityRegistrarProvider createModuleAvailabilityRegistrarProvider(String clusterName);
+}

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/ModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/ModuleAvailabilityRegistrarProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.clustering.ejb.remote;
+
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.wildfly.service.descriptor.NullaryServiceDescriptor;
+import org.wildfly.subsystem.service.ServiceInstaller;
+
+/**
+ * interface defining ModuleAvailabilityRegistrarProvider instances, used to install configured module availability registrar services.
+ *
+ * @author Richard Achmatowicz
+ */
+public interface ModuleAvailabilityRegistrarProvider {
+    NullaryServiceDescriptor<ModuleAvailabilityRegistrarProvider> SERVICE_DESCRIPTOR = NullaryServiceDescriptor.of("org.wildfly.clustering.ejb.module-availability-registrar-provider", ModuleAvailabilityRegistrarProvider.class);
+
+    Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support);
+}

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/ModuleAvailabilityRegistrarProvider.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/remote/ModuleAvailabilityRegistrarProvider.java
@@ -6,6 +6,8 @@
 package org.wildfly.clustering.ejb.remote;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.subsystem.service.ServiceInstaller;
 
@@ -16,6 +18,7 @@ import org.wildfly.subsystem.service.ServiceInstaller;
  */
 public interface ModuleAvailabilityRegistrarProvider {
     NullaryServiceDescriptor<ModuleAvailabilityRegistrarProvider> SERVICE_DESCRIPTOR = NullaryServiceDescriptor.of("org.wildfly.clustering.ejb.module-availability-registrar-provider", ModuleAvailabilityRegistrarProvider.class);
+    NullaryServiceDescriptor<ServiceProviderRegistrar<Object, GroupMember>> MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR = NullaryServiceDescriptor.of("org.wildfly.ejb.remote.module-availability-registrar-service-provider-registrar", (Class<ServiceProviderRegistrar<Object, GroupMember>>) (Class<?>) ServiceProviderRegistrar.class);
 
     Iterable<ServiceInstaller> getServiceInstallers(CapabilityServiceSupport support);
 }

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/AbstractServiceProviderRegistrarServiceInstallerFactory.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/AbstractServiceProviderRegistrarServiceInstallerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.clustering.server.provider;
+
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+import org.wildfly.clustering.server.service.BinaryServiceInstallerFactory;
+import org.wildfly.clustering.server.service.ClusteringServiceDescriptor;
+import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+
+/**
+ * Builds a cache-based {@link ServiceProviderRegistrarFactory} service.
+ * @author Paul Ferraro
+ */
+public abstract class AbstractServiceProviderRegistrarServiceInstallerFactory<T> implements BinaryServiceInstallerFactory<ServiceProviderRegistrar<T, GroupMember>> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public BinaryServiceDescriptor<ServiceProviderRegistrar<T, GroupMember>> getServiceDescriptor() {
+        return (BinaryServiceDescriptor<ServiceProviderRegistrar<T, GroupMember>>) (BinaryServiceDescriptor<?>) ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR;
+    }
+}

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/CacheServiceProviderRegistrarServiceInstallerFactory.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/CacheServiceProviderRegistrarServiceInstallerFactory.java
@@ -24,7 +24,7 @@ import org.wildfly.subsystem.service.ServiceInstaller;
  * Builds a cache-based {@link ServiceProviderRegistrationFactory} service.
  * @author Paul Ferraro
  */
-public class CacheServiceProviderRegistrarServiceInstallerFactory<T> extends ServiceProviderRegistrarServiceInstallerFactory<T> {
+public class CacheServiceProviderRegistrarServiceInstallerFactory<T> extends AbstractServiceProviderRegistrarServiceInstallerFactory<T> {
 
     @Override
     public ServiceInstaller apply(CapabilityServiceSupport support, BinaryServiceConfiguration configuration) {

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/LocalServiceProviderRegistrarServiceInstallerFactory.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/LocalServiceProviderRegistrarServiceInstallerFactory.java
@@ -17,7 +17,7 @@ import org.wildfly.subsystem.service.ServiceInstaller;
 /**
  * @author Paul Ferraro
  */
-public class LocalServiceProviderRegistrarServiceInstallerFactory<T> extends ServiceProviderRegistrarServiceInstallerFactory<T> {
+public class LocalServiceProviderRegistrarServiceInstallerFactory<T> extends AbstractServiceProviderRegistrarServiceInstallerFactory<T> {
 
     @Override
     public ServiceInstaller apply(CapabilityServiceSupport support, BinaryServiceConfiguration configuration) {

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/ServiceProviderRegistrarServiceInstallerFactory.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/provider/ServiceProviderRegistrarServiceInstallerFactory.java
@@ -1,24 +1,24 @@
-/*
- * Copyright The WildFly Authors
- * SPDX-License-Identifier: Apache-2.0
- */
 package org.wildfly.extension.clustering.server.provider;
 
-import org.wildfly.clustering.server.GroupMember;
-import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.server.service.BinaryServiceConfiguration;
 import org.wildfly.clustering.server.service.BinaryServiceInstallerFactory;
-import org.wildfly.clustering.server.service.ClusteringServiceDescriptor;
-import org.wildfly.service.descriptor.BinaryServiceDescriptor;
+import org.wildfly.subsystem.service.ServiceInstaller;
+
+import java.util.function.BiFunction;
 
 /**
- * Builds a cache-based {@link ServiceProviderRegistrationFactory} service.
+ * Configures a cache or local service provider registry.
  * @author Paul Ferraro
  */
-public abstract class ServiceProviderRegistrarServiceInstallerFactory<T> implements BinaryServiceInstallerFactory<ServiceProviderRegistrar<T, GroupMember>> {
+@MetaInfServices(BinaryServiceInstallerFactory.class)
+public class ServiceProviderRegistrarServiceInstallerFactory<T> extends AbstractServiceProviderRegistrarServiceInstallerFactory<T>{
 
-    @SuppressWarnings("unchecked")
     @Override
-    public BinaryServiceDescriptor<ServiceProviderRegistrar<T, GroupMember>> getServiceDescriptor() {
-        return (BinaryServiceDescriptor<ServiceProviderRegistrar<T, GroupMember>>) (BinaryServiceDescriptor<?>) ClusteringServiceDescriptor.SERVICE_PROVIDER_REGISTRAR;
+    public ServiceInstaller apply(CapabilityServiceSupport support, BinaryServiceConfiguration configuration) {
+        BiFunction<CapabilityServiceSupport, BinaryServiceConfiguration, ServiceInstaller> factory = configuration.getParentName().equals(ModelDescriptionConstants.LOCAL) ? new LocalServiceProviderRegistrarServiceInstallerFactory<>() : new CacheServiceProviderRegistrarServiceInstallerFactory<>();
+        return factory.apply(support, configuration);
     }
 }

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/distributable-ejb-local.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/distributable-ejb-local.xml
@@ -15,6 +15,7 @@
             <param name="max-active-beans" value="10000"/>
         </feature>
         <feature spec="subsystem.distributable-ejb.client-mappings-registry.local"/>
+        <feature spec="subsystem.distributable-ejb.module-availability-registrar.local"/>
         <feature spec="subsystem.distributable-ejb.infinispan-timer-management">
             <param name="infinispan-timer-management" value="persistent"/>
             <param name="cache-container" value="ejb"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/distributable-ejb.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/distributable-ejb.xml
@@ -17,6 +17,10 @@
             <param name="cache-container" value="ejb"/>
             <param name="cache" value="client-mappings"/>
         </feature>
+        <feature spec="subsystem.distributable-ejb.module-availability-registrar.infinispan">
+            <param name="cache-container" value="ejb"/>
+            <param name="cache" value="module-availability"/>
+        </feature>
         <feature spec="subsystem.distributable-ejb.infinispan-timer-management">
             <param name="infinispan-timer-management" value="persistent"/>
             <param name="cache-container" value="ejb"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/infinispan-dist-ejb.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/infinispan-dist-ejb.xml
@@ -39,6 +39,12 @@
                     <param name="interval" value="0"/>
                 </feature>
             </feature>
+            <feature spec="subsystem.infinispan.cache-container.replicated-cache">
+                <param name="replicated-cache" value="module-availability"/>
+                <feature spec="subsystem.infinispan.cache-container.replicated-cache.component.expiration">
+                    <param name="interval" value="0"/>
+                </feature>
+            </feature>
             <feature spec="subsystem.infinispan.cache-container.distributed-cache">
                 <param name="distributed-cache" value="persistent"/>
                 <feature spec="subsystem.infinispan.cache-container.distributed-cache.component.locking">

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
@@ -27,6 +27,7 @@
         <!-- Enable dynamic loading of legacy distributable bean manager provider -->
         <module name="org.wildfly.clustering.ejb.infinispan" services="import" optional="true"/>
         <module name="org.wildfly.clustering.marshalling.spi"/>
+        <module name="org.wildfly.clustering.server.api"/>
         <module name="org.wildfly.clustering.server.spi"/>
         <module name="org.wildfly.service"/>
         <module name="org.wildfly.subsystem"/>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3255,4 +3255,8 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 536, value = "Unsupported EJB receiver protocol %s")
     IllegalArgumentException unsupportedEJBReceiverProtocol(String uriScheme);
+
+    @LogMessage(level = WARN)
+    @Message(id = 537, value = "No module availability registrar provider found for %s; using legacy provider based on static configuration")
+    void legacyModuleAvailabilityRegistrarProviderInUse(String name);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrar.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrar.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.ejb3.remote;
+
+/**
+ * A ModuleAvailabilityRegistrar which manages a view of deployed modules across the cluster.
+ *
+ * This service is used the a basis for generating module availability updates to remote clients.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public interface ModuleAvailabilityRegistrar {
+
+    /*
+     * Adds a ModuleAvailabilityRegistrarListener to receive callbacks on module availability-related events.
+     */
+    void addListener(ModuleAvailabilityRegistrarListener listener);
+
+    /*
+     * Removes a ModuleAvailabilityRegistrarListener from receiving callbacks on module availability-related events.
+     */
+    void removeListener(ModuleAvailabilityRegistrarListener listener);
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarListener.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
+import org.wildfly.clustering.server.GroupMember;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Listener class that notifies on cluster-wide module availability changes.
+ *
+ * @author Richard Achmatowicz
+ */
+public interface ModuleAvailabilityRegistrarListener {
+
+    /*
+     * Provides a map of available modules, and the nodes they reside on, which are deployed on servers in a cluster.
+     */
+    void modulesAvailable(Map<DeploymentModuleIdentifier, List<GroupMember>> modules) ;
+
+    /*
+     * Provides a map of unavailable modules, and the nodes they are no longer reside on,which have been undeployed on
+     * servers in a cluster.
+     */
+    void modulesUnavailable(Map<DeploymentModuleIdentifier, List<GroupMember>> modules) ;
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarService.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
+import org.jboss.as.ejb3.deployment.DeploymentRepository;
+import org.jboss.as.ejb3.deployment.DeploymentRepositoryListener;
+import org.jboss.as.ejb3.deployment.ModuleDeployment;
+import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.as.server.suspend.ServerResumeContext;
+import org.jboss.as.server.suspend.ServerSuspendContext;
+import org.jboss.as.server.suspend.SuspendableActivity;
+import org.jboss.as.server.suspend.SuspendableActivityRegistry;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.manager.Service;
+import org.wildfly.clustering.server.provider.ServiceProviderListener;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistration;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A service which implements a ModuleAvailabilityRegistrar.
+ * <p>
+ * The purpose of this class is to take local module availablity information and make it globally available
+ * across the cluster. It does this by listening for local deployment events (provided by a DeploymentRepository)
+ * as well as remote deployment events (provided by a distributed ServiceProviderRegistry) and communicate that
+ * module deployment information to local listeners (via ModuleAvailabilityRegistrarListemer).
+ * <p>
+ * This class is also suspend and resume aware, so that locally depployed modules will be marked as unavailable
+ * when the server is suspended, and marked as available when the server is resumed.
+ */
+public class ModuleAvailabilityRegistrarService implements ModuleAvailabilityRegistrar, Service {
+    private final DeploymentRepository deploymentRepository;
+    private final ServiceProviderRegistrar<Object, GroupMember> registrar;
+    private final SuspendableActivityRegistry registry;
+
+    private final DeploymentRepositoryListener deploymentRepositoryListener ;
+    private final SuspendableActivity activity;
+
+    private final List<ModuleAvailabilityRegistrarListener> listeners = new ArrayList<>();
+    private final Map<DeploymentModuleIdentifier, ServiceProviderRegistration<Object, GroupMember>> registrations = new HashMap<>();
+
+    /**
+     * Create an instance of a ModuleAvailabilityRegistrar which reflects the content of a given DepoymentRepository.
+     *
+     * @param deploymentRepository the repository this registrar listens to for module availability information on a given host
+     * @param registrar            the ServiceProviderRegistrar instance used to store module availability information
+     * @param registry             the suspendable activity registry to register our server activity with
+     */
+    public ModuleAvailabilityRegistrarService(SuspendableActivityRegistry registry, ServiceProviderRegistrar<Object, GroupMember> registrar, DeploymentRepository deploymentRepository) {
+        this.registry = registry;
+        this.registrar = registrar;
+        this.deploymentRepository = deploymentRepository;
+
+        this.activity = new ModuleAvailabilityRegistrarSuspendableActivity();
+        this.deploymentRepositoryListener = new ModuleAvailabilityRegistrarDeploymentRepositoryListener();
+    }
+
+    // service interface
+    @Override
+    public boolean isStarted() {
+        // how to check started
+        return true;
+    }
+
+    @Override
+    public void start() {
+        EjbLogger.ROOT_LOGGER.info("Starting ModuleAvailabilityRegistrarService");
+        // register as a listener of the DeploymentRepository
+        deploymentRepository.addListener(this.deploymentRepositoryListener);
+
+        // register as a ServerActivity
+        registry.registerActivity(this.activity);
+    }
+
+    @Override
+    public void stop() {
+        EjbLogger.ROOT_LOGGER.info("Stopping ModuleAvailabilityRegistrarService");
+        // unregister as a listener of the DeploymentRepository
+        deploymentRepository.removeListener(this.deploymentRepositoryListener);
+
+        // unregister as a ServerActivity
+        registry.unregisterActivity(this.activity);
+    }
+
+    // the ModuleAvailabilityRegistrar listener interface
+
+    @Override
+    public void addListener(final ModuleAvailabilityRegistrarListener listener) {
+        synchronized (this) {
+            listeners.add(listener);
+        }
+    }
+
+    @Override
+    public void removeListener(final ModuleAvailabilityRegistrarListener listener) {
+        synchronized (this) {
+            listeners.remove(listener);
+        }
+    }
+
+    /*
+     * A SuspendableActivity that controls what happens when the server is suspended and resumed.
+     */
+    class ModuleAvailabilityRegistrarSuspendableActivity implements SuspendableActivity {
+
+        /**
+         * Prepare the ServiceProviderRegistry for suspension of the server.
+         * When the server is suspended:
+         * - unregister all registered service providers
+         * - for each service provider unregistered, callback clients will be notified that the module is no longer available
+         *
+         * @param context the server suspend context
+         * @return
+         */
+        @Override
+        public CompletionStage<Void> suspend(ServerSuspendContext context) {
+            // avoid spurious stop on startup during activity restoration
+            if (!context.isStarting()) {
+                EjbLogger.ROOT_LOGGER.debug("Suspending ModuleAvailabilityRegistrar service");
+                // unregister all of the service providers we have registered
+                Iterator<Map.Entry<DeploymentModuleIdentifier, ServiceProviderRegistration<Object, GroupMember>>> iterator = registrations.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<DeploymentModuleIdentifier, ServiceProviderRegistration<Object, GroupMember>> entry = iterator.next();
+                    DeploymentModuleIdentifier moduleId = entry.getKey();
+                    ServiceProviderRegistration<Object, GroupMember> registration = entry.getValue();
+                    registration.close();
+                    iterator.remove();
+                }
+            }
+            return SuspendableActivity.COMPLETED;
+        }
+
+        /**
+         * Prepare the ServiceProviderRegistry for resuming the server.
+         * When the server is resumed:
+         * - find out which modules are in the deployment repository
+         * - register all deployed modules as service providers
+         * - for each service provider registered, callback clients will be notified (automatically) that the module is again available
+         *
+         * @param context the server resume context
+         * @return
+         */
+        @Override
+        public CompletionStage<Void> resume(ServerResumeContext context) {
+            EjbLogger.ROOT_LOGGER.debug("Resuming ModuleAvailabilityRegistrar service");
+            // interrogate the deployment repository and register the current deployments
+            Map<DeploymentModuleIdentifier, ModuleDeployment> deployedModules = deploymentRepository.getModules();
+            // create one service entry for each module
+            for (DeploymentModuleIdentifier moduleId : deployedModules.keySet()) {
+                ModuleAvailabilityRegistrarServiceProviderListener listener = new ModuleAvailabilityRegistrarServiceProviderListener(moduleId, listeners);
+                ServiceProviderRegistration<Object, GroupMember> registration = registrar.register(moduleId, listener);
+                // set the initial value of the providers
+                listener.setCurrentProviders(registration.getProviders());
+                // keep track of registrartions
+                registrations.putIfAbsent(moduleId, registration);
+            }
+            return SuspendableActivity.COMPLETED;
+        }
+    }
+
+    /*
+     * This listener is notified of changes for a particular service that has been registered.
+     *
+     * NOTE: because this listener reports changes to providers only, in order to determine if providers were added
+     * orremoved, we need to keep track of the current providers to determine whether nodes were addede or removed
+     * for this module.
+     */
+    class ModuleAvailabilityRegistrarServiceProviderListener implements ServiceProviderListener<GroupMember> {
+
+        private final DeploymentModuleIdentifier moduleId;
+        private final List<ModuleAvailabilityRegistrarListener> listeners;
+        private Set<GroupMember> providers;
+
+        public ModuleAvailabilityRegistrarServiceProviderListener(DeploymentModuleIdentifier moduleId, List<ModuleAvailabilityRegistrarListener> listeners) {
+            this.moduleId = moduleId;
+            this.listeners = listeners;
+        }
+
+        /**
+         * Set the initial value of current providers, immediately after registration
+         *
+         * @param currentProviders
+         */
+        public void setCurrentProviders(Set<GroupMember> currentProviders) {
+            this.providers = currentProviders;
+        }
+
+        /**
+         * Use the information on changes in providers to notifiy listeners that modules have been added or removed.
+         * NOTE: called even when the change in providers is locally initiated.
+         *
+         * @param providers the new set of group members providing the given service
+         */
+        @Override
+        public void providersChanged(Set<GroupMember> providers) {
+            // check if this module has been added or removed
+
+            // calculate providers which have not changed
+            Set<GroupMember> intersection = new HashSet<GroupMember>();
+            intersection.addAll(this.providers);
+            intersection.retainAll(providers);
+
+            // calculate providers which have left
+            Set<GroupMember> removed = new HashSet<GroupMember>();
+            removed.addAll(this.providers);
+            removed.removeAll(intersection);
+
+            // calculate providers which have appeared
+            Set<GroupMember> added = new HashSet<GroupMember>();
+            added.addAll(providers);
+            added.removeAll(intersection);
+
+            if (! added.isEmpty()) {
+                // some providers were added
+                for (ModuleAvailabilityRegistrarListener listener : this.listeners) {
+                    List<GroupMember> list = new ArrayList<GroupMember>();
+                    list.addAll(added);
+                    // EJBModuleIdentifier
+                    Map<DeploymentModuleIdentifier, List<GroupMember>> map = Map.of(moduleId, list);
+                    listener.modulesAvailable(map);
+                }
+            }
+
+            if (! removed.isEmpty()) {
+                // some providers were removed, advise our listeners
+                for (ModuleAvailabilityRegistrarListener listener : this.listeners) {
+                    List<GroupMember> list = new ArrayList<GroupMember>();
+                    list.addAll(removed);
+                    Map<DeploymentModuleIdentifier, List<GroupMember>> map = Map.of(moduleId, list);
+                    listener.modulesUnavailable(map);
+                }
+            }
+        }
+    }
+
+
+    /*
+     * This listener receives events concerning the local deployment repository and adds the information to the
+     * shared ServiceProviderRegistry.so that remote nodes can see what is deployed on this node.
+     */
+    class ModuleAvailabilityRegistrarDeploymentRepositoryListener implements DeploymentRepositoryListener {
+
+        /**
+         * Adjust the contents of the ServiceProviderRegistrar to account for a set of new deployment (possibly
+         * nt yet started).
+         *
+         * @param repository the deployment repository
+         */
+        @Override
+        public void listenerAdded (DeploymentRepository repository){
+            // get all deployments in the DeploymentRepository, started or not
+            Map<DeploymentModuleIdentifier, ModuleDeployment> availableModules = repository.getModules();
+            for (DeploymentModuleIdentifier moduleId : availableModules.keySet()){
+                // initialize the listener for the new service
+                ModuleAvailabilityRegistrarServiceProviderListener listener = new ModuleAvailabilityRegistrarServiceProviderListener(moduleId, listeners);
+                // register the new service
+                ServiceProviderRegistration<Object, GroupMember> registration = registrar.register(moduleId, listener);
+                // set the initial value of the providers
+                listener.setCurrentProviders(registration.getProviders());
+                // keep track of registrations
+                ModuleAvailabilityRegistrarService.this.registrations.putIfAbsent(moduleId, registration);
+            }
+        }
+
+        /**
+         * Adjust the contents of the ServiceProviderRegistrar to account for a new deployment (possibly
+         * not yet started).
+         *
+         * @param deployment The deployment
+         * @param moduleDeployment module deployment
+         */
+        @Override
+        public void deploymentAvailable (DeploymentModuleIdentifier deployment, ModuleDeployment moduleDeployment){
+            // add an entry to the ServiceProviderRegistrar
+
+            ServiceProviderRegistration<Object, GroupMember> registration = registrar.register(deployment);
+            // keep track of which services are registered
+            registrations.putIfAbsent(deployment, registration);
+
+        }
+
+        /**
+         * Adjust the contents of the ServiceProviderRegistrar to account for a new deployment which has now started.
+         *
+         * @param deployment The deployment
+         * @param moduleDeployment module deployment
+         */
+        @Override
+        public void deploymentStarted (DeploymentModuleIdentifier deployment, ModuleDeployment moduleDeployment){
+            // TODO: how do we differentiate between deployments whch have not started and those which have started?
+
+        }
+
+        /**
+         * Adjust the contents of the ServiceProviderRegistrar to account for a deployment which has been removed.
+         *
+         * @param deployment The deployment
+         */
+        @Override
+        public void deploymentRemoved (DeploymentModuleIdentifier deployment){
+            // get hod of the deployment's service registration
+            //ServiceProviderRegistration<Object, GroupMember> registration = ModuleAvailabilityRegistrarService.this.registrations.remove(deployment);
+            ServiceProviderRegistration<Object, GroupMember> registration = registrations.remove(deployment);
+            // close the registrarion
+            registration.close();
+        }
+
+        @Override
+        public void deploymentSuspended (DeploymentModuleIdentifier deployment){
+            // this method will be deprecated
+        }
+
+        @Override
+        public void deploymentResumed (DeploymentModuleIdentifier deployment){
+            // this method will be deprecated
+        }
+
+
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
@@ -8,9 +8,9 @@ package org.jboss.as.ejb3.remote;
 import org.jboss.as.controller.RequirementServiceTarget;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.DeploymentRepositoryService;
-//import org.jboss.as.ejb3.subsystem.EJB3RemoteResourceDefinition;
 import org.jboss.as.server.suspend.SuspendableActivityRegistry;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
 import org.wildfly.clustering.server.GroupMember;
 import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
@@ -18,7 +18,7 @@ import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.ServiceInstaller;
 import java.util.List;
 /**
- * Used to install a ModuleAvailabilityRegistrar service to support module avalability updates sent
+ * Used to install a ModuleAvailabilityRegistrar service to support module availability updates sent
  * to remote EJB clients.
  *
  * @author Richard Achmatowicz
@@ -31,7 +31,16 @@ public class ModuleAvailabilityRegistrarServiceInstaller implements ServiceInsta
         ServiceDependency<SuspendableActivityRegistry> activityRegistry = ServiceDependency.on(SuspendableActivityRegistry.SERVICE_DESCRIPTOR);
         // NOTE: choose the correct builder to avoid service installation issues (need a supplier builder here)
         return ServiceInstaller.builder(() -> new ModuleAvailabilityRegistrarService(activityRegistry, serviceProviderRegistrar, deploymentRepository))
+                // this service performs blocking operations
+                .blocking()
+                // and depends in start()/stop() methods
+                .onStart(ModuleAvailabilityRegistrarService::start)
+                .onStop(ModuleAvailabilityRegistrarService::stop)
                 .requires(List.of(deploymentRepository, serviceProviderRegistrar, activityRegistry))
+                // doesn't need a name but give it one anyway for debugging
+                .provides(ServiceName.parse("org.jboss.as.ejb3.remote.module-availability-registrar-service"))
+                // TODO: this service ideally needs to ON_DEMAND and made avaioable upon depoyment of one or more EJBs
+                .asActive()
                 .build()
                 .install(target);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
@@ -17,7 +17,6 @@ import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.ServiceInstaller;
 import java.util.List;
-
 /**
  * Used to install a ModuleAvailabilityRegistrar service to support module avalability updates sent
  * to remote EJB clients.
@@ -31,7 +30,7 @@ public class ModuleAvailabilityRegistrarServiceInstaller implements ServiceInsta
         ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = ServiceDependency.on(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
         ServiceDependency<SuspendableActivityRegistry> activityRegistry = ServiceDependency.on(SuspendableActivityRegistry.SERVICE_DESCRIPTOR);
         // NOTE: choose the correct builder to avoid service installation issues (need a supplier builder here)
-        return ServiceInstaller.builder(() -> new ModuleAvailabilityRegistrarService(activityRegistry.get(), serviceProviderRegistrar.get(), deploymentRepository.get()))
+        return ServiceInstaller.builder(() -> new ModuleAvailabilityRegistrarService(activityRegistry, serviceProviderRegistrar, deploymentRepository))
                 .requires(List.of(deploymentRepository, serviceProviderRegistrar, activityRegistry))
                 .build()
                 .install(target);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.controller.RequirementServiceTarget;
+import org.jboss.as.ejb3.deployment.DeploymentRepository;
+import org.jboss.as.ejb3.deployment.DeploymentRepositoryService;
+import org.jboss.as.ejb3.subsystem.EJB3RemoteResourceDefinition;
+import org.jboss.as.server.suspend.SuspendableActivityRegistry;
+import org.jboss.msc.service.ServiceController;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+import org.wildfly.subsystem.service.ServiceDependency;
+import org.wildfly.subsystem.service.ServiceInstaller;
+
+import java.util.List;
+
+/**
+ * Used to install a ModuleAvailabilityRegistrar service to support module avalability updates sent
+ * to remote EJB clients.
+ *
+ * @author Richard Achmatowicz
+ */
+public class ModuleAvailabilityRegistrarServiceInstaller implements ServiceInstaller {
+    @Override
+    public ServiceController<?> install(RequirementServiceTarget target) {
+        System.out.println("ModuleAvailabilityRegistrarServiceInstaller: calling install");
+        ServiceDependency<DeploymentRepository> deploymentRepository = ServiceDependency.on(DeploymentRepositoryService.SERVICE_NAME);
+        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = ServiceDependency.on(EJB3RemoteResourceDefinition.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
+        ServiceDependency<SuspendableActivityRegistry> activityRegistry = ServiceDependency.on(SuspendableActivityRegistry.SERVICE_DESCRIPTOR);
+        return ServiceInstaller.builder(new ModuleAvailabilityRegistrarService(activityRegistry.get(), serviceProviderRegistrar.get(), deploymentRepository.get()))
+                .requires(List.of(deploymentRepository, serviceProviderRegistrar, activityRegistry))
+                .build()
+                .install(target);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/ModuleAvailabilityRegistrarServiceInstaller.java
@@ -8,14 +8,14 @@ package org.jboss.as.ejb3.remote;
 import org.jboss.as.controller.RequirementServiceTarget;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.DeploymentRepositoryService;
-import org.jboss.as.ejb3.subsystem.EJB3RemoteResourceDefinition;
+//import org.jboss.as.ejb3.subsystem.EJB3RemoteResourceDefinition;
 import org.jboss.as.server.suspend.SuspendableActivityRegistry;
 import org.jboss.msc.service.ServiceController;
+import org.wildfly.clustering.ejb.remote.ModuleAvailabilityRegistrarProvider;
 import org.wildfly.clustering.server.GroupMember;
 import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.ServiceInstaller;
-
 import java.util.List;
 
 /**
@@ -27,11 +27,11 @@ import java.util.List;
 public class ModuleAvailabilityRegistrarServiceInstaller implements ServiceInstaller {
     @Override
     public ServiceController<?> install(RequirementServiceTarget target) {
-        System.out.println("ModuleAvailabilityRegistrarServiceInstaller: calling install");
         ServiceDependency<DeploymentRepository> deploymentRepository = ServiceDependency.on(DeploymentRepositoryService.SERVICE_NAME);
-        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = ServiceDependency.on(EJB3RemoteResourceDefinition.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
+        ServiceDependency<ServiceProviderRegistrar<Object, GroupMember>> serviceProviderRegistrar = ServiceDependency.on(ModuleAvailabilityRegistrarProvider.MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR);
         ServiceDependency<SuspendableActivityRegistry> activityRegistry = ServiceDependency.on(SuspendableActivityRegistry.SERVICE_DESCRIPTOR);
-        return ServiceInstaller.builder(new ModuleAvailabilityRegistrarService(activityRegistry.get(), serviceProviderRegistrar.get(), deploymentRepository.get()))
+        // NOTE: choose the correct builder to avoid service installation issues (need a supplier builder here)
+        return ServiceInstaller.builder(() -> new ModuleAvailabilityRegistrarService(activityRegistry.get(), serviceProviderRegistrar.get(), deploymentRepository.get()))
                 .requires(List.of(deploymentRepository, serviceProviderRegistrar, activityRegistry))
                 .build()
                 .install(target);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -28,9 +28,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.server.GroupMember;
 import org.wildfly.clustering.server.registry.Registry;
-import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
-import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.subsystem.resource.capability.CapabilityReference;
 
 import java.util.List;
@@ -53,9 +51,6 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
     @SuppressWarnings("unchecked")
     static final UnaryServiceDescriptor<Registry<GroupMember, String, List<ClientMapping>>> CLIENT_MAPPINGS_REGISTRY = UnaryServiceDescriptor.of("org.wildfly.ejb.remote.client-mappings-registry", (Class<Registry<GroupMember, String, List<ClientMapping>>>) (Class<?>) Registry.class);
-
-    @SuppressWarnings("unchecked")
-    public static final NullaryServiceDescriptor<ServiceProviderRegistrar<Object, GroupMember>> MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR = NullaryServiceDescriptor.of("org.wildfly.ejb.remote.module-availability-registrar-service-provider-registrar", (Class<ServiceProviderRegistrar<Object, GroupMember>>) (Class<?>) ServiceProviderRegistrar.class);
 
     static final RuntimeCapability<Void> EJB_REMOTE_CAPABILITY = RuntimeCapability.Builder.of(EJB_REMOTE_CAPABILITY_NAME)
             .setServiceType(Void.class)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -28,7 +28,9 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.server.GroupMember;
 import org.wildfly.clustering.server.registry.Registry;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
+import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.subsystem.resource.capability.CapabilityReference;
 
 import java.util.List;
@@ -51,6 +53,9 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
     @SuppressWarnings("unchecked")
     static final UnaryServiceDescriptor<Registry<GroupMember, String, List<ClientMapping>>> CLIENT_MAPPINGS_REGISTRY = UnaryServiceDescriptor.of("org.wildfly.ejb.remote.client-mappings-registry", (Class<Registry<GroupMember, String, List<ClientMapping>>>) (Class<?>) Registry.class);
+
+    @SuppressWarnings("unchecked")
+    public static final NullaryServiceDescriptor<ServiceProviderRegistrar<Object, GroupMember>> MODULE_AVAILABILITY_REGISTRAR_SERVICE_PROVIDER_REGISTRAR = NullaryServiceDescriptor.of("org.wildfly.ejb.remote.module-availability-registrar-service-provider-registrar", (Class<ServiceProviderRegistrar<Object, GroupMember>>) (Class<?>) ServiceProviderRegistrar.class);
 
     static final RuntimeCapability<Void> EJB_REMOTE_CAPABILITY = RuntimeCapability.Builder.of(EJB_REMOTE_CAPABILITY_NAME)
             .setServiceType(Void.class)

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -153,6 +153,11 @@
             <artifactId>wildfly-clustering-web-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-ejb3</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/ModuleAvailabilityRegistrarTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/ModuleAvailabilityRegistrarTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.moduleavailability;
+
+//import java.util.List;
+//import java.util.Map;
+import java.util.Set;
+import java.util.PropertyPermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.moduleavailability.bean.ModuleAvailabilityRegistrarRetriever;
+import org.jboss.as.test.clustering.cluster.ejb.moduleavailability.bean.ModuleAvailabilityRegistrarRetrieverBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+// import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class ModuleAvailabilityRegistrarTestCase extends AbstractClusteringTestCase {
+    private static final String MODULE_NAME = ModuleAvailabilityRegistrarTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment();
+    }
+
+    /*
+     * An EJB deployment which has two functions:
+     * - to allow a remote client to interrgate the ModuleAvailabilityRegistrar
+     * - to represent a generic deployment on the server which provides content for the ModuleAvailabilityRegistrar
+     */
+    private static Archive<?> createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
+                .addPackage(ModuleAvailabilityRegistrarRetrieverBean.class.getPackage())
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read"), new RuntimePermission("getClassLoader")), "permissions.xml")
+                ;
+    }
+
+    @Test
+    public void test() throws Exception {
+        this.test(ModuleAvailabilityRegistrarRetrieverBean.class);
+    }
+
+    public void test(Class<? extends ModuleAvailabilityRegistrarRetriever> beanClass) throws Exception {
+        try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
+            ModuleAvailabilityRegistrarRetriever bean = context.lookupStateless(beanClass, ModuleAvailabilityRegistrarRetriever.class);
+            // test the ModuleAvailabilityRegistrar ServiceProviderRegistry behaviour
+
+            Set<String> modules = bean.getServices();
+            assertEquals(2, modules.size());
+//            assertTrue(names.toString(), names.contains(NODE_1));
+//            assertTrue(names.toString(), names.contains(NODE_2));
+
+            undeploy(DEPLOYMENT_1);
+
+            modules = bean.getServices();
+            assertEquals(1, modules.size());
+//            assertTrue(names.contains(NODE_2));
+
+            deploy(DEPLOYMENT_1);
+
+            modules = bean.getServices();
+            assertEquals(2, modules.size());
+//            assertTrue(names.contains(NODE_1));
+//            assertTrue(names.contains(NODE_2));
+
+            stop(NODE_2);
+
+            modules = bean.getServices();
+            assertEquals(1, modules.size());
+//            assertTrue(names.contains(NODE_1));
+
+            start(NODE_2);
+
+            modules = bean.getServices();
+            assertEquals(2, modules.size());
+//            assertTrue(names.contains(NODE_1));
+//            assertTrue(names.contains(NODE_2));
+
+        }
+    }
+
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarBean.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.moduleavailability.bean;
+
+import java.util.Set;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.Local;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+
+import org.wildfly.clustering.server.Group;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistration;
+import org.wildfly.clustering.server.provider.ServiceProviderListener;
+
+/**
+ * An EJB wrapper for the ServiceProviderRegistrar instance used by the ModuleAvailabilityListenerService which manages
+ * module availability updates to EJB clients.
+ */
+@Singleton
+@Startup
+@Local(ServiceProviderRegistrar.class)
+public class ModuleAvailabilityRegistrarBean implements ServiceProviderRegistrar<Object, GroupMember>, ServiceProviderListener<GroupMember> {
+
+    // inject the ServiceProviderRegistrar instance used by ModuleAvailabilityRegistrarService
+    @Resource(name = "java:jboss/clustering/server/service-provider-registrar/ejb/module-availability")
+    ServiceProviderRegistrar<Object, GroupMember> registrar;
+
+    // ServiceProviderRegistrar interface
+    @Override
+    public Group<GroupMember> getGroup() {
+        return registrar.getGroup();
+    }
+
+    @Override
+    public ServiceProviderRegistration<Object, GroupMember> register(Object service) {
+        return registrar.register(service);
+    }
+
+    @Override
+    public ServiceProviderRegistration<Object, GroupMember> register(Object service, ServiceProviderListener<GroupMember> listener) {
+        return registrar.register(service, listener);
+    }
+
+    @Override
+    public Set<GroupMember> getProviders(Object service) {
+        return registrar.getProviders(service);
+    }
+
+    @Override
+    public Set<Object> getServices() {
+        return registrar.getServices();
+    }
+
+    // ServiceProviderRegistrarListener interface
+    @Override
+    public void providersChanged(Set<GroupMember> providers) {
+        System.out.println("Providers changed: " + providers);
+    }
+
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarRetriever.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarRetriever.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.moduleavailability.bean;
+
+import java.util.Set;
+
+/**
+ * Interface for gaining remote access to the ModuleAvailabilityRegistrar ServiceProviderRegistry contents.
+ */
+public interface ModuleAvailabilityRegistrarRetriever {
+    Set<String> getServices() ;
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarRetrieverBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/moduleavailability/bean/ModuleAvailabilityRegistrarRetrieverBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.cluster.ejb.moduleavailability.bean;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import jakarta.ejb.EJB;
+import jakarta.ejb.Remote;
+import jakarta.ejb.Stateless;
+
+import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
+import org.wildfly.clustering.server.GroupMember;
+import org.wildfly.clustering.server.provider.ServiceProviderRegistrar;
+
+/**
+ * A stateless bean which provides remote access to the ServiceProviderRegistrar instance of the ModuleAvaiabilityRegistrar
+ * service.
+ */
+@Stateless
+@Remote(ModuleAvailabilityRegistrarRetriever.class)
+public class ModuleAvailabilityRegistrarRetrieverBean implements ModuleAvailabilityRegistrarRetriever {
+
+    @EJB
+    ServiceProviderRegistrar<Object, GroupMember> registrar;
+
+    @Override
+    public Set<String> getServices() {
+        Set<String> deployedModules = new HashSet();
+        System.out.println("Calling getServices()");
+        for (Object module : registrar.getServices()) {
+            // cast each registered service to DeploymentModuleIdentifier
+            String moduleId = ((DeploymentModuleIdentifier) module).toString();
+            deployedModules.add(moduleId);
+        }
+        return deployedModules;
+    }
+}


### PR DESCRIPTION
This PR is does the following:
- adds a new resource to the distributable-ejb subsystem, a module availability registrar provider
- allows the ejb3 subsystem to install amn instance of the registrar to store module deployment information across the cluster
- integrates the registrar with the deployment repository to (1) populate its values and (2) move suspend resume awareness from the deployment repository to the module availability registrar
-  use the values of the module avaipability registrar to (1) generate module updates for  EJB client applications and (2) populate discovery requests for EJB/HTTP discovery

For more information, see: https://issues.redhat.com/browse/WFLY-20091