### PR TITLE
Fix for WFLY-20979, microprofile-reactive-messaging layer has a wrong name in its spec

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
@@ -4,7 +4,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="reactive-messaging">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-messaging">
     <props>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.reactive.messaging.*"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.reactive.messaging.*"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20979
