### PR TITLE
[WFLY-20619] Upgrade WildFly Core to 28.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>6.0.1.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>28.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>28.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20619

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/28.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/28.0.0.Final...28.0.1.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7210'>WFCORE-7210</a>] -         Unescaped characters throw a NPE although allowed in settings
</li>
</ul>
                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7218'>WFCORE-7218</a>] -         Upgrade WildFly Elytron to 2.6.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7219'>WFCORE-7219</a>] -         Upgrade Elytron Web to 4.1.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7248'>WFCORE-7248</a>] -         Upgrade WildFly Elytron to 2.6.4.Final
</li>
</ul>
</details>

