### PR TITLE
[WFLY-20989] Don't use System.getProperties() in ts util code that ma…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -88,7 +88,8 @@ public class PooledEJBLifecycleTestCase {
         archive.addAsManifestResource(
                 createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read"),
                         new PropertyPermission("ts.preview", "read"),
-                        new PropertyPermission("ts.bootable.preview", "read")),
+                        new PropertyPermission("ts.bootable.preview", "read"),
+                        new PropertyPermission("preview-server-tests", "read")),
                 "jboss-permissions.xml");
         return archive;
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -8,7 +8,6 @@ package org.jboss.as.test.shared.util;
 import static org.junit.Assume.assumeTrue;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Set;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -318,9 +317,12 @@ public class AssumeTestGroupUtil {
     }
 
     private static boolean anyOf(final String... keys) {
-        final Set<String> names = Set.of(keys);
-        return System.getProperties().stringPropertyNames().stream()
-                .anyMatch(names::contains);
+        for (String key : keys) {
+            if (System.getProperty(key) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
…y run in the deployment stack; add new PropertyPermission to PooledEJBLifecycleTestCase

https://issues.redhat.com/browse/WFLY-20989
