### PR TITLE
[WFLY-20390] Upgrade WildFly Core to 28.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>5.0.4.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>28.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>28.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20390

Note: There is no Beta2 release available. I had to discard it and go straight to Beta3.

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/28.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/28.0.0.Beta1...28.0.0.Beta3

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7151'>WFCORE-7151</a>] -         Upgrade WildFly Galleon Plugins to 7.3.1.Final
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7102'>WFCORE-7102</a>] -         AccessDeniedException on Windows when using a read-only configuration dir
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7153'>WFCORE-7153</a>] -         CVE-2025-23367 org.wildfly.core/wildfly-server: Wildfly improper RBAC permission
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7116'>WFCORE-7116</a>] -         Remove ModuleIdentifier from Extension handling
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7143'>WFCORE-7143</a>] -         Consolidate HostControllerBootstrap and EmbeddedHostControllerBootstrap
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7149'>WFCORE-7149</a>] -         Deprecate for removal the last public constructor of server&#39;s ModuleDependency class
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7150'>WFCORE-7150</a>] -         Remove deprecated Attachments.ADDITIONAL_ANNOTATION_INDEXES
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6846'>WFCORE-6846</a>] -         Upgrade commons-daemon to 1.4.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7155'>WFCORE-7155</a>] -         Upgrade io.smallrye:jandex from 3.2.3 to 3.2.4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7156'>WFCORE-7156</a>] -         Upgrade WildFly Maven Plugin to 5.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7157'>WFCORE-7157</a>] -         Upgrade io.smallrye:jandex from 3.2.4 to 3.2.5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7158'>WFCORE-7158</a>] -         Upgrade commons-daemon to 1.4.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7159'>WFCORE-7159</a>] -         Upgrade io.smallrye:jandex from 3.2.5 to 3.2.6
</li>
</ul>
</details>

