### PR TITLE
WFLY-20364 Upgrade SmallRye Fault Tolerance from 6.7.3 to 6.8.0

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -684,6 +684,17 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-apiimpl</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
                 <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
                 <exclusions>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -95,6 +95,10 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-apiimpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
         </dependency>
         <dependency>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/fault-tolerance/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/fault-tolerance/main/module.xml
@@ -14,6 +14,7 @@
     <resources>
         <artifact name="${io.smallrye:smallrye-fault-tolerance}"/>
         <artifact name="${io.smallrye:smallrye-fault-tolerance-api}"/>
+        <artifact name="${io.smallrye:smallrye-fault-tolerance-apiimpl}"/>
         <artifact name="${io.smallrye:smallrye-fault-tolerance-autoconfig-core}"/>
         <artifact name="${io.smallrye:smallrye-fault-tolerance-core}"/>
     </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.6.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.9.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.7.3</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.8.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.6.2</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20364