### PR TITLE
[WFLY-20393] Ensure that only one bytecode transformer is added for each Persistence Unit (also includes [WFLY-20394])

### DIFF
--- a/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceUnitMetadata.java
+++ b/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceUnitMetadata.java
@@ -90,4 +90,6 @@ public interface PersistenceUnitMetadata extends PersistenceUnitInfo {
 
     List<ClassTransformer> getTransformers();
 
+    boolean needsJPADelegatingClassFileTransformer();
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.ValidationMode;
@@ -99,6 +100,8 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     private volatile ClassLoader cachedTempClassLoader;
 
     private volatile Map<URL, Index> annotationIndex;
+
+    private final AtomicBoolean needsJPADelegatingClassFileTransformer = new AtomicBoolean(false);
 
     @Override
     public void setPersistenceUnitName(String name) {
@@ -377,6 +380,12 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     @Override
     public List<ClassTransformer> getTransformers() {
         return transformers;
+    }
+
+    @Override
+    public boolean needsJPADelegatingClassFileTransformer() {
+        // WFLY-20393 Ensure that only one internal JPADelegatingClassFileTransformer bytecode transformer is configured for each Persistence Unit
+        return needsJPADelegatingClassFileTransformer.compareAndSet(false, true);
     }
 
     @Override

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -757,4 +757,15 @@ public interface JpaLogger extends BasicLogger {
     @Message(id = 75, value="Illegal to call this method from injected, managed EntityManager")
     IllegalStateException illegalCallOnCloseMethod();
 
+    /**
+     * Logs warning that a mix of bytecode enhanced + non-enhanced in this deployment was detected.
+     * Also see discussion on https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/ORM.20bytecode.20enhancement.20.2B.20WildFly if possible.
+     * Also see https://hibernate.atlassian.net/browse/HHH-19168 + https://hibernate.atlassian.net/browse/HHH-19169
+     *
+     * @param scopedPuNames comma separated list of fully scoped persistence unit names that are non-enhanced
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 76, value = "Some persistence units are configured to be bytecode enhanced but persistence unit(s) { %s } are configured to disable bytecode enhancement.  Bytecode enhancement will be performed.  Consider making all of the persistence units use bytecode enhancement.")
+    void mixedEnhancedAndNotEnhanced(String scopedPuNames);
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -52,6 +52,9 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
                         }
                     }
                 }
+                if ( pu.needsJPADelegatingClassFileTransformer()) {
+                    transformer.addTransformer(new JPADelegatingClassFileTransformer(pu));
+                }
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20393
https://issues.redhat.com/browse/WFLY-20394 also was added which covers `Ensure that bytecode enhancement only happens if all persistence units allow bytecode enhancement`
____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> Wildfly issue links:
> * [WFLY-20394](https://issues.redhat.com/browse/WFLY-20394)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)