### PR TITLE
[WFLY-20505] Upgrade WildFly Core to 28.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>6.0.0.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>28.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>28.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20505

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/28.0.0.Beta6
Diff: https://github.com/wildfly/wildfly-core/compare/28.0.0.Beta5...28.0.0.Beta6

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6779'>WFCORE-6779</a>] -         PersistentResourceXMLDescription is hot garbage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7188'>WFCORE-7188</a>] -         AddResourceOperationStepHandler not detecting that current resource is a required child of parent
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7195'>WFCORE-7195</a>] -         PersistentResourceXMLParserTestCase.MyParser model is not consistent with its PersistentResourceXMLDescription
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7196'>WFCORE-7196</a>] -         PersistentResourceXMLDescription of elytron subsystem contains duplicate attributes/children
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7198'>WFCORE-7198</a>] -         AttributeParsers.MapParser leaves reader in inconsistent state when no wrapping element is present
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7197'>WFCORE-7197</a>] -         IgnoreResourcesTestCase creates invalid io subsystem configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7199'>WFCORE-7199</a>] -         Migrate IO subsystem to SubsystemResourceXMLSchema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7200'>WFCORE-7200</a>] -         Migrate discovery subsystem to SubsystemResourceXMLSchema
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7194'>WFCORE-7194</a>] -         Upgrade JBoss Remoting to 5.0.31.Final
</li>
</ul>
</details>
