### PR TITLE
[WFLY-20770] Update jboss-client.jar to integrate with JDK Mission Co…

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -387,7 +387,7 @@
                         <Bundle-SymbolicName>org.jboss.client</Bundle-SymbolicName>
                         <Bundle-Version>1.0</Bundle-Version>
                         <Bundle-Name>Jakarta Enterprise Beans and Jakarta Messaging client library</Bundle-Name>
-                        <Fragment-Host>org.openjdk.jmc.rjmx</Fragment-Host>
+                        <Fragment-Host>org.openjdk.jmc.rjmx.common</Fragment-Host>
                         <Export-Package>*</Export-Package>
                         <Automatic-Module-Name>org.jboss.client</Automatic-Module-Name>
                     </manifestEntries>
@@ -444,7 +444,7 @@
                                         <Bundle-SymbolicName>org.jboss.client</Bundle-SymbolicName>
                                         <Bundle-Version>1.0</Bundle-Version>
                                         <Bundle-Name>Jakarta Enterprise Beans and Jakarta Messaging client library</Bundle-Name>
-                                        <Fragment-Host>org.openjdk.jmc.rjmx</Fragment-Host>
+                                        <Fragment-Host>org.openjdk.jmc.rjmx.common</Fragment-Host>
                                         <Export-Package>*</Export-Package>
                                         <Automatic-Module-Name>org.jboss.client</Automatic-Module-Name>
                                     </manifestEntries>


### PR DESCRIPTION
…ntrol 9+

https://issues.redhat.com/browse/WFLY-20770

With a build of the jboss-client.jar from a build of this branch integrated into JMC 9.1, I was able to connect to both a WildFly from that build and an unzip of the jboss-eap-7.4.0.zip.

I was also able to take a recent jboss-client.jar from JBoss EAP 7.4, integrate that into JMC 8.3 and connect to the WildFly built from this branch. The point of this latter bit is it demonstrates that after we make the change in this PR there is still a path for JMC 8 users to work with current WildFly. They just need to use an older client library.