### PR TITLE
[WFLY-20400] Add the org.jboss.weld:weld-api to MicroProfile REST Cli…

### DIFF
--- a/testsuite/integration/microprofile-tck/rest-client/pom.xml
+++ b/testsuite/integration/microprofile-tck/rest-client/pom.xml
@@ -156,6 +156,11 @@
         <!-- End permission requirement -->
 
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
…ent TCK.

https://issues.redhat.com/browse/WFLY-20400

This is a failure on Java 24 and 25 only. I"m not entirely sure how it passes on older JVM's, but this dependency seems to be needed.
