### PR TITLE
[WFLY-20211] / [WFLY-20950] / [WFLY-20996] Jakarta Authorization 3.0 for Jakarta EE 11

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -63,7 +63,7 @@
         <version.org.hibernate.models>1.0.1</version.org.hibernate.models>
         <version.org.hibernate.search>8.1.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.0.1.Final</version.org.hibernate.validator>
-        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta1</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta3-SNAPSHOT</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
 
     <dependencyManagement>
@@ -941,9 +941,22 @@
                 <version>${ee.maven.version}</version>
             </dependency>
 
+            <!-- TODO Before we reach the end we need to ensure every elytron-ee component is listed -->
+            <!-- Otherwise we risk a weird hybrid mix of dependencies.                               -->
             <dependency>
                 <groupId>org.wildfly.security.jakarta</groupId>
                 <artifactId>jakarta-authentication</artifactId>
+                <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security.jakarta</groupId>
+                <artifactId>jakarta-authorization</artifactId>
                 <version>${version.org.wildfly.security.jakarta.elytron-ee}</version>
                 <exclusions>
                     <exclusion>

--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -63,7 +63,7 @@
         <version.org.hibernate.models>1.0.1</version.org.hibernate.models>
         <version.org.hibernate.search>8.1.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.0.1.Final</version.org.hibernate.validator>
-        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta3-SNAPSHOT</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta3</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>
 
     <dependencyManagement>

--- a/preview/galleon-local/src/main/resources/feature_groups/jacc-policy.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/jacc-policy.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<feature-group-spec name="jacc-policy" xmlns="urn:jboss:galleon:feature-group:1.0" />


### PR DESCRIPTION

https://issues.redhat.com/browse/WFLY-20211
https://issues.redhat.com/browse/WFLY-20950
https://issues.redhat.com/browse/WFLY-20996

This PR does require an updated WildFly Core before it will compile / run the server correctly.

There is a risk that due to API changes in Jakarta Authorization this may run into testsuite issues once we get it running.