### PR TITLE
[WFLY-20854] Override the version of the Elasticsearch client in the WildFly Preview

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -51,6 +51,7 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <!-- Required for Hibernate Search -->
         <version.org.apache.lucene>9.12.2</version.org.apache.lucene>
+        <version.org.elasticsearch.client.rest-client>9.1.2</version.org.elasticsearch.client.rest-client>
         <version.org.bytebuddy>1.17.6</version.org.bytebuddy>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.3</version.org.glassfish.jakarta.faces>
@@ -563,6 +564,30 @@
                 <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
                 <version>${version.org.hibernate.search}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${version.org.elasticsearch.client.rest-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+                <version>${version.org.elasticsearch.client.rest-client}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20854

This just resolves the merge conflict in #19135 plus puts the new deps in alphabetical order by GAV. The original passed CI and was approved but then another PR came in and added a conflict.