### PR TITLE
[WFLY-20854] Override the version of the Elasticsearch client in the WildFly Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -51,6 +51,7 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <!-- Required for Hibernate Search -->
         <version.org.apache.lucene>9.12.2</version.org.apache.lucene>
+        <version.org.elasticsearch.client.rest-client>9.1.2</version.org.elasticsearch.client.rest-client>
         <version.org.bytebuddy>1.17.6</version.org.bytebuddy>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.3</version.org.glassfish.jakarta.faces>
@@ -563,6 +564,30 @@
                 <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${version.org.elasticsearch.client.rest-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+                <version>${version.org.elasticsearch.client.rest-client}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20854

We should match the version of ES client libs that Search is expecting, and since preview has gone much further in versions ... Search now is based on ES 9.1.2 (for Hibernate Search 8.1.1). This should go on top of the ORM/Search upgrade and will probably need a rebase once the other pr is merged, so I'll open it as a draft for now, just so we won't forget about doing this).

- Follows up on: https://github.com/wildfly/wildfly/pull/19104
