### PR TITLE
WFLY-20779 Infinispan subsystem doesn't use the latest available mode…

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java
@@ -37,10 +37,10 @@ public enum InfinispanSubsystemModel implements SubsystemModel {
     VERSION_17_0_0(17, 0, 0), // WildFly 28-29
     VERSION_17_1_0(17, 1, 0), // EAP 8.0
     VERSION_18_0_0(18, 0, 0), // WildFly 30-34
-    VERSION_19_0_0(19, 0, 0), // WildFly 35, EAP 8.1
-    VERSION_20_0_0(20, 0, 0), // WildFly 36-present
+    VERSION_19_0_0(19, 0, 0), // WildFly 35-36, EAP 8.1
+    VERSION_20_0_0(20, 0, 0), // WildFly 37-present
     ;
-    static final InfinispanSubsystemModel CURRENT = VERSION_19_0_0;
+    static final InfinispanSubsystemModel CURRENT = VERSION_20_0_0;
 
     private final ModelVersion version;
 


### PR DESCRIPTION
…l version

https://issues.redhat.com/browse/WFLY-20779

This https://github.com/wildfly/wildfly/blob/37.0.0.Beta1/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java#L43 needs to use model 20.

Also descriptions are out of date since https://github.com/wildfly/wildfly/blob/36.0.1.Final/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemModel.java#L40-L41 still only used 19.