### PR TITLE
[WFLY-20714]:  [WFLY-20714]: Upgrade artemis-wildfly-integration from 2.0.3.Final to 2.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
         <version.org.infinispan>15.2.1.Final</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.jberet>3.1.0.Final</version.org.jberet>
-        <version.org.jboss.activemq.artemis.integration>2.0.3.Final</version.org.jboss.activemq.artemis.integration>
+        <version.org.jboss.activemq.artemis.integration>2.0.4.Final</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>5.0.8.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.4.0.Final</version.org.jboss.ejb3.ext-api>


### PR DESCRIPTION
* This should make use of a jar without Artemis test classes

Jira: https://issues.redhat.com/browse/WFLY-20714