### PR TITLE
[WFLY-20723] Json processing failed with error java.lang.UnsupportedOperationException at java.sql/java.sql.Date.toInstant

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <module name="java.logging"/>
+        <module name="java.desktop"/>
+        <module name="java.naming"/>
+        <module name="java.sql"/>
+        <module name="java.xml"/>
         <module name="jakarta.enterprise.api"/>
         <module name="jakarta.json.api"/>
         <module name="jakarta.json.bind.api"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20723

Missing java.sql dependency results in Yasson SqlDateSerializer not being initialized and fallback to DateSerializer, which fails with java.lang.UnsupportedOperationException at java.sql/java.sql.Date.toInstant