### PR TITLE
[WFLY-20496] Upgrade to Hibernate Search 7.2.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.6.7.Final</version.org.hibernate>
-        <version.org.hibernate.search>7.2.2.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>7.2.3.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.2.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>15.1.7.Final</version.org.infinispan>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20496

This release has a fix for a sorting bug in the Lucene backend.