### PR TITLE
[WFLY-20570][WFLY-20571] Jakarta MVC is not available to ear libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
         <version.org.wildfly.core>28.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
-        <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>
+        <version.org.wildfly.mvc.krazo>1.0.1.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.vertx>1.0.2.Final</version.org.wildfly.vertx>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/MVCTestUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/MVCTestUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.EXTENSION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+public class MVCTestUtil {
+
+    public static void callAndTest(String warName, String controllerPath, String resultContent) throws IOException {
+        callAndTest(warName, "app" ,controllerPath, resultContent);
+    }
+    public static void callAndTest(String warName, String appPath, String controllerPath, String resultContent) throws IOException {
+        String appSegment = appPath == null ? "/" : "/" + appPath + "/";
+        String contextPath = warName.substring(0, warName.length() - 4);
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            String uri = "http://" + TestSuiteEnvironment.getServerAddress() + ":8080/" + contextPath + appSegment + controllerPath;
+            HttpGet get = new HttpGet(uri);
+            HttpResponse response = client.execute(get);
+            Assert.assertEquals("Wrong response code from " + uri, 200, response.getStatusLine().getStatusCode());
+            String result = EntityUtils.toString(response.getEntity());
+            Assert.assertTrue("Wrong response entity from " + uri, result.contains(resultContent));
+        }
+    }
+
+    public static final class ServerSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            executeForResult(managementClient.getControllerClient(),
+                    Util.createAddOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.mvc-krazo")));
+            executeForResult(managementClient.getControllerClient(),
+                    Util.createAddOperation(PathAddress.pathAddress(SUBSYSTEM, "mvc-krazo")));
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+            // no need to do anything as the other task uses snapshot/restore
+        }
+
+        private void executeForResult(final ModelControllerClient client, final ModelNode operation) throws Exception {
+            final ModelNode response = client.execute(operation);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/MVCEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/MVCEarTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.ear;
+
+import static org.wildfly.test.integration.mvc.MVCTestUtil.callAndTest;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.formatter.Formatters;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.mvc.MVCTestUtil;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Preview.class, MVCTestUtil.ServerSetup.class})
+public class MVCEarTestCase {
+
+    private static final Logger LOGGER = Logger.getLogger(MVCEarTestCase.class.getName());
+
+    private static final String WITH_CONTROLLER = "with-controller.war";
+    private static final String NO_CONTROLLER = "no-controller.war";
+    private static final String JSP_VIEW = "JSP View";
+
+    @Deployment
+    public static EnterpriseArchive earWithLib() {
+
+        String localResourcePath = MVCEarTestCase.class.getPackage().getName().replace('.', '/');
+
+        // Shared jar in ear/lib
+        JavaArchive sharedJar = ShrinkWrap.create(JavaArchive.class, "shared.jar")
+                .addClasses(SharedMVCController.class);
+
+        // a war that includes a @Controller class, plus can access one in the shared jar
+        WebArchive withController = ShrinkWrap.create(WebArchive.class, WITH_CONTROLLER)
+                .addClasses(TestApplication.class, UnsharedMVCController.class, NonMVCResource.class)
+                .addAsWebInfResource(new ClassLoaderAsset(localResourcePath + "/view.jsp"), "views/view.jsp");
+
+        // a war that doesn't have any @Controller and can only use one in the shared jar
+        WebArchive noController = ShrinkWrap.create(WebArchive.class, NO_CONTROLLER)
+                .addClasses(TestApplication.class, NonMVCResource.class)
+                .addAsWebInfResource(new ClassLoaderAsset(localResourcePath + "/view.jsp"), "views/view.jsp");
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, MVCEarTestCase.class + ".ear")
+                .addAsLibrary(sharedJar)
+                // a war that includes a @Controller class, plus can access one in the shared jar
+                .addAsModule(withController)
+                // a war that doesn't have any @Controller and can only use one in the shared jar
+                .addAsModule(noController);
+
+        LOGGER.info(sharedJar.toString(Formatters.VERBOSE));
+        LOGGER.info(withController.toString(Formatters.VERBOSE));
+        LOGGER.info(noController.toString(Formatters.VERBOSE));
+        LOGGER.info(ear.toString(Formatters.VERBOSE));
+        return ear;
+    }
+
+    @Test
+    public void test() throws IOException {
+        callAndTest(WITH_CONTROLLER, "non-mvc", "No View");
+        callAndTest(WITH_CONTROLLER, "unshared", JSP_VIEW);
+        callAndTest(WITH_CONTROLLER, "shared", JSP_VIEW);
+        callAndTest(NO_CONTROLLER, "non-mvc", "No View");
+        callAndTest(NO_CONTROLLER, "shared", JSP_VIEW);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/NonMVCResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/NonMVCResource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.ear;
+
+import java.util.logging.Logger;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/non-mvc")
+@RequestScoped
+public class NonMVCResource {
+
+    private static final Logger LOGGER = Logger.getLogger(NonMVCResource.class.getName());
+
+    @GET
+    public String test() {
+
+        LOGGER.info(getClass().getSimpleName() + "test() called");
+        return "No View";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/SharedMVCController.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/SharedMVCController.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.ear;
+
+import java.util.logging.Logger;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.mvc.Controller;
+import jakarta.mvc.View;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/shared")
+@Controller
+@RequestScoped
+public class SharedMVCController {
+
+    private static final Logger LOGGER = Logger.getLogger(SharedMVCController.class.getName());
+
+    @GET
+    @View("view.jsp")
+    public void test() {
+        LOGGER.info(getClass().getSimpleName() + "test() called");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/TestApplication.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.ear;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class TestApplication extends Application {
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/UnsharedMVCController.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/UnsharedMVCController.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.mvc.ear;
+
+import java.util.logging.Logger;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.mvc.Controller;
+import jakarta.mvc.View;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/unshared")
+@Controller
+@RequestScoped
+public class UnsharedMVCController {
+
+    private static final Logger LOGGER = Logger.getLogger(UnsharedMVCController.class.getName());
+
+    @GET
+    @View("view.jsp")
+    public void test() {
+        LOGGER.info(getClass().getSimpleName() + "test() called");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/view.jsp
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/ear/view.jsp
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+    <body>
+        <p>
+            JSP View from the ${engine} view engine!
+        </p>
+    </body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/ViewEngineTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/mvc/viewengine/ViewEngineTestCase.java
@@ -5,70 +5,30 @@
 
 package org.wildfly.test.integration.mvc.viewengine;
 
-import static org.jboss.as.controller.client.helpers.ClientConstants.EXTENSION;
-import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
-import static org.jboss.as.controller.client.helpers.ClientConstants.SUBSYSTEM;
-import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+import static org.wildfly.test.integration.mvc.MVCTestUtil.callAndTest;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.shared.CdiUtils;
-import org.jboss.as.test.shared.ServerReload;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.integration.mvc.MVCTestUtil;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Preview.class, ViewEngineTestCase.ServerSetup.class})
+@ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Preview.class, MVCTestUtil.ServerSetup.class})
 public class ViewEngineTestCase {
-
-    public static final class ServerSetup implements ServerSetupTask {
-
-        @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            executeForResult(managementClient.getControllerClient(),
-                    Util.createAddOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.mvc-krazo")));
-            executeForResult(managementClient.getControllerClient(),
-                    Util.createAddOperation(PathAddress.pathAddress(SUBSYSTEM, "mvc-krazo")));
-
-            ServerReload.executeReloadAndWaitForCompletion(managementClient);
-        }
-
-        @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
-            // no need to do anything as the other task uses snapshot/restore
-        }
-
-        private void executeForResult(final ModelControllerClient client, final ModelNode operation) throws Exception {
-            final ModelNode response = client.execute(operation);
-            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
-        }
-    }
 
     public static final String SIMPLE_WAR = "ViewEngineTestCase-simple.war";
     public static final String SIMPLE_EAR = "ViewEngineTestCase-simple.ear";
@@ -115,7 +75,6 @@ public class ViewEngineTestCase {
     }
 
     @Test
-    @Ignore("WFLY-20570")
     public void testEarLib() throws IOException {
         test(EAR_WITH_LIB, SIMPLE_WAR);
     }
@@ -128,21 +87,10 @@ public class ViewEngineTestCase {
     private void test(String deploymentName, String warName) throws IOException {
         deployer.deploy(deploymentName);
         try {
-            callAndTest(warName);
+            callAndTest(warName, "test", "Mock View");
         } finally {
             deployer.undeploy(deploymentName);
         }
     }
 
-    private void callAndTest(String warName) throws IOException {
-        String contextPath = warName.substring(0, warName.length() - 4);
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
-            String uri = "http://" + TestSuiteEnvironment.getServerAddress() + ":8080/" + contextPath + "/app/test";
-            HttpGet get = new HttpGet(uri);
-            HttpResponse response = client.execute(get);
-            Assert.assertEquals("Wrong response code from " + uri, 200, response.getStatusLine().getStatusCode());
-            String result = EntityUtils.toString(response.getEntity());
-            Assert.assertEquals("Wrong response entity from " + uri, "Mock View", result);
-        }
-    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20570
https://issues.redhat.com/browse/WFLY-20571

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-19970](https://issues.redhat.com/browse/WFLY-19970)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)