### PR TITLE
Fix for WFLY-20748, Potential mismatch between provisioning of HAL bits and config enablement of the console

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -10,6 +10,7 @@
         <config model="standalone" name="standalone-core.xml" >
             <layers>
                 <include name="ee-core-profile-server"/>
+                <include name="web-console"/>
             </layers>
         </config>
         <config model="standalone" name="standalone-genericjms.xml">
@@ -67,9 +68,6 @@
                 <include name="management"/>
                 <include name="elytron"/>
             </layers>
-            <feature spec="core-service.management.management-interface.http-interface">
-                <param name="console-enabled" value="false"/>
-            </feature>
         </config>
         <config model="standalone" name="standalone-rts.xml">
             <layers>

--- a/ee-feature-pack/galleon-shared/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
@@ -10,5 +10,6 @@
         <include name="management"/>
         <include name="logging"/>
         <include name="undertow-load-balancer"/>
+        <include name="web-console"/>
     </layers>
 </config>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/management-console.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/management-console.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<feature-group-spec name="management-console" xmlns="urn:jboss:galleon:feature-group:1.0">
+  <feature spec="core-service.management.management-interface.http-interface">
+    <param name="console-enabled" value="true"/>
+  </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/management/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/management/layer-spec.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="management">
+    <dependencies>
+        <layer name="elytron"/>
+    </dependencies>
+
+    <feature-group name="unsecured-management"/>
+
+    <feature spec="core-service.management.management-interface.http-interface">
+        <param name="console-enabled" value="false"/>
+        <param name="socket-binding" value="management-http"/>
+        <param name="http-authentication-factory" value="management-http-authentication"/>
+        <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
+            <param name="sasl-authentication-factory" value="management-sasl-authentication"/>
+        </feature>
+    </feature>
+
+</layer-spec>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
@@ -13,6 +13,7 @@
     <dependencies>
         <layer name="management"/>
     </dependencies>
+    <feature-group name="management-console"/>
     <packages>
         <package name="org.jboss.as.console"/>
     </packages>

--- a/galleon-pack/galleon-local/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
@@ -20,6 +20,7 @@
         <include name="jpa-distributed"/>
         <include name="web-clustering"/>
         <include name="elytron-oidc-client"/>
+        <include name="web-console"/>
     </layers>
     <!-- TODO WFLY-15021 Add an undertow-https layer -->
     <feature-group name="undertow-https"/>

--- a/galleon-pack/galleon-local/src/main/resources/configs/standalone/standalone-microprofile.xml/config.xml
+++ b/galleon-pack/galleon-local/src/main/resources/configs/standalone/standalone-microprofile.xml/config.xml
@@ -17,6 +17,7 @@
         <include name="opentelemetry"/>
         <include name="microprofile-telemetry"/>
         <include name="elytron-oidc-client"/>
+        <include name="web-console"/>
     </layers>
     <!-- TODO WFLY-15021 Add an undertow-https layer -->
     <feature-group name="undertow-https"/>

--- a/galleon-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/galleon-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -11,6 +11,7 @@
             <layers>
                 <include name="ee-core-profile-server"/>
                 <include name="microprofile-platform"/>
+                <include name="web-console"/>
             </layers>
         </config>
     </example-configs>

--- a/preview/galleon-local/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
+++ b/preview/galleon-local/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
@@ -18,6 +18,7 @@
         <include name="jpa-distributed"/>
         <include name="web-clustering"/>
         <include name="elytron-oidc-client"/>
+        <include name="web-console"/>
     </layers>
     <!-- TODO WFLY-15021 Add an undertow-https layer -->
     <feature-group name="undertow-https"/>

--- a/preview/galleon-local/src/main/resources/configs/standalone/standalone-microprofile.xml/config.xml
+++ b/preview/galleon-local/src/main/resources/configs/standalone/standalone-microprofile.xml/config.xml
@@ -15,6 +15,7 @@
         <include name="microprofile-openapi"/>
         <include name="microprofile-telemetry"/>
         <include name="elytron-oidc-client"/>
+        <include name="web-console"/>
     </layers>
     <!-- TODO WFLY-15021 Add an undertow-https layer -->
     <feature-group name="undertow-https"/>

--- a/preview/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/preview/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -64,9 +64,6 @@
                 <include name="management"/>
                 <include name="elytron"/>
             </layers>
-            <feature spec="core-service.management.management-interface.http-interface">
-                <param name="console-enabled" value="false"/>
-            </feature>
         </config>
         <config model="standalone" name="standalone-rts.xml">
             <layers>
@@ -219,6 +216,7 @@
             <layers>
                 <include name="ee-core-profile-server"/>
                 <include name="microprofile-platform"/>
+                <include name="web-console"/>
             </layers>
         </config>
     </example-configs>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1220,10 +1220,11 @@
                                 <error>ambiguous resource injection. Enable verbose output to see the locations.</error>
                                 <error>jakarta.naming.Context or InitialContext lookup. Enable verbose output to see the locations.</error>
                             </expected-errors>
-                            <expected-discovery>[bean-validation, cdi, datasources, ee-concurrency, ee-integration, ejb-lite, h2-datasource, h2-driver, jaxrs, jpa, jsonb, jsonp, mail, messaging-activemq, naming, resource-adapters, servlet, transactions]==>ee-core-profile-server,ejb-lite,h2-datasource,jaxrs,jpa,mail,messaging-activemq</expected-discovery>
+                            <expected-discovery>[bean-validation, cdi, datasources, ee-concurrency, ee-integration, ejb-lite, h2-datasource, h2-driver, jaxrs, jpa, jsonb, jsonp, mail, management, messaging-activemq, naming, resource-adapters, servlet, transactions, web-console]==>ee-core-profile-server,ejb-lite,h2-datasource,jaxrs,jpa,mail,messaging-activemq,web-console</expected-discovery>
                             <surefire-execution-for-included-classes>microprofile.surefire</surefire-execution-for-included-classes>
                             <add-ons>
                                 <add-on>h2-database</add-on>
+                                <add-on>hal-web-console</add-on>
                             </add-ons>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20748

* This Fix should depend on the fix WFCORE-7284 but an override of it has been made in this PR (in an additional commit). Such commit will have to be removed when we upgrade wildfly-core.
* Enable the management-console in the web-console layer
* Enable the web-console in all configs that require it.

In the core override part we have: 
* A copy of the management layer that disables the console.
* A new management-console feature-group that enables the console.