### PR TITLE
[WFLY-20812] Add test case for ear-exclusions-cascaded-to-subdeployments and its implicit sub-deployments

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsExplicitSubdeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsExplicitSubdeploymentTestCase.java
@@ -15,15 +15,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class EarJbossStructureCascadeExclusionsTestCase {
+public class EarJbossStructureCascadeExclusionsExplicitSubdeploymentTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war");
-        war.addClasses(TestAA.class, EarJbossStructureCascadeExclusionsTestCase.class);
+        WebArchive explicitWar = ShrinkWrap.create(WebArchive.class, "explicit.war");
+        explicitWar.addClasses(TestAA.class, EarJbossStructureCascadeExclusionsExplicitSubdeploymentTestCase.class);
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);
-        ear.addAsModule(war);
+        ear.addAsModule(explicitWar);
         //test the 1.3 structure parser cascade exclusions
         ear.addAsManifestResource(new StringAsset(
                         "<jboss-deployment-structure xmlns=\"urn:jboss:deployment-structure:1.3\">" +
@@ -33,7 +33,7 @@ public class EarJbossStructureCascadeExclusionsTestCase {
                         "      <module name=\"org.jboss.logging\" />" +
                         "   </exclusions>" +
                         "</deployment>" +
-                        "<sub-deployment name=\"test.war\">" +
+                        "<sub-deployment name=\"explicit.war\">" +
                         "   <dependencies>" +
                         "       <module name=\"org.jboss.classfilewriter\" />" +
                         "   </dependencies>" +

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsImplicitSubdeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureCascadeExclusionsImplicitSubdeploymentTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.deployment.classloading.ear;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class EarJbossStructureCascadeExclusionsImplicitSubdeploymentTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive implicitWar = ShrinkWrap.create(WebArchive.class, "implicit.war");
+        implicitWar.addClasses(TestBB.class, EarJbossStructureCascadeExclusionsImplicitSubdeploymentTestCase.class);
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);
+        ear.addAsModule(implicitWar);
+
+        ear.addAsManifestResource(new StringAsset(
+                        "<jboss-deployment-structure xmlns=\"urn:jboss:deployment-structure:1.3\">" +
+                        "<ear-exclusions-cascaded-to-subdeployments>true</ear-exclusions-cascaded-to-subdeployments>" +
+                        "<deployment>" +
+                        "   <exclusions>" +
+                        "      <module name=\"org.jboss.logging\" />" +
+                        "   </exclusions>" +
+                        "</deployment>" +
+                "</jboss-deployment-structure>"),
+                "jboss-deployment-structure.xml");
+        return ear;
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testImplicitWarDoesNotHaveAccessToJbossLogging() throws ClassNotFoundException {
+        loadClass("org.jboss.logging.Logger", getClass().getClassLoader());
+    }
+
+    @Test
+    public void testImplicitWarDoesHaveAccessToSlf4jLogger() throws ClassNotFoundException {
+        loadClass("org.slf4j.Logger", getClass().getClassLoader());
+    }
+
+    private static Class<?> loadClass(String name, ClassLoader cl) throws ClassNotFoundException {
+        return Class.forName(name, false, cl);
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20812

/cc @yersan 
PR for WFCORE: https://github.com/wildfly/wildfly-core/pull/6467
These are the integration tests for WFCORE-7310 https://issues.redhat.com/browse/WFCORE-7310

> [!IMPORTANT]
>  EarJbossStructureCascadeExclusionsImplicitSubdeploymentTestCase is expected to fail with the current implementation of WildFly Core.

There might be a discussion about whether `EarJbossStructureCascadeExclusionsExplicitSubdeploymentTestCase` is needed at all, since having a test-case for sub-deployment is redundant.