### PR TITLE
[WFLY-20728] Upgrade Hibernate Validator to 9.0.1.Final in WildFly preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -60,7 +60,7 @@
         <version.org.hibernate>7.0.1.Final</version.org.hibernate>
         <version.org.hibernate.models>1.0.0</version.org.hibernate.models>
         <version.org.hibernate.search>8.0.0.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>9.0.0.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>9.0.1.Final</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20728

There are a few updates to the new constraints + a small change in the internal traversable resolver.

- https://github.com/hibernate/hibernate-validator/compare/9.0.0.Final...9.0.1.Final
- https://in.relation.to/2025/06/13/hibernate-validator-9-0-1-Final/
