### PR TITLE
[WFLY-16653] Use a state for the LongRunningBatchlet to be thread-saf…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspend/SuspendBatchletTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/suspend/SuspendBatchletTestCase.java
@@ -114,7 +114,7 @@ public class SuspendBatchletTestCase extends AbstractBatchTestCase {
     @Test
     public void testSuspendResume() throws Exception {
         final Properties jobProperties = new Properties();
-        jobProperties.setProperty("max.seconds", "10");
+        jobProperties.setProperty("max.seconds", Integer.toString(TimeoutUtil.adjust(10)));
         final JobOperator jobOperator = BatchRuntime.getJobOperator();
 
         long executionId = jobOperator.start("suspend-batchlet", jobProperties);
@@ -123,7 +123,7 @@ public class SuspendBatchletTestCase extends AbstractBatchTestCase {
         suspendServer();
 
         // check job is stopped
-        checkJobExecution(jobOperator, jobExecution, BatchStatus.STOPPED, "KO");
+        checkJobExecution(jobOperator, jobExecution, BatchStatus.STOPPED, "STOPPED");
 
         resumeServer();
 


### PR DESCRIPTION
…e. The previous version failed intermittently. Using better response names for the error message as well.

https://issues.redhat.com/browse/WFLY-16653