### PR TITLE
[WFLY-20867]:  Upgrading Artemis to 2.42.0 in Reactive Messaging tests

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunArtemisAmqpSetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunArtemisAmqpSetupTask.java
@@ -54,8 +54,7 @@ public class RunArtemisAmqpSetupTask implements ServerSetupTask {
     @Override
     public void setup(ManagementClient managementClient, String containerId) throws Exception {
         try {
-
-            DockerImageName imageName = DockerImageName.parse("quay.io/artemiscloud/activemq-artemis-broker:1.0.32");
+            DockerImageName imageName = DockerImageName.parse("quay.io/arkmq-org/activemq-artemis-broker:artemis.2.42.0");
             container = new GenericContainer<>(imageName);
             container.addExposedPort(AMQP_PORT);
             container.withEnv(Map.of(


### PR DESCRIPTION
* Using the new Quay repository and updating the artemis container image version.

Jira: https://issues.redhat.com/browse/WFLY-20867