### PR TITLE
[WFLY-21002] Upgrade WildFly Core to 30.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
         <version.org.wildfly.clustering>7.0.13.Final</version.org.wildfly.clustering>
-        <version.org.wildfly.core>30.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>30.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21002


---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/30.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/30.0.0.Beta3...30.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7370'>WFCORE-7370</a>] -         StandaloneRootResourceTestCase also needs to call getCanonicalHostName
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7369'>WFCORE-7369</a>] -         Drop direct dependencies on &quot;org.wildfly.security.authz.jacc.JaccDelegatingPolicy&quot;
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7371'>WFCORE-7371</a>] -         Update AuthorizationRegistration interaction to split across the MODEL and RUNTIME stages.
</li>
</ul>
                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7373'>WFCORE-7373</a>] -         Upgrade Elytron EE to 3.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7374'>WFCORE-7374</a>] -         Upgrade WildFly Elytron to 2.7.0.Final
</li>
</ul>
</details>

