### PR TITLE
WFLY-20828 Upgrade SmallRye Fault Tolerance from 6.9.1 to 6.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <version.io.smallrye.open-api>4.0.12</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-config>3.12.4</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.9.1</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.9.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.7.0</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20828