### PR TITLE
[WFLY-20898] Do not import services for Jackson dependencies, and the…

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
@@ -90,14 +90,14 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
         // add them here so they can be excluded vs exporting them in the module.
 
         // These were previously exported on the org.jboss.resteasy.resteasy-jackson2-provider.
-        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-annotations", true, false);
-        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-core", true, false);
-        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-databind", true, false);
-        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.jakarta.jackson-jakarta-json-provider", true, false);
+        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-annotations", true, false, false);
+        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-core", true, false, false);
+        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.core.jackson-databind", true, false, false);
+        addDependency(moduleSpecification, moduleLoader, "com.fasterxml.jackson.jakarta.jackson-jakarta-json-provider", true, false, false);
 
         // These were perviously exported on the org.jboss.resteasy.resteasy-rxjava2 module.
-        addDependency(moduleSpecification, moduleLoader, "org.reactivestreams", true, false);
-        addDependency(moduleSpecification, moduleLoader, "io.reactivex.rxjava2.rxjava", true, false);
+        addDependency(moduleSpecification, moduleLoader, "org.reactivestreams", true, false, false);
+        addDependency(moduleSpecification, moduleLoader, "io.reactivex.rxjava2.rxjava", true, false, false);
 
         // End add exported modules
 
@@ -135,7 +135,16 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
 
     private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
                                String moduleIdentifier, boolean optional, boolean deploymentBundlesClientBuilder) {
-        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, moduleIdentifier).setOptional(optional).setImportServices(true).build();
+        addDependency(moduleSpecification, moduleLoader, moduleIdentifier, optional, deploymentBundlesClientBuilder, true);
+    }
+
+    private void addDependency(final ModuleSpecification moduleSpecification, final ModuleLoader moduleLoader,
+                               final String moduleIdentifier, final boolean optional,
+                               final boolean deploymentBundlesClientBuilder, final boolean importServices) {
+        ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, moduleIdentifier)
+                .setOptional(optional)
+                .setImportServices(importServices)
+                .build();
         if(deploymentBundlesClientBuilder) {
             dependency.addImportFilter(PathFilters.is(CLIENT_BUILDER), false);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/jackson/JacksonResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/jackson/JacksonResource.java
@@ -39,4 +39,11 @@ public class JacksonResource {
     public Optional<String> optional() {
         return Optional.of("optional string");
     }
+
+    @GET
+    @Path("named")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public NamedEntity named() {
+        return new NamedEntity(1L, "Jackson");
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/jackson/NamedEntity.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/jackson/NamedEntity.java
@@ -1,0 +1,45 @@
+package org.jboss.as.test.integration.jaxrs.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@XmlRootElement(name = "named-entity")
+public class NamedEntity {
+
+    private long id;
+    private String name;
+
+    public NamedEntity() {
+    }
+
+    public NamedEntity(final long id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @JsonProperty("jsonId")
+    @XmlElement(name = "xml-id")
+    public long getId() {
+        return id;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+
+    @JsonProperty("jsonName")
+    @XmlElement(name = "xml-name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
… reactive dependencies, added to deployments in the jaxrs subsystem. Previously these dependencies were added via a module.xml and the services were not imported.

https://issues.redhat.com/browse/WFLY-20898

Follows up the PR #19008 to ensure that services are not imported for previous module dependencies where they were not imported before.