### PR TITLE
[WFLY-20958] Upgrade Jakarta Mail from 2.1.3 to 2.1.5 and Angus Mail to 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.16</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
-        <version.jakarta.activation.jakarta.activation-api>2.1.3</version.jakarta.activation.jakarta.activation-api>
+        <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.batch.jakarta.batch-api>2.1.1</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.data.jakarta-data-api>1.0.1</version.jakarta.data.jakarta-data-api>
@@ -467,7 +467,7 @@
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
-        <version.org.eclipse.angus.angus-activation>2.0.2</version.org.eclipse.angus.angus-activation>
+        <version.org.eclipse.angus.angus-activation>2.0.3</version.org.eclipse.angus.angus-activation>
         <version.org.eclipse.angus.angus-mail>2.0.4</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.33.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile>7.1</version.org.eclipse.microprofile>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
         <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.json.bind.api>3.0.1</version.jakarta.json.bind.api>
-        <version.jakarta.mail-api>2.1.3</version.jakarta.mail-api>
+        <version.jakarta.mail-api>2.1.5</version.jakarta.mail-api>
         <version.jakarta.mvc.jakarta-mvc-api>2.1.0</version.jakarta.mvc.jakarta-mvc-api>
         <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
@@ -468,7 +468,7 @@
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
         <version.org.eclipse.angus.angus-activation>2.0.3</version.org.eclipse.angus.angus-activation>
-        <version.org.eclipse.angus.angus-mail>2.0.4</version.org.eclipse.angus.angus-mail>
+        <version.org.eclipse.angus.angus-mail>2.0.5</version.org.eclipse.angus.angus-mail>
         <version.org.eclipse.jdt>3.33.0</version.org.eclipse.jdt>
         <version.org.eclipse.microprofile>7.1</version.org.eclipse.microprofile>
         <version.org.eclipse.microprofile.config.api>3.1</version.org.eclipse.microprofile.config.api>


### PR DESCRIPTION
Built on top of #19208 to avoid conflicting

Jira issue: https://issues.redhat.com/browse/WFLY-20958

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-20957](https://issues.redhat.com/browse/WFLY-20957)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)