### PR TITLE
[WFLY-20662] [CVE-2025-48734] Upgrade commons-beanutils to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.com.sun.istack>4.1.2</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>2.1.1</version.com.sun.xml.fastinfoset>
         <version.com.sun.xml.messaging.saaj>3.0.0</version.com.sun.xml.messaging.saaj>
-        <version.commons-beanutils>1.9.4</version.commons-beanutils>
+        <version.commons-beanutils>1.11.0</version.commons-beanutils>
         <version.commons-codec>1.17.2</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-io>2.16.1</version.commons-io>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20662

Resolves https://nvd.nist.gov/vuln/detail/CVE-2025-48734

@ehsavoie and @ropalka I've requested review due to this usage:

```
$ git grep beanutils | grep module.xml
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/commons/main/module.xml:        <module name="org.apache.commons.beanutils" />
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml:        <module name="org.apache.commons.beanutils" />
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml:        <module name="org.apache.commons.beanutils" />
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml:<module xmlns="urn:jboss:module:1.9" name="org.apache.commons.beanutils">
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml:        <artifact name="${commons-beanutils:commons-beanutils}"/>
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml:        <module name="org.apache.commons.beanutils"/>
ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml:        <module name="org.apache.commons.beanutils"/>
jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml:        <module name="org.apache.commons.beanutils"/>
jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml:        <module name="org.apache.commons.beanutils"/>
jsf/subsystem/src/test/resources/modules/jakarta/faces/impl/myfaces/module.xml:        <module name="org.apache.commons.beanutils"/>
jsf/subsystem/src/test/resources/modules2/jakarta/faces/impl/myfaces2/module.xml:        <module name="org.apache.commons.beanutils"/>
```

@jasondlee You too because of the myfaces stuff, but looking at https://github.com/wildfly-extras/wildfly-myfaces-feature-pack/blob/master/galleon-content/src/main/resources/modules/jakarta/faces/impl/myfaces/module.xml I suspect that stuff may be out of date.