### PR TITLE
[WFLY-19970] Work around Eclipse Krazo's use of CDI.current() to reso…

### DIFF
--- a/boms/standard-test/pom.xml
+++ b/boms/standard-test/pom.xml
@@ -74,6 +74,18 @@
             </dependency>
 
             <dependency>
+                <groupId>jakarta.mvc</groupId>
+                <artifactId>jakarta.mvc-api</artifactId>
+                <version>${version.jakarta.mvc}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>${version.io.rest-assured}</version>
@@ -150,6 +162,18 @@
                     <exclusion>
                         <groupId>xml-apis</groupId>
                         <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-core</artifactId>
+                <version>${version.org.eclipse.krazo}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@
         <version.io.rest-assured>5.5.1</version.io.rest-assured>
         <legacy.version.jakarta.enterprise>2.0.2</legacy.version.jakarta.enterprise>
         <legacy.version.jakarta.inject.jakarta.inject-api>1.0.5</legacy.version.jakarta.inject.jakarta.inject-api>
+        <version.jakarta.mvc>2.1.0</version.jakarta.mvc>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jsoup>1.15.4</version.jsoup>
         <version.junit>4.13.2</version.junit>
@@ -293,6 +294,7 @@
         <version.org.awaitility.awaitility>4.0.3</version.org.awaitility.awaitility>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jetty>11.0.25</version.org.eclipse.jetty>
+        <version.org.eclipse.krazo>3.0.1</version.org.eclipse.krazo>
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.hamcrest.legacy>1.3</version.org.hamcrest.legacy>
         <version.org.htmlunit>4.10.0</version.org.htmlunit>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -152,6 +152,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.mvc</groupId>
+            <artifactId>jakarta.mvc-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
             <scope>test</scope>
@@ -204,6 +209,11 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.krazo</groupId>
+            <artifactId>krazo-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/MockViewEngine.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/MockViewEngine.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.viewengine;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.mvc.engine.ViewEngine;
+import jakarta.mvc.engine.ViewEngineContext;
+import jakarta.mvc.engine.ViewEngineException;
+import org.eclipse.krazo.engine.ViewEngineConfig;
+
+/**
+ * Mock variant of the kind of thing found in the
+ * <a href="https://github.com/eclipse-ee4j/krazo-extensions">krazo-extensions repo</a>.
+ */
+@ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
+public class MockViewEngine implements ViewEngine {
+
+    @Inject
+    @ViewEngineConfig
+    private String message;
+
+    @Override
+    public boolean supports(String view) {
+        return view.endsWith(".ve");
+    }
+
+    @Override
+    public void processView(ViewEngineContext viewEngineContext) throws ViewEngineException {
+        try {
+            viewEngineContext.getOutputStream().write(message.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new ViewEngineException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/MockViewEngineConfigProducer.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/MockViewEngineConfigProducer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.viewengine;
+
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.krazo.engine.ViewEngineConfig;
+
+/**
+ * Producer for a fake 'config' object to
+ * inject into our fake {@code MockViewEngine}.
+ */
+public class MockViewEngineConfigProducer {
+
+    @Produces
+    @ViewEngineConfig
+    public String getViewMessage() {
+        return "Mock View";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/TestApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.viewengine;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class TestApplication extends Application {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/TestMVCController.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/TestMVCController.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.viewengine;
+
+import java.util.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.mvc.Controller;
+import jakarta.mvc.View;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/test")
+@Controller
+@ApplicationScoped
+public class TestMVCController {
+
+    private static final Logger LOGGER = Logger.getLogger(TestMVCController.class.getName());
+
+    @GET
+    @View("test.ve")
+    public void test() {
+        LOGGER.info(getClass().getSimpleName() + "test() called");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/ViewEngineTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/ViewEngineTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.viewengine;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.EXTENSION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.CdiUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Preview.class, ViewEngineTestCase.ServerSetup.class})
+public class ViewEngineTestCase {
+
+    public static final class ServerSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            executeForResult(managementClient.getControllerClient(),
+                    Util.createAddOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.mvc-krazo")));
+            executeForResult(managementClient.getControllerClient(),
+                    Util.createAddOperation(PathAddress.pathAddress(SUBSYSTEM, "mvc-krazo")));
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+            // no need to do anything as the other task uses snapshot/restore
+        }
+
+        private void executeForResult(final ModelControllerClient client, final ModelNode operation) throws Exception {
+            final ModelNode response = client.execute(operation);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+    }
+
+    public static final String SIMPLE_WAR = "ViewEngineTestCase-simple.war";
+    public static final String SIMPLE_EAR = "ViewEngineTestCase-simple.ear";
+    public static final String WAR_WITH_LIB = "ViewEngineTestCase-with-lib.war";
+    public static final String EAR_WITH_LIB = "ViewEngineTestCase-with-lib.ear";
+    private static final JavaArchive viewLib = createViewLib();
+
+    private static JavaArchive createViewLib() {
+        return ShrinkWrap.create(JavaArchive.class, "viewEngine.jar")
+                .addClasses(MockViewEngine.class, MockViewEngineConfigProducer.class)
+                .addAsManifestResource(CdiUtils.createBeansXml(), "beans.xml");
+    }
+
+    private static WebArchive simpleWar(String name) {
+        return ShrinkWrap.create(WebArchive.class, name)
+                .addClasses(TestApplication.class, TestMVCController.class);
+    }
+
+    @Deployment(name = WAR_WITH_LIB, managed = false, testable = false)
+    public static WebArchive warWithLib() {
+        return simpleWar(WAR_WITH_LIB)
+                .addAsLibrary(viewLib);
+    }
+
+    @Deployment(name = SIMPLE_EAR, managed = false, testable = false)
+    public static EnterpriseArchive simpleEar() {
+        return ShrinkWrap.create(EnterpriseArchive.class, SIMPLE_EAR)
+                .addAsModule(warWithLib());
+    }
+
+    @Deployment(name = EAR_WITH_LIB, managed = false, testable = false)
+    public static EnterpriseArchive earWithLib() {
+        return ShrinkWrap.create(EnterpriseArchive.class, EAR_WITH_LIB)
+                .addAsModule(simpleWar(SIMPLE_WAR))
+                .addAsLibrary(viewLib);
+    }
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Test
+    public void testWarLib() throws IOException {
+        test(WAR_WITH_LIB, WAR_WITH_LIB);
+    }
+
+    @Test
+    @Ignore("WFLY-20570")
+    public void testEarLib() throws IOException {
+        test(EAR_WITH_LIB, SIMPLE_WAR);
+    }
+
+    @Test
+    public void testWarLibInEar() throws IOException {
+        test(SIMPLE_EAR, WAR_WITH_LIB);
+    }
+
+    private void test(String deploymentName, String warName) throws IOException {
+        deployer.deploy(deploymentName);
+        try {
+            callAndTest(warName);
+        } finally {
+            deployer.undeploy(deploymentName);
+        }
+    }
+
+    private void callAndTest(String warName) throws IOException {
+        String contextPath = warName.substring(0, warName.length() - 4);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            String uri = "http://" + TestSuiteEnvironment.getServerAddress() + ":8080/" + contextPath + "/app/test";
+            HttpGet get = new HttpGet(uri);
+            HttpResponse response = client.execute(get);
+            Assert.assertEquals("Wrong response code from " + uri, 200, response.getStatusLine().getStatusCode());
+            String result = EntityUtils.toString(response.getEntity());
+            Assert.assertEquals("Wrong response entity from " + uri, "Mock View", result);
+        }
+    }
+}

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
@@ -77,8 +77,9 @@ public class WeldProvider implements CDIProvider {
         public BeanManager getBeanManager() {
             checkContainerState(container);
             final String callerName = getCallingClassName();
-            if(callerName.startsWith("org.glassfish.soteria")) {
-                //the Jakarta EE Security RI uses CDI.current() to perform bean lookup, however
+            if (callerName.startsWith("org.glassfish.soteria")
+                    || callerName.startsWith("org.eclipse.krazo")) {
+                //the Jakarta Security and Jakarta MVC RIs use CDI.current() to perform bean lookup, however
                 //as it is part of the container its bean archive does not have visibility to deployment beans
                 //we use this code path to enable it to get the bean manager of the current module
                 //so it can look up the deployment beans it needs to work


### PR DESCRIPTION
…lve beans

https://issues.redhat.com/browse/WFLY-19970
Upstream: #18893
