### PR TITLE
[WFLY-20834] Upgrade Hibernate Validator to 8.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate>6.6.19.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.4.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>8.0.2.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>
         <version.org.infinispan>15.2.4.Final</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20834

There are a few backports from 9 in this release. (In particular, a user was asking for `Alphanumeric CNPJ` for an EE 10 env) 