### PR TITLE
[WFLY-20742] Upgrade the OWASP dependency check plugin to 12.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <version.org.jacoco>0.8.12</version.org.jacoco>
         <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
         <version.org.jboss.wildscribe>3.1.0.Final</version.org.jboss.wildscribe>
-        <version.org.owasp.dependency-check>12.1.0</version.org.owasp.dependency-check>
+        <version.org.owasp.dependency-check>12.1.3</version.org.owasp.dependency-check>
         <version.org.wildfly.bom-builder-plugin>2.0.8.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>


### PR DESCRIPTION

https://issues.redhat.com/browse/WFLY-20742