### PR TITLE
[WFLY-20521] Added a test to ensure CDI integration works with Jakart…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/AbstractManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/AbstractManagedInjectionTestCase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import java.util.PropertyPermission;
+
+import jakarta.inject.Inject;
+import org.hibernate.validator.HibernateValidatorPermission;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class AbstractManagedInjectionTestCase {
+    private static final String PERSISTENCE_XML = """
+            <persistence xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                                             https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+                version="3.0">
+                <persistence-unit name="test">
+                    <jta-data-source>%s</jta-data-source>
+                    <properties>
+                        <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create" />
+                        %s
+                    </properties>
+                </persistence-unit>
+            </persistence>
+            """;
+
+    @Inject
+    private UserRegistry userRegistry;
+
+    @Inject
+    private UserCollector collector;
+
+    @Before
+    public void cleanup() {
+        collector.clear();
+    }
+
+    static WebArchive createDeployment() {
+        return createDeploymentWithPersistenceXml(String.format(PERSISTENCE_XML, "java:comp/DefaultDataSource", ""));
+    }
+
+    static WebArchive createDeployment(final boolean enhance) {
+        final String property = String.format("<property name=\"jboss.as.jpa.classtransformer\" value=\"%s\" />", enhance);
+        final String persistenceXml = String.format(PERSISTENCE_XML, "java:comp/DefaultDataSource", property);
+        return createDeploymentWithPersistenceXml(persistenceXml);
+    }
+
+    static WebArchive createDeployment(final String jndiName) {
+        final String persistenceXml = String.format(PERSISTENCE_XML, jndiName, "");
+        return createDeploymentWithPersistenceXml(persistenceXml);
+    }
+
+    static WebArchive createDeployment(final String jndiName, final boolean enhance) {
+        final String property = String.format("<property name=\"jboss.as.jpa.classtransformer\" value=\"%s\" />", enhance);
+        final String persistenceXml = String.format(PERSISTENCE_XML, jndiName, property);
+        return createDeploymentWithPersistenceXml(persistenceXml);
+    }
+
+    private static WebArchive createDeploymentWithPersistenceXml(final String persistenceXml) {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(
+                        AbstractManagedInjectionTestCase.class,
+                        AddDataSourceSetupTask.class,
+                        EventType.class,
+                        User.class,
+                        UserCollector.class,
+                        UserListener.class,
+                        UserRegistry.class,
+                        TimeoutUtil.class
+                )
+                .addAsWebInfResource(new StringAsset(persistenceXml), "classes/META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(DeploymentDescriptors.createPermissionsXmlAsset(
+                        new PropertyPermission("ts.timeout.factor", "read"),
+                        new HibernateValidatorPermission("accessPrivateMembers")
+                ), "permissions.xml");
+    }
+
+    /**
+     * Tests that the {@link jakarta.persistence.PrePersist} and {@link jakarta.persistence.PostPersist} methods
+     * were invoked on the listener.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @InSequence(1)
+    public void addUser() throws Exception {
+        final User user = new User();
+        user.setName("JBoss");
+        user.setEmail("jboss@jboss.org");
+        final User added = userRegistry.add(user);
+        Assert.assertNotNull(added);
+        Assert.assertNotNull(added.getId());
+        compareUser(added, collector.pop(EventType.PRE_PERSIST));
+        compareUser(added, collector.pop(EventType.POST_PERSIST));
+    }
+
+    /**
+     * Tests that the {@link jakarta.persistence.PreUpdate} and {@link jakarta.persistence.PostUpdate} methods
+     * were invoked on the listener.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @InSequence(2)
+    public void updateUser() throws Exception {
+        final User user = new User();
+        user.setId(1L);
+        user.setName("Changed");
+        user.setEmail("changed@jboss.org");
+        final User updated = userRegistry.update(user);
+        compareUser(updated, collector.pop(EventType.PRE_UPDATE));
+        compareUser(updated, collector.pop(EventType.POST_UPDATE));
+    }
+
+    /**
+     * Tests that the {@link jakarta.persistence.PostLoad} method was invoked in the listener.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @InSequence(3)
+    public void getUser() throws Exception {
+        final User user = userRegistry.getUserById(1L);
+        compareUser(user, collector.pop(EventType.POST_LOAD));
+    }
+
+    /**
+     * Tests that the {@link jakarta.persistence.PreRemove} and {@link jakarta.persistence.PostRemove} methods
+     * were invoked on the listener.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    @InSequence(4)
+    public void removeUser() throws Exception {
+        final User removed = userRegistry.remove(1L);
+        compareUser(removed, collector.pop(EventType.PRE_REMOVE));
+        compareUser(removed, collector.pop(EventType.POST_REMOVE));
+        // The way the remove works is it first loads the entity, then removes it. We may as well check this was invoked.
+        compareUser(removed, collector.pop(EventType.POST_LOAD));
+    }
+
+    private void compareUser(final User expected, final User actual) {
+        Assert.assertNotNull("The expected user cannot be null", expected);
+        Assert.assertNotNull("The actual user cannot be null", actual);
+        Assert.assertEquals(expected.getId(), actual.getId());
+        Assert.assertEquals(expected.getName(), actual.getName());
+        Assert.assertEquals(expected.getEmail(), actual.getEmail());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/AddDataSourceSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/AddDataSourceSetupTask.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import org.jboss.as.arquillian.api.ReloadIfRequired;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ReloadIfRequired
+public class AddDataSourceSetupTask implements ServerSetupTask {
+    static final String JNDI_NAME = "java:jboss/datasource/TestDataSource";
+    private static final ModelNode ADDRESS = Operations.createAddress("subsystem", "datasources", "data-source", "test-ds");
+
+    @Override
+    public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        final ModelNode op = Operations.createAddOperation(ADDRESS);
+        op.get("jndi-name").set(JNDI_NAME);
+        op.get("driver-name").set("h2");
+        op.get("user-name").set("sa");
+        op.get("password").set("sa");
+        op.get("jta").set(true);
+        op.get("connection-url").set("jdbc:h2:mem:secondary;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}");
+        executeOperation(managementClient, op);
+    }
+
+    @Override
+    public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        executeOperation(managementClient, Operations.createRemoveOperation(ADDRESS));
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DefaultEnhancementManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DefaultEnhancementManagedInjectionTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is unset.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+public class DefaultEnhancementManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DefaultEnhancementSecondaryDataSourceManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DefaultEnhancementSecondaryDataSourceManagedInjectionTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is unset.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+@ServerSetup(AddDataSourceSetupTask.class)
+public class DefaultEnhancementSecondaryDataSourceManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment(AddDataSourceSetupTask.JNDI_NAME);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DisabledEnhancementManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DisabledEnhancementManagedInjectionTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is set to {@code false}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+public class DisabledEnhancementManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment(false);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DisabledEnhancementSecondaryDataSourceManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/DisabledEnhancementSecondaryDataSourceManagedInjectionTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is set to {@code false}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+@ServerSetup(AddDataSourceSetupTask.class)
+public class DisabledEnhancementSecondaryDataSourceManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment(AddDataSourceSetupTask.JNDI_NAME, false);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EnabledEnhancementManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EnabledEnhancementManagedInjectionTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is set to {@code true}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+@Ignore("This test can be enabled once the default data source can be used. Currently the test methods will throw a " +
+        "NullPointerException due the jpa subsystem explicitly disabling CDI support.")
+public class EnabledEnhancementManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment(true);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EnabledEnhancementSecondaryDataSourceManagedInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EnabledEnhancementSecondaryDataSourceManagedInjectionTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that an entity callbacks, e.g. {@link jakarta.persistence.PostPersist}, work with Jakarta Context and Dependency
+ * Injection when the {@code jboss.as.jpa.classtransformer} property is set to {@code true}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+@RunWith(Arquillian.class)
+@ServerSetup(AddDataSourceSetupTask.class)
+public class EnabledEnhancementSecondaryDataSourceManagedInjectionTestCase extends AbstractManagedInjectionTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return createDeployment(AddDataSourceSetupTask.JNDI_NAME, true);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EventType.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/EventType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public enum EventType {
+    /**
+     * @see jakarta.persistence.PrePersist
+     */
+    PRE_PERSIST,
+    /**
+     * @see jakarta.persistence.PreRemove
+     */
+    PRE_REMOVE,
+    /**
+     * @see jakarta.persistence.PreUpdate
+     */
+    PRE_UPDATE,
+    /**
+     * @see jakarta.persistence.PostLoad
+     */
+    POST_LOAD,
+    /**
+     * @see jakarta.persistence.PostPersist
+     */
+    POST_PERSIST,
+    /**
+     * @see jakarta.persistence.PostRemove
+     */
+    POST_REMOVE,
+    /**
+     * @see jakarta.persistence.PostUpdate
+     */
+    POST_UPDATE,
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/User.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/User.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Entity
+@Table(name = "test_users")
+@EntityListeners({UserListener.class})
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    @Email
+    private String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(@Email final String emailAddress) {
+        this.email = emailAddress;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof final User other)) {
+            return false;
+        }
+        return Objects.equals(getId(), other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+
+    @Override
+    public String toString() {
+        return "User[id=" + getId() + ", name=" + getName() + ", emailAddress=" + getEmail() + "]";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserCollector.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserCollector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.as.test.shared.TimeoutUtil;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+public class UserCollector {
+
+    private final Map<EventType, User> events = new EnumMap<>(EventType.class);
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition condition = lock.newCondition();
+
+    public User pop(final EventType eventType) throws InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            long nanos = TimeUnit.SECONDS.toNanos(TimeoutUtil.adjust(5));
+            User value;
+            while ((value = events.remove(eventType)) == null) {
+                if (nanos <= 0) {
+                    return value;
+                }
+                nanos = condition.awaitNanos(nanos);
+            }
+            return value;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void push(final EventType eventType, final User user) {
+        lock.lock();
+        try {
+            if (events.containsKey(eventType)) {
+                throw new IllegalArgumentException(String.format("Event type %s already has an entry: %s", eventType, events.get(eventType)));
+            }
+            events.put(eventType, user);
+            condition.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void clear() {
+        lock.lock();
+        try {
+            events.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
+import jakarta.persistence.PreUpdate;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+public class UserListener {
+
+    @Inject
+    private UserCollector collector;
+
+    @PrePersist
+    public void prePersist(final User entity) {
+        collector.push(EventType.PRE_PERSIST, entity);
+    }
+
+    @PreRemove
+    public void preRemove(final User entity) {
+        collector.push(EventType.PRE_REMOVE, entity);
+    }
+
+    @PreUpdate
+    public void preUpdate(final User entity) {
+        collector.push(EventType.PRE_UPDATE, entity);
+    }
+
+    @PostLoad
+    public void postLoad(final User entity) {
+        collector.push(EventType.POST_LOAD, entity);
+    }
+
+    @PostPersist
+    public void postPersist(final User entity) {
+        collector.push(EventType.POST_PERSIST, entity);
+    }
+
+    @PostRemove
+    public void postRemove(final User entity) {
+        collector.push(EventType.POST_REMOVE, entity);
+    }
+
+    @PostUpdate
+    public void postUpdate(final User entity) {
+        collector.push(EventType.POST_UPDATE, entity);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserRegistry.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/cdi/UserRegistry.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.ee.injection.support.jpa.cdi;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Manages the user repository.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RequestScoped
+@Transactional
+public class UserRegistry {
+    @PersistenceContext(unitName = "test")
+    private EntityManager em;
+
+    /**
+     * Finds the user given the id.
+     *
+     * @param id the user id
+     *
+     * @return the user or {@code null} if not found
+     */
+    public User getUserById(final long id) {
+        return em.find(User.class, id);
+    }
+
+    /**
+     * Updates, or adds if missing, the user.
+     *
+     * @param user the user to update
+     *
+     * @return the updated user
+     */
+    public User update(@NotNull final User user) {
+        return em.merge(user);
+    }
+
+    /**
+     * Adds a user to the repository.
+     *
+     * @param user the user to add
+     *
+     * @return the user
+     */
+    public User add(@NotNull final User user) {
+        em.persist(user);
+        return user;
+    }
+
+    /**
+     * Deletes the user, if it exists, from the repository.
+     *
+     * @param id the user id
+     *
+     * @return the deleted user
+     */
+    public User remove(final long id) {
+        final User user = em.find(User.class, id);
+        if (user != null) {
+            em.remove(user);
+        }
+        return user;
+    }
+}


### PR DESCRIPTION
…a Persistence listeners and the default data source. There is one disabled test which can be enabled once a fix is done to enable CDI support when bytecode enhancement is enabled.

https://issues.redhat.com/browse/WFLY-20521

This is a follow for #18848 to ensure there is no future regression.
