### PR TITLE
[WFLY-20726] Upgrade the MVC Krazo integration to 2.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
         <version.org.wildfly.core>29.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
-        <version.org.wildfly.mvc.krazo>1.0.1.Final</version.org.wildfly.mvc.krazo>
+        <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.vertx>1.0.2.Final</version.org.wildfly.vertx>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20726

It's a major version bump because the project's baseline SE went from 11 to 17, but otherwise it'd be a micro.