### PR TITLE
[WFLY-21138][WFLY-21137]: Feature-spec generation treats all host parameters as bound to domain mode and Galleon upgrade

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -25,7 +25,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="full-ha"/>
+        <param name="__profile" value="full-ha"/>
         <feature-group name="domain-ha-profile">
             <feature spec="subsystem.modcluster">
                 <feature spec="subsystem.modcluster.proxy">

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -19,7 +19,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="ha"/>
+        <param name="__profile" value="ha"/>
         <feature-group name="domain-ha-profile">
             <feature spec="subsystem.modcluster">
                 <feature spec="subsystem.modcluster.proxy">

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
@@ -25,7 +25,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="full-ha"/>
+        <param name="__profile" value="full-ha"/>
         <feature-group name="domain-ha-profile"/>
         <feature-group name="iiop-openjdk"/>
         <feature-group name="messaging-activemq-ha"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-full.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-full.xml
@@ -24,7 +24,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="full"/>
+        <param name="__profile" value="full"/>
         <feature-group name="domain-profile"/>
         <feature-group name="iiop-openjdk"/>
         <feature-group name="messaging-activemq"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -76,7 +76,7 @@
 
             <feature-group name="adjust-standalone-full-config"/>
             <feature spec="subsystem.rts">
-                <param name="host-feature" value="default-host"/>
+                <param name="host" value="default-host"/>
                 <param name="socket-binding" value="http"/>
                 <param name="server" value="default-server"/>
             </feature>
@@ -89,7 +89,7 @@
 
             <feature-group name="adjust-standalone-full-config"/>
             <feature spec="subsystem.xts">
-                <param name="host-feature" value="default-host"/>
+                <param name="host" value="default-host"/>
                 <param name="url" value="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
                 <param name="default-context-propagation" value="true"/>
             </feature>
@@ -1048,6 +1048,7 @@
                 <exclude spec="domain.server-group"/>
             </feature-group>
             <feature spec="domain.server-group">
+                <param name="__profile" value="full" />
                 <param name="server-group" value="main-server-group"/>
                 <param name="profile" value="full" />
                 <param name="socket-binding-group" value="full-sockets" />
@@ -1058,6 +1059,7 @@
                 </feature>
             </feature>
             <feature spec="domain.server-group">
+                <param name="__profile" value="full-ha" />
                 <param name="server-group" value="other-server-group"/>
                 <param name="profile" value="full-ha" />
                 <param name="socket-binding-group" value="full-ha-sockets" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/core-host-primary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/core-host-primary.xml
@@ -7,7 +7,7 @@
 <feature-group-spec name="core-host-primary" xmlns="urn:jboss:galleon:feature-group:1.0">
     <!-- TODO Temporary fork to remove security realms. -->
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <param name="persist-name" value="true"/>
 
         <feature spec="core-service.management"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/core-host-secondary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/core-host-secondary.xml
@@ -6,7 +6,7 @@
 
 <feature-group-spec name="core-host-secondary" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="host">
-        <param name="host" value="secondary"/>
+        <param name="__host" value="secondary"/>
         <param name="persist-name" value="false"/>
 
         <feature spec="core-service.management"/>
@@ -33,8 +33,7 @@
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
                 <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
-                <param name="host-feature" value="${jboss.domain.primary.address}"/>
-                <param name="host" value="secondary"/>
+                <param name="host" value="${jboss.domain.primary.address}"/>
                 <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-ha.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-ha.xml
@@ -19,7 +19,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="ha"/>
+        <param name="__profile" value="ha"/>
         <feature-group name="domain-ha-profile"/>
     </feature>
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-load-balancer.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-load-balancer.xml
@@ -15,7 +15,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="load-balancer"/>
+        <param name="__profile" value="load-balancer"/>
             <feature-group name="logging">
                 <include feature-id="subsystem.logging.root-logger.ROOT:subsystem=logging,root-logger=ROOT">
                     <param name="handlers" value="[FILE]"/>
@@ -23,7 +23,7 @@
                 <exclude spec="subsystem.logging.console-handler"/>
             </feature-group>
             <feature-group name="io"/>
-            <feature-group name="undertow-load-balancer"/>        
+            <feature-group name="undertow-load-balancer"/>
         <feature-group name="domain-server-groups"/>
     </feature>
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-server-groups.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-server-groups.xml
@@ -9,6 +9,7 @@
     <feature spec="domain.server-group">
         <param name="server-group" value="main-server-group"/>
         <param name="profile" value="full" />
+        <param name="__profile" value="full" />
         <param name="socket-binding-group" value="full-sockets" />
         <feature spec="domain.server-group.jvm">
             <param name="jvm" value="default"/>
@@ -19,6 +20,7 @@
     <feature spec="domain.server-group">
         <param name="server-group" value="other-server-group"/>
         <param name="profile" value="full-ha" />
+        <param name="__profile" value="full-ha" />
         <param name="socket-binding-group" value="full-ha-sockets" />
         <feature spec="domain.server-group.jvm">
             <param name="jvm" value="default"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain.xml
@@ -20,7 +20,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="default"/>
+        <param name="__profile" value="default"/>
         <feature-group name="domain-profile"/>
     </feature>
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host-primary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host-primary.xml
@@ -7,7 +7,7 @@
 <feature-group-spec name="host-primary" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature-group name="servlet-host-primary"/>
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;]"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host-secondary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host-secondary.xml
@@ -10,7 +10,7 @@
         <exclude feature-id="host.interface:host=secondary,interface=private"/>
     </feature-group>
     <feature spec="host">
-        <param name="host" value="secondary"/>
+        <param name="__host" value="secondary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;]"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/host.xml
@@ -10,7 +10,7 @@
         <exclude feature-id="host.interface:host=primary,interface=private"/>
     </feature-group>
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
             <param name="jvm-options" value="[&quot;-server&quot;]"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host-primary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host-primary.xml
@@ -9,7 +9,7 @@
     <feature-group name="core-host-primary"/>
 
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
 
         <!-- TODO Track back and check why this override is needed. --> 
         <feature spec="host.core-service.management.management-interface.http-interface">

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host-secondary.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host-secondary.xml
@@ -9,7 +9,7 @@
 
     <feature-group name="core-host-secondary">
         <exclude spec="host.core-service.management.management-interface.http-interface"/>
-        <include feature-id="host:host=secondary">
+        <include feature-id="host:__host=secondary">
             <feature spec="host.jvm">
                 <param name="jvm" value="default"/>
                 <param name="heap-size" value="64m"/>
@@ -21,7 +21,7 @@
     </feature-group>
 
     <feature spec="host">
-        <param name="host" value="secondary"/>
+        <param name="__host" value="secondary"/>
         
         <!-- TODO Add an authentication client example.
 
@@ -52,6 +52,7 @@
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
                 <param name="protocol" value="${jboss.domain.primary.protocol:remote+http}"/>
+                <param name="host" value="${jboss.domain.primary.address}"/>
                 <param name="port" value="${jboss.domain.primary.port:9990}"/>
             </feature>
         </feature>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/servlet-host.xml
@@ -9,7 +9,7 @@
     <feature-group name="core-host"/>
 
     <feature spec="host">
-        <param name="host" value="primary"/>
+        <param name="__host" value="primary"/>
         <feature spec="host.interface">
             <param name="interface" value="private"/>
             <param name="inet-address" value="${jboss.bind.address.private:127.0.0.1}"/>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
@@ -11,7 +11,7 @@
     </origin>
 
     <feature spec="profile">
-        <param name="profile" value="full-ha"/>
+        <param name="__profile" value="full-ha"/>
         <feature spec="subsystem.microprofile-config-smallrye"/>
         <feature spec="subsystem.microprofile-jwt-smallrye"/>
     </feature>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-full.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-full.xml
@@ -11,7 +11,7 @@
     </origin>
 
     <feature spec="profile">
-        <param name="profile" value="full"/>
+        <param name="__profile" value="full"/>
         <feature spec="subsystem.microprofile-config-smallrye"/>
         <feature spec="subsystem.microprofile-jwt-smallrye"/>
     </feature>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-ha.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain-ha.xml
@@ -11,7 +11,7 @@
     </origin>
 
     <feature spec="profile">
-        <param name="profile" value="ha"/>
+        <param name="__profile" value="ha"/>
         <feature spec="subsystem.microprofile-config-smallrye"/>
         <feature spec="subsystem.microprofile-jwt-smallrye"/>
     </feature>

--- a/galleon-pack/galleon-local/src/main/resources/feature_groups/domain.xml
+++ b/galleon-pack/galleon-local/src/main/resources/feature_groups/domain.xml
@@ -11,7 +11,7 @@
     </origin>
 
     <feature spec="profile">
-        <param name="profile" value="default"/>
+        <param name="__profile" value="default"/>
         <feature spec="subsystem.microprofile-config-smallrye"/>
         <feature spec="subsystem.microprofile-jwt-smallrye"/>
     </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -288,12 +288,12 @@
         <version.ant.junit>1.10.15</version.ant.junit>
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.12</version.org.jacoco>
-        <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>6.1.1.Final</version.org.jboss.galleon>
         <version.org.owasp.dependency-check>12.1.6</version.org.owasp.dependency-check>
         <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>8.0.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.0.2.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.5.1.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Final</version.org.wildfly.plugin>

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-full-ha.xml
@@ -26,7 +26,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="full-ha"/>
+        <param name="__profile" value="full-ha"/>
         <feature-group name="domain-ha-profile"/>
         <feature-group name="ejb3-mdb"/>
         <feature-group name="iiop-openjdk"/>

--- a/preview/galleon-local/src/main/resources/feature_groups/domain-full.xml
+++ b/preview/galleon-local/src/main/resources/feature_groups/domain-full.xml
@@ -25,7 +25,7 @@
     </feature>
 
     <feature spec="profile">
-        <param name="profile" value="full"/>
+        <param name="__profile" value="full"/>
         <feature-group name="domain-profile"/>
         <feature-group name="ejb3-mdb"/>
         <feature-group name="iiop-openjdk"/>

--- a/preview/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/preview/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -74,7 +74,7 @@
             <feature-group name="adjust-standalone-full-config"/>
 
             <feature spec="subsystem.rts">
-                <param name="host-feature" value="default-host"/>
+                <param name="host" value="default-host"/>
                 <param name="socket-binding" value="http"/>
                 <param name="server" value="default-server"/>
             </feature>
@@ -89,7 +89,7 @@
             <feature-group name="adjust-standalone-full-config"/>
 
             <feature spec="subsystem.xts">
-                <param name="host-feature" value="default-host"/>
+                <param name="host" value="default-host"/>
                 <param name="url" value="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
                 <param name="default-context-propagation" value="true"/>
             </feature>


### PR DESCRIPTION
* WFCORE-7372: Renaming host and profile address parameters to __host and __profile  when they are the 1st elements of the address to avoid confusion
* WFLY-21137: Updating Galleon and Galleon plugins to align with Core   

Requires https://github.com/wildfly/wildfly-core/pull/6532 to be merged and core to be updated.
  
Jira: 
 - https://issues.redhat.com/browse/WFLY-21138
 - https://issues.redhat.com/browse/WFLY-21137 (Galleon upgrade required)

