### PR TITLE
[WFLY-20563] HAPROXY configuration: add "check" keyword

### DIFF
--- a/docs/src/main/asciidoc/_high-availability/load-balancing/Affinity_Cookie.adoc
+++ b/docs/src/main/asciidoc/_high-availability/load-balancing/Affinity_Cookie.adoc
@@ -47,8 +47,8 @@ backend myservers
 mode http
 cookie SRV indirect preserve
 option redispatch
-server server1 127.0.0.1:8080 cookie ribera1
-server server2 127.0.0.1:8180 cookie ribera2
+server server1 127.0.0.1:8080 check cookie ribera1
+server server2 127.0.0.1:8180 check cookie ribera2
 ----
 
 Notice that the proxy server defined cookie names need to correspond with the application server's `instance-id`.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20563

In e.g. https://www.haproxy.com/blog/enable-sticky-sessions-in-haproxy the check cookie is used: @rhusar should we add it here?

Btw, is https://github.com/wildfly/wildfly.github.io/pull/88 needed?
