### PR TITLE
[WFLY-20533] Do not set the -Djava.security.manager=allow by default. Only add the property if -secmgr is passed.

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.bat
@@ -116,10 +116,12 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-setlocal EnableDelayedExpansion
-call "!DIRNAME!common.bat" :setSecurityManagerDefault
-set "JAVA_OPTS=!JAVA_OPTS! !SECURITY_MANAGER_CONFIG_OPTION!"
-setlocal DisableDelayedExpansion
+if "%SECMGR%" == "true" (
+    setlocal EnableDelayedExpansion
+    call "!DIRNAME!common.bat" :setSecurityManagerDefault
+    set "JAVA_OPTS=!JAVA_OPTS! !SECURITY_MANAGER_CONFIG_OPTION!"
+    setlocal DisableDelayedExpansion
+)
 
 rem Set the module options
 set "MODULE_OPTS="

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.sh
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/bin/appclient.sh
@@ -143,8 +143,10 @@ if $cygwin; then
 fi
 
 # Set default Security Manager configuration value
-setSecurityManagerDefault
-JAVA_OPTS="$JAVA_OPTS $SECURITY_MANAGER_CONFIG_OPTION"
+if [ "$SECMGR" = "true" ]; then
+    setSecurityManagerDefault
+    JAVA_OPTS="$JAVA_OPTS $SECURITY_MANAGER_CONFIG_OPTION"
+fi
 
 # Process the JAVA_OPTS failing if the java.security.manager is set.
 SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "java\.security\.manager"`

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -102,4 +102,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>allow-security-manager</id>
+            <activation>
+                <jdk>[17,24)</jdk>
+            </activation>
+
+            <properties>
+                <!-- Required to enable the security manager for testing -->
+                <surefire.system.args>-Djava.security.manager=allow</surefire.system.args>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
             --add-opens=java.management/javax.management=ALL-UNNAMED
             --add-opens=java.naming/javax.naming=ALL-UNNAMED
         </modular.jdk.args>
-        <security.manager.props></security.manager.props>
 
         <!--
             See ChildFirstClassLoaderBuilder in model-test for the explanation of the org.jboss.model.test.cache.root and org.jboss.model.test.classpath.cache properties.
@@ -174,7 +173,7 @@
         <surefire.extra.args></surefire.extra.args>
         <surefire.jpda.args></surefire.jpda.args>
         <surefire.non-modular.system.args>-ea -Duser.region=US -Duser.language=en ${surefire.jpda.args} ${surefire.extra.args} ${surefire.jacoco.args}</surefire.non-modular.system.args>
-        <surefire.system.args>${modular.jdk.args} ${security.manager.props} ${surefire.non-modular.system.args}</surefire.system.args>
+        <surefire.system.args>${modular.jdk.args} ${surefire.non-modular.system.args}</surefire.system.args>
         <arquillian.servlet.protocol>Servlet 5.0</arquillian.servlet.protocol>
         <testLogToFile>true</testLogToFile>
         <maven.test.redirectTestOutputToFile>${testLogToFile}</maven.test.redirectTestOutputToFile>
@@ -1526,17 +1525,6 @@
             </modules>
         </profile>
 
-        <profile>
-            <id>jdk18</id>
-            <activation>
-                <jdk>[18,24)</jdk>
-            </activation>
-            <properties>
-                <security.manager.props>
-                    -Djava.security.manager=allow
-                </security.manager.props>
-            </properties>
-        </profile>
         <profile>
             <id>jdk23</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
              on the dependency on the MicroProfile REST Client TCK POM.
          -->
         <version.org.testng.mp.rest.client>7.10.2</version.org.testng.mp.rest.client>
-        <version.org.wildfly.arquillian>5.1.0.Beta10</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.1.0.Beta11</version.org.wildfly.arquillian>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <legacy.version.org.wildfly.naming-client>1.0.17.Final</legacy.version.org.wildfly.naming-client>
 

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <version.org.wildfly.clustering>6.0.1.Final</version.org.wildfly.clustering>
         <version.org.wildfly.core>28.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
-        <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
+        <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.vertx>1.0.2.Final</version.org.wildfly.vertx>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -160,13 +160,13 @@
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
         <!-- The JPMS settings needed by the client side of a portion of the testsuite.
-             Defaults to ${modular.jdk.args} plus ${security.manager.props}, i.e. the standard list of recommended
+             Defaults to ${modular.jdk.args}, i.e. the standard list of recommended
              client side JPMS settings for users of our client-side libraries.
              If particular tests need additional settings to support client-side behavior
              in their test code, then this property should be overridden in as fine-grained
              a location as is practical; no more coarse-grained than the global config of
              the pom for the maven module that includes the test. -->
-        <modular.jdk.testsuite.args>${modular.jdk.args} ${security.manager.props}</modular.jdk.testsuite.args>
+        <modular.jdk.testsuite.args>${modular.jdk.args}</modular.jdk.testsuite.args>
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />
         <!-- needed for arquillian-byteman-extension -->


### PR DESCRIPTION
This PR removes the `-Djava.security.manager=allow` argument by default and only adds it if the `-secmgr` is added.

The `ws*` scripts seem to support this, but it doesn't make sense to really do this I would think. However, I left it as I didn't want to change the behavior if the security manager is enabled for whatever reason.

This is the full version https://github.com/wildfly/wildfly-core/pull/6391. Note the way the scripts work in the tests for this PR, it's not really possible to check the JVM parameters. For that reason I was not able to validate via a test. However, this should work.

* https://issues.redhat.com/browse/WFLY-20533
* https://issues.redhat.com/browse/WFLY-20537
* https://issues.redhat.com/browse/WFLY-20538
