### PR TITLE
WFLY-20722 log that the app client persistence.xml will not be deployed in server mode

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -757,4 +757,8 @@ public interface JpaLogger extends BasicLogger {
     @Message(id = 75, value="Illegal to call this method from injected, managed EntityManager")
     IllegalStateException illegalCallOnCloseMethod();
 
+    @LogMessage(level = INFO)
+    @Message(id = 76, value = "persistence.xml in application client %s deployment will not be deployed in server mode")
+    void ignoreAppclientPersistenceUnitsInServer(String deploymentName);
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -94,6 +94,11 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
                 deploymentRoot.putAttachment(PersistenceUnitMetadataHolder.PERSISTENCE_UNITS, emptyholder);
                 addApplicationDependenciesOnProvider (deploymentUnit, emptyholder);
                 // if not in appclient container, do not deploy persistence units contained in appclient container archive
+                VirtualFile persistence_xml = deploymentRoot.getRoot().getChild(META_INF_PERSISTENCE_XML);
+                if (persistence_xml.exists() && persistence_xml.isFile() ) {
+                    // log that the (app client container) persistence.xml will be ignored since we are in server mode
+                    ROOT_LOGGER.ignoreAppclientPersistenceUnitsInServer(deploymentUnit.getName());
+                }
                 return;
             }
             // ordered list of PUs


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20722

Log that the persistence.xml contained in the application client archive will not be deployed by the WildFly server:
> 2025-06-17 15:12:22,475 INFO  [org.jboss.as.jpa] (MSC service thread 1-8) WFLYJPA0076: persistence.xml in application client database-ejb-1.0.12-SNAPSHOT.jar deployment will not be deployed in server mode



