### PR TITLE
[WFLY-20995] Account for the inject env entry in the test assertion

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/DuplicatePostConstructTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/DuplicatePostConstructTestCase.java
@@ -50,6 +50,6 @@ public class DuplicatePostConstructTestCase {
                         HttpResponse.BodyHandlers.ofString())
                 .body();
 
-        Assert.assertEquals("1", response);
+        Assert.assertEquals("34", response);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/postcontstruct/beanjar/SimpleServlet.java
@@ -32,6 +32,6 @@ public class SimpleServlet extends HttpServlet {
 
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setContentType("text/plain");
-        resp.getWriter().write(""+m_postCount.get());
+        resp.getWriter().write(""+(m_postCount.get() + m_cInteger));
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20995

@jasondlee Perhaps this env entry could just be removed as I'm not sure it's adding anything, unless the injection was somehow a factor in triggering duplicate PostConstruct calls. But I didn't want to think hard about that so I just made use of the value.