### PR TITLE
[WFLY-20593] Remove no longer used verifier.product.release.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,6 @@
         <ee.maven.groupId>${project.groupId}</ee.maven.groupId>
         <ee.maven.version>${project.version}</ee.maven.version>
         <product.docs.server.version>36</product.docs.server.version>
-        <!-- A short variant of product.release.version used in 'startsWith' tests done by dist verification logic -->
-        <verifier.product.release.version>${product.docs.server.version}.0</verifier.product.release.version>
         <!-- The Galleon channel for the minor version with which this branch is associated.  -->
         <galleon.minor.channel>${product.docs.server.version}.0</galleon.minor.channel>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20593

Leftover after https://issues.redhat.com/browse/WFLY-18578

Not used anywhere else:
```
$ grep -r verifier.product.release.version
pom.xml:        <verifier.product.release.version>${product.docs.server.version}.0</verifier.product.release.version>
```
