### PR TITLE
[WFLY-20934]: Add a comment in Wild…Fly pom as to why we have artemis-cli as a dependency

### DIFF
--- a/messaging-activemq/subsystem/pom.xml
+++ b/messaging-activemq/subsystem/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>artemis-server</artifactId>
         </dependency>
 
+        <!--
+        This dependecy on artemis-cli is required for the import/export journal operation.
+        Thus all the transitive dependencies not strictly required should be excluded.
+        -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-cli</artifactId>
@@ -123,6 +127,14 @@
                 <exclusion>
                     <groupId>org.jline</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>info.picocli</groupId>
+                    <artifactId>picocli</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>info.picocli</groupId>
+                    <artifactId>picocli-shell-jline3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
* Comment added
* Excluding picoli from the transitive dependencies of artemis-cli

Jira: https://issues.redhat.com/browse/WFLY-20934