### PR TITLE
WFLY-20587 Upgrade JBoss Metadata to 16.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
         <version.org.jboss.iiop-client>2.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>3.0.13.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.metadata>16.0.0.Final</version.org.jboss.metadata>
+        <version.org.jboss.metadata>16.1.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.1.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.2.1.Final</version.org.jboss.narayana>
         <version.org.jboss.narayana.lra>1.0.0.Final</version.org.jboss.narayana.lra>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -274,5 +274,10 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/SharedSessionConfigSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/SharedSessionConfigSchema.java
@@ -14,20 +14,25 @@ import org.jboss.as.controller.xml.VersionedNamespace;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.jbossallxml.JBossAllSchema;
 import org.jboss.as.web.session.SharedSessionManagerConfig;
+import org.jboss.metadata.parser.servlet.Version;
 import org.jboss.staxmapper.IntVersion;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
+ * Describes the supported shared-session-config XML schema versions.
  * @author Paul Ferraro
  */
 public enum SharedSessionConfigSchema implements JBossAllSchema<SharedSessionConfigSchema, SharedSessionManagerConfig> {
-    VERSION_1_0(1, 0),
-    VERSION_2_0(2, 0),
+    VERSION_1_0(1, 0, Version.SERVLET_5_0),
+    VERSION_2_0(2, 0, Version.SERVLET_5_0),
+    VERSION_3_0(3, 0, Version.SERVLET_6_0), // WF 37 - present
     ;
     private final VersionedNamespace<IntVersion, SharedSessionConfigSchema> namespace;
+    private final Version servletVersion;
 
-    SharedSessionConfigSchema(int major, int minor) {
+    SharedSessionConfigSchema(int major, int minor, Version servletVersion) {
         this.namespace = IntVersionSchema.createURN(List.of(IntVersionSchema.JBOSS_IDENTIFIER, this.getLocalName()), new IntVersion(major, minor));
+        this.servletVersion = servletVersion;
     }
 
     @Override
@@ -38,6 +43,10 @@ public enum SharedSessionConfigSchema implements JBossAllSchema<SharedSessionCon
     @Override
     public VersionedNamespace<IntVersion, SharedSessionConfigSchema> getNamespace() {
         return this.namespace;
+    }
+
+    Version getServletVersion() {
+        return this.servletVersion;
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/SharedSessionConfigXMLReader.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/SharedSessionConfigXMLReader.java
@@ -57,7 +57,7 @@ public class SharedSessionConfigXMLReader implements XMLElementReader<SharedSess
                     break;
                 }
                 case "session-config": {
-                    result.setSessionConfig(SessionConfigMetaDataParser.parse(reader, this.replacer));
+                    result.setSessionConfig(new SessionConfigMetaDataParser(this.schema.getServletVersion()).parse(reader, this.replacer));
                     break;
                 }
                 case "distributable": {

--- a/undertow/src/main/resources/schema/shared-session-config_3_0.xsd
+++ b/undertow/src/main/resources/schema/shared-session-config_3_0.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            targetNamespace="urn:jboss:shared-session-config:3.0"
+            xmlns="urn:jboss:shared-session-config:3.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+    <xs:import namespace="https://jakarta.ee/xml/ns/jakartaee" schemaLocation="https://jakarta.ee/xml/ns/jakartaee/web-common_6_0.xsd"/>
+
+    <!-- Root element -->
+    <xs:element name="shared-session-config" type="sharedSessionType">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the shared session config. If this is present in the root of
+                an ear then all war's deployed in the ear will share a single session manager.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="sharedSessionType">
+        <xs:all>
+            <xs:element name="distributable" type="jakartaee:emptyType" minOccurs="0"/>
+            <xs:element name="max-active-sessions" type="xs:string" minOccurs="0"/>
+            <xs:element name="session-config" type="jakartaee:session-configType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/session/shared-session-config-3.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/session/shared-session-config-3.0.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<shared-session-config xmlns="urn:jboss:shared-session-config:3.0">
+    <distributable/>
+    <max-active-sessions>10</max-active-sessions>
+    <session-config>
+        <cookie-config>
+            <path>/</path>
+            <attribute>
+                <attribute-name>SameSite</attribute-name>
+                <attribute-value>None</attribute-value>
+            </attribute>
+        </cookie-config>
+    </session-config>
+</shared-session-config>


### PR DESCRIPTION
Adds 3.0 version of shared-session-config schema whose session-config is parsed using the Servlet 6.0 version of the metadata parser.

https://issues.redhat.com/browse/WFLY-20587