### PR TITLE
[WFLY-20601]:Upgrade Apache Artemis to 2.41.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <version.joda-time>2.12.7</version.joda-time>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>8.0.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.40.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.41.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>2.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.12.0</version.org.apache.avro>
         <version.org.apache.cxf>4.0.6</version.org.apache.cxf>


### PR DESCRIPTION
* Upgrading Apache Artemis from 2.40.0 to 2.41.0.

Release note: https://activemq.apache.org/components/artemis/download/release-notes-2.41.0
Jira: https://issues.redhat.com/browse/WFLY-20601