### PR TITLE
WFLY-20926 FaultToleranceOpenTelemetryIntegrationTestCase intermitten…

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -6,7 +6,6 @@
 package org.wildfly.test.integration.microprofile.faulttolerance.opentelemetry;
 
 import java.net.URL;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -100,7 +99,7 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
                     .findFirst();
             Assert.assertTrue(prometheusMetric.isPresent());
             Assert.assertEquals(0, Integer.parseInt(prometheusMetric.get().getValue()), 0);
-        }, Duration.ofSeconds(70)); // n.b. this in ~2% of cases needs slightly more time on our CI given the asynchronicity
+        });
     }
 
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -41,8 +41,16 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     public static final String OTEL_COLLECTOR_CONFIG_YAML = "/etc/otel-collector-config.yaml";
 
     private final JaegerContainer jaegerContainer;
+
+    /**
+     * The default timeout in seconds configurable by -Dtestsuite.integration.container.timeout=... and adjustable by -Dts.timeout.factor=...
+     * Note that this is not a waiting time, but the maximum allowable time while actively polling.
+     * Defaults to 2 minutes.
+     */
     private final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(
-            TimeoutUtil.adjust(Integer.parseInt(System.getProperty("testsuite.integration.container.timeout", "30"))));
+            TimeoutUtil.adjust(
+                    Integer.parseInt(
+                            System.getProperty("testsuite.integration.container.timeout", "120"))));
 
     public OpenTelemetryCollectorContainer() {
         super("OpenTelemetryCollector", IMAGE_NAME, IMAGE_VERSION,


### PR DESCRIPTION
…tly fails; timeout is not adjustable via tooling for slow machines + WFLY-20928 OpenTelemetryMetricsTestCase#getMetrics intermittently fails; increase timeout to 2 minutes

https://issues.redhat.com/browse/WFLY-20926
https://issues.redhat.com/browse/WFLY-20928