### PR TITLE
WFLY-19694 Add prototype for the equivalent of having a PersistenceProvider.getClassTransformer() to allow entity enhancement and bootstrap of the persistence unit to occur in two phases

### DIFF
--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
@@ -214,6 +214,11 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
         hibernateExtendedBeanManager.beanManagerIsAvailableForUse();
     }
 
+    @Override
+    public void addClassFileTransformer(PersistenceUnitMetadata pu) {
+        pu.addTransformer(new WildFlyClassTransformer());
+    }
+
     /* start of TwoPhaseBootstrapCapable methods */
 
     public EntityManagerFactoryBuilder getBootstrap(final PersistenceUnitInfo info, final Map map) {
@@ -221,5 +226,6 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
     }
 
     /* end of TwoPhaseBootstrapCapable methods */
+
 }
 

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.jpa.hibernate;
+
+import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
+import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
+import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
+
+/**
+ * WildFlyClassTransformer is simple wrapper of Hibernate ORM EnhancingClassTransformerImpl
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
+
+    public WildFlyClassTransformer() {
+        super(new DefaultEnhancementContext() {
+
+            public boolean isEntityClass(UnloadedClass classDescriptor) {
+                return super.isEntityClass(classDescriptor);
+            }
+
+            public boolean isCompositeClass(UnloadedClass classDescriptor) {
+                return super.isCompositeClass(classDescriptor);
+            }
+
+            public boolean doBiDirectionalAssociationManagement(UnloadedField field) {
+                return super.doBiDirectionalAssociationManagement(field);
+            }
+
+            public boolean doDirtyCheckingInline(UnloadedClass classDescriptor) {
+                return super.doDirtyCheckingInline(classDescriptor);
+            }
+
+            public boolean hasLazyLoadableAttributes(UnloadedClass classDescriptor) {
+                return super.hasLazyLoadableAttributes(classDescriptor);
+            }
+
+            public boolean isLazyLoadable(UnloadedField field) {
+                return super.isLazyLoadable(field);
+            }
+
+            public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {
+                // doesn't make any sense to have extended enhancement enabled at runtime. we only enhance entities anyway.
+                return false;
+            }
+
+        });
+    }
+}
+

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
@@ -218,6 +218,11 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
         hibernateExtendedBeanManager.beanManagerIsAvailableForUse();
     }
 
+    @Override
+    public void addClassFileTransformer(PersistenceUnitMetadata pu) {
+        pu.addTransformer(new WildFlyClassTransformer());
+    }
+
     /* start of TwoPhaseBootstrapCapable methods */
 
     public EntityManagerFactoryBuilder getBootstrap(final PersistenceUnitInfo info, final Map map) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
@@ -1,0 +1,50 @@
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
+import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
+import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
+
+/**
+ * WildFlyClassTransformer is simple wrapper of Hibernate ORM EnhancingClassTransformerImpl
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
+
+    public WildFlyClassTransformer() {
+        super(new DefaultEnhancementContext() {
+
+            public boolean isEntityClass(UnloadedClass classDescriptor) {
+                return super.isEntityClass(classDescriptor);
+            }
+
+            public boolean isCompositeClass(UnloadedClass classDescriptor) {
+                return super.isCompositeClass(classDescriptor);
+            }
+
+            public boolean doBiDirectionalAssociationManagement(UnloadedField field) {
+                return super.doBiDirectionalAssociationManagement(field);
+            }
+
+            public boolean doDirtyCheckingInline(UnloadedClass classDescriptor) {
+                return super.doDirtyCheckingInline(classDescriptor);
+            }
+
+            public boolean hasLazyLoadableAttributes(UnloadedClass classDescriptor) {
+                return super.hasLazyLoadableAttributes(classDescriptor);
+            }
+
+            public boolean isLazyLoadable(UnloadedField field) {
+                return super.isLazyLoadable(field);
+            }
+
+            public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {
+                // doesn't make any sense to have extended enhancement enabled at runtime. we only enhance entities anyway.
+                return false;
+            }
+
+        });
+    }
+}
+

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.wildfly.persistence.jipijapa.hibernate7;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;

--- a/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderAdaptor.java
+++ b/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderAdaptor.java
@@ -94,5 +94,8 @@ public interface PersistenceProviderAdaptor {
     Object beanManagerLifeCycle(BeanManager beanManager);
 
     void markPersistenceUnitAvailable(Object wrapperBeanManagerLifeCycle);
+
+    default void addClassFileTransformer(PersistenceUnitMetadata pu) {
+    }
 }
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -382,7 +382,9 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     @Override
     public void addTransformer(ClassTransformer classTransformer) {
-        if(classTransformer.getClass().getName().contains("org.hibernate")) {
+        // Do not add Hibernate ORM 6.x/7.x bytecode enhancement class transformers
+        // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl)
+        if(classTransformer.getClass().getName().startsWith("org.hibernate")) {
             return;
         }
         transformers.add(classTransformer);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -385,8 +385,8 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     @Override
     public void addTransformer(ClassTransformer classTransformer) {
         // WFLY-19694 Do not add Hibernate ORM 6.x/7.x bytecode enhancement class transformers
-        // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl) 
-        // which were already added earlier via org.jboss.as.jpa.hibernate.WildFlyClassTransformer 
+        // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl)
+        // which were already added earlier via org.jboss.as.jpa.hibernate.WildFlyClassTransformer
         // or org.wildfly.persistence.jipijapa.hibernate7.WildFlyClassTransformer
         if(classTransformer.getClass().getName().startsWith(ORG_HIBERNATE_ORM_PROVIDER_CLASS_ENHANCER_PACKAGE)) {
             return;

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -102,6 +102,8 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     private volatile List<String> qualifierAnnotationNames = List.of();
     private volatile boolean isDuplicate;
 
+    private static final String ORG_HIBERNATE_ORM_PROVIDER_CLASS_ENHANCER_PACKAGE = "org.hibernate.";
+
     @Override
     public void setPersistenceUnitName(String name) {
         this.name = name;
@@ -384,7 +386,7 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     public void addTransformer(ClassTransformer classTransformer) {
         // Do not add Hibernate ORM 6.x/7.x bytecode enhancement class transformers
         // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl)
-        if(classTransformer.getClass().getName().startsWith("org.hibernate")) {
+        if(classTransformer.getClass().getName().startsWith(ORG_HIBERNATE_ORM_PROVIDER_CLASS_ENHANCER_PACKAGE)) {
             return;
         }
         transformers.add(classTransformer);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -384,8 +384,10 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     @Override
     public void addTransformer(ClassTransformer classTransformer) {
-        // Do not add Hibernate ORM 6.x/7.x bytecode enhancement class transformers
-        // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl)
+        // WFLY-19694 Do not add Hibernate ORM 6.x/7.x bytecode enhancement class transformers
+        // (e.g. org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl) 
+        // which were already added earlier via org.jboss.as.jpa.hibernate.WildFlyClassTransformer 
+        // or org.wildfly.persistence.jipijapa.hibernate7.WildFlyClassTransformer
         if(classTransformer.getClass().getName().startsWith(ORG_HIBERNATE_ORM_PROVIDER_CLASS_ENHANCER_PACKAGE)) {
             return;
         }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -382,6 +382,9 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     @Override
     public void addTransformer(ClassTransformer classTransformer) {
+        if(classTransformer.getClass().getName().contains("org.hibernate")) {
+            return;
+        }
         transformers.add(classTransformer);
         if (ROOT_LOGGER.isTraceEnabled()) {
             ROOT_LOGGER.tracef("added entity class transformer '%s' for '%s'",

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -284,15 +284,13 @@ public class PersistenceUnitServiceHandler {
                                 deployPersistenceUnitPhaseOne(deploymentUnit, eeModuleDescription, serviceTarget,
                                         classLoader, pu, adaptor, integratorAdaptors);
                             }
-                            else {
-                                final boolean allowCdiBeanManagerAccess = true;
-                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget,
-                                        classLoader, pu, provider, adaptor, integratorAdaptors, allowCdiBeanManagerAccess);
-                            }
                         }
                         else { // !startEarly
                             if (twoPhaseBootStrapCapable) {
                                 deployPersistenceUnitPhaseTwo(deploymentUnit, eeModuleDescription, serviceTarget, classLoader, pu, provider, adaptor, integratorAdaptors);
+                            } else {
+                                deployPersistenceUnit(deploymentUnit, eeModuleDescription, serviceTarget,
+                                        classLoader, pu, provider, adaptor, integratorAdaptors);
                             }
                         }
                     }
@@ -316,7 +314,6 @@ public class PersistenceUnitServiceHandler {
      * @param provider
      * @param adaptor
      * @param integratorAdaptors Adapters for integrators, e.g. Hibernate Search.
-     * @param allowCdiBeanManagerAccess
      * @throws DeploymentUnitProcessingException
      */
     private static void deployPersistenceUnit(
@@ -327,8 +324,7 @@ public class PersistenceUnitServiceHandler {
             final PersistenceUnitMetadata pu,
             final PersistenceProvider provider,
             final PersistenceProviderAdaptor adaptor,
-            final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors,
-            final boolean allowCdiBeanManagerAccess) throws DeploymentUnitProcessingException {
+            final List<PersistenceProviderIntegratorAdaptor> integratorAdaptors) throws DeploymentUnitProcessingException {
         pu.setClassLoader(classLoader);
         TransactionManager transactionManager = ContextTransactionManager.getInstance();
         TransactionSynchronizationRegistry transactionSynchronizationRegistry = deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
@@ -414,7 +410,7 @@ public class PersistenceUnitServiceHandler {
             // JPA 2.1 sections 3.5.1 + 9.1 require the Jakarta Contexts and Dependency Injection bean manager to be passed to the peristence provider
             // if the persistence unit is contained in a deployment that is a Jakarta Contexts and Dependency Injection bean archive (has beans.xml).
             final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-            if (support.hasCapability(WELD_CAPABILITY_NAME) && allowCdiBeanManagerAccess) {
+            if (support.hasCapability(WELD_CAPABILITY_NAME)) {
                 support.getOptionalCapabilityRuntimeAPI(WELD_CAPABILITY_NAME, WeldCapability.class).get()
                         .addBeanManagerService(deploymentUnit, builder, service.getBeanManagerInjector());
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19694 + implements provides a prototype of the Persistence 4.0 feature https://github.com/jakartaee/persistence/issues/650

The idea is for WildFly to (very early in deployment) register the Hibernate ORM bytecode enhancement to be done for the application deployment.  This ensures that the bytecode enhancement can be done for the deployment.

This change also removes the Persistence deployment code that previously disabled CDI for deployments that use Persistence bytecode enhancement along with application datasources or default datasource.

This pull request replaces https://github.com/wildfly/wildfly/pull/18850