### PR TITLE
[36.x] [WFLY-20596] Upgrade Velocity Engine to 2.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
         <version.org.apache.neethi>3.2.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.34.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>3.0.5</version.org.apache.santuario>
-        <version.org.apache.velocity>2.3</version.org.apache.velocity>
+        <version.org.apache.velocity>2.4.1</version.org.apache.velocity>
         <version.org.apache.wss4j>3.0.4</version.org.apache.wss4j>
         <version.org.apache.ws.xmlschema>2.3.0</version.org.apache.ws.xmlschema>
         <version.org.bitbucket.jose4j>0.9.6</version.org.bitbucket.jose4j>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20596

As Velocity Engine 2.3 shades in commons-io it is getting incorrectly flagged as containing a vulnerability.

https://github.com/apache/velocity-engine/compare/2.3...2.4.1

Upstream PR https://github.com/wildfly/wildfly/pull/18911