### PR TITLE
[WFLY-20609]: ActiveMQ Artemis fails to launch if system property with prefix "brokerconfig." is present.

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/client/main/module.xml
@@ -18,6 +18,7 @@
         <module name="java.management.rmi"/>
         <module name="java.naming"/>
         <module name="java.rmi"/>
+        <module name="java.xml"/>
         <module name="org.apache.activemq.artemis.commons"/>
         <!-- export is required to get  access to InVMConnectorFactory -->
         <module name="org.apache.activemq.artemis" optional="true" export="true"/>


### PR DESCRIPTION
 * Adding java.xml as a module dependency for `org.apache.activemq.artemis.client`.

Jira: https://issues.redhat.com/browse/WFLY-20609