### PR TITLE
[EE11] [WFLY-20989] Check for the preview-server-tests as wll when checking …

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -8,6 +8,7 @@ package org.jboss.as.test.shared.util;
 import static org.junit.Assume.assumeTrue;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -289,7 +290,7 @@ public class AssumeTestGroupUtil {
     }
 
     public static boolean isWildFlyPreview() {
-        return System.getProperty("ts.preview") != null || System.getProperty("ts.bootable.preview") != null;
+        return anyOf("ts.preview", "ts.bootable.preview", "preview-server-tests");
     }
 
     public static void assumeBootableJar() {
@@ -314,6 +315,12 @@ public class AssumeTestGroupUtil {
                 return null;
             }
         });
+    }
+
+    private static boolean anyOf(final String... keys) {
+        final Set<String> names = Set.of(keys);
+        return System.getProperties().stringPropertyNames().stream()
+                .anyMatch(names::contains);
     }
 
 }


### PR DESCRIPTION
…if WildFly Preview is enabled.

https://issues.redhat.com/browse/WFLY-20989

EE 11 test run of #19235 