### PR TITLE
[WFLY-20620] Disable ProvisioningConsistencyTestCase on s390x

### DIFF
--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.logging.Logger;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -70,7 +71,18 @@ public abstract class ProvisioningConsistencyBaseTest {
      * externally given through the jboss.dist Maven property.
      */
     @BeforeClass
-    public static void assumeJbossDistIsNotExternallySet() throws IOException {
+    public static void assumeCompatibleEnvironment() throws IOException {
+        assumeJbossDistIsNotExternallySet();
+        assumeNotS390();
+    }
+
+    private static void assumeNotS390() {
+        if ("s390x".equalsIgnoreCase(System.getProperty("os.arch"))) {
+            IntermittentFailure.thisTestIsFailingIntermittently("WFLY-20543");
+        }
+    }
+
+    private static void assumeJbossDistIsNotExternallySet() throws IOException {
         Path jbossDist = new File(System.getProperty("jboss.dist")).getCanonicalFile().toPath();
         Path defaultJbossDist = SOURCE_HOME.resolve(System.getProperty("build.output.dir"));
         Assume.assumeTrue(jbossDist.equals(defaultJbossDist));


### PR DESCRIPTION
This disables the tests on s390x pending resolution of WFLY-20543.

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-20620](https://issues.redhat.com/browse/WFLY-20620)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)