### PR TITLE
[WFLY-14748] Add ability to set default async context as part of Serv…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncLeash.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncLeash.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.servlet.async;
+
+import jakarta.ejb.Remote;
+
+@Remote
+public interface AsyncLeash {
+    void init(long l);
+
+    void onTimeout(Throwable throwable);
+
+    void onComplete();
+
+    void onError(Throwable throwable);
+
+    void onStartAsync();
+
+    boolean isTimeout();
+
+    String detail();
+
+    long timeoutTStamp();
+
+    long initTStamp();
+
+    boolean initialized();
+
+    long getExpectedTDiff();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncLeashBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncLeashBean.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.servlet.async;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.LinkedList;
+
+import jakarta.ejb.Singleton;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@Singleton
+@ApplicationScoped
+public class AsyncLeashBean implements AsyncLeash {// , AsyncListener{
+
+    private long initTStamp = -1;
+    private long timeoutTStamp = -1;
+    private long expectedTDiff = -1;
+    private LinkedList<Event> details;
+
+    @Override
+    public void init(final long expected) {
+        this.initTStamp = System.currentTimeMillis();
+        this.expectedTDiff = expected;
+        this.details = new LinkedList<Event>();
+        log("init", null);
+    }
+
+    @Override
+    public void onTimeout(final Throwable throwable) {
+        log("onTimeout", throwable);
+        this.timeoutTStamp = System.currentTimeMillis();
+    }
+
+    @Override
+    public void onComplete() {
+        log("onError", null);
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        log("onError", throwable);
+    }
+
+    @Override
+    public void onStartAsync() {
+        log("onStartAsync", null);
+    }
+
+    @Override
+    public boolean isTimeout() {
+        return timeoutTStamp != -1;
+    }
+
+    @Override
+    public String detail() {
+        final StringBuilder sb = new StringBuilder();
+        for(Event e: details) {
+            sb.append(isTimeout()).append(e.toString()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public long timeoutTStamp() {
+        return this.timeoutTStamp;
+    }
+
+    @Override
+    public long initTStamp() {
+        return this.initTStamp;
+    }
+
+    @Override
+    public boolean initialized() {
+        return initTStamp != -1;
+    }
+
+    @Override
+    public long getExpectedTDiff() {
+        return expectedTDiff;
+    }
+
+    //just to give insight into test run, JIC.
+    private void log(final String name, final Throwable t) {
+        final Event e = new Event(name, t);
+        this.details.add(e);
+    }
+    private final class Event{
+        final String name;
+        final long eventTStamp = System.currentTimeMillis();
+        final String stackTrace;
+        public Event(String name, Throwable t) {
+            this.name = name;
+            if(t != null) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                t.printStackTrace(pw);
+                stackTrace = sw.toString();
+            } else {
+                stackTrace  = "N/A";
+            }
+        }
+
+        public String toString() {
+            return this.name+"\n - tStamp: "+this.eventTStamp+"\n - trace: "+this.stackTrace;
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncNonDispatchServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncNonDispatchServlet.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.servlet.async;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = ("/init/*"), name = "PathMappingServlet", asyncSupported = true)
+public class AsyncNonDispatchServlet extends HttpServlet {
+
+    @EJB(mappedName = "java:global/asynctimeout/AsyncLeashBean!org.jboss.as.test.integration.web.servlet.async.AsyncLeash")
+    private AsyncLeash leash;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final AsyncContext ctx = req.startAsync();
+        ctx.addListener(new AsyncGuard(), req, resp);
+        String t = req.getParameter("timeout");
+        if (t != null) {
+            ctx.setTimeout(Long.parseLong(t));
+        }
+        leash.init(ctx.getTimeout());
+        Thread tr = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(ctx.getTimeout() + 1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        tr.start();
+
+    }
+
+    private class AsyncGuard implements AsyncListener, Serializable {
+        public void onComplete(AsyncEvent event) throws IOException {
+            try {
+                lookupEJB().onComplete();
+            } catch (NamingException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+        public void onTimeout(AsyncEvent event) throws IOException {
+            try {
+                lookupEJB().onTimeout(event.getThrowable());
+            } catch (NamingException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+        public void onError(AsyncEvent event) throws IOException {
+            try {
+                lookupEJB().onError(event.getThrowable());
+            } catch (NamingException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            try {
+                lookupEJB().onStartAsync();
+            } catch (NamingException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    public static AsyncLeash lookupEJB() throws NamingException {
+        final Context context = getInitialContext();
+        return (AsyncLeash) context
+                .lookup("ejb:/asynctimeout/AsyncLeashBean!org.jboss.as.test.integration.web.servlet.async.AsyncLeash");
+    }
+
+    private static InitialContext getInitialContext() throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.as.naming.InitialContextFactory");
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        return new InitialContext(jndiProperties);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletContainerTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletContainerTimeoutTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.servlet.async;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.wildfly.extension.undertow.Constants.SERVLET_CONTAINER;
+
+import java.io.IOException;
+
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.wildfly.extension.undertow.Constants;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
+
+@ServerSetup(StabilityServerSetupSnapshotRestoreTasks.Preview.class)
+public class AsyncServletContainerTimeoutTestCase extends AsyncServletTimeoutTestCaseBase {
+
+    private static final PathAddress SERVLET_CONTAINER_ADDRESS = PathAddress
+            .pathAddress(PathElement.pathElement(SUBSYSTEM, "undertow"), PathElement.pathElement(SERVLET_CONTAINER, "default"));
+
+    private void setDefaultTimeout(final long timeout) throws IOException {
+        final ModelNode setTimeoutOperation = Operations.createWriteAttributeOperation(SERVLET_CONTAINER_ADDRESS.toModelNode(),
+                Constants.DEFAULT_ASYNC_CONTEXT_TIMEOUT, timeout);
+        final ModelControllerClient controllerClient = managementClient.getControllerClient();
+        final ModelNode response = controllerClient.execute(setTimeoutOperation);
+        Assert.assertTrue(Operations.isSuccessfulOutcome(response));
+        ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+    }
+
+    @Override
+    protected String getUrl() {
+        return url + "init/execute";
+    }
+
+    @Override
+    protected long getTimeout() {
+        return 3000;
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        setDefaultTimeout(getTimeout());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletSetTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletSetTimeoutTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.servlet.async;
+
+import java.io.IOException;
+
+public class AsyncServletSetTimeoutTestCase extends AsyncServletTimeoutTestCaseBase {
+
+    @Override
+    protected String getUrl() {
+        return url + "init/execute?timeout=" + getTimeout();
+    }
+
+    @Override
+    protected long getTimeout() {
+        return 1000;
+    }
+
+    @Override
+    protected void setup() throws IOException {
+        // NOP
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletTimeoutTestCaseBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/async/AsyncServletTimeoutTestCaseBase.java
@@ -1,0 +1,82 @@
+package org.jboss.as.test.integration.web.servlet.async;
+
+import java.io.IOException;
+import java.net.URL;
+
+import javax.naming.NamingException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.ServerSnapshot;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class AsyncServletTimeoutTestCaseBase {
+    public static final String DEPLOYMENT_NAME = "asynctimeout";
+    public static final String DEPLOYMENT_NAME_WAR = DEPLOYMENT_NAME + ".war";
+
+    protected AutoCloseable serverSnapshot;
+    @ArquillianResource
+    protected ManagementClient managementClient;
+    @ArquillianResource
+    protected URL url;
+
+    @Deployment
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME_WAR);
+        war.addClass(AsyncLeash.class);
+        war.addClass(AsyncLeashBean.class);
+        war.addClass(AsyncNonDispatchServlet.class);
+        return war;
+    }
+
+    @Before
+    public void before() throws Exception {
+        serverSnapshot = ServerSnapshot.takeSnapshot(managementClient);
+    }
+
+    @After
+    public void after() throws Exception {
+        serverSnapshot.close();
+    }
+
+    @Test
+    public void testTimeout() throws IOException, InterruptedException, NamingException {
+        final long customTimeout = getTimeout();
+        setup();
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final HttpGet request = new HttpGet(getUrl());
+            final HttpResponse response = httpClient.execute(request);
+            Assert.assertEquals(500, response.getStatusLine().getStatusCode());
+            final HttpEntity entity = response.getEntity();
+            final String responseMessage = EntityUtils.toString(entity);
+            AsyncLeash leash = AsyncNonDispatchServlet.lookupEJB();
+            Assert.assertTrue(leash.initialized());
+            Assert.assertTrue(leash.detail(), leash.isTimeout());
+            Assert.assertTrue(leash.detail(), leash.timeoutTStamp() - leash.initTStamp() - customTimeout < 150);// 150 ms should
+                                                                                                                // be enough?
+        }
+    }
+
+    protected abstract void setup() throws IOException;
+
+    protected abstract String getUrl();
+
+    protected abstract long getTimeout();
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -192,6 +192,7 @@ public interface Constants {
     String DISABLE_NODES = "disable-nodes";
     String STOP_NODES = "stop-nodes";
     String DEFAULT_SESSION_TIMEOUT = "default-session-timeout";
+    String DEFAULT_ASYNC_CONTEXT_TIMEOUT = "default-async-context-timeout";
     String PREDICATE = "predicate";
     String SSL_SESSION_CACHE_SIZE = "ssl-session-cache-size";
     String SSL_SESSION_TIMEOUT = "ssl-session-timeout";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
@@ -77,6 +77,7 @@ final class ServletContainerAdd extends AbstractBoottimeAddStepHandler {
         Integer maxSessions = ServletContainerDefinition.MAX_SESSIONS.resolveModelAttribute(resolver, model).asIntOrNull();
 
         final int sessionTimeout = ServletContainerDefinition.DEFAULT_SESSION_TIMEOUT.resolveModelAttribute(resolver, model).asInt();
+        final long defaultAsyncContextTimeout = ServletContainerDefinition.DEFAULT_ASYNC_CONTEXT_TIMEOUT.resolveModelAttribute(resolver, model).asLong();
 
         WebsocketsDefinition.WebSocketInfo webSocketInfo = WebsocketsDefinition.getConfig(resolver, model.get(WebsocketsDefinition.PATH_ELEMENT.getKeyValuePair()));
 
@@ -266,6 +267,11 @@ final class ServletContainerAdd extends AbstractBoottimeAddStepHandler {
             @Override
             public boolean isOrphanSessionAllowed() {
                 return orphanSessionAllowed;
+            }
+
+            @Override
+            public long getDefaultAsyncContextTimeout() {
+               return defaultAsyncContextTimeout;
             }
         };
         builder.setInstance(Service.newInstance(builder.provides(ServletContainerDefinition.SERVLET_CONTAINER_CAPABILITY), service));

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
@@ -20,7 +20,9 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -187,6 +189,16 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
                     .setDefaultValue(ModelNode.FALSE)
                     .build();
 
+    static final AttributeDefinition DEFAULT_ASYNC_CONTEXT_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_ASYNC_CONTEXT_TIMEOUT, ModelType.LONG)
+                    .setRequired(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setAllowExpression(true)
+                    .setDefaultValue(new ModelNode(30000))
+                    .setValidator(new LongRangeValidator(0))
+                    .setStability(Stability.PREVIEW)
+                    .build();
+
     static final Collection<AttributeDefinition> ATTRIBUTES = List.of(
             ALLOW_NON_STANDARD_WRAPPERS,
             DEFAULT_BUFFER_CACHE,
@@ -208,7 +220,8 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
             FILE_CACHE_TIME_TO_LIVE,
             DEFAULT_COOKIE_VERSION,
             PRESERVE_PATH_ON_FORWARD,
-            ORPHAN_SESSION_ALLOWED);
+            ORPHAN_SESSION_ALLOWED,
+            DEFAULT_ASYNC_CONTEXT_TIMEOUT);
 
     ServletContainerDefinition() {
         super(new SimpleResourceDefinition.Parameters(PATH_ELEMENT, UndertowExtension.getResolver(PATH_ELEMENT.getKey()))

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
@@ -94,4 +94,6 @@ public interface ServletContainerService {
     boolean isPreservePathOnForward();
 
     boolean isOrphanSessionAllowed();
+
+    long getDefaultAsyncContextTimeout();
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
@@ -50,35 +50,42 @@ public class UndertowExtensionTransformerRegistration implements ExtensionTransf
                 }
             }
 
-            if (UndertowSubsystemModel.VERSION_14_0_0.requiresTransformation(version)) {
-                final ResourceTransformationDescriptionBuilder handlers = subsystem.addChildResource(HandlerDefinitions.PATH_ELEMENT);
-                final ResourceTransformationDescriptionBuilder reverseProxy = handlers.addChildResource(ReverseProxyHandlerDefinition.PATH_ELEMENT);
-                final AttributeTransformationDescriptionBuilder reverseProxyAttributeTransformationDescriptionBuilder = reverseProxy.getAttributeBuilder();
-                final ResourceTransformationDescriptionBuilder ajpListener = server.addChildResource(AjpListenerResourceDefinition.PATH_ELEMENT);
+            if (UndertowSubsystemModel.VERSION_15_0_0.requiresTransformation(version)) {
+                final ResourceTransformationDescriptionBuilder servletContainer = subsystem.addChildResource(ServletContainerDefinition.PATH_ELEMENT);
+                final AttributeTransformationDescriptionBuilder sevletContainerAttribyteDescriptionBuilder = servletContainer.getAttributeBuilder();
+                sevletContainerAttribyteDescriptionBuilder
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, ServletContainerDefinition.DEFAULT_ASYNC_CONTEXT_TIMEOUT)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, ServletContainerDefinition.DEFAULT_ASYNC_CONTEXT_TIMEOUT);
 
-                reverseProxyAttributeTransformationDescriptionBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, ReverseProxyHandlerDefinition.REUSE_X_FORWARDED_HEADER)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, ReverseProxyHandlerDefinition.REUSE_X_FORWARDED_HEADER)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, ReverseProxyHandlerDefinition.REWRITE_HOST_HEADER)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, ReverseProxyHandlerDefinition.REWRITE_HOST_HEADER)
-                .end();
+                if (UndertowSubsystemModel.VERSION_14_0_0.requiresTransformation(version)) {
+                    final ResourceTransformationDescriptionBuilder handlers = subsystem.addChildResource(HandlerDefinitions.PATH_ELEMENT);
+                    final ResourceTransformationDescriptionBuilder reverseProxy = handlers.addChildResource(ReverseProxyHandlerDefinition.PATH_ELEMENT);
+                    final AttributeTransformationDescriptionBuilder reverseProxyAttributeTransformationDescriptionBuilder = reverseProxy.getAttributeBuilder();
+                    final ResourceTransformationDescriptionBuilder ajpListener = server.addChildResource(AjpListenerResourceDefinition.PATH_ELEMENT);
 
-                final AttributeTransformationDescriptionBuilder ajpListenerAttributeTransformationDescriptionBuilder = ajpListener.getAttributeBuilder();
-                ajpListenerAttributeTransformationDescriptionBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
-                .end();
-
-                if (UndertowSubsystemModel.VERSION_13_0_0.requiresTransformation(version)) {
-                    final ResourceTransformationDescriptionBuilder servletContainer = subsystem.addChildResource(ServletContainerDefinition.PATH_ELEMENT);
-                    servletContainer.getAttributeBuilder()
-                        .setDiscard(DiscardAttributeChecker.UNDEFINED, ServletContainerDefinition.ORPHAN_SESSION_ALLOWED)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, ServletContainerDefinition.ORPHAN_SESSION_ALLOWED)
-                        .end();
-
-                    servletContainer.rejectChildResource(AffinityCookieDefinition.PATH_ELEMENT);
-
-                    ajpListenerAttributeTransformationDescriptionBuilder
-                    .setValueConverter(AttributeConverter.DEFAULT_VALUE, ListenerResourceDefinition.WRITE_TIMEOUT, ListenerResourceDefinition.READ_TIMEOUT)
+                    reverseProxyAttributeTransformationDescriptionBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, ReverseProxyHandlerDefinition.REUSE_X_FORWARDED_HEADER)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, ReverseProxyHandlerDefinition.REUSE_X_FORWARDED_HEADER)
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, ReverseProxyHandlerDefinition.REWRITE_HOST_HEADER)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, ReverseProxyHandlerDefinition.REWRITE_HOST_HEADER)
                     .end();
+
+                    final AttributeTransformationDescriptionBuilder ajpListenerAttributeTransformationDescriptionBuilder = ajpListener.getAttributeBuilder();
+                    ajpListenerAttributeTransformationDescriptionBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
+                    .end();
+
+                    if (UndertowSubsystemModel.VERSION_13_0_0.requiresTransformation(version)) {
+                        servletContainer.getAttributeBuilder()
+                            .setDiscard(DiscardAttributeChecker.UNDEFINED, ServletContainerDefinition.ORPHAN_SESSION_ALLOWED)
+                            .addRejectCheck(RejectAttributeChecker.DEFINED, ServletContainerDefinition.ORPHAN_SESSION_ALLOWED)
+                            .end();
+
+                        servletContainer.rejectChildResource(AffinityCookieDefinition.PATH_ELEMENT);
+
+                        ajpListenerAttributeTransformationDescriptionBuilder
+                        .setValueConverter(AttributeConverter.DEFAULT_VALUE, ListenerResourceDefinition.WRITE_TIMEOUT, ListenerResourceDefinition.READ_TIMEOUT)
+                        .end();
+                    }
                 }
             }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
@@ -17,9 +17,10 @@ public enum UndertowSubsystemModel implements SubsystemModel {
     VERSION_11_0_0(11), // WildFly 23-26.x, EAP 7.4.x
     VERSION_12_0_0(12), // WildFly 27
     VERSION_13_0_0(13), // WildFly 28
-    VERSION_14_0_0(14), // WildFly 32-present
+    VERSION_14_0_0(14), // WildFly 32-40
+    VERSION_15_0_0(15), // WildFly 40-present
     ;
-    static final UndertowSubsystemModel CURRENT = VERSION_14_0_0;
+    static final UndertowSubsystemModel CURRENT = VERSION_15_0_0;
 
     private final ModelVersion version;
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -64,10 +64,11 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
     VERSION_13_0(13),   // WildFly 27       N.B. There were no schema changes between 12.0 and 13.0!
     VERSION_14_0(14),   // WildFly 28-present
     VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-35
-    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY)   // WildFly 36-present
+    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY),  // WildFly 36-present
+    VERSION_15_0_PREVIEW(15, 0, Stability.PREVIEW)
     ;
 
-    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_14_0, VERSION_14_0_COMMUNITY);
+    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_14_0, VERSION_14_0_COMMUNITY, VERSION_15_0_PREVIEW);
     private final VersionedNamespace<IntVersion, UndertowSubsystemSchema> namespace;
     private final PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -995,6 +995,8 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
 
             d.setPreservePathOnForward(servletContainer.isPreservePathOnForward());
 
+            d.setDefaultAsyncConextTimeout(servletContainer.getDefaultAsyncContextTimeout());
+
             return d;
         } catch (ClassNotFoundException e) {
             throw new StartException(e);

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -61,6 +61,7 @@ undertow.servlet-container.file-cache-time-to-live=The length of time in ms an i
 undertow.servlet-container.default-cookie-version=The default cookie version servlet applications will send
 undertow.servlet-container.preserve-path-on-forward=If this is true Undertow will reset request path, URL and URI information to original values after forward.
 undertow.servlet-container.allow-orphan-session=Indicates whether session creation should be permitted after a response-closing operation, e.g. HttpServletResponse.sendRedirect(...). Enabling this behavior is generally discouraged, as the created session will be unreferenceable.
+undertow.servlet-container.default-async-context-timeout=Default timeout for async http context. Specified in milliseconds.
 undertow.mime-mapping=The servlet container mime mapping config
 undertow.mime-mapping.add=Adds a mime mapping
 undertow.mime-mapping.remove=Removes a mime mapping

--- a/undertow/src/main/resources/schema/wildfly-undertow_preview_15_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_preview_15_0.xsd
@@ -1,0 +1,1111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:undertow:preview:15.0"
+           targetNamespace="urn:jboss:domain:undertow:preview:15.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <!-- The undertow subsystem root element -->
+    <xs:element name="subsystem" type="undertow-subsystemType"/>
+
+    <xs:complexType name="undertow-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the undertow subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="byte-buffer-pool" type="byte-buffer-poolType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="buffer-cache" type="buffer-cacheType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="server" type="serverType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="servlet-container" type="servletContainerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="handlers" type="handlerType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="filters" type="filterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="application-security-domains" type="applicationSecurityDomainsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="default-server" type="xs:string" default="default-server"/>
+        <xs:attribute name="default-virtual-host" type="xs:string" default="default-host"/>
+        <xs:attribute name="default-servlet-container" type="xs:string" default="default"/>
+        <xs:attribute name="instance-id" type="xs:string" use="optional"/>
+        <xs:attribute name="obfuscate-session-route" type="xs:boolean" use="optional"/>
+        <xs:attribute name="default-security-domain" type="xs:string" use="optional" default="other"/>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Whether statistics are to be gathered for undertow subsystem.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="serverType">
+        <xs:sequence>
+            <xs:element name="ajp-listener" type="ajp-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-listener" type="http-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="https-listener" type="https-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="host" type="hostType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="default-host" use="optional" type="xs:string" default="default-host"/>
+        <xs:attribute name="servlet-container" use="optional" type="xs:string" default="default"/>
+    </xs:complexType>
+
+    <xs:complexType name="socket-options-type">
+        <xs:attribute name="receive-buffer" type="xs:int"/>
+        <xs:attribute name="send-buffer" type="xs:int"/>
+        <xs:attribute name="tcp-backlog" type="xs:int" default="10000"/>
+        <xs:attribute name="tcp-keep-alive" type="xs:boolean"/>
+        <xs:attribute name="read-timeout" type="xs:long" default="90000"/>
+        <xs:attribute name="write-timeout" type="xs:long" default="90000"/>
+        <xs:attribute name="max-connections" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="listener-type">
+        <xs:complexContent>
+            <xs:extension base="socket-options-type">
+                <xs:attribute name="name" use="required" type="xs:string"/>
+                <xs:attribute name="socket-binding" use="required" type="xs:string"/>
+                <xs:attribute name="worker" type="xs:string" default="default"/>
+                <xs:attribute name="buffer-pool" type="xs:string" default="default"/>
+                <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+                <xs:attribute name="resolve-peer-address" type="xs:boolean" default="false"/>
+                <xs:attribute name="max-post-size" type="xs:long" default="10485760"/>
+                <xs:attribute name="buffer-pipelined-data" type="xs:boolean" default="false"/>
+                <xs:attribute name="max-header-size" type="xs:long" default="1048576"/>
+                <xs:attribute name="max-parameters" type="xs:long" default="1000"/>
+                <xs:attribute name="max-headers" type="xs:long" default="200"/>
+                <xs:attribute name="max-cookies" type="xs:long" default="200"/>
+                <xs:attribute name="allow-encoded-slash" type="xs:boolean" default="false"/>
+                <xs:attribute name="decode-url" type="xs:boolean" default="true"/>
+                <xs:attribute name="url-charset" type="xs:string" default="UTF-8"/>
+                <xs:attribute name="always-set-keep-alive" type="xs:boolean" default="true"/>
+                <xs:attribute name="max-buffered-request-size" type="xs:long" default="16384"/>
+                <xs:attribute name="record-request-start-time" type="xs:boolean" default="false"/>
+                <xs:attribute name="allow-equals-in-cookie-value" type="xs:boolean" default="false"/>
+                <xs:attribute name="no-request-timeout" type="xs:int" default="60000"/>
+                <xs:attribute name="request-parse-timeout" type="xs:int"/>
+                <xs:attribute name="disallowed-methods" type="stringList" default="TRACE"/>
+                <xs:attribute name="secure" type="xs:boolean" default="false"/>
+                <xs:attribute name="rfc6265-cookie-validation" type="xs:boolean" default="false"/>
+                <xs:attribute name="allow-unescaped-characters-in-url" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT
+                                attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                undertow will automatically redirect the request to the socket binding port specified here.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="enable-http2" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              Enables HTTP2 upgrade and prior knowledge connections
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+                <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+                <xs:attribute name="require-host-http11" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="proxy-protocol" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="https-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SSLContext that should be used by this listener.
+
+                            If neither ssl-context or security-realm are set the JVM wide default SSLContext will be used instead.
+
+                            If this attribute is defined, the attributes 'verify-client', 'enabled-cipher-suites', 'enabled-protocols',
+                            'ssl-session-cache-size', and 'ssl-session-timeout' must not be set.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT
+                                                attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="security-realm" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Deprecated:  ssl-context should be set instead to reference a defined SSLContext.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="verify-client" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-cipher-suites" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-protocols" use="optional" type="xs:string"/>
+                <xs:attribute name="enable-http2" use="optional" type="xs:string"/>
+                <xs:attribute name="enable-spdy" use="optional" type="xs:string"/>
+                <xs:attribute name="ssl-session-cache-size" use="optional" type="xs:string"/>
+                <xs:attribute name="ssl-session-timeout" use="optional" type="xs:string"/>
+                <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+                <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+                <xs:attribute name="require-host-http11" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="proxy-protocol" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ajp-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="scheme" type="xs:string"/>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                                undertow will automatically redirect the request to the socket binding port specified here.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="max-ajp-packet-size" type="xs:int"/>
+                <xs:attribute name="allowed-request-attributes-pattern" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                Pattern which will be used to match AJP attributes that should be supported as part of request. Value is simple java regex.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="servletContainerType">
+        <xs:sequence>
+            <xs:element name="jsp-config" type="jsp-configurationType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="affinity-cookie" type="affinityCookieType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="session-cookie" type="sessionCookieType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="persistent-sessions" type="persistent-sessionsType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="websockets" type="websocketsType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="mime-mappings" type="mime-mappingsType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="welcome-files" type="welcome-filesType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="crawler-session-management" type="crawler-session-managementType" maxOccurs="1" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="allow-non-standard-wrappers" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-buffer-cache" use="optional" type="xs:string"/>
+        <xs:attribute name="stack-trace-on-error" use="optional" default="local-only"/>
+        <xs:attribute name="default-encoding" type="xs:string" use="optional"/>
+        <xs:attribute name="use-listener-encoding" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="ignore-flush" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="eager-filter-initialization" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="default-session-timeout" type="xs:integer" use="optional" default="30"/>
+        <xs:attribute name="disable-caching-for-secured-pages" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="directory-listing" type="xs:boolean" use="optional" />
+        <xs:attribute name="proactive-authentication" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="session-id-length" type="xs:int" use="optional" default="30" />
+        <xs:attribute name="max-sessions" type="xs:int" use="optional" />
+        <xs:attribute name="disable-file-watch-service" type="xs:boolean" use="optional" />
+        <xs:attribute name="disable-session-id-reuse" type="xs:boolean" use="optional" />
+        <xs:attribute name="file-cache-max-file-size" type="xs:integer" use="optional" default="10485760"/>
+        <xs:attribute name="file-cache-metadata-size" type="xs:integer" use="optional" default="100"/>
+        <xs:attribute name="file-cache-time-to-live" type="xs:integer" use="optional"/>
+        <xs:attribute name="default-cookie-version" type="xs:integer"  use="optional"/>
+        <xs:attribute name="preserve-path-on-forward" type="xs:boolean" default="false"/>
+        <xs:attribute name="allow-orphan-session" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-async-context-timeout" type="xs:integer" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="mime-mappingsType">
+        <xs:sequence>
+            <xs:element name="mime-mapping" type="mime-mappingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mime-mappingType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="welcome-filesType">
+        <xs:sequence>
+            <xs:element name="welcome-file" type="welcome-fileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="welcome-fileType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="hostType">
+        <xs:sequence>
+            <xs:element name="location" type="locationType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="access-log" type="accessLogType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="console-access-log" type="consoleAccessLogType" minOccurs="0"/>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="single-sign-on" minOccurs="0" maxOccurs="1" type="singleSignOnType"/>
+            <xs:element name="http-invoker" minOccurs="0" maxOccurs="1" type="http-invokerType"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="alias" use="optional" type="xs:string"/>
+        <xs:attribute name="default-web-module" use="optional" type="xs:string" default="ROOT.war"/>
+        <xs:attribute name="default-response-code" use="optional" type="xs:int" default="404">
+            <xs:annotation>
+                <xs:documentation>Default response code should be set in case server should respond with nonstandard code( other than 404 ) for unavailable resource.
+                    For instance, server behind load balancer might want to respond with 5xx code to avoid being dropped by it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="disable-console-redirect" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="queue-requests-on-start" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="http-invokerType">
+        <xs:attribute name="path" use="optional" type="xs:string" default="wildfly-services"/>
+        <xs:attribute name="http-authentication-factory" type="xs:string" use="optional"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated: The http-authentication-factory attribute should be used to configure authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="websocketsType">
+        <xs:attribute name="worker" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="buffer-pool" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="dispatch-to-worker" use="optional" type="xs:boolean" default="true"/>
+        <xs:attribute name="per-message-deflate" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="deflater-level" use="optional" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="crawler-session-managementType">
+        <xs:attribute name="user-agents" use="optional" type="xs:string"/>
+        <xs:attribute name="session-timeout" use="optional" type="xs:integer"/>
+    </xs:complexType>
+
+    <xs:complexType name="jsp-configurationType">
+        <xs:attribute name="disabled" default="false" type="xs:boolean"/>
+        <xs:attribute name="development" default="false" type="xs:boolean"/>
+        <xs:attribute name="keep-generated" default="true" type="xs:boolean"/>
+        <xs:attribute name="trim-spaces" default="false" type="xs:boolean"/>
+        <xs:attribute name="tag-pooling" default="true" type="xs:boolean"/>
+        <xs:attribute name="mapped-file" default="true" type="xs:boolean"/>
+        <xs:attribute name="check-interval" default="0" type="xs:int"/>
+        <xs:attribute name="modification-test-interval" default="4" type="xs:int"/>
+        <xs:attribute name="recompile-on-fail" default="false" type="xs:boolean"/>
+        <xs:attribute name="smap" default="true" type="xs:boolean"/>
+        <xs:attribute name="dump-smap" default="false" type="xs:boolean"/>
+        <xs:attribute name="generate-strings-as-char-arrays" default="false" type="xs:boolean"/>
+        <xs:attribute name="error-on-use-bean-invalid-class-attribute" default="false" type="xs:boolean"/>
+        <xs:attribute name="scratch-dir" type="xs:string"/>
+        <xs:attribute name="source-vm" default="1.8" type="xs:string"/>
+        <xs:attribute name="target-vm" default="1.8" type="xs:string"/>
+        <xs:attribute name="java-encoding" default="UTF8" type="xs:string"/>
+        <xs:attribute name="x-powered-by" default="true" type="xs:boolean"/>
+        <xs:attribute name="display-source-fragment" default="true" type="xs:boolean"/>
+        <xs:attribute name="optimize-scriptlets" default="false" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="sessionCookieType">
+        <xs:complexContent>
+            <xs:extension base="commonCookieType">
+                <xs:attribute name="name" type="xs:string" use="optional"/>
+                <xs:attribute name="comment" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="affinityCookieType">
+        <xs:complexContent>
+            <xs:extension base="commonCookieType">
+                <xs:attribute name="name" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="commonCookieType" abstract="true">
+        <xs:attribute name="domain" type="xs:string"/>
+        <xs:attribute name="http-only" type="xs:boolean"/>
+        <xs:attribute name="secure" type="xs:boolean"/>
+        <xs:attribute name="max-age" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="persistent-sessionsType">
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                  The path to store the session data. If not specified the data will just be stored in memory only.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerType">
+        <xs:sequence>
+            <xs:element name="file" type="file-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reverse-proxy" type="reverse-proxy-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:complexType name="filterType">
+        <xs:sequence>
+            <xs:element name="request-limit" type="request-limitType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="response-header" type="response-headerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="gzip" type="gzipType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="error-page" type="errorPageType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="mod-cluster" type="modClusterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="filter" type="customFilterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="expression-filter" type="expressionFilterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="rewrite" type="rewriteFilterType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="locationType">
+        <xs:sequence>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="handler" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="accessLogType">
+        <xs:attribute name="pattern" use="optional" type="xs:string" default="common"/>
+        <xs:attribute name="worker" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="directory" use="optional" type="xs:string" default="${jboss.server.log.dir}"/>
+        <xs:attribute name="relative-to" use="optional" type="xs:string" />
+        <xs:attribute name="prefix" use="optional" type="xs:string" default="access_log."/>
+        <xs:attribute name="suffix" use="optional" type="xs:string" default="log"/>
+        <xs:attribute name="rotate" use="optional" type="xs:string" default="true"/>
+        <xs:attribute name="use-server-log" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="extended" use="optional" type="xs:string" default="false" />
+        <xs:attribute name="predicate" use="optional" type="xs:string" />
+    </xs:complexType>
+    <xs:complexType name="consoleAccessLogType">
+        <xs:sequence minOccurs="0">
+            <xs:element name="attributes" type="attributesType" minOccurs="0"/>
+            <xs:element name="metadata" type="propertiesType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="include-host-name" type="xs:boolean" default="true"/>
+        <xs:attribute name="worker" type="xs:string" default="default"/>
+        <xs:attribute name="predicate" type="xs:string" />
+    </xs:complexType>
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form meta-data properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="attributesType">
+        <xs:annotation>
+            <xs:documentation>
+                The available attributes to be included in the structured access log output.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="authentication-type" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="bytes-sent" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="date-time" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="date-format" type="xs:string"/>
+                    <xs:attribute name="time-zone" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="host-and-port" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-ip" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-port" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-server-name" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="path-parameter" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="predicate" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="query-parameter" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="query-string" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="include-question-mark" type="xs:boolean" default="false"/>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relative-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-host" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-ip" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="obfuscated" type="xs:boolean" default="false"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-user" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-header" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-line" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-method" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-scheme" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-url" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resolved-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-code" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-header" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-reason-phrase" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-time" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="time-unit" default="MILLISECONDS">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="NANOSECONDS"/>
+                                <xs:enumeration value="MICROSECONDS"/>
+                                <xs:enumeration value="MILLISECONDS"/>
+                                <xs:enumeration value="SECONDS"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="secure-exchange" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-cipher" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-client-cert" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-session-id" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="stored-response" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="thread-name" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="transport-protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="errorPageType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="code" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+
+
+    <xs:complexType name="customFilterType">
+        <xs:sequence>
+            <xs:element name="param" type="paramType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="class-name" use="required" type="xs:string"/>
+        <xs:attribute name="module" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="expressionFilterType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="expression" use="required" type="xs:string"/>
+        <xs:attribute name="module" use="optional" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="rewriteFilterType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="target" use="required" type="xs:string"/>
+        <xs:attribute name="redirect" use="optional" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="file-handlerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+        <xs:attribute name="cache-buffer-size" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="cache-buffers" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="directory-listing" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="follow-symlink" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="safe-symlink-paths" use="optional" type="stringList"/>
+        <xs:attribute name="case-sensitive" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:simpleType name="stringList">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="reverse-proxy-handlerType">
+        <xs:sequence>
+            <xs:element name="host" type="reverse-proxy-hostType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="connections-per-thread" use="optional" type="xs:integer" default="40"/>
+        <xs:attribute name="session-cookie-names" use="optional" type="xs:string" default="JSESSIONID"/>
+        <xs:attribute name="problem-server-retry" use="optional" type="xs:integer" default="30"/>
+        <xs:attribute name="max-request-time" use="optional" type="xs:integer" default="-1"/>
+        <xs:attribute name="request-queue-size" use="optional" type="xs:integer" default="10"/>
+        <xs:attribute name="cached-connections-per-thread" use="optional" type="xs:integer" default="5"/>
+        <xs:attribute name="connection-idle-timeout" use="optional" type="xs:integer" default="60000"/>
+        <xs:attribute name="max-retries" type="xs:int" use="optional" default="1"/>
+        <xs:attribute name="reuse-x-forwarded-header" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="rewrite-host-header" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="reverse-proxy-hostType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="outbound-socket-binding" use="required" type="xs:string"/>
+        <xs:attribute name="scheme" use="optional" type="xs:string" default="http"/>
+        <xs:attribute name="path" use="optional" type="xs:string" default=""/>
+        <xs:attribute name="instance-id" use="optional" type="xs:string"/>
+        <xs:attribute name="ssl-context" type="xs:string" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated: The ssl-context attribute should be used to reference a defined SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-http2" type="xs:boolean" use="optional" default="false" />
+    </xs:complexType>
+
+    <xs:complexType name="filter-refType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="predicate" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                          Predicates provide a simple way of making a true/false decision  based on an exchange. Many handlers have a requirement that they be applied conditionally, and predicates provide a general way to specify a condition. Predicates can be created programatically (they are just java classes that implement the Predicate interface), however there is also a simple language for specifying a predicate. Some examples below:
+                          regex['/resources/*.\.css'] - regular expression match of the relative URL
+                          regex[pattern='text/.*', value='%{i,Content-Type}, full-match=true] - Matches requests with a text/.* content type
+                          equals[{'%{i,Content-Type}', 'text/xml'}] - Matches if the content type header is text/xml
+                          contains[search='MSIE', value='%{i,User-Agent}'] and path-suffix['.js'] - User agent contains MSIE and request URL ends with .js
+                          regex['/resources/(*.)\.css'] and equals[{'$1', 'myCssFile'}] - regex match, with a reference to match group 1 later in the expression
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="priority" use="optional" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="singleSignOnType">
+        <xs:attribute name="domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie domain to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie path to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-only" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie httpOnly attribute
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="secure" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie secure attribute
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cookie-name" type="xs:string" default="JSESSIONIDSSO">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cooke name
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="buffer-cacheType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                  A buffer cache. I cache consists of 1 or more regions, that are split up into smaller buffers.
+                  The total cache size is the buffer size * the buffers per region * the number of regions.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:string"/>
+        <xs:attribute name="buffers-per-region" use="optional" type="xs:string"/>
+        <xs:attribute name="max-regions" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="byte-buffer-poolType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The buffer pool used for IO operations
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:int"/>
+        <xs:attribute name="direct" use="optional" type="xs:boolean"/>
+        <xs:attribute name="thread-local-cache-size" use="optional" type="xs:int"/>
+        <xs:attribute name="max-pool-size" use="optional" type="xs:int"/>
+        <xs:attribute name="leak-detection-percent" use="optional" type="xs:int"/>
+    </xs:complexType>
+    <xs:complexType name="request-limitType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="max-concurrent-requests" use="required" type="xs:integer"/>
+        <xs:attribute name="queue-size" use="optional" type="xs:integer" default="0"/>
+    </xs:complexType>
+    <xs:complexType name="response-headerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="header-name" use="required" type="xs:string"/>
+        <xs:attribute name="header-value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="gzipType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="modClusterType">
+        <xs:sequence minOccurs="0">
+            <xs:choice>
+                <xs:group ref="affinity"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="management-socket-binding" type="xs:string" use="required"/>
+        <xs:attribute name="advertise-socket-binding" type="xs:string" use="optional"/>
+        <xs:attribute name="security-key" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-protocol" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-path" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-frequency" type="xs:int" use="optional"/>
+        <xs:attribute name="failover-strategy" type="failoverStrategy" default="LOAD_BALANCED" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Determines how a failover node is chosen, in the event that the node to which a session has affinity is not available.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="health-check-interval" type="xs:int" use="optional"/>
+        <xs:attribute name="broken-node-timeout" type="xs:int" use="optional"/>
+        <xs:attribute name="worker" type="xs:string" use="optional" />
+        <xs:attribute name="max-request-time" type="xs:int" use="optional"/>
+        <xs:attribute name="management-access-predicate" type="xs:string" use="optional"/>
+        <xs:attribute name="connections-per-thread" type="xs:int" use="optional" />
+        <xs:attribute name="cached-connections-per-thread" type="xs:int" use="optional" />
+        <xs:attribute name="connection-idle-timeout" type="xs:int" use="optional" />
+        <xs:attribute name="request-queue-size" type="xs:int" use="optional" />
+        <xs:attribute name="ssl-context" type="xs:string" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated: The ssl-context attribute should be used to reference a defined SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-alias" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="enable-http2" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="max-ajp-packet-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+        <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+        <xs:attribute name="max-retries" type="xs:int" use="optional" />
+    </xs:complexType>
+
+    <xs:group name="affinity">
+        <xs:choice>
+            <xs:element name="no-affinity" type="empty">
+                <xs:annotation>
+                    <xs:documentation>
+                        Web requests will not have an affinity for any particular server, routing information will be ignored.
+                        Intended for use cases where web session state is not maintained within the application server.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="single-affinity" type="empty">
+                <xs:annotation>
+                    <xs:documentation>
+                        Web requests have an affinity for the member that last handled a given session.
+                        This option corresponds to traditional sticky session behavior.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ranked-affinity" type="ranked-affinity">
+                <xs:annotation>
+                    <xs:documentation>
+                        Web requests will have an affinity for the first available node in a list typically comprised of: primary owner, backup nodes, local node (if not a primary nor backup owner).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="ranked-affinity">
+        <xs:attribute name="delimiter" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The delimiter used to separate ranked routes within the session ID.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="empty">
+        <xs:sequence/>
+    </xs:complexType>
+
+    <xs:simpleType name="failoverStrategy">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="LOAD_BALANCED">
+                <xs:annotation>
+                    <xs:documentation>
+                        Failover target chosen via load balancing mechanism.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DETERMINISTIC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Failover target chosen deterministically from the associated session identifier.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="applicationSecurityDomainsType">
+        <xs:annotation>
+            <xs:documentation>
+                Listing of security domains from applications that should be mapped to an Elytron
+                backed authentication policy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="application-security-domain" type="applicationSecurityDomainType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="applicationSecurityDomainType">
+        <xs:sequence>
+            <xs:element name="single-sign-on" type="applicationSecurityDomainSingleSignOnType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the security domain as specified in deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-authentication-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the HttpAuthenticationFactory that should be used.
+
+                    Exactly one of http-authentication-factory or security-domain must be defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="override-deployment-config" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    The references HttpServerAuthenticationMechanismFactory contains it's own policy configuration
+                    to control the authentication mechanisms it supports, if this attribute is set to 'true'
+                    that policy will override the methods specified within the deployment.
+
+                    This attribute can only be specified if a http-authentication-factory is also specified.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the security-domain that should be associated with the deployment, where a
+                    security-domain is referenced instead of a http-authentication-factory the authentication mechanisms
+                    BASIC, DIGEST, FORM and CLIENT_CERT will be availble for the deployment to use - additionally the deployment
+                    can make use of the programatic login API.
+
+                    Exactly one of http-authentication-factory or security-domain must be defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-jacc" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable authorization using JACC.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-jaspi" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Should deployments matching against this 'application-security-domain' have
+                    JASPI enabled, by setting to false JASPI will be completely disabled for the deployment.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="integrated-jaspi" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    When integrated-jaspi is enabled during JASPI authentication the resulting
+                    identity will be loaded from the SecurityDomain referenced by the deployment, if
+                    this is switched off AdHoc identities will be created instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="applicationSecurityDomainSingleSignOnType">
+        <xs:complexContent>
+            <xs:extension base="singleSignOnType">
+                <xs:sequence>
+                    <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References key store containing the key used to sign and verify logout requests.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-alias" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The alias of the key used to sign and verify logout requests.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="client-ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The ssl context used to secure back-channel logout connections.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-preview-15.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-preview-15.0.xml
@@ -1,0 +1,111 @@
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<subsystem xmlns="urn:jboss:domain:undertow:preview:15.0" default-server="some-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+   <byte-buffer-pool name="default" thread-local-cache-size="45" buffer-size="1000" direct="false" leak-detection-percent="50" max-pool-size="1000"/>
+   <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
+   <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
+   <server default-host="other-host" name="some-server" servlet-container="myContainer">
+      <ajp-listener disallowed-methods="FOO TRACE" allow-unescaped-characters-in-url="true" allowed-request-attributes-pattern="test" max-parameters="5000" name="ajp-connector" no-request-timeout="10000" receive-buffer="5000" redirect-socket="ajps" request-parse-timeout="2000" resolve-peer-address="true" secure="true" send-buffer="50000" socket-binding="ajp" tcp-backlog="500" tcp-keep-alive="true" max-ajp-packet-size="10000"/>
+      <http-listener always-set-keep-alive="${prop.smth:false}" certificate-forwarding="true" name="default" proxy-address-forwarding="${prop.smth:false}" redirect-socket="ajp" resolve-peer-address="true" socket-binding="http" proxy-protocol="true"/>
+      <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="second" redirect-socket="https-non-default" require-host-http11="true" socket-binding="http-2" url-charset="windows-1250"/>
+      <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="no-redirect" socket-binding="http-3" url-charset="windows-1250" worker="non-default"/>
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https" record-request-start-time="true" require-host-http11="true" resolve-peer-address="true" security-realm="UndertowRealm" socket-binding="https-non-default" verify-client="REQUESTED"/>
+      <https-listener certificate-forwarding="true" allow-unescaped-characters-in-url="true" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" name="https-2" proxy-address-forwarding="true" read-timeout="-1" security-realm="UndertowRealm" socket-binding="https-2" write-timeout="-1"/>
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-3" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-3" ssl-context="TestContext" rfc6265-cookie-validation="true" proxy-protocol="true"/>
+      <!--<https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-4" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-4" />--> <!-- this one must fail-->
+      <host alias="localhost,some.host" default-response-code="503" default-web-module="something.war" name="default-virtual-host">
+         <location handler="welcome-content" name="/">
+            <filter-ref name="limit-connections"/>
+            <filter-ref name="headers" priority="${some.priority:10}"/>
+            <filter-ref name="404-handler"/>
+            <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
+         </location>
+         <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <console-access-log predicate="not path-suffix(*.css)" worker="default">
+            <attributes>
+               <authentication-type/>
+               <date-time date-format="yyyy-MM-dd'T'HH:mm:ss" key="timestamp"/>
+               <query-parameter>
+                  <name value="test"/>
+               </query-parameter>
+               <request-header key-prefix="requestHeader">
+                  <name value="Content-Type"/>
+                  <name value="Content-Encoding"/>
+               </request-header>
+               <response-code/>
+               <response-time time-unit="MICROSECONDS"/>
+            </attributes>
+            <metadata>
+               <property name="@version" value="1"/>
+               <property name="host" value="${jboss.host.name:localhost}"/>
+            </metadata>
+         </console-access-log>
+      </host>
+      <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host" queue-requests-on-start="false">
+         <location handler="welcome-content" name="/">
+            <filter-ref name="limit-connections"/>
+            <filter-ref name="headers"/>
+            <filter-ref name="static-gzip" predicate="path-suffix('.js') or path-suffix('.css') or path-prefix('/resources')"/>
+            <filter-ref name="404-handler"/>
+            <filter-ref name="mod-cluster"/>
+            <filter-ref name="mod-cluster-other"/>
+         </location>
+         <filter-ref name="headers"/>
+         <http-invoker http-authentication-factory="factory" path="services"/>
+      </host>
+   </server>
+   <servlet-container default-buffer-cache="extra" default-encoding="utf-8" default-session-timeout="100" default-async-context-timeout="100" directory-listing="true" eager-filter-initialization="true" ignore-flush="true" name="myContainer" proactive-authentication="${prop.pro:false}" use-listener-encoding="${prop.foo:false}"  disable-session-id-reuse="${prop.foo:true}" disable-file-watch-service="${prop.foo:true}" file-cache-metadata-size="50" file-cache-max-file-size="5000" file-cache-time-to-live="1000"  default-cookie-version="1" preserve-path-on-forward="false" allow-orphan-session="true">
+      <jsp-config check-interval="${prop.check-interval:20}" disabled="${prop.disabled:false}" display-source-fragment="${prop.display-source-fragment:true}" dump-smap="${prop.dump-smap:true}" error-on-use-bean-invalid-class-attribute="${prop.error-on-use-bean-invalid-class-attribute:true}" generate-strings-as-char-arrays="${prop.generate-strings-as-char-arrays:true}" java-encoding="${prop.java-encoding:utf-8}" keep-generated="${prop.keep-generated:true}" mapped-file="${prop.mapped-file:true}" modification-test-interval="${prop.modification-test-interval:1000}" optimize-scriptlets="${prop.optimise-scriptlets:true}" recompile-on-fail="${prop.recompile-on-fail:true}" scratch-dir="${prop.scratch-dir:/some/dir}" smap="${prop.smap:true}" source-vm="${prop.source-vm:1.7}" tag-pooling="${prop.tag-pooling:true}" target-vm="${prop.target-vm:1.7}" trim-spaces="${prop.trim-spaces:true}" x-powered-by="${prop.x-powered-by:true}"/>
+      <affinity-cookie domain="example.com" http-only="true" max-age="1000" name="SRV" secure="true"/>
+      <session-cookie comment="session cookie" domain="example.com" http-only="true" max-age="1000" name="MYSESSIONCOOKIE" secure="true"/>
+      <websockets deflater-level="0" dispatch-to-worker="false" per-message-deflate="false"/>
+      <mime-mappings>
+         <mime-mapping name="txt" value="text/plain"/>
+      </mime-mappings>
+      <welcome-files>
+         <welcome-file name="index.seam"/>
+      </welcome-files>
+      <crawler-session-management session-timeout="2" user-agents=".*googlebot.*"/>
+   </servlet-container>
+   <handlers>
+      <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
+      <reverse-proxy connection-idle-timeout="60000" max-request-time="60000" connections-per-thread="30" max-retries="10" name="reverse-proxy" reuse-x-forwarded-header="true" rewrite-host-header="false">
+         <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
+         <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
+      </reverse-proxy>
+   </handlers>
+   <filters>
+      <request-limit max-concurrent-requests="15000" name="limit-connections" queue-size="100"/>
+      <response-header header-name="MY_HEADER" header-value="someValue" name="headers"/>
+      <gzip name="static-gzip"/>
+      <error-page code="404" name="404-handler" path="/opt/data/404.html"/>
+      <mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp"
+                   advertise-socket-binding="advertise-socket-binding" broken-node-timeout="1000"
+                   cached-connections-per-thread="10" connection-idle-timeout="10"
+                   failover-strategy="DETERMINISTIC" health-check-interval="600"
+                   management-access-predicate="method[GET]" management-socket-binding="test3"
+                   max-request-time="1000" max-retries="10" name="mod-cluster"
+                   security-key="password" ssl-context="TestContext" max-ajp-packet-size="10000">
+         <ranked-affinity delimiter="."/>
+      </mod-cluster>
+      <mod-cluster name="mod-cluster-other" management-socket-binding="test3">
+         <single-affinity/>
+      </mod-cluster>
+      <filter class-name="io.undertow.server.handlers.HttpTraceHandler" module="io.undertow.core" name="custom-filter">
+         <param name="foo" value="bar"/>
+      </filter>
+      <expression-filter expression="dump-request" name="requestDumper"/>
+      <rewrite name="redirects" redirect="true" target="'/foo/'"/>
+   </filters>
+   <application-security-domains>
+      <application-security-domain enable-jacc="true" http-authentication-factory="elytron-factory" name="other" override-deployment-config="true" enable-jaspi="false" integrated-jaspi="false">
+         <single-sign-on client-ssl-context="my-ssl-context" cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" key-alias="my-key-alias" key-store="my-key-store" path="/path" secure="true">
+            <credential-reference alias="my-credential-alias" store="my-credential-store" type="password"/>
+         </single-sign-on>
+      </application-security-domain>
+      <application-security-domain security-domain="elytron-domain" name="domain-ref" />
+   </application-security-domains>
+</subsystem>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14748
Requires: https://github.com/undertow-io/undertow/pull/1731
Proposals: https://github.com/wildfly/wildfly-proposals/pull/743

Im going to add 'hold' to it. Given that its a backport, its bound for system property being sole conveyor for info. For sake of being thorough  I looked up undertow xsd at its possible to define servlet-container elements. Given that it might cause concurrency issues.