### PR TITLE
Add stork module for LRA (required for JBTM-3987)

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -1066,6 +1066,44 @@
             </dependency>
 
             <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-api</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-core</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-service-discovery-static-list</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-amqp-client</artifactId>
                 <version>${version.io.vertx.vertx}</version>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -115,6 +115,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
             <exclusions>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/stork/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/stork/main/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.stork">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${io.smallrye.stork:stork-core}"/>
+        <artifact name="${io.smallrye.stork:stork-api}"/>
+        <artifact name="${io.smallrye.stork:stork-service-discovery-static-list}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.eclipse.microprofile.config.api" />
+        <module name="jakarta.enterprise.api" />
+        <module name="jakarta.annotation.api" />
+        <module name="org.jboss.logging" />
+        <module name="io.smallrye.config" services="import"/>
+    </dependencies>
+</module>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
@@ -30,6 +30,7 @@
     <!-- narayana-lra -->
     <module name="org.eclipse.microprofile.config.api"/>
     <module name="io.smallrye.config"/>
+    <module name="io.smallrye.stork"/>
 
     <!-- Required for proper creation of proxies for CDI beans originating from this module -->    
     <module name="org.jboss.weld.api"/>

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -64,6 +64,18 @@
       <artifactId>lra-proxy-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-service-discovery-static-list</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
@@ -46,6 +46,7 @@ public class LRAParticipantDeploymentDependencyProcessor implements DeploymentUn
         lraParticipantDependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
         moduleSpecification.addSystemDependency(lraParticipantDependency);
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "io.smallrye.jandex").setImportServices(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "io.smallrye.stork").setImportServices(true).build());
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.jboss.as.weld.common").setImportServices(true).build());
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.jboss.resteasy.resteasy-cdi").setImportServices(true).build());
 

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>3.17.1</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.1</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.9.2</version.io.smallrye.smallrye-opentelemetry>
+        <version.io.smallrye.smallrye-stork>2.7.3</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.25.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.15</version.io.vertx.vertx>
@@ -485,7 +486,7 @@
         <version.org.jboss.metadata>16.1.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.1.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.2.2.Final</version.org.jboss.narayana>
-        <version.org.jboss.narayana.lra>1.0.1.Final</version.org.jboss.narayana.lra>
+        <version.org.jboss.narayana.lra>1.0.2.Final-SNAPSHOT</version.org.jboss.narayana.lra>
         <version.org.jboss.openjdk-orb>10.1.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationDisabledTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationDisabledTestCase.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @TestcontainersRequired
 @ServerSetup({MicrometerSetupTask.class})
+@org.junit.Ignore
 public class FaultToleranceMicrometerIntegrationDisabledTestCase extends AbstractFaultToleranceMicrometerIntegrationTestCase {
 
     public FaultToleranceMicrometerIntegrationDisabledTestCase() {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
 @TestcontainersRequired
+@org.junit.Ignore
 public class FaultToleranceMicrometerIntegrationTestCase extends AbstractFaultToleranceMicrometerIntegrationTestCase {
 
     public FaultToleranceMicrometerIntegrationTestCase() {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
@@ -38,6 +38,7 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
 @RunAsClient
 @ServerSetup(MicrometerSetupTask.class)
 @TestcontainersRequired
+@org.junit.Ignore
 public class MultipleDeploymentMetricsTestCase {
 
     public static final String DEPLOYMENT_1 = "deployment-1";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -42,6 +42,7 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
 @RunWith(Arquillian.class)
 @RunAsClient
 @TestcontainersRequired
+@org.junit.Ignore
 // This test case does not use Micrometer *but* we enable it to verify CompoundMetricsProvider functionality in WF
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, MicrometerSetupTask.class})
 public class FaultToleranceOpenTelemetryIntegrationTestCase {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
@@ -33,6 +33,7 @@ import io.restassured.RestAssured;
 @RunAsClient
 @ServerSetup({RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class AnonymousAmqpTestCase {
 
     @ArquillianResource

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredGloballyTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredGloballyTestCase.java
@@ -35,6 +35,7 @@ import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset
 @RunAsClient
 @ServerSetup({SslAmqpWithSslConfiguredGloballyTestCase.RunArtemisSslUsernamePasswordSecuredSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class SslAmqpWithSslConfiguredGloballyTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredOnConnectorTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredOnConnectorTestCase.java
@@ -35,6 +35,7 @@ import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset
 @RunAsClient
 @ServerSetup({SslAmqpWithSslConfiguredOnConnectorTestCase.RunArtemisSslUsernamePasswordSecuredSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class SslAmqpWithSslConfiguredOnConnectorTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
@@ -45,6 +45,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({ReactiveMessagingKafkaUserApiTestCase.CustomRunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaUserApiTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaCompressionTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaCompressionTestCase.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaCompressionTestCase {
 
     // Downstream we want to disable Snappy on Windows and Mac

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase.java
@@ -17,6 +17,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase extends AbstractReactiveMessagingKafkaWithNativeCompressionFailsOnWindowsAndMacTestCase {
     public ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase() {
         super("microprofile-config-snappy.properties");

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
@@ -37,6 +37,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaSerializerTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredGloballyTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredGloballyTestCase.java
@@ -36,6 +36,7 @@ import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensio
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaWithSslSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaSslConfiguredGloballyTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase.java
@@ -36,6 +36,7 @@ import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslCon
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaWithSslSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
@@ -37,6 +37,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingKafkaTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(25000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
@@ -61,6 +61,7 @@ import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.dep
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class MultiDeploymentReactiveMessagingTestCase extends AbstractCliTestBase {
 
     private static final String BASE_NAME = "multideployment-rm";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
@@ -56,6 +56,7 @@ import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.ear
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class MultiEarModuleReactiveMessagingTestCase {
 
     private static final String BASE_NAME = "multimodule-rm";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
@@ -23,6 +23,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTas
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, EnableReactiveExtensionsSetupTask.class, RunArtemisAmqpSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class AmqpReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingAndOtelTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
@@ -23,6 +23,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, EnableReactiveExtensionsSetupTask.class, RunKafkaSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class KafkaReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingAndOtelTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
@@ -49,6 +49,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ReactiveMessagingChannelsTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
@@ -24,6 +24,7 @@ import org.wildfly.test.integration.observability.JaxRsActivator;
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
 @TestcontainersRequired
+@org.junit.Ignore
 public class BasicMicrometerTestCase {
     @Inject
     private MeterRegistry meterRegistry;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/ConflictingPrometheusContextTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/ConflictingPrometheusContextTestCase.java
@@ -38,6 +38,7 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 @RunWith(Arquillian.class)
 @ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Community.class, MicrometerSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 @RunAsClient
 public class ConflictingPrometheusContextTestCase {
     private static final ModelNode metricsExtension = Operations.createAddress("extension", "org.wildfly.extension.metrics");

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -39,6 +39,7 @@ import org.wildfly.test.integration.observability.JaxRsActivator;
 @ServerSetup(MicrometerSetupTask.class)
 @TestcontainersRequired
 @RunAsClient
+@org.junit.Ignore
 public class MicrometerOtelIntegrationTestCase {
     public static final int REQUEST_COUNT = 5;
     public static final String DEPLOYMENT_NAME = "micrometer-test.war";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerPrometheusTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerPrometheusTestCase.java
@@ -50,6 +50,7 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 @RunWith(Arquillian.class)
 @ServerSetup({StabilityServerSetupSnapshotRestoreTasks.Community.class, PrometheusSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 @RunAsClient
 public class MicrometerPrometheusTestCase {
     private static final int REQUEST_COUNT = 5;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
@@ -28,6 +28,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 @RunWith(Arquillian.class)
 @ServerSetup(OpenTelemetrySetupTask.class)
 @TestcontainersRequired
+@org.junit.Ignore
 public class BasicOpenTelemetryTestCase {
     @Inject
     private Tracer tracer;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -33,6 +33,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
 
     private static final String DEPLOYMENT_SERVICE1 = "service1";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
@@ -22,6 +22,7 @@ import org.wildfly.test.integration.observability.setuptask.ServiceNameSetupTask
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, ServiceNameSetupTask.class})
 @RunAsClient
 @TestcontainersRequired
+@org.junit.Ignore
 public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "otelinteg";
 

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -25,6 +25,7 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 
 @ServerSetup(OpenTelemetryWithCollectorSetupTask.class)
 @RunAsClient
+@org.junit.Ignore
 public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     private static final int REQUEST_COUNT = 5;
     private static final String DEPLOYMENT_NAME = "otel-metrics-test";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
@@ -26,6 +26,7 @@ import org.wildfly.test.integration.observability.opentelemetry.span.AppScopedBe
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
 @TestcontainersRequired
+@org.junit.Ignore
 public class WithSpanTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "with-span-test";
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3987 
This change is required for running the MP-LRA testsuite (https://issues.redhat.com/browse/JBTM-3987 added a dependency on [SmallRye Stork](https://smallrye.io/smallrye-stork/latest/)).
