### PR TITLE
[WFLY-20548] Upgrade WildFly Core to 28.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>6.0.1.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>28.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>28.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20548

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/28.0.0.Final
Diff: https://github.com/wildfly/wildfly-core/compare/28.0.0.Beta6...28.0.0.Final

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6864'>WFCORE-6864</a>] -         Deprecate PersistentResourceDefinition
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7107'>WFCORE-7107</a>] -         Use ModuleDependency.Builder instead of deprecated ModuleDependency ctor in Server
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7133'>WFCORE-7133</a>] -         Remove ModuleIdentifier use in domain-http-interface
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7134'>WFCORE-7134</a>] -         Remove ModuleIdentifier use in the elytron subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7135'>WFCORE-7135</a>] -         Remove ModuleIdentifier use in the testsuite
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7136'>WFCORE-7136</a>] -         Remove ModuleIdentifier use from JBossDeploymentStructureParser##
</li>
</ul>
                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5718'>WFCORE-5718</a>] -         Support remote+tls with EJBClient and remote-outbound-connection
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6779'>WFCORE-6779</a>] -         PersistentResourceXMLDescription is hot garbage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6937'>WFCORE-6937</a>] -         Testing of write-attribute calls is low for the Elytron subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7102'>WFCORE-7102</a>] -         AccessDeniedException on Windows when using a read-only configuration dir
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7123'>WFCORE-7123</a>] -         Embedded ignores invalid options
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7124'>WFCORE-7124</a>] -         CLI uses server-side dependencies
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7130'>WFCORE-7130</a>] -         Enhance CLI tests to ignore warning about JDK&#39;s sun.misc.Unsafe usage on JDK24+
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7153'>WFCORE-7153</a>] -         CVE-2025-23367 org.wildfly.core/wildfly-server: Wildfly improper RBAC permission
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7160'>WFCORE-7160</a>] -         &quot;grep: warning: stray \ before :&quot; at console after server startup with GC_LOG=true
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7176'>WFCORE-7176</a>] -         PersistentResourceXMLDescription created via PersistentResourceXMLDescription.Factory is not wrappable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7178'>WFCORE-7178</a>] -         Intermittent failures in SuspendControllerTestCase#serverActivityCallbackOrderTest
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7188'>WFCORE-7188</a>] -         AddResourceOperationStepHandler not detecting that current resource is a required child of parent
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7195'>WFCORE-7195</a>] -         PersistentResourceXMLParserTestCase.MyParser model is not consistent with its PersistentResourceXMLDescription
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7196'>WFCORE-7196</a>] -         PersistentResourceXMLDescription of elytron subsystem contains duplicate attributes/children
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7198'>WFCORE-7198</a>] -         AttributeParsers.MapParser leaves reader in inconsistent state when no wrapping element is present
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7208'>WFCORE-7208</a>] -         Intermittent failures in DeploymentOperationsTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7211'>WFCORE-7211</a>] -         Only add -Djava.security.manager=allow if the security mangaer is explicitly enabled
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6903'>WFCORE-6903</a>] -         Remove usage of deprecated AbstractWriteAttributeHandler constructors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7061'>WFCORE-7061</a>] -         Bump the kernel management API version to 29.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7062'>WFCORE-7062</a>] -         Remove all non-breaking uses of ModuleIdentifier
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7110'>WFCORE-7110</a>] -         Deprecate the Security Manager subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7115'>WFCORE-7115</a>] -         Remove use of ModuleIdentifier from AdditionalModuleSpecification
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7116'>WFCORE-7116</a>] -         Remove ModuleIdentifier from Extension handling
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7125'>WFCORE-7125</a>] -         Remove deprected Authentication methods
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7126'>WFCORE-7126</a>] -         Remove cruft testsuite/server-provisioning.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7127'>WFCORE-7127</a>] -         Replace Attachments.CLASS_PATH_ENTRIES
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7141'>WFCORE-7141</a>] -         Removed deprecated Attachments.ADDITIONAL_ANNOTATION_INDEXES_BY_MODULE
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7143'>WFCORE-7143</a>] -         Consolidate HostControllerBootstrap and EmbeddedHostControllerBootstrap
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7149'>WFCORE-7149</a>] -         Deprecate for removal the last public constructor of server&#39;s ModuleDependency class
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7150'>WFCORE-7150</a>] -         Remove deprecated Attachments.ADDITIONAL_ANNOTATION_INDEXES
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7170'>WFCORE-7170</a>] -         Reduce ModuleIdentifier usage from Server module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7171'>WFCORE-7171</a>] -         Remove ModuleIdentifier usage from Host Controller module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7175'>WFCORE-7175</a>] -         Remove ModuleIdentifier usage from server/moduleservice
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7184'>WFCORE-7184</a>] -         Remove ModuleIdentifier usage from server/deployment
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7186'>WFCORE-7186</a>] -         Mark ModuleIdentifierUtil as deprecated for removal
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7197'>WFCORE-7197</a>] -         IgnoreResourcesTestCase creates invalid io subsystem configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7199'>WFCORE-7199</a>] -         Migrate IO subsystem to SubsystemResourceXMLSchema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7200'>WFCORE-7200</a>] -         Migrate discovery subsystem to SubsystemResourceXMLSchema
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7217'>WFCORE-7217</a>] -         Defer to AttributeMarshaller.marshallElementContent(..) for writing element content
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6846'>WFCORE-6846</a>] -         Upgrade commons-daemon to 1.4.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7128'>WFCORE-7128</a>] -         Upgrade Byteman to 4.0.24
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7131'>WFCORE-7131</a>] -         Upgrade JBoss Marshalling to 2.2.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7142'>WFCORE-7142</a>] -         Upgrade BouncyCastle from 1.79 to 1.80
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7151'>WFCORE-7151</a>] -         Upgrade WildFly Galleon Plugins to 7.3.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7155'>WFCORE-7155</a>] -         Upgrade io.smallrye:jandex from 3.2.3 to 3.2.4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7156'>WFCORE-7156</a>] -         Upgrade WildFly Maven Plugin to 5.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7157'>WFCORE-7157</a>] -         Upgrade io.smallrye:jandex from 3.2.4 to 3.2.5
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7158'>WFCORE-7158</a>] -         Upgrade commons-daemon to 1.4.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7159'>WFCORE-7159</a>] -         Upgrade io.smallrye:jandex from 3.2.5 to 3.2.6
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7162'>WFCORE-7162</a>] -         Upgrade snakeyaml to 2.4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7164'>WFCORE-7164</a>] -         [GSS](7.4.z) Upgrade commons-io from 2.10.0 to 2.14.0 or later
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7165'>WFCORE-7165</a>] -         Upgrade io.smallrye:jandex from 3.2.6 to 3.2.7
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7166'>WFCORE-7166</a>] -         Upgrade Galleon to 6.0.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7168'>WFCORE-7168</a>] -         Upgrade Elytron EE to 3.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7174'>WFCORE-7174</a>] -         Upgrade jboss-logging-tools to 3.0.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7177'>WFCORE-7177</a>] -         Upgrade SSHD from 2.14.0 to 2.15.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7179'>WFCORE-7179</a>] -         Upgrade Elytron EE to 3.1.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7180'>WFCORE-7180</a>] -         Upgrade WildFly Elytron to 2.6.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7187'>WFCORE-7187</a>] -         Upgrade WildFly Elytron to 2.6.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7194'>WFCORE-7194</a>] -         Upgrade JBoss Remoting to 5.0.31.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7204'>WFCORE-7204</a>] -         Upgrade to unstable-api-annotation-utils 1.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7212'>WFCORE-7212</a>] -         Upgrade JBoss Marshalling to 2.2.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7214'>WFCORE-7214</a>] -         Upgrade wildfly-launcher to 1.0.2.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7120'>WFCORE-7120</a>] -         Add an embedding SPI; decouple embedded module from server and host-controller modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7132'>WFCORE-7132</a>] -         Improve logging of exceptions during embedded process exit
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7161'>WFCORE-7161</a>] -         Improve deployment message on duplicate runtime name
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7205'>WFCORE-7205</a>] -         Add proper xs:attribute support to generic XMLElement
</li>
</ul>
</details>

