### PR TITLE
[WFLY-20378] Task. Decouple test product-conf module version from the…

### DIFF
--- a/testsuite/aggregator-base/pom.xml
+++ b/testsuite/aggregator-base/pom.xml
@@ -63,12 +63,12 @@
                 <module>../integration/rts</module>
                 <module>../integration/rbac</module>
                 <module>../integration/multinode</module>
+                <module>../test-product-conf</module> <!-- needed by manualmode -->
                 <module>../integration/manualmode</module>
                 <module>../integration/secman</module>
                 <module>../integration/legacy</module>
                 <module>../domain</module>
                 <module>../scripts</module>
-                <module>../test-product-conf</module>
             </modules>
         </profile>
 

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -350,7 +350,7 @@
         <dependency>
             <groupId>${ee.maven.groupId}</groupId>
             <artifactId>wildfly-ee-feature-pack-product-conf</artifactId>
-            <version>100000.0.1.Final-SNAPSHOT</version>
+            <version>100000.0.1.TEST-stable-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/testsuite/integration/manualmode/src/test/resources/filtered/product-conf-override-manifest.yaml
+++ b/testsuite/integration/manualmode/src/test/resources/filtered/product-conf-override-manifest.yaml
@@ -7,4 +7,4 @@ description: "Manifest for testing overriding the org.wildfly:wildfly-ee-feature
 streams:
   - groupId: "${project.groupId}"
     artifactId: "wildfly-ee-feature-pack-product-conf"
-    version: "100000.0.1.Final-SNAPSHOT"
+    version: "100000.0.1.TEST-stable-SNAPSHOT"

--- a/testsuite/test-product-conf/pom.xml
+++ b/testsuite/test-product-conf/pom.xml
@@ -26,13 +26,41 @@
         with the same GA.</description>
 
     <artifactId>wildfly-ee-feature-pack-product-conf</artifactId>
-    <!-- DO NOT CHANGE THIS. It's a fixed, deliberate value for this test-only artifact
-         chosen to avoid interferin with the release artifact with the same GA.
-         Other test infrastructure (e.g. a custom channel manifest) relies on this value. -->
-    <version>100000.0.1.Final-SNAPSHOT</version>
+    <!-- This version is a deliberate value for this test-only artifact
+         chosen to avoid interfering with the release artifact with the same GA.-->
+    <version>100000.0.1.TEST-SNAPSHOT</version>
 
     <build>
         <plugins>
+            <plugin>
+                <!--
+                    This is a test-only artifact with a never-changing version.
+                    The artifact version is decoupled from this module version to keep it always stable
+                    since this test artifact is used in other tests that rely on this version.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>custom-product-conf-install</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>100000.0.1.TEST-stable-SNAPSHOT</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
… installed artifact version

Jira issue: https://issues.redhat.com/browse/WFLY-20378

This change will allow us to always install the test product-conf artifact under a stable version number, independently of the module version that produces this artifact. It will make it more resilient to product version alignments.
