### PR TITLE
[WFLY-20797] Add missing Weld dependencies to the org.jboss.resteasy.…

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
@@ -23,6 +23,7 @@
         <module name="jakarta.validation.api"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
+        <module name="org.jboss.weld.api"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
         <module name="org.jboss.logging"/>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-client-microprofile/main/module.xml
@@ -28,6 +28,11 @@
         <module name="org.jboss.resteasy.resteasy-client" services="import"/>
         <module name="org.jboss.resteasy.resteasy-core" services="import"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
+        <!-- The org.jboss.resteasy.microprofile.client.CdiPropertyInjector uses Weld via reflection and requires these
+        dependencies. -->
+        <module name="org.jboss.weld.api"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
         <module name="org.reactivestreams"/>
     </dependencies>
 </module>


### PR DESCRIPTION
…cdi module and org.jboss.resteasy.resteasy-client-microprofile module.

https://issues.redhat.com/browse/WFLY-20797