### PR TITLE
[WFLY-18960] StatefulTimeoutTestCase: make sfsb timeout higher becaus…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/bean/TimeoutIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/bean/TimeoutIncrementorBean.java
@@ -15,7 +15,7 @@ import jakarta.ejb.Stateful;
 import jakarta.ejb.StatefulTimeout;
 
 @Stateful
-@StatefulTimeout(value = 1, unit = TimeUnit.SECONDS)
+@StatefulTimeout(value = 2, unit = TimeUnit.SECONDS)
 public class TimeoutIncrementorBean implements Incrementor {
     private final AtomicInteger count = new AtomicInteger(0);
     private volatile boolean active = false;


### PR DESCRIPTION
…e of intermittent test failures

https://issues.redhat.com/browse/WFLY-18960

@pferraro please review

I can reproduce this very intermittent error by dividing this timeout by two, so maybe when we multiply it by two it will dissappear forever
