### PR TITLE
[WFLY-20955] Update the JaccService implementations to call the PolicyRegistration SPI

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/security/AbstractSecurityDeployer.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/AbstractSecurityDeployer.java
@@ -6,7 +6,9 @@
 package org.jboss.as.ee.security;
 
 import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.modules.Module;
 
 /**
  * A helper class for security deployment processors
@@ -32,7 +34,8 @@ public abstract class AbstractSecurityDeployer<T> {
         if (deploymentUnit.getParent() == null) {
             standalone = Boolean.TRUE;
         }
-        return createService(jaccContextId, metaData, standalone);
+        Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+        return createService(jaccContextId, metaData, standalone, module.getClassLoader());
     }
 
     public void undeploy(DeploymentUnit deploymentUnit) {
@@ -46,7 +49,7 @@ public abstract class AbstractSecurityDeployer<T> {
      * @param standalone
      * @return
      */
-    protected abstract JaccService<T> createService(String contextId, T metaData, Boolean standalone);
+    protected abstract JaccService<T> createService(String contextId, T metaData, Boolean standalone, ClassLoader deploymentClassLoader);
 
     /**
      * Return the type of metadata

--- a/ee/src/main/java/org/jboss/as/ee/security/EarSecurityDeployer.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/EarSecurityDeployer.java
@@ -20,7 +20,7 @@ public class EarSecurityDeployer extends AbstractSecurityDeployer<EarMetaData> {
      * {@inheritDoc}
      */
     @Override
-    protected JaccService<EarMetaData> createService(String contextId, EarMetaData metaData, Boolean standalone) {
+    protected JaccService<EarMetaData> createService(String contextId, EarMetaData metaData, Boolean standalone, ClassLoader deploymentClassLoader) {
         return new EarJaccService(contextId, metaData, standalone);
     }
 

--- a/ee/src/main/java/org/jboss/as/ee/security/JaccService.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/JaccService.java
@@ -9,6 +9,8 @@ import static org.jboss.as.ee.logging.EeLogger.ROOT_LOGGER;
 import static org.wildfly.common.Assert.checkNotNullParam;
 import static org.wildfly.security.authz.jacc.PolicyUtil.getPolicyUtil;
 
+import java.security.GeneralSecurityException;
+
 import jakarta.security.jacc.PolicyConfiguration;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContextException;
@@ -149,11 +151,11 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
     /**
      * Begin any Policy set up for this Context.
      */
-    public void beginContextPolicy() throws SecurityException {};
+    public void beginContextPolicy() throws GeneralSecurityException {};
 
     /**
      * End any Policy set up for this Context.
      */
-    public void endContextPolicy() throws SecurityException {};
+    public void endContextPolicy() throws GeneralSecurityException {};
 
 }

--- a/ee/src/main/java/org/jboss/as/ee/security/JaccService.java
+++ b/ee/src/main/java/org/jboss/as/ee/security/JaccService.java
@@ -34,7 +34,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
 
     public static final ServiceName SERVICE_NAME = ServiceName.of("jacc");
 
-    private final String contextId;
+    protected final String contextId;
 
     private final T metaData;
 
@@ -85,6 +85,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
                 // Allow the policy to incorporate the policy configs
                 getPolicyUtil().refresh();
             }
+            beginContextPolicy();
         } catch (Exception e) {
             throw ROOT_LOGGER.unableToStartException("JaccService", e);
         }
@@ -120,6 +121,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
                 policyConfiguration = pcf.getPolicyConfiguration(contextId, false);
                 policyConfiguration.delete();
             }
+            endContextPolicy();
         } catch (Exception e) {
             ROOT_LOGGER.errorDeletingJACCPolicy(e);
         }
@@ -143,5 +145,15 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
      * @throws PolicyContextException
      */
     public abstract void createPermissions(T metaData, PolicyConfiguration policyConfiguration) throws PolicyContextException;
+
+    /**
+     * Begin any Policy set up for this Context.
+     */
+    public void beginContextPolicy() throws SecurityException {};
+
+    /**
+     * End any Policy set up for this Context.
+     */
+    public void endContextPolicy() throws SecurityException {};
 
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/EjbSecurityDeployer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/EjbSecurityDeployer.java
@@ -31,7 +31,7 @@ public class EjbSecurityDeployer extends AbstractSecurityDeployer<AttachmentList
      * {@inheritDoc}
      */
     @Override
-    protected JaccService<AttachmentList<EjbJaccConfig>> createService(String contextId, AttachmentList<EjbJaccConfig> metaData, Boolean standalone) {
-        return new EjbJaccService(contextId, metaData, standalone);
+    protected JaccService<AttachmentList<EjbJaccConfig>> createService(String contextId, AttachmentList<EjbJaccConfig> metaData, Boolean standalone, ClassLoader deploymentClassLoader) {
+        return new EjbJaccService(contextId, metaData, standalone, deploymentClassLoader);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EjbJaccService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EjbJaccService.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.ejb3.security;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.security.Permission;
 import java.util.Map.Entry;
 
@@ -13,6 +15,7 @@ import jakarta.security.jacc.PolicyContextException;
 
 import org.jboss.as.ee.security.JaccService;
 import org.jboss.as.server.deployment.AttachmentList;
+import org.wildfly.security.jakarta.authz.PolicyRegistration;
 
 /**
  * A service that creates JACC permissions for an ejb deployment
@@ -24,8 +27,11 @@ import org.jboss.as.server.deployment.AttachmentList;
  */
 public class EjbJaccService extends JaccService<AttachmentList<EjbJaccConfig>> {
 
-    public EjbJaccService(String contextId, AttachmentList<EjbJaccConfig> metaData, Boolean standalone) {
+    private final ClassLoader deploymentClassLoader;
+
+    public EjbJaccService(String contextId, AttachmentList<EjbJaccConfig> metaData, Boolean standalone, ClassLoader deploymClassLoader) {
         super(contextId, metaData, standalone);
+        this.deploymentClassLoader = checkNotNullParam("deploymentClassLoader", deploymClassLoader);
     }
 
     @Override
@@ -42,4 +48,16 @@ public class EjbJaccService extends JaccService<AttachmentList<EjbJaccConfig>> {
             }
         }
     }
+
+    @Override
+    public void beginContextPolicy() throws SecurityException {
+        PolicyRegistration.beginContextPolicy(contextId, deploymentClassLoader);
+    }
+
+    @Override
+    public void endContextPolicy() throws SecurityException {
+        PolicyRegistration.endContextPolicy(contextId);
+    }
+
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EjbJaccService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EjbJaccService.java
@@ -7,6 +7,7 @@ package org.jboss.as.ejb3.security;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
 
+import java.security.GeneralSecurityException;
 import java.security.Permission;
 import java.util.Map.Entry;
 
@@ -50,12 +51,12 @@ public class EjbJaccService extends JaccService<AttachmentList<EjbJaccConfig>> {
     }
 
     @Override
-    public void beginContextPolicy() throws SecurityException {
+    public void beginContextPolicy() throws GeneralSecurityException {
         PolicyRegistration.beginContextPolicy(contextId, deploymentClassLoader);
     }
 
     @Override
-    public void endContextPolicy() throws SecurityException {
+    public void endContextPolicy() throws GeneralSecurityException {
         PolicyRegistration.endContextPolicy(contextId);
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCDeployer.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCDeployer.java
@@ -29,8 +29,8 @@ public class WarJACCDeployer extends AbstractSecurityDeployer<WarMetaData> {
      * {@inheritDoc}
      */
     @Override
-    protected JaccService<WarMetaData> createService(String contextId, WarMetaData metaData, Boolean standalone) {
-        return new WarJACCService(contextId, metaData, standalone);
+    protected JaccService<WarMetaData> createService(String contextId, WarMetaData metaData, Boolean standalone, ClassLoader deploymentClassLoader) {
+        return new WarJACCService(contextId, metaData, standalone, deploymentClassLoader);
     }
 
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/WarJACCService.java
@@ -7,6 +7,7 @@ package org.wildfly.extension.undertow.security.jacc;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
 
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -398,12 +399,12 @@ public class WarJACCService extends JaccService<WarMetaData> {
     }
 
     @Override
-    public void beginContextPolicy() throws SecurityException {
+    public void beginContextPolicy() throws GeneralSecurityException {
         PolicyRegistration.beginContextPolicy(contextId, deploymentClassLoader);
     }
 
     @Override
-    public void endContextPolicy() throws SecurityException {
+    public void endContextPolicy() throws GeneralSecurityException {
         PolicyRegistration.endContextPolicy(contextId);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20955

For Jakarta EE 10 this is no-op.

For Jakarta EE 11 it enabled the context i.e. deployment specific Policy instance to be instantiated and registered.
