### PR TITLE
WFLY-20630 Upgrade wildfly licenses-plugin to 2.4.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.4.1.Final</version.org.wildfly.glow>
-        <version.org.wildfly.licenses.plugin>2.4.1.Final</version.org.wildfly.licenses.plugin>
+        <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.2.Final</version.org.wildfly.unstable.annotation.api>
         <version.org.wildfly.wildfly-channel-plugin>1.0.20</version.org.wildfly.wildfly-channel-plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20630

The new version recognized more license SPDX identifiers, such as "MIT".