### PR TITLE
WFLY-20740 Add EAP 8.1.0 transform/reject tests for infinispan subsystem + WFLY-19522 Add EAP 8.0.0 transform/reject tests for infinispan subsystem

### DIFF
--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
@@ -53,8 +53,11 @@ import org.wildfly.clustering.jgroups.spi.ForkChannelFactory;
 public class InfinispanTransformersTestCase extends AbstractSubsystemTest {
 
     private static final Map<ModelTestControllerVersion, InfinispanSubsystemModel> VERSIONS = new EnumMap<>(ModelTestControllerVersion.class);
+
     static {
         VERSIONS.put(ModelTestControllerVersion.EAP_7_4_0, InfinispanSubsystemModel.VERSION_14_0_0);
+        VERSIONS.put(ModelTestControllerVersion.EAP_8_0_0, InfinispanSubsystemModel.VERSION_17_1_0);
+        VERSIONS.put(ModelTestControllerVersion.EAP_8_1_0, InfinispanSubsystemModel.VERSION_19_0_0);
     }
 
     @Parameters
@@ -62,39 +65,81 @@ public class InfinispanTransformersTestCase extends AbstractSubsystemTest {
         return VERSIONS.keySet();
     }
 
-    private static String formatArtifact(String artifactId, ModelTestControllerVersion version) {
-        return String.format("%s:%s:%s", version.getMavenGroupId(), artifactId, version.getMavenGavVersion());
+    // TODO Replace with variants from after wf-core upgrade https://issues.redhat.com/browse/WFCORE-7298
+    // n.b. workaround for https://issues.redhat.com/browse/WFCORE-7297
+    public String createGAV(String artifactId) {
+        return String.format("%s:%s:%s", this.controllerVersion.getMavenGroupId(), artifactId, this.controllerVersion.getMavenGavVersion());
     }
 
-    private static String[] getDependencies(ModelTestControllerVersion version) {
-        switch (version) {
-            case EAP_7_4_0:
-                return new String[] {
-                        "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:2.0.0.Final",
-                        "org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec:2.0.0.Final",
-                        "org.infinispan:infinispan-commons:11.0.9.Final-redhat-00001",
-                        "org.infinispan:infinispan-core:11.0.9.Final-redhat-00001",
-                        "org.infinispan:infinispan-cachestore-jdbc:11.0.9.Final-redhat-00001",
-                        "org.infinispan:infinispan-client-hotrod:11.0.9.Final-redhat-00001",
-                        "org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec:2.0.0.Final-redhat-00001",
-                        // Following are needed for InfinispanSubsystemInitialization
-                        formatArtifact("wildfly-clustering-api", version),
-                        formatArtifact("wildfly-clustering-common", version),
-                        formatArtifact("wildfly-clustering-infinispan-client", version),
-                        formatArtifact("wildfly-clustering-infinispan-extension", version),
-                        formatArtifact("wildfly-clustering-infinispan-spi", version),
-                        formatArtifact("wildfly-clustering-jgroups-extension", version),
-                        formatArtifact("wildfly-clustering-jgroups-spi", version),
-                        formatArtifact("wildfly-clustering-server", version),
-                        formatArtifact("wildfly-clustering-service", version),
-                        formatArtifact("wildfly-clustering-singleton-api", version),
-                        formatArtifact("wildfly-clustering-spi", version),
-                        formatArtifact("wildfly-connector", version),
-                };
-            default: {
-                throw new IllegalArgumentException();
-            }
-        }
+    public String createCoreGAV(String artifactId) {
+        return String.format("%s:%s:%s", this.controllerVersion.getCoreMavenGroupId(), artifactId, this.controllerVersion.getCoreVersion());
+    }
+
+    private String[] getDependencies(ModelTestControllerVersion version) {
+        return switch (version) {
+            case EAP_7_4_0 -> new String[] {
+                    "org.infinispan:infinispan-cachestore-jdbc:11.0.9.Final-redhat-00001",
+                    "org.infinispan:infinispan-client-hotrod:11.0.9.Final-redhat-00001",
+                    "org.infinispan:infinispan-commons:11.0.9.Final-redhat-00001",
+                    "org.infinispan:infinispan-core:11.0.9.Final-redhat-00001",
+                    "org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec:2.0.0.Final",
+                    "org.jboss.spec.javax.resource:jboss-connector-api_1.7_spec:2.0.0.Final-redhat-00001",
+                    "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:2.0.0.Final",
+                    // Following are needed for InfinispanSubsystemInitialization
+                    createGAV("wildfly-clustering-api"),
+                    createGAV("wildfly-clustering-common"),
+                    createGAV("wildfly-clustering-infinispan-client"),
+                    createGAV("wildfly-clustering-infinispan-extension"),
+                    createGAV("wildfly-clustering-infinispan-spi"),
+                    createGAV("wildfly-clustering-jgroups-extension"),
+                    createGAV("wildfly-clustering-jgroups-spi"),
+                    createGAV("wildfly-clustering-server"),
+                    createGAV("wildfly-clustering-service"),
+                    createGAV("wildfly-clustering-singleton-api"),
+                    createGAV("wildfly-clustering-spi"),
+                    createGAV("wildfly-connector"),
+            };
+            case EAP_8_0_0 -> new String[] {
+                    "org.infinispan:infinispan-cachestore-jdbc:14.0.27.Final-redhat-00001",
+                    "org.infinispan:infinispan-client-hotrod:14.0.27.Final-redhat-00001",
+                    "org.infinispan:infinispan-commons:14.0.27.Final-redhat-00001",
+                    "org.infinispan:infinispan-core:14.0.27.Final-redhat-00001",
+                    // Following are needed for InfinispanSubsystemInitialization
+                    createCoreGAV("wildfly-controller"),
+                    createGAV("wildfly-clustering-common"),
+                    createGAV("wildfly-clustering-infinispan-client-service"),
+                    createGAV("wildfly-clustering-infinispan-embedded-api"),
+                    createGAV("wildfly-clustering-infinispan-embedded-service"),
+                    createGAV("wildfly-clustering-infinispan-embedded-spi"),
+                    createGAV("wildfly-clustering-infinispan-extension"),
+                    createGAV("wildfly-clustering-jgroups-extension"),
+                    createGAV("wildfly-clustering-jgroups-spi"),
+                    createGAV("wildfly-clustering-server-service"),
+                    createGAV("wildfly-clustering-service"),
+                    createGAV("wildfly-clustering-singleton-api"),
+                    createGAV("wildfly-connector"),
+            };
+            case EAP_8_1_0 -> new String[] {
+                    // TODO replace with actual versions once EAP is released
+                    "org.infinispan:infinispan-cachestore-jdbc:15.0.11.Final",
+                    "org.infinispan:infinispan-client-hotrod:15.0.11.Final",
+                    "org.infinispan:infinispan-commons:15.0.11.Final",
+                    "org.infinispan:infinispan-core:15.0.11.Final",
+                    // Following are needed for InfinispanSubsystemInitialization
+                    createCoreGAV("wildfly-subsystem"),
+                    createGAV("wildfly-clustering-common"),
+                    createGAV("wildfly-clustering-infinispan-client-service"),
+                    createGAV("wildfly-clustering-infinispan-embedded-service"),
+                    createGAV("wildfly-clustering-infinispan-extension"),
+                    createGAV("wildfly-clustering-jgroups-extension"),
+                    createGAV("wildfly-clustering-jgroups-spi"),
+                    createGAV("wildfly-clustering-server-service"),
+                    createGAV("wildfly-clustering-service"),
+                    createGAV("wildfly-clustering-singleton-api"),
+                    createGAV("wildfly-connector"),
+            };
+            default -> throw new IllegalArgumentException();
+        };
     }
 
     private final ModelTestControllerVersion controllerVersion;
@@ -151,15 +196,17 @@ public class InfinispanTransformersTestCase extends AbstractSubsystemTest {
         KernelServices services = this.build(builder);
 
         ModelFixer fixer = model -> {
-            if (InfinispanSubsystemModel.VERSION_16_0_0.requiresTransformation(this.subsystemVersion)) {
-                Map<String, List<PathElement>> containers = Map.ofEntries(Map.entry("minimal", List.of(CacheResourceRegistration.DISTRIBUTED.pathElement("dist"))),
-                        Map.entry("maximal", List.of(CacheResourceRegistration.DISTRIBUTED.pathElement("dist"), CacheResourceRegistration.LOCAL.pathElement("local"), CacheResourceRegistration.REPLICATED.pathElement("cache-with-jdbc-store"), CacheResourceRegistration.SCATTERED.pathElement("scattered"))));
-                for (Map.Entry<String, List<PathElement>> entry : containers.entrySet()) {
-                    PathElement containerPath = PathElement.pathElement(CacheContainerResourceDefinitionRegistrar.REGISTRATION.getPathElement().getKey(), entry.getKey());
-                    ModelNode containerModel = model.get(containerPath.getKeyValuePair());
+            Map<String, List<PathElement>> containers = Map.ofEntries(Map.entry("minimal", List.of(CacheResourceRegistration.DISTRIBUTED.pathElement("dist"))),
+                    Map.entry("maximal", List.of(CacheResourceRegistration.DISTRIBUTED.pathElement("dist"), CacheResourceRegistration.LOCAL.pathElement("local"), CacheResourceRegistration.REPLICATED.pathElement("cache-with-jdbc-store"), CacheResourceRegistration.SCATTERED.pathElement("scattered"))));
+            for (Map.Entry<String, List<PathElement>> entry : containers.entrySet()) {
+                PathElement containerPath = PathElement.pathElement(CacheContainerResourceDefinitionRegistrar.REGISTRATION.getPathElement().getKey(), entry.getKey());
+                ModelNode containerModel = model.get(containerPath.getKeyValuePair());
+                if (InfinispanSubsystemModel.VERSION_16_0_0.requiresTransformation(this.subsystemVersion)) {
                     containerModel.get("module").set(new ModelNode());
-                    for (PathElement cachePath : entry.getValue()) {
-                        ModelNode cacheModel = containerModel.get(cachePath.getKey()).get(cachePath.getValue());
+                }
+                for (PathElement cachePath : entry.getValue()) {
+                    ModelNode cacheModel = containerModel.get(cachePath.getKey()).get(cachePath.getValue());
+                    if (InfinispanSubsystemModel.VERSION_16_0_0.requiresTransformation(this.subsystemVersion)) {
                         cacheModel.get("module").set(new ModelNode());
                         if (cacheModel.hasDefined(MemoryResourceRegistration.HEAP.getPathElement().getKeyValuePair())) {
                             ModelNode memoryModel = cacheModel.get(MemoryResourceRegistration.HEAP.getPathElement().getKeyValuePair());
@@ -174,6 +221,14 @@ public class InfinispanTransformersTestCase extends AbstractSubsystemTest {
                             }
                         }
                     }
+                    if (this.subsystemVersion.getMajor() > 14 && InfinispanSubsystemModel.VERSION_20_0_0.requiresTransformation(this.subsystemVersion)) {
+                        if (cacheModel.hasDefined(ComponentResourceRegistration.PARTITION_HANDLING.getPathElement().getKeyValuePair())) {
+                            ModelNode partitionHandlingModel = cacheModel.get(ComponentResourceRegistration.PARTITION_HANDLING.getPathElement().getKeyValuePair());
+                            partitionHandlingModel.get("enabled").set(new ModelNode());
+                        }
+                    }
+                }
+                if (InfinispanSubsystemModel.VERSION_16_0_0.requiresTransformation(this.subsystemVersion)) {
                     for (ScheduledThreadPool pool : EnumSet.allOf(ScheduledThreadPool.class)) {
                         if (containerModel.hasDefined(pool.getPathElement().getKeyValuePair())) {
                             ModelNode poolModel = containerModel.get(pool.getPathElement().getKeyValuePair());

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-17.1.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-17.1.0.xml
@@ -1,0 +1,115 @@
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<subsystem xmlns="urn:jboss:domain:infinispan:15.0">
+    <cache-container name="minimal" default-cache="local" marshaller="LEGACY" modules="org.wildfly.clustering.singleton.server org.wildfly.clustering.server.infinispan">
+        <local-cache name="local"/>
+    </cache-container>
+    <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" modules="org.infinispan" marshaller="LEGACY" statistics-enabled="true">
+        <transport channel="maximal-channel" lock-timeout="120000"/>
+        <listener-thread-pool min-threads="21"
+                              max-threads="22"
+                              queue-length="23"
+                              keepalive-time="24"/>
+        <expiration-thread-pool min-threads="71"
+                                keepalive-time="72"/>
+        <local-cache name="local" modules="org.infinispan" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
+            <transaction mode="BATCH" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true">
+                <write-behind modification-queue-size="2048"/>
+            </file-store>
+        </local-cache>
+        <invalidation-cache name="invalid" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <off-heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <remote-store cache="default" remote-servers="hotrod-server-1 hotrod-server-2" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false">
+                <write-behind modification-queue-size="2048"/>
+                <property name="valueSizeEstimate">100</property>
+            </remote-store>
+        </invalidation-cache>
+        <invalidation-cache name="invalidation-hotrod">
+            <hotrod-store cache-configuration="transactional" remote-cache-container="my-remote-container"/>
+        </invalidation-cache>
+        <replicated-cache name="repl" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
+            <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <off-heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false">
+                <write-behind modification-queue-size="2048"/>
+                <property name="location">${java.io.tmpdir}</property>
+            </store>
+            <state-transfer timeout="0" chunk-size="10000"/>
+        </replicated-cache>
+        <distributed-cache name="dist" l1-lifespan="1200000" owners="4" remote-timeout="35000" segments="2" capacity-factor="1.0" statistics-enabled="true" modules="org.wildfly.clustering.session.infinispan.embedded">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <partition-handling when-split="DENY_READ_WRITES" merge-policy="PREFERRED_ALWAYS"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+            <backups>
+                <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
+                <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>
+                <backup site="LON" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true">
+                    <take-offline after-failures="3" min-wait="10000"/>
+                </backup>
+            </backups>
+        </distributed-cache>
+        <scattered-cache name="scattered" remote-timeout="35000" segments="2" invalidation-batch-size="100" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <partition-handling merge-policy="NONE"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+        </scattered-cache>
+        <replicated-cache name="cache-with-jdbc-store" statistics-enabled="true">
+            <jdbc-store data-source="ExampleDS" dialect="MARIA_DB" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" max-batch-size="100">
+                <write-behind modification-queue-size="2048"/>
+                <table prefix="ispn_bucket" fetch-size="100">
+                    <id-column name="id" type="VARCHAR"/>
+                    <data-column name="datum" type="BINARY"/>
+                    <timestamp-column name="version" type="BIGINT"/>
+                </table>
+            </jdbc-store>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+        </replicated-cache>
+    </cache-container>
+    <remote-cache-container connection-timeout="1000"
+                            default-remote-cluster="primary-site"
+                            key-size-estimate="512"
+                            max-retries="2"
+                            modules="org.wildfly.clustering.session.infinispan.remote"
+                            marshaller="LEGACY"
+                            name="my-remote-container"
+                            protocol-version="3.0"
+                            socket-timeout="1000"
+                            tcp-no-delay="false"
+                            tcp-keep-alive="true"
+                            transaction-timeout="1000"
+                            value-size-estimate="1234">
+        <async-thread-pool min-threads="90"
+                           max-threads="100"
+                           queue-length="500"
+                           keepalive-time="1000"/>
+        <connection-pool exhausted-action="EXCEPTION"
+                         max-active="1"
+                         max-wait="3"
+                         min-evictable-idle-time="4"
+                         min-idle="5"
+        />
+        <property name="infinispan.client.hotrod.auth_username">username</property>
+        <property name="infinispan.client.hotrod.auth_password">password</property>
+        <remote-clusters>
+            <remote-cluster name="primary-site" socket-bindings="jdg1 jdg2 jdg3"/>
+            <remote-cluster name="failover-site" socket-bindings="jdg4 jdg5 jdg6"/>
+        </remote-clusters>
+        <security ssl-context="hotrod-elytron"/>
+    </remote-cache-container>
+</subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-19.0.0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transform-19.0.0.xml
@@ -1,0 +1,115 @@
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<subsystem xmlns="urn:jboss:domain:infinispan:15.0">
+    <cache-container name="minimal" default-cache="local" marshaller="LEGACY" modules="org.wildfly.clustering.singleton.server org.wildfly.clustering.server.infinispan">
+        <local-cache name="local"/>
+    </cache-container>
+    <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" modules="org.infinispan" marshaller="LEGACY" statistics-enabled="true">
+        <transport channel="maximal-channel" lock-timeout="120000"/>
+        <listener-thread-pool min-threads="21"
+                              max-threads="22"
+                              queue-length="23"
+                              keepalive-time="24"/>
+        <expiration-thread-pool min-threads="71"
+                                keepalive-time="72"/>
+        <local-cache name="local" modules="org.infinispan" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
+            <transaction mode="BATCH" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true">
+                <write-behind modification-queue-size="2048"/>
+            </file-store>
+        </local-cache>
+        <invalidation-cache name="invalid" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <off-heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <remote-store cache="default" remote-servers="hotrod-server-1 hotrod-server-2" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false">
+                <write-behind modification-queue-size="2048"/>
+                <property name="valueSizeEstimate">100</property>
+            </remote-store>
+        </invalidation-cache>
+        <invalidation-cache name="invalidation-hotrod">
+            <hotrod-store cache-configuration="transactional" remote-cache-container="my-remote-container"/>
+        </invalidation-cache>
+        <replicated-cache name="repl" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
+            <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <off-heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false">
+                <write-behind modification-queue-size="2048"/>
+                <property name="location">${java.io.tmpdir}</property>
+            </store>
+            <state-transfer timeout="0" chunk-size="10000"/>
+        </replicated-cache>
+        <distributed-cache name="dist" l1-lifespan="1200000" owners="4" remote-timeout="35000" segments="2" capacity-factor="1.0" statistics-enabled="true" modules="org.wildfly.clustering.session.infinispan.embedded">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <partition-handling when-split="DENY_READ_WRITES" merge-policy="PREFERRED_ALWAYS"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+            <backups>
+                <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
+                <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>
+                <backup site="LON" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true">
+                    <take-offline after-failures="3" min-wait="10000"/>
+                </backup>
+            </backups>
+        </distributed-cache>
+        <scattered-cache name="scattered" remote-timeout="35000" segments="2" invalidation-batch-size="100" statistics-enabled="true">
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
+            <heap-memory size="20000"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <partition-handling merge-policy="NONE"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+        </scattered-cache>
+        <replicated-cache name="cache-with-jdbc-store" statistics-enabled="true">
+            <jdbc-store data-source="ExampleDS" dialect="MARIA_DB" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" max-batch-size="100">
+                <write-behind modification-queue-size="2048"/>
+                <table prefix="ispn_bucket" fetch-size="100">
+                    <id-column name="id" type="VARCHAR"/>
+                    <data-column name="datum" type="BINARY"/>
+                    <timestamp-column name="version" type="BIGINT"/>
+                </table>
+            </jdbc-store>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+        </replicated-cache>
+    </cache-container>
+    <remote-cache-container connection-timeout="1000"
+                            default-remote-cluster="primary-site"
+                            key-size-estimate="512"
+                            max-retries="2"
+                            modules="org.wildfly.clustering.session.infinispan.remote"
+                            marshaller="LEGACY"
+                            name="my-remote-container"
+                            protocol-version="3.0"
+                            socket-timeout="1000"
+                            tcp-no-delay="false"
+                            tcp-keep-alive="true"
+                            transaction-timeout="1000"
+                            value-size-estimate="1234">
+        <async-thread-pool min-threads="90"
+                           max-threads="100"
+                           queue-length="500"
+                           keepalive-time="1000"/>
+        <connection-pool exhausted-action="EXCEPTION"
+                         max-active="1"
+                         max-wait="3"
+                         min-evictable-idle-time="4"
+                         min-idle="5"
+        />
+        <property name="infinispan.client.hotrod.auth_username">username</property>
+        <property name="infinispan.client.hotrod.auth_password">password</property>
+        <remote-clusters>
+            <remote-cluster name="primary-site" socket-bindings="jdg1 jdg2 jdg3"/>
+            <remote-cluster name="failover-site" socket-bindings="jdg4 jdg5 jdg6"/>
+        </remote-clusters>
+        <security ssl-context="hotrod-elytron"/>
+    </remote-cache-container>
+</subsystem>


### PR DESCRIPTION
Requires
https://github.com/wildfly/wildfly/pull/19069

Resolves
[WFLY-20740](https://issues.redhat.com/browse/WFLY-20740) Add EAP 8.1.0 transform/reject tests for infinispan subsystem
[WFLY-19522](https://issues.redhat.com/browse/WFLY-19522) Add EAP 8.0.0 transform/reject tests for infinispan subsystem

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-20779](https://issues.redhat.com/browse/WFLY-20779)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)