### PR TITLE
WFLY-20440 Fix domain-standard.xml to comply with the messaging-activemq subsystem schema.

### DIFF
--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -586,8 +586,8 @@
             <subsystem xmlns="urn:jboss:domain:messaging-activemq:13.0">
                 <server name="default"
                         persistence-enabled="false">
-                    <journal file-size="1024" />
                     <security elytron-domain="ApplicationDomain"/>
+                    <journal file-size="1024" />
                     <security-setting name="#">
                         <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                     </security-setting>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -300,8 +300,8 @@
             <subsystem xmlns="urn:jboss:domain:messaging-activemq:13.0">
                 <server name="default"
                         persistence-enabled="false">
-                    <journal file-size="1024" />
                     <security elytron-domain="ApplicationDomain"/>
+                    <journal file-size="1024" />
                     <security-setting name="#">
                         <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                     </security-setting>
@@ -657,8 +657,8 @@
             <subsystem xmlns="urn:jboss:domain:messaging-activemq:13.0">
                 <server name="default"
                         persistence-enabled="false">
-                    <journal file-size="1024" />
                     <security elytron-domain="ApplicationDomain"/>
+                    <journal file-size="1024" />
                     <security-setting name="#">
                         <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                     </security-setting>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20440

As seen in https://ci.wildfly.org/buildConfiguration/WildFlyCore_PullRequest_WildFlyCorePreviewIntegrationLinuxJdk21/490069

Elements of a <server/> are ordered, and this test XML does not comply with that order.