### PR TITLE
 [WFLY-20998] Update the producers to only be added if there was not already a producer available provided by the application.

### DIFF
--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -238,3 +238,57 @@ embedded broker is still supported. We've added to the $WILDFLY_HOME/docs/exampl
 * WildFly Preview includes the `jakarta-data` subsystem in its out-of-the-box `standalone.xml`, `standalone-ha.xml`, `standalone-full.xml`, `standalone-full-ha.xml`, `standalone-microprofile.xml` and `standalone-microprofile-ha.xml` configuration files. It also include the subsystem in the out-of-the-box `domain.xml` configuration file's `default`, `ha`, `full` and `full-ha` profiles. Standard WildFly includes support for the `jakarta-data` subsystem but does not include it in any out-of-the-box-configuration file. link:https://jakarta.ee/specifications/data/[Jakarta Data] is a new Jakarta specification that will be part of Jakarta EE 11.
 * WildFly Preview includes a new xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability] `org.wildfly.extension.vertx` extension and its `vertx` subsystem, along with a new `vertx` Galleon layer so you can provision it in a slimmed server. This subsystem can be used to configure the Vert.x instance used by our OpenTelemetry integration.
 * The Hibernate ORM integration used by the link:Developer_Guide{outfilesuffix}#JPA_Reference_Guide[JPA subsystem's] Hibernate Search feature supports using outbox polling as a coordination strategy for automatic indexing.
+
+== Jakarta Persistence 3.2+
+
+In https://jakarta.ee/specifications/persistence/3.2/[Jakarta Persistence 3.2] and https://jakarta.ee/specifications/platform/11/[Jakarta EE 11+],
+there is a requirement to produce the following types for CDI injection:
+
+* `CriteriaBuilder`
+* `EntityManager`
+* `EntityManagerFactory`
+* `Metamodel`
+* `PersistenceUnitUtil`
+* `SchemaManager`
+
+As noted in the https://jakarta.ee/specifications/platform/11/jakarta-platform-spec-11.0#a441[specification], the
+`EntityManager` has a default scope of `@TransactionScoped`. The `EntityManagerFactory` has a scope of `@ApplicationScoped`.
+All other types have a scope of `@Dependent`.
+
+In the `persistence.xml`, each persistence unit can define their own scope and own qualifiers. It's important to note
+if you choose to use CDI for your Jakarta Persistence application, you must create CDI qualifiers if you have more than
+one persistence unit defined in your `persistence.xml` file. Without this you will likely see deployment failures due
+to ambiguous beans.
+
+.Example persistence.xml
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="https://jakarta.ee/xml/ns/persistence"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+        https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.2">
+    <persistence-unit name="auth">
+        <jta-data-source>java:jboss/datasources/AuthDS</jta-data-source>
+        <qualifier>org.wildfly.example.AuthDb</qualifier>
+    </persistence-unit>
+    <persistence-unit name="default">
+        <jta-data-source>java:jboss/datasources/defaultDS</jta-data-source>
+    </persistence-unit>
+</persistence>
+----
+
+At most one persistence unit is allowed to have no qualifier defined in the `persistence.xml`. This will be the default
+scoped `EntityManagerFactory` and `EntityManager`.
+
+NOTE: If you already have CDI producers defined in your application to inject any of these types, they should continue
+to work. However, you may be able to remove these producers and rely on the default behavior.
+
+=== Special Notes
+
+It should be noted that there is some ambiguity in the Jakarta EE 11 specification when defining beans for the
+`EntityManagerFactory`. It's noted that bean name is given by the name of the persistence unit. In most cases this
+should be fine. However, if multiple persistence units with the same name exist in a deployment,
+we've opted to not give the bean a name. This will only affect you if you want to use Jakarta Expression Language to
+get the `EntityManagerFactory` and you've got more than one persistence unit with the same name.

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Persistence_Reference_Guide.adoc
@@ -33,7 +33,7 @@ for the JPA interfaces]and https://jcp.org/en/jsr/detail?id=338[JPA 2.2
 specification].
 
 The index of the Hibernate documentation is at
-https://hibernate.org/orm/documentation/6.1/
+https://hibernate.org/orm/documentation/6.6/
 
 [[update-your-persistence.xml-for-hibernate]]
 == Update your Persistence.xml for Hibernate

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/IgnoreDefaultProducerTestCase.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/IgnoreDefaultProducerTestCase.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.persistence.cdi;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.SchemaManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that when a deployment includes a producer, those CDI producers are used and the default ones are not
+ * registered.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ApplicationScoped
+public class IgnoreDefaultProducerTestCase {
+
+    private static final String DEPLOYMENT_NAME = IgnoreDefaultProducerTestCase.class.getSimpleName() + ".war";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
+                .addClasses(Employee.class, PersistenceProducers.class)
+                .addAsWebInfResource(IgnoreDefaultProducerTestCase.class.getPackage(), "simple-persistence.xml", "classes/META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private EntityManager entityManager;
+
+    @Inject
+    private EntityManagerFactory entityManagerFactory;
+
+    @Inject
+    private CriteriaBuilder criteriaBuilder;
+
+    @Inject
+    private PersistenceUnitUtil persistenceUnitUtil;
+
+    @Inject
+    private Metamodel metamodel;
+
+    @Inject
+    private SchemaManager schemaManager;
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Test
+    public void checkEntityManager() {
+        Assert.assertNotNull(entityManager);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#default", entityManager.getEntityManagerFactory().getName());
+    }
+
+    @Test
+    public void checkEntityManagerProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(EntityManager.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkEntityManagerFactory() {
+        Assert.assertNotNull(entityManagerFactory);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#default", entityManagerFactory.getName());
+    }
+
+    @Test
+    public void checkEntityManagerFactoryProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(EntityManagerFactory.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkCriteriaBuilder() {
+        Assert.assertNotNull(criteriaBuilder);
+    }
+
+    @Test
+    public void checkCriteriaBuilderProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(CriteriaBuilder.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkPersistenceUnitUtil() {
+        Assert.assertNotNull(persistenceUnitUtil);
+    }
+
+    @Test
+    public void checkPersistenceUnitUtilProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(PersistenceUnitUtil.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkMetamodel() {
+        Assert.assertNotNull(metamodel);
+    }
+
+    @Test
+    public void checkMetamodelProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(Metamodel.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkSchemaManager() {
+        Assert.assertNotNull(schemaManager);
+    }
+
+    @Test
+    public void checkSchemaManagerProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(SchemaManager.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceProducers.class, bean.getBeanClass());
+    }
+}

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/LegacyInjectionTestCase.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/LegacyInjectionTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.persistence.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceUnit;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that in a CDI enabled deployment that the legacy {@link PersistenceContext} and {@link PersistenceUnit} still
+ * work and don't cause deployment issues.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ApplicationScoped
+public class LegacyInjectionTestCase {
+
+    private static final String DEPLOYMENT_NAME = LegacyInjectionTestCase.class.getSimpleName() + ".war";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
+                .addClasses(Employee.class)
+                .addAsWebInfResource(LegacyInjectionTestCase.class.getPackage(), "legacy-persistence.xml", "classes/META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @PersistenceContext(unitName = "pu1")
+    private EntityManager emPu1;
+
+    @PersistenceContext(unitName = "pu2")
+    private EntityManager emPu2;
+
+    @PersistenceUnit(unitName = "pu1")
+    private EntityManagerFactory emfPu1;
+
+    @PersistenceUnit(unitName = "pu2")
+    private EntityManagerFactory emfPu2;
+
+    @Test
+    public void checkPu1EntityManager() {
+        Assert.assertNotNull(emPu1);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#pu1", emPu1.getEntityManagerFactory().getName());
+    }
+
+    @Test
+    public void checkPu2EntityManager() {
+        Assert.assertNotNull(emPu2);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#pu2", emPu2.getEntityManagerFactory().getName());
+    }
+
+    @Test
+    public void checkPu1EntityManagerFactory() {
+        Assert.assertNotNull(emfPu1);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#pu1", emfPu1.getName());
+    }
+
+    @Test
+    public void checkPu2EntityManagerFactory() {
+        Assert.assertNotNull(emfPu2);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#pu2", emfPu2.getName());
+    }
+}

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/PersistenceProducers.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/PersistenceProducers.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.persistence.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceUnit;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.SchemaManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+
+/**
+ * Produces Jakarta Persistence resources for CDI injection.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+public class PersistenceProducers {
+
+    @Produces
+    @PersistenceContext(unitName = "default")
+    EntityManager em;
+
+    @Produces
+    @PersistenceUnit(unitName = "default")
+    EntityManagerFactory emf;
+
+    @Produces
+    public CriteriaBuilder criteriaBuilder(final EntityManagerFactory emf) {
+        return emf.getCriteriaBuilder();
+    }
+
+    @Produces
+    public PersistenceUnitUtil persistenceUnitUtil(final EntityManagerFactory emf) {
+        return emf.getPersistenceUnitUtil();
+    }
+
+    @Produces
+    public Metamodel metamodel(final EntityManagerFactory emf) {
+        return emf.getMetamodel();
+    }
+
+    @Produces
+    public SchemaManager schemaManager(final EntityManagerFactory emf) {
+        return emf.getSchemaManager();
+    }
+}

--- a/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/RequiredInjectionTestCase.java
+++ b/testsuite/preview/basic/src/test/java/org/wildfly/test/preview/persistence/cdi/RequiredInjectionTestCase.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.preview.persistence.cdi;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.SchemaManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.transaction.UserTransaction;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the required CDI producers work as expected.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ApplicationScoped
+public class RequiredInjectionTestCase {
+
+    private static final String DEPLOYMENT_NAME = RequiredInjectionTestCase.class.getSimpleName() + ".war";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
+                .addClasses(Employee.class)
+                .addAsWebInfResource(RequiredInjectionTestCase.class.getPackage(), "simple-persistence.xml", "classes/META-INF/persistence.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private UserTransaction userTransaction;
+
+    @Inject
+    private EntityManager entityManager;
+
+    @Inject
+    private EntityManagerFactory entityManagerFactory;
+
+    @Inject
+    private CriteriaBuilder criteriaBuilder;
+
+    @Inject
+    private PersistenceUnitUtil persistenceUnitUtil;
+
+    @Inject
+    private Metamodel metamodel;
+
+    @Inject
+    private SchemaManager schemaManager;
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Test
+    public void checkEntityManager() throws Exception {
+        // The default scope is TransactionScoped which means we need to being a transaction before injection will work
+        userTransaction.begin();
+        try {
+            Assert.assertNotNull(entityManager);
+            Assert.assertEquals(DEPLOYMENT_NAME + "#default", entityManager.getEntityManagerFactory().getName());
+        } finally {
+            if (userTransaction.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    @Test
+    public void checkEntityManagerProducer() throws Exception {
+        // The default scope is TransactionScoped which means we need to being a transaction before injection will work
+        userTransaction.begin();
+        try {
+            final Set<Bean<?>> beans = beanManager.getBeans(EntityManager.class);
+            // We should only have one bean which is a producer method
+            Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+            final Bean<?> bean = beans.iterator().next();
+            Assert.assertEquals(EntityManager.class, bean.getBeanClass());
+        } finally {
+            if (userTransaction.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    @Test
+    public void checkEntityManagerFactory() {
+        Assert.assertNotNull(entityManagerFactory);
+        Assert.assertEquals(DEPLOYMENT_NAME + "#default", entityManagerFactory.getName());
+    }
+
+    @Test
+    public void checkEntityManagerFactoryProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(EntityManagerFactory.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(EntityManagerFactory.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkCriteriaBuilder() {
+        Assert.assertNotNull(criteriaBuilder);
+    }
+
+    @Test
+    public void checkCriteriaBuilderProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(CriteriaBuilder.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(CriteriaBuilder.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkPersistenceUnitUtil() {
+        Assert.assertNotNull(persistenceUnitUtil);
+    }
+
+    @Test
+    public void checkPersistenceUnitUtilProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(PersistenceUnitUtil.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(PersistenceUnitUtil.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkMetamodel() {
+        Assert.assertNotNull(metamodel);
+    }
+
+    @Test
+    public void checkMetamodelProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(Metamodel.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(Metamodel.class, bean.getBeanClass());
+    }
+
+    @Test
+    public void checkSchemaManager() {
+        Assert.assertNotNull(schemaManager);
+    }
+
+    @Test
+    public void checkSchemaManagerProducer() {
+        final Set<Bean<?>> beans = beanManager.getBeans(SchemaManager.class);
+        // We should only have one bean which is a producer method
+        Assert.assertEquals(String.format("Expected 1 bean, but got %s", beans), 1, beans.size());
+        final Bean<?> bean = beans.iterator().next();
+        Assert.assertEquals(SchemaManager.class, bean.getBeanClass());
+    }
+}

--- a/testsuite/preview/basic/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/preview/basic/src/test/resources/arquillian-bootable.xml
@@ -7,8 +7,6 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="jmx-as7" />
-
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="installDir">${install.dir}</property>

--- a/testsuite/preview/basic/src/test/resources/arquillian.xml
+++ b/testsuite/preview/basic/src/test/resources/arquillian.xml
@@ -7,8 +7,6 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="jmx-as7" />
-
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${jboss.install.dir}</property>

--- a/testsuite/preview/basic/src/test/resources/org/wildfly/test/preview/persistence/cdi/legacy-persistence.xml
+++ b/testsuite/preview/basic/src/test/resources/org/wildfly/test/preview/persistence/cdi/legacy-persistence.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+        https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd"
+             version="3.1">
+    <persistence-unit name="pu1">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="pu2">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/testsuite/preview/basic/src/test/resources/org/wildfly/test/preview/persistence/cdi/simple-persistence.xml
+++ b/testsuite/preview/basic/src/test/resources/org/wildfly/test/preview/persistence/cdi/simple-persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+        https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.2">
+    <persistence-unit name="default">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20998

This also adds more testing for the Jakarta Persistence and CDI integration as well as some documentation in a separate commit.