### PR TITLE
[WFLY-20648] Upgrade WildFly Core to 29.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.0.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>29.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>29.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.0.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20648

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/29.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/29.0.0.Beta2...29.0.0.Beta3

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7253'>WFCORE-7253</a>] -         Prepare wildfly-legacy-test to be released based on WF35 controllers
</li>
</ul>
                                    
<h2>        Component Upgrade Subtask
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7254'>WFCORE-7254</a>] -         Upgrade WildFly Legacy Tests to 10.0.0.Final
</li>
</ul>
            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5898'>WFCORE-5898</a>] -         Intermittent failures in DeploymentScannerUnitTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5917'>WFCORE-5917</a>] -         Duplicating -Djboss.server.base.dir if defined in more than one place
</li>
</ul>
                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7256'>WFCORE-7256</a>] -         Upgrade io.smallrye:jandex from 3.3.0 to 3.3.1
</li>
</ul>
</details>

