### PR TITLE
WFLY-20922 Upgrade wildfly-channel-maven-plugin to 1.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
         <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.unstable.annotation.api>1.0.2.Final</version.org.wildfly.unstable.annotation.api>
-        <version.org.wildfly.wildfly-channel-plugin>1.0.25</version.org.wildfly.wildfly-channel-plugin>
+        <version.org.wildfly.wildfly-channel-plugin>1.0.29</version.org.wildfly.wildfly-channel-plugin>
         <version.org.wildfly.wildfly-maven-gpg-plugin>3.2.8.SP1</version.org.wildfly.wildfly-maven-gpg-plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>
         <version.xml.plugin>1.0.2</version.xml.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20922

This brings no functional changes to the the edit-manifest goal, which AFAIK is the only functionality that Wildfly relies on.