### PR TITLE
[WFLY-20975] Upgrade WildFly Core to 30.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.13.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>30.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>30.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-20975


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/30.0.0.Beta3
Diff: https://github.com/wildfly/wildfly-core/compare/30.0.0.Beta2...30.0.0.Beta3

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7320'>WFCORE-7320</a>] -          Intermittent failures for Git tests under org.jboss.as.controller.persistence
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7343'>WFCORE-7343</a>] -         jboss.qualified.host.name may not be properly calculated
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7361'>WFCORE-7361</a>] -         Suspend/resume operation handlers can throw IllegalArgumentException if failed future has no cause
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7312'>WFCORE-7312</a>] -         Consider replacing the &#39;release&#39; profile with &#39;jboss-release&#39;
</li>
</ul>
                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7324'>WFCORE-7324</a>] -         Upgrade Apache Commons CLI from 1.9.0 to 1.10.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7337'>WFCORE-7337</a>] -         Upgrade wildfly-common to 2.0.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7363'>WFCORE-7363</a>] -         Upgrade WildFly Maven Plugin to 5.1.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7364'>WFCORE-7364</a>] -         Upgrade BouncyCastle from 1.81 to 1.82
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7366'>WFCORE-7366</a>] -         Upgrade WildFly Elytron to 2.7.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7367'>WFCORE-7367</a>] -         Upgrade Elytron EE to 3.2.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7368'>WFCORE-7368</a>] -         Upgrade smallrye-common to 2.13.9
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7322'>WFCORE-7322</a>] -         Update the Elytron subsystem to support the initalisation of Jakarta Authorization defined by ELYEE-73
</li>
</ul>
</details>
