### PR TITLE
WFLY-20626 - Add explicit tests for multiple war support

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMicrometerMultipleTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMicrometerMultipleTestCase.java
@@ -5,8 +5,6 @@
 package org.wildfly.test.integration.observability.micrometer.multiple;
 
 import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -18,7 +16,6 @@ import org.jboss.arquillian.testcontainers.api.Testcontainer;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
-import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 
@@ -26,7 +23,7 @@ import org.junit.runner.RunWith;
 @ServerSetup(MicrometerSetupTask.class)
 @DockerRequired
 @RunAsClient
-public abstract class BaseMultipleTestCase {
+public abstract class BaseMicrometerMultipleTestCase {
     protected static final String SERVICE_ONE = "service-one";
     protected static final String SERVICE_TWO = "service-two";
     protected static final int REQUEST_COUNT = 5;
@@ -41,11 +38,5 @@ public abstract class BaseMultipleTestCase {
                 Assert.assertEquals(200, target.request().get().getStatus());
             }
         }
-    }
-
-    protected List<PrometheusMetric> getMetricsByName(List<PrometheusMetric> metrics, String key) {
-        return metrics.stream()
-                .filter(m -> m.getKey().equals(key))
-                .collect(Collectors.toList());
     }
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerEarDeploymentTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerEarDeploymentTestCase.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -19,16 +20,15 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
-import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 
-public class EarDeploymentTestCase extends BaseMultipleTestCase {
+public class MicrometerEarDeploymentTestCase extends BaseMicrometerMultipleTestCase {
     protected static final String ENTERPRISE_APP = "enterprise-app";
 
     @Deployment(name = ENTERPRISE_APP, testable = false)
     public static EnterpriseArchive createDeployment() {
         return ShrinkWrap.create(EnterpriseArchive.class, ENTERPRISE_APP + ".ear")
-                .addAsModule(MultipleWarTestCase.createDeployment1())
-                .addAsModule(MultipleWarTestCase.createDeployment2())
+                .addAsModule(MicrometerMultipleWarTestCase.createDeployment1())
+                .addAsModule(MicrometerMultipleWarTestCase.createDeployment2())
                 .setApplicationXML(new StringAsset("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                         + "<application xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" " +
                         "       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
@@ -56,7 +56,7 @@ public class EarDeploymentTestCase extends BaseMultipleTestCase {
 
 
         otelCollector.assertMetrics(prometheusMetrics -> {
-            List<PrometheusMetric> results = getMetricsByName(prometheusMetrics,
+            List<PrometheusMetric> results = otelCollector.getMetricsByName(prometheusMetrics,
                     DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
 
             Assert.assertEquals(2, results.size());

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerMultipleWarTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerMultipleWarTestCase.java
@@ -4,7 +4,7 @@
  */
 package org.wildfly.test.integration.observability.micrometer.multiple;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -24,7 +24,7 @@ import org.wildfly.test.integration.observability.JaxRsActivator;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
 
-public class MultipleWarTestCase extends BaseMultipleTestCase {
+public class MicrometerMultipleWarTestCase extends BaseMicrometerMultipleTestCase {
     @Deployment(name = SERVICE_ONE, order = 1, testable = false)
     public static WebArchive createDeployment1() {
         return ShrinkWrap.create(WebArchive.class, SERVICE_ONE + ".war")
@@ -49,7 +49,7 @@ public class MultipleWarTestCase extends BaseMultipleTestCase {
         makeRequests(new URI(String.format("%s/%s", serviceTwo, DuplicateMetricResource2.TAG)));
 
         otelCollector.assertMetrics(prometheusMetrics -> {
-            List<PrometheusMetric> results = getMetricsByName(prometheusMetrics,
+            List<PrometheusMetric> results = otelCollector.getMetricsByName(prometheusMetrics,
                     DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
 
             assertEquals(2, results.size());

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -59,7 +59,7 @@ public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     }
 
     // Request the published metrics from the OpenTelemetry Collector via the configured Prometheus exporter and check
-    // a few metrics to verify there existence
+    // a few metrics to verify their existence
     @Test
     @InSequence(3)
     public void getMetrics() throws InterruptedException {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMultipleWarTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMultipleWarTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
+import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
+import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
+import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.test.integration.observability.opentelemetry.application.OtelMetricResource;
+
+/**
+ * This test verifies that two OpenTelemetry applications can be deployed to the same server while their
+ * observability signals remain distinct. It deploys two applications and makes several requests to each to
+ * generate data. It then verifies that traces for each application are successfully exported to the Collector.
+ * Each trace will have a span with a tag of <code>url.path</code>. The value of that tag should be the name of
+ * the archive (i.e., 'service-one' or 'service-two'). Similarly, there should be a counter exported for each
+ * service with the tag <code>job</code> that contains the name of the archive. The value of the metric should
+ * equal <code>REQUEST_COUNT</code>.
+ */
+@RunAsClient
+@ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
+@DockerRequired
+public class OpenTelemetryMultipleWarTestCase extends BaseOpenTelemetryTest {
+    protected static final String SERVICE_ONE = "service-one";
+    protected static final String SERVICE_TWO = "service-two";
+    private static final int REQUEST_COUNT = 5;
+
+    @Deployment(name = SERVICE_ONE, order = 1, testable = false)
+    public static WebArchive createDeployment1() {
+        return buildBaseArchive(SERVICE_ONE);
+
+    }
+
+    @Deployment(name = SERVICE_TWO, order = 2, testable = false)
+    public static WebArchive createDeployment2() {
+        return buildBaseArchive(SERVICE_TWO);
+    }
+
+    @Test
+    @InSequence(2)
+    public void makeRequests() throws MalformedURLException {
+        try (Client client = ClientBuilder.newClient()) {
+            for (int i = 0; i < REQUEST_COUNT; i++) {
+                Assert.assertEquals(Response.Status.OK.getStatusCode(),
+                    client.target(getDeploymentUrl(SERVICE_ONE) + "?" + SERVICE_ONE).request().get().getStatus());
+                Assert.assertEquals(Response.Status.OK.getStatusCode(),
+                    client.target(getDeploymentUrl(SERVICE_ONE) + "/metrics").request().get().getStatus());
+
+                Assert.assertEquals(Response.Status.OK.getStatusCode(),
+                    client.target(getDeploymentUrl(SERVICE_TWO) + "?" + SERVICE_TWO).request().get().getStatus());
+                Assert.assertEquals(Response.Status.OK.getStatusCode(),
+                    client.target(getDeploymentUrl(SERVICE_TWO) + "/metrics").request().get().getStatus());
+            }
+        }
+    }
+
+    @Test
+    @InSequence(3)
+    public void testTraces() throws InterruptedException {
+        verifyTraces(SERVICE_ONE);
+        verifyTraces(SERVICE_TWO);
+    }
+
+    @Test
+    @InSequence(4)
+    public void getMetrics() throws InterruptedException {
+        verifyMetric(SERVICE_ONE);
+        verifyMetric(SERVICE_TWO);
+    }
+
+    private void verifyTraces(String serviceName) throws InterruptedException {
+        otelCollector.assertTraces(serviceName + ".war", traces -> {
+            Assert.assertFalse(traces.isEmpty());
+
+            Assert.assertTrue(traces.stream()
+                .map(JaegerTrace::getSpans).flatMap(List::stream)
+                .map(JaegerSpan::getTags).flatMap(List::stream)
+                .anyMatch(t ->
+                    Objects.equals(t.getKey(), "url.path") &&
+                        Objects.equals(t.getValue(), "/" + serviceName + "/")));
+
+        });
+    }
+
+    private void verifyMetric(String serviceName) throws InterruptedException {
+        otelCollector.assertMetrics(prometheusMetrics -> {
+            List<PrometheusMetric> results = otelCollector.getMetricsByName(prometheusMetrics,
+                OtelMetricResource.COUNTER_NAME + "_total"); // Adjust for Prometheus naming conventions
+
+            Assert.assertEquals(Integer.toString(REQUEST_COUNT),
+                results.stream()
+                    // Filter tag job=${serviceName}.war
+                    .filter(metric ->
+                        Objects.equals(metric.getTags().get("job"), serviceName + ".war")
+                    )
+                    .findFirst()
+                    .orElseThrow(AssertionError::new)
+                    .getValue());
+        });
+    }
+}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
@@ -33,7 +33,7 @@ public class OtelService1 {
 
     @GET
     public String sayHello(@QueryParam("name") String name) {
-        final Span span = tracer.spanBuilder("Saying hello from server1").startSpan();
+        final Span span = tracer.spanBuilder("Saying hello from service 1").startSpan();
         try (Scope scope = span.makeCurrent()) {
             span.addEvent("some-event");
             span.setAttribute("name", name);
@@ -46,7 +46,7 @@ public class OtelService1 {
     @GET
     @Path("contextProp1")
     public Response contextProp1() throws URISyntaxException {
-        final Span span = tracer.spanBuilder("Handling contextProp1 request from server1").startSpan();
+        final Span span = tracer.spanBuilder("Handling contextProp1 request from service 1").startSpan();
         try (Scope scope = span.makeCurrent()) {
             span.setAttribute("method_called", "contextProp1");
             span.addEvent("The method contextProp1 was called");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -91,6 +91,21 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     }
 
     /**
+     * Given a list of <code>PrometheusMetric</code> instances, return a sublist whose key matches <code>key</code>. Note
+     * that the key name must match the Prometheus conventions (see <a href="https://prometheus.io/docs/practices/naming/">
+     * here</a> for details.
+     * @param metrics List of PrometheusMetrics to filter.
+     * @param key The name of the metric to find
+     * @return a sublist of <code>metrics</code> that matches <code>key</code>
+     */
+    public List<PrometheusMetric> getMetricsByName(List<PrometheusMetric> metrics, String key) {
+        return metrics.stream()
+            .filter(m -> Objects.equals(m.getKey(), key))
+            .toList();
+    }
+
+
+    /**
      * Continually evaluates assertions provided in a consumer until the state obtained from the Jaeger endpoint
      * matches the expected state or until a timeout elapses. By default, polls the collector every second for 30 seconds.
      * Returns snapshot of the Jaeger traces that passed the assertions; typically ignored.


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20626

- Add new test for multiple wars that use OpenTelemetry
- Rename some Micrometer classes to avoid ambiguity
- Move utility method to OpenTelemetryCollectorContainer