### PR TITLE
[37.x] [WFLY-20832] Bump org.eclipse.angus:angus-mail from 2.0.3 to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,7 @@
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.eclipse.angus.angus-activation>2.0.2</version.org.eclipse.angus.angus-activation>
-        <version.org.eclipse.angus.angus-mail>2.0.3</version.org.eclipse.angus.angus-mail>
+        <version.org.eclipse.angus.angus-mail>2.0.4</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.33.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile>7.0</version.org.eclipse.microprofile>
         <version.org.eclipse.microprofile.config.api>3.1</version.org.eclipse.microprofile.config.api>


### PR DESCRIPTION
Upstream PR: https://github.com/wildfly/wildfly/pull/19107
https://issues.redhat.com/browse/WFLY-20832

