### PR TITLE
WFLY-20853 - Upgrade to Hibernate ORM 7.1.0 and Hibernate Search 8.1.1 and register a new internal cache based on Caffeine

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -50,16 +50,16 @@
         <version.jakarta.websocket.jakarta-websocket-api>2.2.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <!-- Required for Hibernate Search -->
-        <version.org.apache.lucene>9.12.1</version.org.apache.lucene>
-        <version.org.bytebuddy>1.15.11</version.org.bytebuddy>
+        <version.org.apache.lucene>9.12.2</version.org.apache.lucene>
+        <version.org.bytebuddy>1.17.6</version.org.bytebuddy>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.3</version.org.glassfish.jakarta.faces>
         <version.org.jboss.resteasy>7.0.0.Beta1</version.org.jboss.resteasy>
         <version.org.jboss.weld.weld>6.0.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
-        <version.org.hibernate>7.0.2.Final</version.org.hibernate>
-        <version.org.hibernate.models>1.0.0</version.org.hibernate.models>
-        <version.org.hibernate.search>8.0.0.Final</version.org.hibernate.search>
+        <version.org.hibernate>7.1.0.Final</version.org.hibernate>
+        <version.org.hibernate.models>1.0.1</version.org.hibernate.models>
+        <version.org.hibernate.search>8.1.1.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.0.1.Final</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>

--- a/jpa/hibernate7/pom.xml
+++ b/jpa/hibernate7/pom.xml
@@ -85,6 +85,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-hibernate-cache-spi</artifactId>
             <scope>provided</scope>

--- a/jpa/hibernate7/pom.xml
+++ b/jpa/hibernate7/pom.xml
@@ -75,12 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.common</groupId>
-            <artifactId>hibernate-commons-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>provided</scope>

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/ServiceContributorImpl.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/ServiceContributorImpl.java
@@ -7,6 +7,7 @@ package org.wildfly.persistence.jipijapa.hibernate7.service;
 import static org.wildfly.persistence.jipijapa.hibernate7.JpaLogger.JPA_LOGGER;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.internal.util.cache.InternalCacheFactory;
 import org.hibernate.service.spi.ServiceContributor;
 import org.kohsuke.MetaInfServices;
 
@@ -61,5 +62,13 @@ public class ServiceContributorImpl implements ServiceContributor {
             JPA_LOGGER.tracef("ServiceContributorImpl#contribute adding ORM initiator for 2lc region factory");
             serviceRegistryBuilder.addInitiator(new WildFlyCustomRegionFactoryInitiator());
         }
+
+        //Now customize the Hibernate "internal cache": this is a component used for internal needs
+        //(it's NOT the second level cache). ORM integrators such as WildFly are encouraged to inject
+        //a better implementation than the one included by default.
+        //WildFly happens to already pack Caffeine, which is an excellent choice so that's what it will use.
+        //This setting is not user configurable.
+        serviceRegistryBuilder.addService(InternalCacheFactory.class, new WildFlyCustomInternalCacheFactory());
     }
+
 }

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomInternalCache.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomInternalCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.hibernate.internal.util.cache.InternalCache;
+
+import java.util.function.Function;
+
+/**
+ * A specialized implementation of {@link InternalCache} that uses a Caffeine-based cache for
+ * improved performance and caching capabilities. Designed for internal use within WildFly to
+ * optimize Hibernate's internal caching mechanism.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org>
+ * @param <K> the type of keys maintained by this cache
+ * @param <V> the type of mapped values
+ */
+final class WildFlyCustomInternalCache<K, V> implements InternalCache<K, V> {
+
+    private final Cache<K, V> cache;
+
+    public WildFlyCustomInternalCache(Cache<K, V> caffeineCache) {
+        this.cache = caffeineCache;
+    }
+
+    @Override
+    public int heldElementsEstimate() {
+        return Math.toIntExact(cache.estimatedSize());
+    }
+
+    @Override
+    public V get(K key) {
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        cache.put(key, value);
+    }
+
+    @Override
+    public void clear() {
+        cache.invalidateAll();
+        cache.cleanUp();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return cache.get(key, mappingFunction);
+    }
+
+}

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomInternalCacheFactory.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/service/WildFlyCustomInternalCacheFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.hibernate.internal.util.cache.InternalCache;
+import org.hibernate.internal.util.cache.InternalCacheFactory;
+
+/**
+ * A factory implementation of {@link InternalCacheFactory} which creates instances of
+ * {@link WildFlyCustomInternalCache}. This implementation leverages the Caffeine library
+ * to enhance caching performance and manage an arbitrary approximate size for the cache.
+ *
+ * This class is designed to integrate with Hibernate to provide a specialized internal
+ * cache implementation tailored for use in WildFly.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org>
+ */
+final class WildFlyCustomInternalCacheFactory implements InternalCacheFactory {
+
+    @Override
+    public <K, V> InternalCache<K, V> createInternalCache(int intendedApproximateSize) {
+        final Cache<K, V> caffeineCache = Caffeine.newBuilder()
+                .maximumSize(intendedApproximateSize)
+                .build();
+        return new WildFlyCustomInternalCache<>(caffeineCache);
+    }
+
+}

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate/main/module.xml
@@ -28,6 +28,7 @@
         <module name="org.infinispan.core" services="import"/>
         <module name="org.infinispan.protostream"/>
         <module name="org.infinispan.hibernate-cache" services="import"/>
+        <module name="com.github.ben-manes.caffeine"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>

--- a/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/preview/galleon-local/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -5,7 +5,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<!-- Represents Hibernate ORM 6  -->
+<!-- Represents Hibernate ORM 7 -->
 <module xmlns="urn:jboss:module:1.9" name="org.hibernate">
 
     <resources>

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/hibernate/orm/internalcache/Employee.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/hibernate/orm/internalcache/Employee.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.hibernate.orm.internalcache;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * A trivial entity with nothing special: we only need to boot the test
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+}

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/hibernate/orm/internalcache/InternalCacheServiceTestCase.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/hibernate/orm/internalcache/InternalCacheServiceTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.hibernate.orm.internalcache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.cache.InternalCache;
+import org.hibernate.internal.util.cache.InternalCacheFactory;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.preview.hibernate.search.coordination.HibernateSearchOutboxPollingTestCase;
+
+/**
+ * Tests that Hibernate ORM is being injected with the Caffeine based implementation
+ * of InternalCacheFactory.
+ * @author Sanne Grinovero
+ */
+@RunWith(Arquillian.class)
+public class InternalCacheServiceTestCase {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, HibernateSearchOutboxPollingTestCase.class.getSimpleName() + ".war")
+                .addClass(InternalCacheServiceTestCase.class)
+                .addClass(Employee.class)
+                .addAsResource(persistenceXml(), "META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    private static Asset persistenceXml() {
+        return new StringAsset(Descriptors.create(PersistenceDescriptor.class)
+                .version("3.2")
+                .createPersistenceUnit()
+                .name("internalCacheIt")
+                .jtaDataSource("java:jboss/datasources/ExampleDS")
+                .getOrCreateProperties()
+                    .createProperty().name("hibernate.hbm2ddl.auto").value("create-drop").up()
+                .up().up()
+                .exportAsString()
+        );
+    }
+
+    @PersistenceUnit(unitName = "internalCacheIt")
+    public EntityManagerFactory emf;
+
+    @Test
+    public void test() throws InterruptedException {
+        assertNotNull("Failed to inject EntityManagerFactory", emf);
+        assertNotNull("Failed to extract SessionFactoryImplementor from EntityManagerFactory", emf.unwrap(SessionFactoryImplementor.class));
+        InternalCacheFactory internalCacheFactory = emf.unwrap(SessionFactoryImplementor.class).getServiceRegistry().requireService(InternalCacheFactory.class);
+        InternalCache<Object, Object> internalCache = internalCacheFactory.createInternalCache(10);//any number will do
+        assertEquals(internalCache.getClass().getName(), "org.wildfly.persistence.jipijapa.hibernate7.service.WildFlyCustomInternalCache");
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20853

As being discussed on:
 - https://wildfly.zulipchat.com/#narrow/channel/174184-wildfly-developers/topic/Hibernate.20ORM.207.2E1/with/532023215

ORM 7.1 introduces the ability to customize the cache implementation which we use internally for a number of reasons, primarily query plans.
The default implementation provided in Hibernate ORM is not very efficient and has some scalability limitations; it's not bad but the Caffeine based implementation is far better: I've had very successful results experimenting with this in Quarkus and I believe we should do the same for WildFly.

Essentially, we need to inject a very trivial wrapper around Caffeine. Caffeine is already among the modules as it's a core dependency of Infinispan, so we can reuse the existing module, improving efficiency without adding additional dependencies. Also, I think eventually we'll need to find a way to deprecate the legacy one included in Hibernate ORM, so this would prepare for that.

N.B. this internal cache is not related to the 2nd level cache implementations.

(no longer a draft)

cc/ @scottmarlow @yrodiere @marko-bekhta

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-20853](https://issues.redhat.com/browse/WFLY-20853)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)