### PR TITLE
[WFLY-20747] Upgrade WildFly Core from 29.0.0.Beta4 to 29.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.6.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>29.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>29.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue:  https://issues.redhat.com/browse/WFLY-20747


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/29.0.0.Beta5
Diff: https://github.com/wildfly/wildfly-core/compare/29.0.0.Beta4...29.0.0.Beta5

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7235'>WFCORE-7235</a>] -         [Community] platform mbeans should be evolved to expose management info for latest supported JDK
</li>
</ul>
    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7276'>WFCORE-7276</a>] -         Configuration of interface is not possible with YAML configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7278'>WFCORE-7278</a>] -         AbstractModelControllerClient can send CancelAsyncRequest when the ActiveOperation is already done
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7185'>WFCORE-7185</a>] -         Remove deprecated ModuleIdentifier usage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7272'>WFCORE-7272</a>] -         Upstream SECURITY.md to reflect that WildFly is now sponsored by Commonhaus
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7275'>WFCORE-7275</a>] -         Remove &#39;throws IOException&#39; from AbstractModelControllerClient.getChannelAssociation()
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7280'>WFCORE-7280</a>] -         Use org.wildfly:wildfly-maven-gpg-plugin for GPG signing
</li>
</ul>
                                                                                                                                            
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7045'>WFCORE-7045</a>] -         Upgrade jboss-threads to 3.9.x
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7279'>WFCORE-7279</a>] -         Upgrade WildFly Galleon Plugins to 7.4.0.Final
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7238'>WFCORE-7238</a>] -         Update wildfly-threads to only use EnhancedQueueExecutor and JBossScheduledThreadPoolExecutor
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7273'>WFCORE-7273</a>] -         Remove JBoss Threads classes from the ModelControllerClient API; use SE&#39;s CompletableFuture
</li>
</ul>
</details>


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/29.0.0.Beta6
Diff: https://github.com/wildfly/wildfly-core/compare/29.0.0.Beta5...29.0.0.Beta6

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7281'>WFCORE-7281</a>] -         ExtendedGarbageCollectorMBean expects non-existent CompositeData fields
</li>
</ul>
</details>
