### PR TITLE
[36.x] WFLY-20584 Upgrade SmallRye Fault Tolerance from 6.9.0 to 6.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-common>2.10.0</version.io.smallrye.smallrye-common>
         <version.io.smallrye.smallrye-config>3.12.4</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.9.0</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.9.1</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.7.0</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
Backport of https://github.com/wildfly/wildfly/pull/18899

Jira
https://issues.redhat.com/browse/WFLY-20584