### PR TITLE
WFLY-20334 Don't include the jipijapa-hibernate7 module if -Dno.preview.build=true

### DIFF
--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -44,11 +44,23 @@
 
     <modules>
         <module>hibernate6</module>
-        <module>hibernate7</module>
         <module>hibernatesearch</module>
         <module>subsystem</module>
         <module>spi</module>
         <module>eclipselink</module>
-
     </modules>
+
+    <profiles>
+        <profile>
+            <id>skip.preview</id>
+            <activation>
+                <property>
+                    <name>!no.preview.build</name>
+                </property>
+            </activation>
+            <modules>
+                <module>hibernate7</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20334

This fixes failing build when `-Dno.preview.build` is used.
