### PR TITLE
[WFLY-20951] Take into account the new Jakarta Authorization capability.

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/security/JaccEarDeploymentProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/JaccEarDeploymentProcessor.java
@@ -5,6 +5,9 @@
 
 package org.jboss.as.ee.security;
 
+import static org.jboss.as.ee.subsystem.EeCapabilities.ELYTRON_JACC_CAPABILITY;
+import static org.jboss.as.ee.subsystem.EeCapabilities.ELYTRON_JAKARTA_AUTHORIZATION;
+
 import jakarta.security.jacc.PolicyConfiguration;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
@@ -27,10 +30,9 @@ import org.jboss.msc.service.ServiceTarget;
  */
 public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
 
-    private final String jaccCapabilityName;
+    private volatile boolean deployed = false;
 
-    public JaccEarDeploymentProcessor(final String jaccCapabilityName) {
-        this.jaccCapabilityName = jaccCapabilityName;
+    public JaccEarDeploymentProcessor() {
     }
 
     /**
@@ -39,23 +41,34 @@ public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        AbstractSecurityDeployer<?> deployer = null;
+
         if (DeploymentTypeMarker.isType(DeploymentType.EAR, deploymentUnit)) {
-            deployer = new EarSecurityDeployer();
-            JaccService<?> service = deployer.deploy(deploymentUnit);
-            if (service != null) {
-                final ServiceName jaccServiceName = deploymentUnit.getServiceName().append(JaccService.SERVICE_NAME);
-                final ServiceTarget serviceTarget = phaseContext.getServiceTarget();
-                ServiceBuilder<?> builder = serviceTarget.addService(jaccServiceName, service);
-                if (deploymentUnit.getParent() != null) {
-                    // add dependency to parent policy
-                    final DeploymentUnit parentDU = deploymentUnit.getParent();
-                    builder.addDependency(parentDU.getServiceName().append(JaccService.SERVICE_NAME), PolicyConfiguration.class,
-                            service.getParentPolicyInjector());
+                    CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+
+            boolean usesElytronJaccPolicy = capabilitySupport.hasCapability(ELYTRON_JACC_CAPABILITY);
+            boolean requireJakartaAuthorization = usesElytronJaccPolicy || capabilitySupport.hasCapability(ELYTRON_JAKARTA_AUTHORIZATION);
+
+            if (requireJakartaAuthorization) {
+                deployed = true;
+                AbstractSecurityDeployer<?> deployer = new EarSecurityDeployer();
+                JaccService<?> service = deployer.deploy(deploymentUnit);
+                if (service != null) {
+                    final ServiceName jaccServiceName = deploymentUnit.getServiceName().append(JaccService.SERVICE_NAME);
+                    final ServiceTarget serviceTarget = phaseContext.getServiceTarget();
+                    ServiceBuilder<?> builder = serviceTarget.addService(jaccServiceName, service);
+                    if (deploymentUnit.getParent() != null) {
+                        // add dependency to parent policy
+                        final DeploymentUnit parentDU = deploymentUnit.getParent();
+                        builder.addDependency(parentDU.getServiceName().append(JaccService.SERVICE_NAME), PolicyConfiguration.class,
+                                service.getParentPolicyInjector());
+                    }
+
+                    if (usesElytronJaccPolicy) {
+                        builder.requires(capabilitySupport.getCapabilityServiceName(ELYTRON_JACC_CAPABILITY));
+                    }
+
+                    builder.setInitialMode(Mode.ACTIVE).install();
                 }
-                CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-                builder.requires(capabilitySupport.getCapabilityServiceName(jaccCapabilityName));
-                builder.setInitialMode(Mode.ACTIVE).install();
             }
         }
     }
@@ -65,9 +78,8 @@ public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
      */
     @Override
     public void undeploy(DeploymentUnit context) {
-        AbstractSecurityDeployer<?> deployer = null;
-        if (DeploymentTypeMarker.isType(DeploymentType.EAR, context)) {
-            deployer = new EarSecurityDeployer();
+        if (deployed && DeploymentTypeMarker.isType(DeploymentType.EAR, context)) {
+            AbstractSecurityDeployer<?> deployer = new EarSecurityDeployer();
             deployer.undeploy(context);
         }
     }

--- a/ee/src/main/java/org/jboss/as/ee/security/JaccEarDeploymentProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/JaccEarDeploymentProcessor.java
@@ -30,8 +30,6 @@ import org.jboss.msc.service.ServiceTarget;
  */
 public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
 
-    private volatile boolean deployed = false;
-
     public JaccEarDeploymentProcessor() {
     }
 
@@ -43,13 +41,13 @@ public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
         if (DeploymentTypeMarker.isType(DeploymentType.EAR, deploymentUnit)) {
-                    CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+            CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
 
+            // See the comment in EeCapabilities for more information regarding this pair of capabilities.
             boolean usesElytronJaccPolicy = capabilitySupport.hasCapability(ELYTRON_JACC_CAPABILITY);
             boolean requireJakartaAuthorization = usesElytronJaccPolicy || capabilitySupport.hasCapability(ELYTRON_JAKARTA_AUTHORIZATION);
 
             if (requireJakartaAuthorization) {
-                deployed = true;
                 AbstractSecurityDeployer<?> deployer = new EarSecurityDeployer();
                 JaccService<?> service = deployer.deploy(deploymentUnit);
                 if (service != null) {
@@ -78,7 +76,7 @@ public class JaccEarDeploymentProcessor implements DeploymentUnitProcessor {
      */
     @Override
     public void undeploy(DeploymentUnit context) {
-        if (deployed && DeploymentTypeMarker.isType(DeploymentType.EAR, context)) {
+        if (DeploymentTypeMarker.isType(DeploymentType.EAR, context)) {
             AbstractSecurityDeployer<?> deployer = new EarSecurityDeployer();
             deployer.undeploy(context);
         }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeCapabilities.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeCapabilities.java
@@ -24,5 +24,6 @@ public final class EeCapabilities {
             .build();
 
     public static final String ELYTRON_JACC_CAPABILITY = "org.wildfly.security.jacc-policy";
+    public static final String ELYTRON_JAKARTA_AUTHORIZATION = "org.wildfly.security.jakarta-authorization";
 
 }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeCapabilities.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeCapabilities.java
@@ -23,6 +23,17 @@ public final class EeCapabilities {
             .addRequirements(PathManager.SERVICE_DESCRIPTOR)
             .build();
 
+    /*
+     * Prior to Jakarta EE 11 the Policy was an instance of java.security.Policy, within the Elytron subsystem
+     * we would make use of an MSC service to handle the global registration. Any deployments that were utilising JACC
+     * would need to depend on the "org.wildfly.security.jacc-policy" capability to ensure registration was complete
+     * before processing the deployment.
+     *
+     * The Elytron subsystem now also supports an immediate registration which is indicated by the
+     * "org.wildfly.security.jakarta-authorization" capability, if this is registered it means Jakarta Authorization
+     * has already been registered.
+     */
+
     public static final String ELYTRON_JACC_CAPABILITY = "org.wildfly.security.jacc-policy";
     public static final String ELYTRON_JAKARTA_AUTHORIZATION = "org.wildfly.security.jakarta-authorization";
 

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
@@ -5,7 +5,6 @@
 
 package org.jboss.as.ee.subsystem;
 
-import static org.jboss.as.ee.subsystem.EeCapabilities.ELYTRON_JACC_CAPABILITY;
 import static org.jboss.as.ee.logging.EeLogger.ROOT_LOGGER;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
@@ -13,7 +12,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ee.component.ReflectiveClassIntrospector;
 import org.jboss.as.ee.component.deployers.ApplicationClassesAggregationProcessor;
@@ -138,9 +136,6 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
         jbossDescriptorPropertyReplacementProcessor.setDescriptorPropertyReplacement(jbossDescriptorPropertyReplacement);
         ejbAnnotationPropertyReplacementProcessor.setDescriptorPropertyReplacement(ejbAnnotationPropertyReplacement);
 
-        CapabilityServiceSupport capabilitySupport = context.getCapabilityServiceSupport();
-        final boolean elytronJacc = capabilitySupport.hasCapability(ELYTRON_JACC_CAPABILITY);
-
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
 
@@ -190,10 +185,7 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EE_INSTANCE_NAME, new InstanceNameBindingProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_APP_NAMING_CONTEXT, new ApplicationContextProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EE_STARTUP_COUNTDOWN, new EEStartupCountdownProcessor());
-
-                if (elytronJacc) {
-                    processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JACC_POLICY, new JaccEarDeploymentProcessor(ELYTRON_JACC_CAPABILITY));
-                }
+                processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JACC_POLICY, new JaccEarDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_RESOLVE_MESSAGE_DESTINATIONS, new MessageDestinationResolutionProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_COMPONENT_AGGREGATION, new ComponentAggregationProcessor());
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/security/JaccEjbDeploymentProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/security/JaccEjbDeploymentProcessor.java
@@ -36,6 +36,16 @@ import org.jboss.msc.service.ServiceTarget;
  */
 public class JaccEjbDeploymentProcessor implements DeploymentUnitProcessor {
 
+    /*
+     * Prior to Jakarta EE 11 the Policy was an instance of java.security.Policy, within the Elytron subsystem
+     * we would make use of an MSC service to handle the global registration. Any deployments that were utilising JACC
+     * would need to depend on the "org.wildfly.security.jacc-policy" capability to ensure registration was complete
+     * before processing the deployment.
+     *
+     * The Elytron subsystem now also supports an immediate registration which is indicated by the
+     * "org.wildfly.security.jakarta-authorization" capability, if this is registered it means Jakarta Authorization
+     * has already been registered.
+     */
     private static final String ELYTRON_JACC_CAPABILITY = "org.wildfly.security.jacc-policy";
     public static final String ELYTRON_JAKARTA_AUTHORIZATION = "org.wildfly.security.jakarta-authorization";
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/security/JaccEjbDeploymentProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/security/JaccEjbDeploymentProcessor.java
@@ -36,16 +36,24 @@ import org.jboss.msc.service.ServiceTarget;
  */
 public class JaccEjbDeploymentProcessor implements DeploymentUnitProcessor {
 
-    private final String jaccCapabilityName;
+    private static final String ELYTRON_JACC_CAPABILITY = "org.wildfly.security.jacc-policy";
+    public static final String ELYTRON_JAKARTA_AUTHORIZATION = "org.wildfly.security.jakarta-authorization";
 
-    public JaccEjbDeploymentProcessor(final String jaccCapabilityName) {
-        this.jaccCapabilityName = jaccCapabilityName;
+    public JaccEjbDeploymentProcessor() {
     }
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         if (deploymentContainsEjbs(deploymentUnit) == false) {
+            return;
+        }
+
+        CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+
+        boolean usesElytronJaccPolicy = capabilitySupport.hasCapability(ELYTRON_JACC_CAPABILITY);
+        boolean requireJakartaAuthorization = usesElytronJaccPolicy || capabilitySupport.hasCapability(ELYTRON_JAKARTA_AUTHORIZATION);
+        if (requireJakartaAuthorization == false) {
             return;
         }
 
@@ -63,8 +71,9 @@ public class JaccEjbDeploymentProcessor implements DeploymentUnitProcessor {
                 builder.addDependency(parentDU.getServiceName().append(JaccService.SERVICE_NAME), PolicyConfiguration.class,
                         service.getParentPolicyInjector());
             }
-            CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-            builder.requires(capabilitySupport.getCapabilityServiceName(jaccCapabilityName));
+            if (usesElytronJaccPolicy) {
+                builder.requires(capabilitySupport.getCapabilityServiceName(ELYTRON_JACC_CAPABILITY));
+            }
             builder.setInitialMode(Mode.ACTIVE).install();
         }
     }
@@ -82,8 +91,7 @@ public class JaccEjbDeploymentProcessor implements DeploymentUnitProcessor {
 
     @Override
     public void undeploy(DeploymentUnit deploymentUnit) {
-        AbstractSecurityDeployer<?> deployer = null;
-        deployer = new EjbSecurityDeployer();
+        AbstractSecurityDeployer<?> deployer = new EjbSecurityDeployer();
         deployer.undeploy(deploymentUnit);
 
         // Jakarta Enterprise Beans maybe included directly in war deployment

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -125,6 +125,17 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
     public static final String OLD_URI_PREFIX = "http://java.sun.com";
     public static final String NEW_URI_PREFIX = "http://xmlns.jcp.org";
 
+    /*
+     * Prior to Jakarta EE 11 the Policy was an instance of java.security.Policy, within the Elytron subsystem
+     * we would make use of an MSC service to handle the global registration. Any deployments that were utilising JACC
+     * would need to depend on the "org.wildfly.security.jacc-policy" capability to ensure registration was complete
+     * before processing the deployment.
+     *
+     * The Elytron subsystem now also supports an immediate registration which is indicated by the
+     * "org.wildfly.security.jakarta-authorization" capability, if this is registered it means Jakarta Authorization
+     * has already been registered.
+     */
+
     private static final String ELYTRON_JACC_CAPABILITY_NAME = "org.wildfly.security.jacc-policy";
     private static final String ELYTRON_JAKARTA_AUTHORIZATION = "org.wildfly.security.jakarta-authorization";
 
@@ -194,7 +205,7 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
 
         ResourceRoot deploymentResourceRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
         final VirtualFile deploymentRoot = deploymentResourceRoot.getRoot();
-        final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+    final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
         if (module == null) {
             throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failedToResolveModule(deploymentUnit));
         }


### PR DESCRIPTION
I am going to start as a draft but this is independently mergable without the rest.

Longer term we may want to introduce a Jakarta Authorization layer / extension - for now the Elytron extension will register Jakarta Authorization 3.0 for Jakarta EE 11 if the integration supports it and if so will record a capability:

https://github.com/darranl/wildfly-core/blob/WFCORE-7322/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java#L490-L497

This means we have a capability we can detect but we don't need to depend on a Service for EE 11.

https://issues.redhat.com/browse/WFLY-20951