### PR TITLE
[WFLY-20449] Upgrade WildFly Core to 28.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,7 +518,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>6.0.0.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>28.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>28.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.0.7.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20449

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/28.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/28.0.0.Beta3...28.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6937'>WFCORE-6937</a>] -         Testing of write-attribute calls is low for the Elytron subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7160'>WFCORE-7160</a>] -         &quot;grep: warning: stray \ before :&quot; at console after server startup with GC_LOG=true
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7061'>WFCORE-7061</a>] -         Bump the kernel management API version to 29.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7170'>WFCORE-7170</a>] -         Reduce ModuleIdentifier usage from Server module
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7142'>WFCORE-7142</a>] -         Upgrade BouncyCastle from 1.79 to 1.80
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7162'>WFCORE-7162</a>] -         Upgrade snakeyaml to 2.4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7164'>WFCORE-7164</a>] -         [GSS](7.4.z) Upgrade commons-io from 2.10.0 to 2.14.0 or later
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7165'>WFCORE-7165</a>] -         Upgrade io.smallrye:jandex from 3.2.6 to 3.2.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7166'>WFCORE-7166</a>] -         Upgrade Galleon to 6.0.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7168'>WFCORE-7168</a>] -         Upgrade Elytron EE to 3.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7174'>WFCORE-7174</a>] -         Upgrade jboss-logging-tools to 3.0.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7177'>WFCORE-7177</a>] -         Upgrade SSHD from 2.14.0 to 2.15.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7179'>WFCORE-7179</a>] -         Upgrade Elytron EE to 3.1.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7180'>WFCORE-7180</a>] -         Upgrade WildFly Elytron to 2.6.1.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7161'>WFCORE-7161</a>] -         Improve deployment message on duplicate runtime name
</li>
</ul>
</details>

