### PR TITLE
[WFLY-20802] Exclude transitive dependency org.apache.activemq:artemis-lockmanager-api.

### DIFF
--- a/boms/common-ee/pom.xml
+++ b/boms/common-ee/pom.xml
@@ -1753,6 +1753,10 @@
                         <artifactId>javax.inject</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>artemis-lockmanager-api</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.commons</groupId>
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
@@ -2013,6 +2017,10 @@
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>artemis-lockmanager-api</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20802