### PR TITLE
[WFLY-20542] EJB: Add SocketPermission to DatabaseTimerServiceMultiNo…

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -10,7 +10,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
+import java.net.SocketPermission;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -170,7 +172,10 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         war.addAsResource(new StringAsset(nodeName), "node.txt");
         war.addAsWebInfResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         if (client) {
-            war.addAsManifestResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+            war.addAsManifestResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
+            war.addAsManifestResource(
+                    createPermissionsXmlAsset(
+                            new SocketPermission("*:9092", "connect,resolve")), "permissions.xml");
         }
         return war;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -172,7 +172,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         war.addAsResource(new StringAsset(nodeName), "node.txt");
         war.addAsWebInfResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         if (client) {
-            war.addAsManifestResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
+            war.addAsManifestResource(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
             war.addAsManifestResource(
                     createPermissionsXmlAsset(
                             new SocketPermission("*:9092", "connect,resolve")), "permissions.xml");


### PR DESCRIPTION
…deExecutionDisabledTestCase

https://issues.redhat.com/browse/WFLY-20542

The test was failing intermittently because the in most cases connection created by server code is reused. If connection is closed and deployment code has to create a new one, then the SocketPermission was lacking.
