### PR TITLE
[WFLY-20991] Moving colliding test port to 8082 in RolloutPlanTestCase

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
@@ -38,7 +38,8 @@ import org.junit.Test;
 public class RolloutPlanTestCase extends AbstractCliTestBase {
 
     private static File warFile;
-    private static final int TEST_PORT = 8081;
+    //8081 might be already occupied by a restraint test harness
+    private static final int TEST_PORT = Integer.getInteger("org.jboss.as.test.integration.domain.management.cli.testport", 8082);
 
     private static final String[] serverGroups = new String[] {"main-server-group", "other-server-group", "test-server-group"};
 


### PR DESCRIPTION
[WFLY-20991](https://issues.redhat.com/browse/WFLY-20991)

In RPM testing environment the port is used by [restraint](https://github.com/restraint-harness/restraint) daemon. Port `8081` is the [default port for its systemd service](https://restraint.readthedocs.io/en/latest/commands.html#restraintd).

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-20991](https://issues.redhat.com/browse/WFLY-20991)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)