### PR TITLE
[WFLY-20767] DatabaseTimerServiceMultiNodeExecutionDisabledTestCase a…

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -186,8 +186,8 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         Context clientContext = getRemoteContext(clientClient);
         RemoteTimedBean clientBean = (RemoteTimedBean) clientContext.lookup(ARCHIVE_NAME + "/" + TimedObjectTimerServiceBean.class.getSimpleName() + "!" + RemoteTimedBean.class.getName());
 
-        clientBean.scheduleTimer(System.currentTimeMillis() + 100, "timer1");
-        Thread.sleep(200);
+        clientBean.scheduleTimer(System.currentTimeMillis() + 100, "timer-disabled");
+        Thread.sleep(1000);
         Assert.assertFalse(clientBean.hasTimerRun());
         clientContext.close();
 
@@ -195,7 +195,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         List<TimerData> res = serverBean.collect(1);
         Assert.assertEquals(1, res.size());
         Assert.assertEquals("server", res.get(0).getNode());
-        Assert.assertEquals("timer1", res.get(0).getInfo());
+        Assert.assertEquals("timer-disabled", res.get(0).getInfo());
     }
 
 


### PR DESCRIPTION
…nd DatabaseTimerServiceMultiNodeTestCase possible interaction - fix attempt

https://issues.redhat.com/browse/WFLY-20767

Those test failed together intermittently, but this failure is suspicous:
* they both use the same h2 server
* they use the same timer name "timer1"
* 0 invocations of timer1 in first test
* 2 invocations of timer1 in second test (1 expected)
* DatabaseTimerServiceMultiNodeExecutionDisabledTestCase didn't manage to refresh timers

Looks like an interaction between the tests.
In this fix attempt I change the timer name so that it is not shared between the tests and I'm also giving more time for the first test to check the timer.
