### PR TITLE
Tie the TS build-demander modules to their associated aggregator modules

### DIFF
--- a/testsuite/aggregator-base/pom.xml
+++ b/testsuite/aggregator-base/pom.xml
@@ -34,6 +34,15 @@
     <description>Controls execution of testsuite modules relevant to testing functionality
                  available via the wildfly-ee-galleon-pack feature pack</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-ts-build-demander-base</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
     <profiles>
 
         <!-- -Dts.smoke -->

--- a/testsuite/aggregator-expansion/pom.xml
+++ b/testsuite/aggregator-expansion/pom.xml
@@ -34,6 +34,15 @@
     <description>Controls execution of testsuite modules relevant to testing functionality
         available via the wildfly-galleon-pack feature pack artifact.</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>${ee.maven.groupId}</groupId>
+            <artifactId>wildfly-ts-build-demander-expansion</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
 
     <profiles>
 

--- a/testsuite/aggregator-preview/pom.xml
+++ b/testsuite/aggregator-preview/pom.xml
@@ -34,6 +34,15 @@
     <description>Controls execution of testsuite modules relevant to testing functionality
         available via the wildfly-preview feature pack</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>${full.maven.groupId}</groupId>
+            <artifactId>wildfly-ts-build-demander-preview</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
 
     <profiles>
 


### PR DESCRIPTION
Currently testsuite/pom.xml executes the build-demander modules before the aggregator modules, but the aggregator modules don't demand on them, so if they fail the tests try and run (and fail.)

The intent here is if the production code build fails for some reason, then the build-demander will skipped, and in turn the aggregator will be skipped, preventing execution of the testsuite modules.


Initially a draft to see what blows up from this.