### PR TITLE
WFLY-20466 Upgrade wildfly-clustering to 6.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <version.org.jboss.ws.spi>5.0.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>4.0.5</version.org.jctools.jctools-core>
-        <version.org.jgroups>5.3.15.Final</version.org.jgroups>
+        <version.org.jgroups>5.3.16.Final</version.org.jgroups>
         <version.org.jgroups.aws>3.0.1.Final</version.org.jgroups.aws>
         <version.org.jgroups.azure>2.0.2.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>2.0.2.Final</version.org.jgroups.kubernetes>
@@ -519,7 +519,7 @@
         <version.org.opensaml.opensaml>4.3.2</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>6.0.0.Final</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>6.0.1.Final</version.org.wildfly.clustering>
         <version.org.wildfly.core>28.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20466

Fixes [WFLY-20464](https://issues.redhat.com/browse/WFLY-20464)