### PR TITLE
[WFLY-20919] Upgrade WildFly Core to 30.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.12.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>29.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>30.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20919


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/30.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/29.0.1.Final...30.0.0.Beta1

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6682'>WFCORE-6682</a>] -         AuditLogBootingSyslogTestCase.testSyslog fails intermittently
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7303'>WFCORE-7303</a>] -         GitRepository.clearExistingFiles removes file in the &#39;ignored&#39; set
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7310'>WFCORE-7310</a>] -         ear-exclusions-cascaded-to-subdeployments doesn&#39;t work correctly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7319'>WFCORE-7319</a>] -         Maven warning: found duplicate declaration of plugin org.apache.maven.plugins:maven-gpg-plugin
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7328'>WFCORE-7328</a>] -         Installer - missing attribute in operation definition (prepare-revert, use-default-local-cache)
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7228'>WFCORE-7228</a>] -         Bump the kernel management API version to 31.0.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7308'>WFCORE-7308</a>] -         Remove ModuleIdentifierUtil.canonicalModuleIdentifier method
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7315'>WFCORE-7315</a>] -         Convert disabling of nxrm3-maven-plugin deploy to using skipNexusStagingDeployMojo
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7321'>WFCORE-7321</a>] -         Replace wildfly-component-matrix-plugin with wildfly-bom-builder-plugin
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7340'>WFCORE-7340</a>] -         Update staging repository profile with the new nexus3 staging URLS
</li>
</ul>
                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7306'>WFCORE-7306</a>] -         Upgrade commons-lang3 to 3.18 (relates to CVE-2025-48924)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7307'>WFCORE-7307</a>] -         [CVE-2025-4949] Upgrade jgit from 6.10.1.202505221210-r to 7.3.0.202506031305-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7309'>WFCORE-7309</a>] -         Upgrade licenses-plugin to 2.4.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7314'>WFCORE-7314</a>] -         Upgrade io.smallrye:jandex from 3.3.2 to 3.4.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7325'>WFCORE-7325</a>] -         Upgrade smallrye-common to 2.13.8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7326'>WFCORE-7326</a>] -         Upgrade to jboss-parent 50; drop pom settings now provided by JBoss Parent
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7330'>WFCORE-7330</a>] -         Upgrade wildfly-bom-builder-plugin to 2.0.9
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7342'>WFCORE-7342</a>] -         Upgrade wildfly-bom-builder-plugin to 2.0.10
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7348'>WFCORE-7348</a>] -         Upgrade WildFly Elytron to 2.6.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7352'>WFCORE-7352</a>] -         Upgrade Undertow from 2.3.18 to 2.3.19
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7346'>WFCORE-7346</a>] -         Introduce new INSTALL_WS_VERIFICATION phase
</li>
</ul>
</details>

