### PR TITLE
[WFLY-20420] Make the undertow extension dependency on org.wildfly.ev…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -73,7 +73,7 @@
         <module name="org.jboss.xnio"/>
         <module name="org.jboss.xnio.nio" services="import"/>
         <module name="org.wildfly.http-client.common"/>
-        <module name="org.wildfly.event.logger" optional="true"/>
+        <module name="org.wildfly.event.logger"/>
         <module name="org.wildfly.common" optional="true"/>
         <module name="org.wildfly.service"/>
         <module name="org.wildfly.subsystem"/>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -52,8 +52,6 @@ public abstract class LayersTestBase {
             "org.hornetq.client",
             // TODO we need to add an xts layer
             "org.jboss.as.xts",
-            // TODO should an undertow layer specify this?
-            "org.wildfly.event.logger",
     };
 
     /**


### PR DESCRIPTION
…ent.logger non-optional

ls tells me this will only add ~ 15.5k bytes to an installation, while doing it allows a slimmed server to configure the console access log

https://issues.redhat.com/browse/WFLY-20420