### PR TITLE
[WFLY-20719] Upgrade to Hibernate ORM 6.6.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.6.17.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.18.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.3.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.2.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20719 is for the upgrade to ORM 6.6.18.Final
https://issues.redhat.com/browse/WFLY-20572 is for the Jakarta EE 10 TCK failures we are currently seeing with WildFly `main`.
https://issues.redhat.com/browse/WFLY-20641 is for the TransactionTestCase failure on IBM JDK 17 & 21 LTS