### PR TITLE
WFLY-20644 Upgrade Hibernate Validator to 9.0.0.Final in WildFly preview / WFLY-20645 Upgrade Expressly to 6.0.0 in WildFly preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -59,7 +59,7 @@
         <version.org.hibernate>7.0.0.Beta5</version.org.hibernate>
         <version.org.hibernate.models>0.9.3</version.org.hibernate.models>
         <version.org.hibernate.search>8.0.0.Alpha1</version.org.hibernate.search>
-        <version.org.hibernate.validator>9.0.0.CR1</version.org.hibernate.validator>
+        <version.org.hibernate.validator>9.0.0.Final</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
 

--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -51,7 +51,7 @@
         <!-- Required for Hibernate Search -->
         <version.org.apache.lucene>9.12.1</version.org.apache.lucene>
         <version.org.bytebuddy>1.15.11</version.org.bytebuddy>
-        <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
+        <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.3</version.org.glassfish.jakarta.faces>
         <version.org.jboss.resteasy>7.0.0.Beta1</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.2.Final</version.org.jboss.weld.weld>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20644
https://issues.redhat.com/browse/WFLY-20645

Both have final versions released now.