### PR TITLE
WFLY-20880 Upgrade wildfly-core to 29.0.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.12.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>29.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>29.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20880