### PR TITLE
[WFLY-20864] Update the referencing of the JNDI lookups for EJB's and…

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
@@ -8,14 +8,15 @@ package org.jboss.as.jaxrs.deployment;
 import static org.jboss.as.jaxrs.logging.JaxrsLogger.JAXRS_LOGGER;
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.ConcurrencyAttachments;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.component.ViewDescription;
-import org.jboss.as.ee.managedbean.component.ManagedBeanComponentDescription;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -23,7 +24,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.weld.WeldCapability;
 import org.jboss.modules.Module;
 import org.jboss.resteasy.util.GetRestful;
-import org.jboss.as.ee.component.ConcurrencyAttachments;
 
 /**
  * Integrates Jakarta RESTful Web Services with managed beans and Jakarta Enterprise Beans's
@@ -41,8 +41,6 @@ public class JaxrsComponentDeployer implements DeploymentUnitProcessor {
      * Kinda yuck, but there is not really any alternative if we want don't want the dependency
      * </p>
      */
-    private static final String SESSION_BEAN_DESCRIPTION_CLASS_NAME = "org.jboss.as.ejb3.component.session.SessionBeanComponentDescription";
-
     private static final String STATEFUL_SESSION_BEAN_DESCRIPTION_CLASS_NAME = "org.jboss.as.ejb3.component.stateful.StatefulComponentDescription";
 
     @Override
@@ -87,63 +85,46 @@ public class JaxrsComponentDeployer implements DeploymentUnitProcessor {
                 throw new DeploymentUnitProcessingException(e);
             }
             if (!GetRestful.isRootResource(componentClass)) continue;
+            if (isSFSB(component)) {
+                //using SFSB's as Jakarta RESTful Web Services endpoints is not recommended, but if people really want to do it they can
 
-            if (isInstanceOf(component, SESSION_BEAN_DESCRIPTION_CLASS_NAME)) {
-                if (isInstanceOf(component, STATEFUL_SESSION_BEAN_DESCRIPTION_CLASS_NAME)) {
-                    //using SFSB's as Jakarta RESTful Web Services endpoints is not recommended, but if people really want to do it they can
-
-                    JAXRS_LOGGER.debugf("Stateful session bean %s is being used as a Jakarta RESTful Web Services endpoint, this is not recommended", component.getComponentName());
-                    if (partOfWeldDeployment) {
-                        //if possible just let CDI handle the integration
-                        continue;
-                    }
+                JAXRS_LOGGER.debugf("Stateful session bean %s is being used as a Jakarta RESTful Web Services endpoint, this is not recommended", component.getComponentName());
+                if (partOfWeldDeployment) {
+                    //if possible just let CDI handle the integration
+                    continue;
                 }
+            }
+            boolean found = false;
+            // Find a binding name for the resource. We simply use the first binding name we find that starts with java:app
+            // for the component. We assume the component will have the correct view that we need.
+            for (ViewDescription view : component.getViews()) {
+                final Set<String> bindings = view.getBindingNames();
+                if (!bindings.isEmpty()) {
+                    found = true;
+                    final String jndiName = bindings.stream()
+                            .filter(name -> name.startsWith("java:app"))
+                            .findFirst()
+                            .orElseThrow(() -> JAXRS_LOGGER.typeNameNotAnEjbView(List.of(GetRestful.getRootResourceClass(componentClass)), component.getComponentName()));
 
-                Class<?>[] jaxrsType = GetRestful.getSubResourceClasses(componentClass);
-                final String jndiName;
-                if (component.getViews().size() == 1) {
-                    //only 1 view, just use the simple JNDI name
-                    jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName();
-                } else {
-                    boolean found = false;
-                    String foundType = null;
-                    for (final ViewDescription view : component.getViews()) {
-                        for (Class<?> subResource : jaxrsType) {
-                            if (view.getViewClassName().equals(subResource.getName())) {
-                                foundType = subResource.getName();
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (found) {
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        throw JAXRS_LOGGER.typeNameNotAnEjbView(Arrays.asList(jaxrsType), component.getComponentName());
-                    }
-                    jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName() + "!" + foundType;
+                    JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi jaxRsTypeName: %s", component.getComponentClassName(), jndiName);
+                    // Resource naming is jndi-name;component-class;cache
+                    resteasy.getScannedJndiComponentResources()
+                            .add(jndiName + ";" + component.getComponentClassName() + ";true");
+                    // make sure it's removed from the scanned resources list
+                    resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
+                    break;
                 }
-
-                JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi jaxRsTypeName: %s", component.getComponentClassName(), jndiName);
-                resteasy.getScannedJndiComponentResources().add(jndiName + ";" + component.getComponentClassName() + ";" + "true");
-                // make sure its removed from list
-                resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
-            } else if (component instanceof ManagedBeanComponentDescription) {
-                String jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName();
-
-                JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi name: %s", component.getComponentClassName(), jndiName);
-                resteasy.getScannedJndiComponentResources().add(jndiName + ";" + component.getComponentClassName() + ";" + "true");
-                // make sure it's removed from list
-                resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
+            }
+            if (!found) {
+                throw JAXRS_LOGGER.typeNameNotAnEjbView(List.of(GetRestful.getRootResourceClass(componentClass)), component.getComponentName());
             }
         }
     }
 
-    private boolean isInstanceOf(ComponentDescription component, String className) {
+    private boolean isSFSB(ComponentDescription component) {
         Class<?> c = component.getClass();
         while (c != Object.class && c != null) {
-            if(c.getName().equals(className)) {
+            if (c.getName().equals(STATEFUL_SESSION_BEAN_DESCRIPTION_CLASS_NAME)) {
                 return true;
             }
             c = c.getSuperclass();


### PR DESCRIPTION
… Managed Beans to use the first views binding name. This allows for cases when multiple views are defined, but the component is not the same type as the view.

https://issues.redhat.com/browse/WFLY-20864

Creating as a draft until a test is added.