### PR TITLE
[WFLY-20917] Upgrade Hibernate ORM to 6.6.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,7 +482,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.6.26.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.28.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.4.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20917

Diff: https://github.com/hibernate/hibernate-orm/compare/6.6.26...6.6.28
