### PR TITLE
Fix for WFLY-20501, Upgrade WildFly Glow to 1.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
-        <version.org.wildfly.glow>1.3.0.Final</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.4.0.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.0.Final</version.org.wildfly.unstable.annotation.api>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20501
This upgrade fixes the https://issues.redhat.com/browse/WFLY-20499 issue.
