### PR TITLE
WFLY-20369 Document manual provisioning of external JGroups protocols to WildFly-managed stacks and document usage of JGroups Raft project

### DIFF
--- a/check_logging.sh
+++ b/check_logging.sh
@@ -32,7 +32,7 @@ while IFS= read -r line; do
   fi
 
   if [[ "$line" =~ ^\+[^+] ]]; then
-    # Ignore lines in the test directories
+    # Ignore lines in the docs and test directories
     if [[ "$CURRENT_FILE" != *"docs/"* && "$CURRENT_FILE" != *"src/test/"* && "$CURRENT_FILE" != *"testsuite/"* && "$CURRENT_FILE" != *"check_logging.sh"* ]]; then
       # Check for any of the patterns, ensuring "//" doesn't precede them
       for pattern in "${PATTERNS[@]}"; do

--- a/docs/src/main/asciidoc/_high-availability/JGroups.adoc
+++ b/docs/src/main/asciidoc/_high-availability/JGroups.adoc
@@ -19,3 +19,7 @@ include::jgroups/Kubernetes.adoc[]
 include::jgroups/AWS-Discovery.adoc[]
 
 // TODO Discovery in Azure
+
+== External Protocols
+
+include::jgroups/External_Protocols.adoc[]

--- a/docs/src/main/asciidoc/_high-availability/advanced-topics/Marshalling.adoc
+++ b/docs/src/main/asciidoc/_high-availability/advanced-topics/Marshalling.adoc
@@ -72,7 +72,7 @@ e.g.
 [source,java]
 ----
 @AutoProtoSchemaBuilder(includeClasses = { Person.class })
-public interface PersonInitalizer extends SerializationContextInitializer {
+public interface PersonInitializer extends SerializationContextInitializer {
 }
 
 public class Person {

--- a/docs/src/main/asciidoc/_high-availability/jgroups/External_Protocols.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/External_Protocols.adoc
@@ -1,0 +1,120 @@
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+=== Adding an External Module
+
+Any JGroups protocol implementing `org.jgroups.stack.Protocol` can be added to the stack.
+While WildFly provides a multitude of JGroups protocols out-of-the-box,
+users sometimes require the addition of external protocols.
+The JGroups community also manages a GitHub organization named https://github.com/jgroups-extras[jgroups-extras] where source code
+for some of these projects is hosted.
+
+In order to use these protocols from WildFly,
+an archive containing the protocols needs to be added as a module,
+and subsequently referenced from the protocol resource definition.
+
+First, locate the desired `jar` on the file system, boot the server and connect to it via the JBoss CLI.
+Update the following command with the module name, set of module dependencies (including `org.jgroups` module)
+and path to the archive.
+
+[source,options="nowrap"]
+----
+module add --name=com.acme.jgroups \
+           --dependencies=org.jgroups \
+           --resources=acme-jgroups.jar
+----
+
+Now, add the protocol from the newly added module to the stack, referencing that module:
+
+[source,options="nowrap"]
+----
+/subsystem=jgroups/stack=tcp/protocol=com.acme.jgroups.MYPROTOCOL:add(module="com.acme.jgroups")
+----
+
+Reload the server and the new protocol is now in operation.
+
+==== JGroups Raft
+
+// EDITOR NOTES: 'Raft', never 'RAFT', is the correct stylization of the consensus algorithm name and our JGroups project name.
+// https://raft.github.io/
+// The all-caps RAFT refers to the protocol name used in the stack configuration only.
+// It's also only one of several protocols that make up the complete implementation.
+
+JGroups Raft is a library implementing the Raft algorithm in JGroups.
+It provides features such as configurable leader election,
+dynamic membership changes in a single step,
+member deduplication, and request redirection.
+The implementation is verified with Jepsen.
+
+The simplest way to use JGroups Raft from WildFly is to use analogous commands to the above.
+First, fetch the protocol archive from Maven to the local repository.
+
+[source,bash]
+----
+mvn dependency:get -Dartifact=org.jgroups:jgroups-raft:1.1.4.Final
+----
+
+Now, boot the server and connect the CLI and add the module:
+
+[source,options="nowrap"]
+----
+module add --name=org.jgroups.raft \
+           --dependencies=org.jgroups \
+           --resources=~/.m2/repository/org/jgroups/jgroups-raft/1.1.4.Final/jgroups-raft-1.1.4.Final.jar
+----
+
+To add the protocols to the stack, run the following CLI commands updating the stack name to the intended stack.
+This example updated the default `udp` stack.
+Note that `NO_DUPES` needs to be positioned below `GMS` in the protocol stack,
+so use `add-index` to specify the correct position (the index depends on the stack configuration).
+
+[source,options="nowrap"]
+----
+batch
+/subsystem=jgroups/stack=udp/protocol=raft.NO_DUPES:add(module="org.jgroups.raft", add-index=9)
+/subsystem=jgroups/stack=udp/protocol=raft.ELECTION:add(module="org.jgroups.raft")
+/subsystem=jgroups/stack=udp/protocol=raft.RAFT:add(module="org.jgroups.raft", properties={members="node-1,node-2",raft_id="node-1"})
+/subsystem=jgroups/stack=udp/protocol=raft.REDIRECT:add(module="org.jgroups.raft")
+/subsystem=jgroups/stack=udp/protocol=raft.CLIENT:add(module="org.jgroups.raft")
+run-batch
+----
+
+NOTE: Remember to provide a unique `raft_id` for each cluster member.
+
+As a quick example usage from a deployment, inject the `ChannelFactory` to create a channel
+and obtain a `RaftHandle` for interacting with JGroups Raft
+from a component that is started with the deployment (e.g. a `@PostConstruct` in a `@WebServlet(loadOnStartup = 1, ...)`):
+
+[source,java]
+----
+@Resource(lookup = "java:jboss/jgroups/factory/default")
+private ChannelFactory channelFactory;
+
+// ...
+
+JChannel channel = channelFactory.createChannel("raft");
+RaftHandle raftHandle = new RaftHandle(channel, stateMachine);
+channel.connect("raft-cluster");
+log.infof("Leader is: %s", raftHandle.leader());
+----
+
+For advanced configuration options, please visit JGroups Raft's https://jgroups-extras.github.io/jgroups-raft/manual/index.html[manual]
+or its https://jgroups-extras.github.io/jgroups-raft/[website].
+
+////
+For editor's convenience, run this batch to rollback changes from the stack:
+
+batch
+/subsystem=jgroups/stack=udp/protocol=raft.CLIENT:remove
+/subsystem=jgroups/stack=udp/protocol=raft.REDIRECT:remove
+/subsystem=jgroups/stack=udp/protocol=raft.RAFT:remove
+/subsystem=jgroups/stack=udp/protocol=raft.ELECTION:remove
+/subsystem=jgroups/stack=udp/protocol=raft.NO_DUPES:remove
+run-batch
+
+////


### PR DESCRIPTION
Resolves
https://redhat.atlassian.net/browse/WFLY-20369

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20369](https://issues.redhat.com/browse/WFLY-20369)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)