### PR TITLE
[WFLY-20765] Add documentation for the brute force authentication detection utility.

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Subsystem_Component_Documentation.adoc
+++ b/docs/src/main/asciidoc/_elytron/Subsystem_Component_Documentation.adoc
@@ -29,5 +29,6 @@ include::components/Failover_Security_Realm.adoc[]
 include::components/Filesystem_Security_Realm.adoc[]
 include::components/JAAS_Security_Realm.adoc[]
 include::components/JDBC_Security_Realm.adoc[]
+include::components/Brute_Force_Detection.adoc[]
 
 :leveloffset: -1

--- a/docs/src/main/asciidoc/_elytron/components/Brute_Force_Detection.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Brute_Force_Detection.adoc
@@ -1,0 +1,94 @@
+[[brute-force-authentication-detection]]
+= Brute Force Authentication Detection
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+Starting from WildFly 38 all security realms used for username / password
+authentication are wrapped by default by a utility realm to add protection
+towards brute force authentication type attacks. This has been added as a
+mitigation regarding http://cve.org/CVERecord?id=CVE-2025-23368[CVE-2025-23368].
+
+NOTE: It should be noted that the tracking of failed authentication attempts is
+in-memory only and does not survive restarts, additionally the state is not
+replicated to other nodes when operating in a cluster.
+
+Brute force authentication detection is applied on a per realm basis and the
+following parameters can be adjusted to tune the operation of the utility.
+
+* enabled - Should the protection be enabled for the realm. [Default: true]
+* max-failed-attempts - The maximum number of failed authentication attempts
+before an identity should be temporarily unavailable. [Default: 25]
+* lockout-interval - The time in minutes the identity should be unavailble for
+once the maximum number of attempts is exceeded. [Default: 15]
+* session-timeout - After the most recent failed authentication, how long in
+minutes to keep the session tracking the identity alive. [Default: 60]
+
+These properties can be set on a realm by realm basis using system properties
+in the form:
+----
+wildfly.elytron.realm.{REALM_NAME}.brute-force.{PROPERTY_NAME}
+----
+
+The security realms which are automatically wrapped are:
+
+ * custom-realm
+ * custom-modifiable-realm
+ * filesystem-realm
+ * jaas-realm
+ * jdbc-realm
+ * ldap-realm
+ * properties-realm
+
+By wrapping the security realms this utility will automatically be applied to the following
+authentication mechanisms:
+
+  * SASL Digest
+  * SASL Scram
+  * SASL Plain
+  * HTTP Basic
+  * HTTP Digest
+  * HTTP Form
+  * HTTP Programmatic
+
+This protection will also apply where code accesses the `SecurityDomain`
+APIs directly for authentication.
+
+== Runtime Operation
+
+Internally within WildFly Elytron, as authentication attempts occur the mechanisms
+emit events to indicate if an authentication has been successful or not for a
+specific identity, the wrapper realm defined here processes the events as follows.
+
+Under normal operation, provided there has not previously been a failed
+authentication for an identity events indicating a successful authentication are
+ignored.
+
+Where an event is received indicating a failed authentication attempt this utility
+will first check if a session has been established for the specific identity to
+track failed authentications and if that session does not exist it will be created.
+Within this session the counter tracking the number of failed authentications will
+be incremented.
+
+Once created a session will remain in the cache for the duration of the `session-timeout` except where a successful authentication event is received for the
+identity, in that case the session will be discarded.
+
+After it has been identified that the number of failed authentications for an
+identity has exceeded the configured `max-failed-attempts` the session will track
+that the identity is disabled for the period defined in `lockout-interval`.
+Repeated attempts after this point will restart the period the identity is locked
+for.
+
+During authentication attempts as this utility realm wraps the underlying realm
+it will check for the identity being authenticated if a session already exists
+tracking failed authentication attempts for that identity and if so are we
+presently in a lockout period. Where the identity is not presently locked out the
+call will be passed to the wrapped realm for authentication to proceed as normal,
+however if the identity is locked a dummy `RealmIdentity` will be returned for
+authentication that is guaranteed to fail all authentication attempts even if at
+this point the caller supplies valid credentials.

--- a/docs/src/main/asciidoc/_elytron/components/Brute_Force_Detection.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Brute_Force_Detection.adoc
@@ -9,7 +9,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-Starting from WildFly 38 all security realms used for username / password
+Starting from WildFly 39.0.1 all security realms used for username / password
 authentication are wrapped by default by a utility realm to add protection
 towards brute force authentication type attacks. This has been added as a
 mitigation regarding http://cve.org/CVERecord?id=CVE-2025-23368[CVE-2025-23368].
@@ -24,7 +24,7 @@ following parameters can be adjusted to tune the operation of the utility.
 * enabled - Should the protection be enabled for the realm. [Default: true]
 * max-failed-attempts - The maximum number of failed authentication attempts
 before an identity should be temporarily unavailable. [Default: 25]
-* lockout-interval - The time in minutes the identity should be unavailble for
+* lockout-interval - The time in minutes the identity should be unavailable for
 once the maximum number of attempts is exceeded. [Default: 15]
 * session-timeout - After the most recent failed authentication, how long in
 minutes to keep the session tracking the identity alive. [Default: 60]
@@ -75,8 +75,9 @@ track failed authentications and if that session does not exist it will be creat
 Within this session the counter tracking the number of failed authentications will
 be incremented.
 
-Once created a session will remain in the cache for the duration of the `session-timeout` except where a successful authentication event is received for the
-identity, in that case the session will be discarded.
+Once created a session will remain in the cache for the duration of the `session-timeout`
+except where a successful authentication event is received for the identity, in that
+case the session will be discarded.
 
 After it has been identified that the number of failed authentications for an
 identity has exceeded the configured `max-failed-attempts` the session will track


### PR DESCRIPTION
This is being enabled by default but can be customised by administrators.

https://issues.redhat.com/browse/WFLY-20765

Requires https://issues.redhat.com/browse/WFCORE-7192

