### PR TITLE
[WFLY-20490]: Upgrade Apache Artemis to 2.40.0.

### DIFF
--- a/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/AttributeDefaultsTest.java
+++ b/messaging-activemq/subsystem/src/test/java/org/wildfly/extension/messaging/activemq/AttributeDefaultsTest.java
@@ -24,7 +24,7 @@ public class AttributeDefaultsTest extends AbstractSubsystemTest {
     @Test
     public void testAttributeValues() {
         Assert.assertNotEquals(ServerDefinition.GLOBAL_MAX_DISK_USAGE.getName(), ServerDefinition.GLOBAL_MAX_DISK_USAGE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMaxDiskUsage());
-        Assert.assertNotEquals(ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getName(), ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMaxGlobalSize());
+        Assert.assertNotEquals(ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getName(), ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMaxGlobalSizeAsPercentOfJvmMaxMemory(ActiveMQDefaultConfiguration.DEFAULT_GLOBAL_MAX_MEMORY_PERCENT));
         Assert.assertNotEquals(ServerDefinition.JOURNAL_POOL_FILES.getName(), ServerDefinition.JOURNAL_POOL_FILES.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalPoolFiles());
 //        Assert.assertNotEquals(ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.getName(), ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize());
 

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.38.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.40.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.0</version.org.apache.avro>
         <version.org.apache.cxf>4.0.6</version.org.apache.cxf>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/PrintDataTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/PrintDataTestCase.java
@@ -63,12 +63,15 @@ public class PrintDataTestCase {
     private static final Pattern ADDRESS_ID = Pattern.compile(";userRecordType=44;isUpdate=false;compactCount=0;"
             + "PersistentAddressBindingEncoding \\[id=([0-9]+), name=jms.queue.PrintDataTestCase-Queue, "
             + "routingTypes=\\{ANYCAST\\}, autoCreated=false, internal=false\\]");
-    private static final Pattern QUEUE_ID = Pattern.compile("^recordID=[0-9]+;userRecordType=21;isUpdate=false;compactCount=0;PersistentQueueBindingEncoding "
-            + "\\[id=([0-9]+), name=jms.queue.PrintDataTestCase-Queue, address=jms.queue.PrintDataTestCase-Queue, filterString=null, "
-            + "user=null, autoCreated=false, maxConsumers=-1, purgeOnNoConsumers=false, enabled=true, exclusive=false, lastValue=false,"
-            + " lastValueKey=null, nonDestructive=false, consumersBeforeDispatch=0, delayBeforeDispatch=-1, routingType=1, "
-            + "configurationManaged=false, groupRebalance=false, groupRebalancePauseDispatch=false, groupBuckets=-1, groupFirstKey=null, "
-            + "autoDelete=false, autoDeleteDelay=0, autoDeleteMessageCount=0, internal=false\\]");
+    private static final Pattern QUEUE_ID = Pattern.compile("^recordID=[0-9]+;userRecordType=21;isUpdate=false;"
+            + "compactCount=0;PersistentQueueBindingEncoding \\[queueConfiguration=QueueConfiguration \\[id=([0-9]+), "
+            + "name=jms.queue.PrintDataTestCase-Queue, address=jms.queue.PrintDataTestCase-Queue, routingType=ANYCAST, "
+            + "filterString=null, durable=null, user=null, maxConsumers=-1, exclusive=false, groupRebalance=false, "
+            + "groupRebalancePauseDispatch=false, groupBuckets=-1, groupFirstKey=null, lastValue=false, "
+            + "lastValueKey=null, nonDestructive=false, purgeOnNoConsumers=false, enabled=true, "
+            + "consumersBeforeDispatch=0, delayBeforeDispatch=-1, consumerPriority=null, autoDelete=false, "
+            + "autoDeleteDelay=0, autoDeleteMessageCount=0, ringSize=-1, configurationManaged=false, temporary=null, "
+            + "autoCreateAddress=null, internal=false, transient=null, autoCreated=false, fqqn=null\\]\\]");
     private static final Pattern SAFE_QUEUE_COUNT = Pattern.compile("queue id [0-9]+,count=1");
 
     @ContainerResource


### PR DESCRIPTION
 * Upgrading Apache Artemis from 2.38.0 to 2.40.0
 * Changing test as the default value is no longer defined in the 'same' way.

Jira: https://issues.redhat.com/browse/WFLY-20490

https://activemq.apache.org/components/artemis/download/release-notes-2.40.0
https://activemq.apache.org/components/artemis/download/release-notes-2.39.0