### PR TITLE
[WFLY-20551] JCA: don't set WorkManager and DistributedWorkManager's …

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -529,9 +529,6 @@ public class JcaExtension implements Extension {
 
 
             }
-
-            // For older versions set 'elytron-enabled' to 'false' if not explicitly set, as that was the default in those xsds
-            handleLegacyWorkManagerSecurity(workManagerOperation, JcaWorkManagerDefinition.WmParameters.ELYTRON_ENABLED.getAttribute(), elementNs);
         }
 
         // WFLY-14587
@@ -653,8 +650,6 @@ public class JcaExtension implements Extension {
 
             }
 
-            // For older versions set 'elytron-enabled' to 'false' if not explicitly set, as that was the default in those xsds
-            handleLegacyWorkManagerSecurity(distributedWorkManagerOperation, JcaDistributedWorkManagerDefinition.DWmParameters.ELYTRON_ENABLED.getAttribute(), elementNS);
         }
 
 
@@ -923,26 +918,6 @@ public class JcaExtension implements Extension {
             writer.writeAttribute("name", name);
             writer.writeCharacters(value);
             writer.writeEndElement();
-
-        }
-
-        private static void handleLegacyWorkManagerSecurity(ModelNode addOp, AttributeDefinition ad, Namespace ns) {
-
-            if (!addOp.hasDefined(ad.getName())) {
-                switch (ns) {
-                    case JCA_1_1:
-                    case JCA_2_0:
-                    case JCA_3_0:
-                    case JCA_4_0:
-                    case JCA_5_0:
-                        // set the old default value from these xsd versions
-                        addOp.get(ad.getName()).set(false);
-                        break;
-                    default:
-                        // unconfigured value in later namespaces matches current AttributeDefinition default
-                        break;
-                }
-            }
 
         }
     }

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -4,20 +4,15 @@
  */
 package org.jboss.as.connector.subsystems.jca;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.SingleClassFilter;
@@ -189,24 +184,6 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
         assertTrue(legacyModel.toString(), legacyModel.get("subsystem", "jca", "workmanager", "anotherWm", "elytron-enabled").asBoolean(false));
         assertTrue(legacyModel.toString(), legacyModel.get("subsystem", "jca", "distributed-workmanager", "MyDWM", "elytron-enabled").asBoolean(false));
         mainServices.shutdown();
-    }
-
-    /** WFLY-16478 Test legacy parser sets old default value for elytron-enabled */
-    @Test
-    public void testLegacyDefaultElytronEnabled() throws Exception {
-        Set<ModelNode> required = new HashSet<>();
-        PathAddress subsystem = PathAddress.pathAddress("subsystem", "jca");
-        required.add(subsystem.append("workmanager", "default").toModelNode());
-        required.add(subsystem.append("workmanager", "anotherWm").toModelNode());
-        required.add(subsystem.append("distributed-workmanager", "MyDWM").toModelNode());
-
-        for (ModelNode op : parse(getSubsystemXml("jca_5_0.xml"))) {
-            if (ADD.equals(op.get(OP).asString()) && required.remove(op.get(ModelDescriptionConstants.OP_ADDR))) {
-                assertFalse(op.toString() + "\n did not correctly define elytron-enabled", op.get("elytron-enabled").asBoolean(true));
-            }
-        }
-
-        assertTrue("Not all expected ops were found\n" + required.toString(), required.isEmpty());
     }
 
     @Override


### PR DESCRIPTION
…elytron-enabled attribute to false in the legacy subsystem versions

https://issues.redhat.com/browse/WFLY-20551
