### PR TITLE
[WFLY-20712] Upgrade WildFly Core to 29.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.5.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>29.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>29.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>1.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue:  https://issues.redhat.com/browse/WFLY-20712


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/29.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/29.0.0.Beta3...29.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7269'>WFCORE-7269</a>] -         ProvisioningConsistencyTestCase failures with s390 Semeru
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7040'>WFCORE-7040</a>] -         Move to SE 17 as the minimum SE version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7242'>WFCORE-7242</a>] -         Undeprecate ModuleIdentifierUtil from org.jboss.as.controller
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7183'>WFCORE-7183</a>] -         Upgrade SLF4J from 2.0.16 to 2.0.17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7260'>WFCORE-7260</a>] -         CVE-2025-4949 - Upgrade JGit from to 6.10.1.202505221210-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7270'>WFCORE-7270</a>] -         Upgrade Galleon to 6.0.6.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7274'>WFCORE-7274</a>] -         Upgrade BouncyCastle from 1.80 to 1.81
</li>
</ul>
</details>
