### PR TITLE
[WFLY-21023][WFLY-21024] Feature pack documentation 

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,10 +25,6 @@
     <name>WildFly: Documentation</name>
 
     <properties>
-        <server.name>wildfly-${project.version}</server.name>
-        <messages.filename>${server.name}.messages</messages.filename>
-        <management-model.filename>${server.name}.dmr</management-model.filename>
-
         <wildfly.github.io.dir>
             ..${file.separator}..${file.separator}wildfly.github.io${file.separator}${product.docs.server.version}
         </wildfly.github.io.dir>
@@ -91,78 +87,28 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.org.wildfly.plugin}</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>server-provisioning</id>
+                        <id>unpack-feature-pack-doc</id>
+                        <phase>process-resources</phase>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>unpack</goal>
                         </goals>
-                        <phase>prepare-package</phase>
                         <configuration>
-                            <provisioningDir>${jboss.home}</provisioningDir>
-                            <recordProvisioningState>false</recordProvisioningState>
-                            <channels>
-                                <channel>
-                                    <manifest>
-                                        <groupId>org.wildfly.channels</groupId>
-                                        <artifactId>wildfly</artifactId>
-                                        <version>${full.maven.version}</version>
-                                    </manifest>
-                                </channel>
-                            </channels>
-                            <feature-packs>
-                                <feature-pack>
+                            <artifactItems>
+                                <artifactItem>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${project.version}</version>
-                                    <inherit-configs>false</inherit-configs>
-                                    <excluded-packages>
-                                        <name>docs</name>
-                                        <name>docs.licenses.merge</name>
-                                    </excluded-packages>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-full-ha.xml</name>
-                                        </config>
-                                    </included-configs>
-                                </feature-pack>
-                            </feature-packs>
+                                    <classifier>doc</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/generated-docs/feature-pack</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jboss.wildscribe</groupId>
-                <artifactId>wildscribe-maven-plugin</artifactId>
-                <version>${version.org.jboss.wildscribe}</version>
-                <configuration>
-                    <jboss-home>${jboss.home}</jboss-home>
-                    <display-name>${full.dist.product.release.name}</display-name>
-                    <display-version>${product.docs.server.version}</display-version>
-                    <site-dir>${project.build.directory}/generated-docs/wildscribe</site-dir>
-                    <stability>experimental</stability>
-                    <required-extensions>
-                        <required-extension>org.wildfly.extension.rts</required-extension>
-                        <required-extension>org.jboss.as.xts</required-extension>
-                        <required-extension>org.wildfly.extension.datasources-agroal</required-extension>
-                        <required-extension>org.wildfly.extension.micrometer</required-extension>
-                        <required-extension>org.wildfly.extension.microprofile.fault-tolerance-smallrye</required-extension>
-                        <required-extension>org.wildfly.extension.microprofile.openapi-smallrye</required-extension>
-                        <required-extension>org.wildfly.extension.microprofile.telemetry</required-extension>
-                        <required-extension>org.wildfly.extension.opentelemetry</required-extension>
-                    </required-extensions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-site</id>
-                        <goals>
-                            <goal>generate-site</goal>
-                        </goals>
-                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
@@ -23,7 +23,7 @@ is `subsystem=batch-jberet`.
 == Default Subsystem Configuration
 
 For up to date information about subsystem configuration options see the
-link:wildscribe[WildFly model reference^].
+link:feature-pack/doc/reference/subsystem/batch-jberet/index.html[/subsystem=batch-jberet model reference].
 
 [[security]]
 == Security

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
@@ -19,7 +19,7 @@ handlers). Each handler declares the log format and output.
 --
 
 [TIP]
-The WildFly Model Reference provides a complete description of the link:./wildscribe/subsystem/logging/index.html[management API for the `logging` subsystem].
+The WildFly Model Reference provides a complete description of the link:feature-pack/doc/reference/subsystem/logging/index.html[/subsystem=logging model reference].
 
 Here is an example of the `logging` subsystem XML configuration:
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_JDBC_Store_for_Messaging_Journal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_JDBC_Store_for_Messaging_Journal.adoc
@@ -50,9 +50,9 @@ You  need at least four connections:
  * one for the lease lock (if you use HA)
  * one for the node manager shared state (if you use HA)
 
-So you should define a link:wildscribe/subsystem/datasources/xa-data-source/index.html#attr-min-pool-size[`min-pool-size`] of 4 for the pool. +
+So you should define a link:feature-pack/doc/reference/subsystem/datasources/xa-data-source/index.html#attr-min-pool-size[`min-pool-size`] of 4 for the pool. +
 But one fact that you need to take into account is that paging and large messages can use an unbounded number of threads.
-The size, a.k.a. link:wildscribe/subsystem/datasources/xa-data-source/index.html#attr-max-pool-size[`max-pool-size`], of the pool should be defined according to the amount of concurrent threads that perform page/large message streaming operations. There is no defined rule for this as there is no 1-1 relation between the number of threads and the number of connections. The number of connections depend on the number of threads processing paging and large messages operations as well as the time you are willing to wait to get a connection (cf. https://docs.wildfly.org/22/wildscribe/subsystem/datasources/xa-data-source/index.html#attr-blocking-timeout-wait-millis[`blocking-timeout-wait-millis`]). When new large messages or paging operations occur they will be in a dedicated thread and will try to get a connection, being enqueued until one is ready or the time to obtain one runs out which will create a failure. +
+The size, a.k.a. link:feature-pack/doc/reference/subsystem/datasources/xa-data-source/index.html#attr-max-pool-size[`max-pool-size`], of the pool should be defined according to the amount of concurrent threads that perform page/large message streaming operations. There is no defined rule for this as there is no 1-1 relation between the number of threads and the number of connections. The number of connections depend on the number of threads processing paging and large messages operations as well as the time you are willing to wait to get a connection (cf. link:feature-pack/doc/reference/subsystem/datasources/xa-data-source/index.html#attr-blocking-timeout-wait-millis[`blocking-timeout-wait-millis`]). When new large messages or paging operations occur they will be in a dedicated thread and will try to get a connection, being enqueued until one is ready or the time to obtain one runs out which will create a failure. +
 You really need to tailor your configuration according to your needs and test it in your environment following the <<DataSource>> subsystem documentation and perform tests and peroformance runs before going to production.
 
 
@@ -65,6 +65,5 @@ You really need to tailor your configuration according to your needs and test it
 https://activemq.apache.org/components/artemis/documentation/latest/persistence.html#configuring-jdbc-persistence
 * WildFly DataSource subsystem documentation -
 <<DataSource>>
-* WildFly datasource configuration model
-link:wildscribe/subsystem/datasources/xa-data-source/index.html
+* link:feature-pack/doc/reference/subsystem/datasources/xa-data-source/index.html[/subsystem=datasources/xa-data-source model reference]
 ****

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Transactions.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Transactions.adoc
@@ -76,7 +76,7 @@ configuration, while the `node-identifer` attribute is defined directly under `/
 resource in the model.
 
 The description of individual attributes and their meaning can be found in the
-link:wildscribe{outfilesuffix/}subsystem/transactions[Model Reference Guide].
+link:feature-pack/doc/reference/subsystem/transactions/index.html[/subsystem=transactions model reference].
 
 ==== jts
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow_using_as_a_Load_Balancer.adoc
@@ -137,4 +137,4 @@ This is all there is to it. If you point your browser to http://localhost:8080/a
 you should be able to see the proxied content.
 
 The full details of all configuration options available can be found in
-the link:wildscribe/subsystem/undertow/index.html[subsystem reference^].
+the link:feature-pack/doc/reference/subsystem/undertow/index.html[/subsystem=undertow model reference].

--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
@@ -495,7 +495,7 @@ Configuration related to the behaviour of the Narayana transaction manager
 is covered under `transactions` subsystem. For the details refer to
 link:Admin_Guide{outfilesuffix}#Transactions_Subsystem[Admin Guide Transactions subsystem].
 
-To check the subsystem model you can use the link:wildscribe[WildFly model reference^]
+To check the subsystem model you can use the link:feature-pack/doc/reference/subsystem/transactions/index.html[/subsystem=transactions model reference]
 or list all the configuration options of the subsystem in `jboss-cli`
 
 [source,bash]

--- a/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/Jakarta_Enterprise_Beans_Deployment_Runtime_Resources.adoc
@@ -23,8 +23,7 @@ and also resources specific to the bean type. For example, these are some of the
 * activation-config
 
 Users can view these enterprise bean resources via WildFly CLI or Administration Console. The following sections
-provides sample CLI and Administration Console output for each enterprise bean type. For complete details, refer to
-https://wildscribe.github.io/[WildFly Model Reference Documentation]
+provides sample CLI and Administration Console output for each enterprise bean type. For complete details, refer to link:feature-pack/doc/reference/index.html[WildFly Model Reference].
 
 [[Stateless_Session_Bean_Runtime_Resources]]
 == Stateless Session Bean Runtime Resources

--- a/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
@@ -68,7 +68,7 @@ To create a JGroups transport using a distinct "alpha" channel, that uses the "t
 /subsystem=infinispan/cache-container=foo/transport=jgroups:add(channel=alpha)
 ----
 
-For a complete list of transport attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of transport attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 To remove an existing JGroups transport, you can either use the standard remove resource operation:
 
@@ -102,7 +102,7 @@ To create a local cache:
 /subsystem=infinispan/cache-container=foo/local-cache=bar:add()
 ----
 
-For a complete list of local-cache attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of local-cache attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Replicated
 
@@ -118,7 +118,7 @@ To create a replicated cache:
 /subsystem=infinispan/cache-container=foo/replicated-cache=bar:add()
 ----
 
-For a complete list of replicated-cache attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of replicated-cache attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Distributed
 
@@ -134,7 +134,7 @@ To create a distributed cache where a given entry is stored on 3 nodes:
 /subsystem=infinispan/cache-container=foo/distributed-cache=bar:add(owners=3)
 ----
 
-For a complete list of distributed-cache attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of distributed-cache attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Scattered
 
@@ -155,7 +155,7 @@ To create a scattered cache:
 /subsystem=infinispan/cache-container=foo/scattered-cache=bar:add()
 ----
 
-For a complete list of scattered-cache attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of scattered-cache attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Invalidation
 
@@ -171,7 +171,7 @@ To create an invalidation cache:
 /subsystem=infinispan/cache-container=foo/invalidation-cache=bar:add()
 ----
 
-For a complete list of invalidation-cache attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of invalidation-cache attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 === Cache features
 
@@ -254,7 +254,7 @@ e.g. To store a maximum of 100 objects in the Java heap:
 /subsystem=infinispan/cache-container=foo/local-cache=bar/memory=object:add(size=100)
 ----
 
-For a complete list of memory=object attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of memory=object attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ===== Binary storage (on-heap)
 
@@ -270,7 +270,7 @@ e.g. To store a maximum of 1 MB of binary data in the Java heap:
 /subsystem=infinispan/cache-container=foo/local-cache=bar/memory=binary:add(size=1048576, eviction-type=MEMORY)
 ----
 
-For a complete list of memory=binary attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of memory=binary attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ===== Off-heap binary storage
 
@@ -285,7 +285,7 @@ e.g. To store a maximum of 1 GB of binary data in native memory outside of the J
 /subsystem=infinispan/cache-container=foo/local-cache=bar/memory=off-heap:add(size=1073741824)
 ----
 
-For a complete list of memory=off-heap attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of memory=off-heap attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Transactions
 
@@ -315,7 +315,7 @@ e.g. To configure a transactional cache using local Infinispan transactions with
 /subsystem=infinispan/cache-container=foo/local-cache=bar/component=transaction(mode=BATCH, locking=OPTIMISTIC)
 ----
 
-For a complete list of transaction attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of transaction attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Locking
 
@@ -337,7 +337,7 @@ e.g. To configure a cache using REPEATABLE_READ isolation:
 /subsystem=infinispan/cache-container=foo/local-cache=bar/component=locking(isolation=REPEATABLE_READ)
 ----
 
-For a complete list of locking attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of locking attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Expiration
 
@@ -353,7 +353,7 @@ e.g. To configure expiration of entries older than 1 day, or that have not been 
 
 CAUTION: max-idle based expiration is not generally safe for use with clustered caches, as the meta data of a cache entry is not replicated by cache read operations
 
-For a complete list of expiration attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of expiration attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Persistence
 
@@ -462,7 +462,7 @@ e.g. To configure a non-blocking state transfer:
 /subsystem=infinispan/cache-container=foo/local-cache=bar/component=state-transfer:add(timeout=0)
 ----
 
-For a complete list of state-transfer attributes, refer to the link:wildscribe[WildFly management model documentation^]
+For a complete list of state-transfer attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 
 ==== Injecting a cache into Jakarta EE applications

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -74,7 +74,7 @@ you how to create a cluster, how to configure the web container and Jakarta Ente
 container for clustering and how to configure load balancing
 and failover.
 
-* The link:wildscribe[WildFly model reference] provides information about all standalone server and managed domain
+* The link:feature-pack/doc/index.html[Feature pack documentation] provides information about the WildFly feature pack, including all standalone server and managed domain
 configuration options, using information generated directly from the WildFly management model.
 
 [[developer-guides]]

--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -233,6 +233,7 @@
                             <release-name>${ee.dist.product.release.name}</release-name>
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
+                            <generate-all-model>true</generate-all-model>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
                         </configuration>
                     </execution>

--- a/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/hibernate-search/layer-spec.xml
@@ -6,6 +6,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="hibernate-search">
     <props>
+        <prop name="org.wildfly.category" value="Database"/>
+        <prop name="org.wildfly.description" value="Support for Hibernate Search."/>
+        <prop name="org.wildfly.note" value="The jpa dependency can be excluded and jpa-distributed used instead."/>
         <prop name="org.wildfly.rule.annotations" value="org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jaxrs-server">
     <props>
+        <prop name="org.wildfly.category" value="Base WildFly server"/>
+        <prop name="org.wildfly.description" value="An extension of 'datasources-web-server' with support for Jakarta RESTful Web Services, CDI and JPA."/>
         <prop name="org.wildfly.rule.kind" value="base-layer"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/batch-jberet/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/batch-jberet/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="batch-jberet">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Batch"/>
         <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/classes/META-INF/batch-jobs"/>
         <prop name="org.wildfly.rule.class" value="jakarta.batch.api.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/bean-validation/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/bean-validation/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="bean-validation">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Bean Validation"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.validation.*"/>
         <prop name="org.wildfly.rule.class" value="jakarta.validation.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cdi/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cdi/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="cdi">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Contexts and Dependency Injection"/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/beans.xml,/WEB-INF/beans.xml]"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.inject,jakarta.enterprise.context"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="cloud-server">
     <props>
+        <prop name="org.wildfly.category" value="Base WildFly server"/>
+        <prop name="org.wildfly.description" value="An extension of jaxrs-server to address common cloud requirements."/>
         <prop name="org.wildfly.rule.kind" value="base-layer"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/core-tools/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="core-tools">
     <props>
+        <prop name="org.wildfly.category" value="Management"/>
+        <prop name="org.wildfly.description" value="Support for 'jboss-cli', 'add-user' and 'elytron-tool' launch scripts and configuration files"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="management,wildfly-cli"/>
         <prop name="org.wildfly.rule.add-on-description" value="Server command line tools: jboss-cli, add-user, elytron-tool."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="datasources-web-server">
     <props>
+        <prop name="org.wildfly.category" value="Base WildFly server"/>
+        <prop name="org.wildfly.description" value="A servlet container with support for datasources"/>
         <prop name="org.wildfly.rule.kind" value="base-layer"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-concurrency/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-concurrency/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-concurrency">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta EE Concurrency"/>
         <prop name="org.wildfly.rule.class" value="jakarta.enterprise.concurrent"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-core-profile-server/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-core-profile-server">
     <props>
+        <prop name="org.wildfly.category" value="Base WildFly server"/>
+        <prop name="org.wildfly.description" value="A Jakarta EE Core Profile server"/>
         <prop name="org.wildfly.rule.kind" value="default-base-layer"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-security/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ee-security/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ee-security">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Support for EE Security"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.security.enterprise.authentication.mechanism.http.*,jakarta.security.enterprise.identitystore"/>
         <prop name="org.wildfly.rule.class" value="jakarta.security.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -8,6 +8,9 @@
 
     <!-- Infinispan cache configuration used for distributed SFSB caching -->
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Infinispan-based distributed cache for stateful session beans."/>
+        <prop name="org.wildfly.note" value="ejb-local-cache layer must be explicitly excluded if ejb-dist-cache is in use."/>
         <prop name="org.wildfly.rule.profile-ha" value="ejb-local-cache"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-http-invoker/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb-http-invoker">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for invoking Jakarta Enterprise Beans over HTTP"/>
         <prop name="org.wildfly.rule.add-on" value="ejb,http-invoker"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for invoking Jakarta Enterprise Beans over HTTP."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
@@ -8,6 +8,8 @@
     <!-- Aggregates the functionality roughly associated with the EJB Lite concept.
          Note that the timer-service feature provides persistent timers which goes beyond EJB Lite requirements. -->
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Enterprise Beans Lite"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.ejb"/>
         <prop name="org.wildfly.rule.class" value="jakarta.ejb"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
@@ -4,7 +4,12 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-local-cache">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb-local-cache">
+    <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Infinispan-based local cache for stateful session beans."/>
+        <prop name="org.wildfly.note" value="This layer must be explicitly excluded if ejb-dist-cache is in use."/>
+    </props>
     <dependencies>
         <layer name="transactions"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/ejb/layer-spec.xml
@@ -7,6 +7,8 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="ejb">
     <!-- Aggregates EJB functionality, excluding ejb-iiop. -->
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Enterprise Beans, excluding the IIOP protocol"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.ejb.MessageDriven,jakarta.ejb.Remote"/>
         <prop name="org.wildfly.rule.class" value="jakarta.ejb.MessageDrivenContext"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/elytron-oidc-client/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/elytron-oidc-client/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="elytron-oidc-client">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Support for securing deployment with OIDC"/>
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/login-config/auth-method,OIDC"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="embedded-activemq">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta Messaging"/>
+        <prop name="org.wildfly.description" value="Support for an embedded Apache Activemq Artemis Jakarta Messaging broker."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:messaging-activemq"/>
         <prop name="org.wildfly.rule.add-on" value="messaging,embedded-activemq"/>
         <prop name="org.wildfly.rule.add-on-cardinality" value="1"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-datasource/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-datasource">
     <props>
+        <prop name="org.wildfly.category" value="Database"/>
+        <prop name="org.wildfly.description" value="Support for an H2 datasource"/>
         <prop name="org.wildfly.rule.add-on" value="database,h2-database"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
         <prop name="org.wildfly.rule.bring-datasource" value="java:jboss/datasources/ExampleDS"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-default-datasource/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-default-datasource">
     <props>
+        <prop name="org.wildfly.category" value="Database"/>
+        <prop name="org.wildfly.description" value="Support for an H2 datasource set as the ee subsystem default datasource."/>
         <prop name="org.wildfly.rule.add-on" value="database,h2-database:default"/>
         <prop name="org.wildfly.rule.add-on-fix-no-default-datasource" value=""/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/h2-driver/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="h2-driver">
     <props>
+        <prop name="org.wildfly.category" value="Database"/>
+        <prop name="org.wildfly.description" value="Support for the H2 JDBC driver"/>
         <prop name="org.wildfly.rule.xml-path" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/datasource/driver,h2"/>
         <prop name="org.wildfly.rule.xml-path-xa" value="[/WEB-INF/*.xml,/META-INF/*.xml],/datasources/xa-datasource/driver,h2"/>
         <prop name="org.wildfly.rule.annotation.field.value-url" value="jakarta.annotation.sql.DataSourceDefinition,url=jdbc:h2:*"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/health/layer-spec.xml
@@ -7,6 +7,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="health">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for runtime health checks."/>
+        <prop name="org.wildfly.note" value="When using the WildFly cloud feature-pack for cloud deployment, this layer will be automatically provisioned. It is required for POD health check."/>
         <prop name="org.wildfly.rule.add-on" value="observability,health"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for runtime health checks."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/iiop-openjdk/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="iiop-openjdk">
     <props>
+        <prop name="org.wildfly.category" value="RPC (Remote Procedure Call)"/>
+        <prop name="org.wildfly.description" value="Support for IIOP"/>
         <prop name="org.wildfly.rule.add-on" value="rpc,iiop" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="none" />
         <prop name="org.wildfly.rule.add-on-description" value="Support for IIOP."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jakarta-data/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jakarta-data/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jakarta-data">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Data"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.data"/>
         <prop name="org.wildfly.rule.class" value="jakarta.data"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs-core/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs-core/layer-spec.xml
@@ -4,7 +4,11 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jaxrs-core">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jaxrs-core">
+    <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta RESTful Web Services."/>
+    </props>
     <dependencies>
         <layer name="ee-integration"/>
         <layer name="servlet"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jaxrs/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jaxrs">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta RESTful Web Services with optional ee-concurrency and deployment scanner layers."/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.ws.rs,jakarta.ws.rs.core"/>
         <prop name="org.wildfly.rule.class" value="jakarta.ws.rs,jakarta.ws.rs.core"/>
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet/servlet-class,jakarta.ws.rs.core.Application"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jdr/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jdr">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for the JBoss Diagnostic Reporting (JDR) subsystem."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="management,jdr"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for the JBoss Diagnostic Reporting (JDR)."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
@@ -4,7 +4,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jms-activemq">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jms-activemq">
     <dependencies>
         <layer name="messaging-activemq"/>
     </dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -6,6 +6,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jpa-distributed">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for JPA with a distributed second level cache."/>
+        <prop name="org.wildfly.note" value="jpa layer must be explicitly excluded if jpa-distributed is in use."/>
         <prop name="org.wildfly.rule.profile-ha" value="jpa"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jpa/layer-spec.xml
@@ -6,6 +6,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jpa">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for JPA (using the latest WildFly supported Hibernate release)."/>
+        <prop name="org.wildfly.note" value="This layer must be explicitly excluded if jpa-distributed is in use."/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/persistence.xml,/WEB-INF/classes/META-INF/persistence.xml]"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.persistence"/>
         <prop name="org.wildfly.rule.class" value="jakarta.persistence,jakarta.persistence.criteria"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsf/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsf/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsf">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Faces."/>
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/servlet/servlet-class,jakarta.faces.webapp.FacesServlet"/>
         <prop name="org.wildfly.rule.expected-file" value="/WEB-INF/faces-config.xml"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.faces.annotation"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonb/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonb/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsonb">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for JSON Binding (Jakarta JSON Binding) provisioning the Jakarta JSON Binding API and Implementation modules."/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.json.bind.annotation" />
         <prop name="org.wildfly.rule.class" value="jakarta.json.bind.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonp/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/jsonp/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="jsonp">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for JSON Processing (Jakarta JSON Processing) provisioning the Jakarta JSON Processing API and Implementation modules."/>
         <!--
             Don't use wildcards here to get children of jakarta.json.
             The jsonb layer has jakarta.json.bind, so specify each sub-package properly

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mail/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mail/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mail">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Mail"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.mail" />
         <prop name="org.wildfly.rule.class" value="jakarta.mail.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="messaging-activemq">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta Messaging"/>
+        <prop name="org.wildfly.description" value="Support for connections to a remote Jakarta Messaging broker"/>
         <prop name="org.wildfly.rule.class" value="jakarta.jms"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.jms"/>
         <prop name="org.wildfly.rule.expect-add-on-family" value="messaging"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/metrics/layer-spec.xml
@@ -7,6 +7,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="metrics">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for base server metrics in Prometheus format."/>
         <prop name="org.wildfly.rule.add-on" value="observability,metrics"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:management"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for base metrics from the WildFly Management Model and JVM MBeans."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/mod_cluster/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="mod_cluster">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for mod_cluster subsystem."/>
         <prop name="org.wildfly.rule.add-on" value="clustering,mod_cluster" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:undertow" />
         <prop name="org.wildfly.rule.add-on-description" value="Support for mod_cluster integration."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/naming/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/naming/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="naming">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for JNDI"/>
         <prop name="org.wildfly.rule.class" value="javax.naming"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -4,7 +4,11 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="observability">
+    <props>
+      <prop name="org.wildfly.category" value="Monitoring"/>
+      <prop name="org.wildfly.description" value="Aggregation of multiple monitoring functionalities"/>
+    </props>
     <dependencies>
         <layer name="metrics" optional="true"/>
         <layer name="health" optional="true" />

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="remote-activemq">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta Messaging"/>
+        <prop name="org.wildfly.description" value="Support for connections to a remote Apache Activemq Artemis Jakarta Messaging broker"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:messaging-activemq"/>
         <prop name="org.wildfly.rule.add-on" value="messaging,remote-activemq"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for connections to a remote Apache Activemq Artemis Jakarta Messaging broker."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="resource-adapters">
      <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for deployment of Jakarta Connectors resource adapters."/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/ra.xml,/META-INF/ironjacamar.xml]"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/sar/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/sar/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="sar">
     <props>
+        <prop name="org.wildfly.category" value="Management"/>
+        <prop name="org.wildfly.description" value="Support for SAR archives to deploy MBeans."/>
         <prop name="org.wildfly.rule.expected-file" value="/META-INF/jboss-service.xml"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-ha/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-ha/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="singleton-ha">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for WildFly singleton HA."/>
         <prop name="org.wildfly.rule.profile-ha" value="singleton-local"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-local/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/singleton-local/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="singleton-local">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for WildFly singleton."/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/singleton-deployment.xml,/WEB-INF/classes/META-INF/singleton-deployment.xml]"/>
         <prop name="org.wildfly.rule.class" value="org.wildfly.clustering.singleton.*"/>
     </props>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-https/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="undertow-https">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Support for securing web access with HTTPS"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="security,ssl"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for the Undertow HTTPS listener."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/undertow-load-balancer/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="undertow-load-balancer">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for Undertow configured as a load balancer."/>
         <prop name="org.wildfly.rule.add-on" value="web,load-balancer"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for Undertow configured as a load balancer."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-clustering">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for distributable web applications. Configures a non-local Infinispan-based container web cache for data session handling suitable to clustering environments."/>
         <prop name="org.wildfly.rule.profile-ha" value="web-passivation"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-console/layer-spec.xml
@@ -6,6 +6,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-console">
     <props>
+        <prop name="org.wildfly.category" value="Management"/>
+        <prop name="org.wildfly.description" value="Support for loading the HAL web console from the /console context on the HTTP 
+management interface."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="management,hal-web-console"/>
         <prop name="org.wildfly.rule.add-on-description" value="Management Web console. Make sure to add an initial user."/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-passivation/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/web-passivation/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="web-passivation">
     <props>
+        <prop name="org.wildfly.category" value="Clustering"/>
+        <prop name="org.wildfly.description" value="Support for distributable web applications. Configures a local Infinispan-based container web cache for data session handling suitable to single node environments."/>
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/distributable"/>
     </props>
     <dependencies>

--- a/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/webservices/layer-spec.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/layers/standalone/webservices/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="webservices">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta XML Web Services"/>
         <prop name="org.wildfly.rule.annotations" value="jakarta.jws,jakarta.jws.soap,jakarta.xml.ws.*"/>
         <prop name="org.wildfly.rule.class" value="jakarta.xml.ws.*"/>
     </props>

--- a/galleon-pack/galleon-feature-pack/pom.xml
+++ b/galleon-pack/galleon-feature-pack/pom.xml
@@ -33,6 +33,7 @@
         <galleon.shared.resources.directory>${basedir}/../galleon-shared/src/main/resources</galleon.shared.resources.directory>
         <galleon.shared.generated.resources.directory>${basedir}/../galleon-shared/target/index</galleon.shared.generated.resources.directory>
         <galleon.local.resources.directory>${basedir}/../galleon-local/src/main/resources</galleon.local.resources.directory>
+        <copyright>The WildFly authors</copyright>
     </properties>
 
     <build>
@@ -74,6 +75,30 @@
                                  robust exclude artifact metadata content -->
                             <excludes>**/pom.xml,META-INF,META-INF/**</excludes>
                             <outputDirectory>${galleon.unpacked.resources.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- WildFly is composed of 2 feature packs so we copy the artifact list from
+                             the ee-galleon-pack (in addition to this artifact list)
+                             to generate all the log and error code when the feature pack doc is created
+                        -->
+                        <id>copy-ee-artifact-list</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>artifact-list</classifier>
+                                    <type>txt</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>
@@ -217,6 +242,8 @@
                             <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <generate-channel-manifest>true</generate-channel-manifest>
                             <deploy-channel-manifest>false</deploy-channel-manifest>
+                            <generate-complete-model>true</generate-complete-model>
+                            <copyright>${copyright}</copyright>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/micrometer/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="micrometer">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for Micrometer"/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:cdi"/>
         <prop name="org.wildfly.rule.add-on" value="observability,micrometer"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for Micrometer."/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
@@ -7,6 +7,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-config">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Config"/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.config.inject"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.config.*"/>
         <prop name="org.wildfly.rule.expected-file" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties]"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-fault-tolerance/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-fault-tolerance/layer-spec.xml
@@ -7,6 +7,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-fault-tolerance">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Fault Tolerance."/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.faulttolerance"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.faulttolerance.*"/> 
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
@@ -7,6 +7,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-health">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Health"/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.health"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.health.*"/> 
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-jwt/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-jwt/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-jwt">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile JWT."/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.jwt,org.eclipse.microprofile.auth.LoginConfig"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.jwt.*"/>
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-coordinator/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-lra-coordinator">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for acting as coordinator of MicroProfile LRA long-running actions."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="none"/>
         <prop name="org.wildfly.rule.add-on" value="lra,lra-coordinator"/>
         <prop name="org.wildfly.rule.add-on-description" value="Support for MicroProfile LRA Coordinator."/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-participant/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-lra-participant/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-lra-participant">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for acting as a participant in MicroProfile LRA long-running actions."/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.lra.annotation,org.eclipse.microprofile.lra.annotation.ws.rs"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.lra.*"/>
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-openapi/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-openapi">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile OpenAPI."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:jaxrs"/>
         <prop name="org.wildfly.rule.add-on" value="jaxrs,openapi"/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.openapi.*"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-platform/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-platform/layer-spec.xml
@@ -3,7 +3,11 @@
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-platform">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-platform">
+    <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for available MicroProfile platform specifications."/>
+    </props>
     <dependencies>
         <layer name="microprofile-config" optional="true"/>
         <layer name="microprofile-fault-tolerance" optional="true"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-amqp/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-amqp/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-messaging-amqp">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Reactive Messaging AMQP connector."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="reactive-messaging,amqp"/>
         <prop name="org.wildfly.rule.properties-file-match-mp-amqp-property" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.connector.smallrye-amqp.*"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging-kafka/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-messaging-kafka">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Reactive Messaging Kafka connector."/>
         <prop name="org.wildfly.rule.add-on-depends-on" value="all-dependencies"/>
         <prop name="org.wildfly.rule.add-on" value="reactive-messaging,kafka"/>
         <prop name="org.wildfly.rule.properties-file-match-mp-kafka-property" value="[/META-INF/microprofile-config.properties,/WEB-INF/classes/META-INF/microprofile-config.properties],mp.messaging.connector.smallrye-kafka.*"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-messaging/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-messaging">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Reactive Messaging."/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.reactive.messaging.*"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.reactive.messaging.*"/>
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-streams-operators/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-reactive-streams-operators/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-reactive-streams-operators">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Reactive Streams Operators."/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.reactive.streams.operators.*"/>
     </props>
     <dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-rest-client/layer-spec.xml
@@ -5,6 +5,8 @@
   -->
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-rest-client">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile REST client."/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.rest.client.annotation,org.eclipse.microprofile.rest.client.inject"/>
         <prop name="org.wildfly.rule.class" value="org.eclipse.microprofile.rest.client.*"/>
     </props>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/microprofile-telemetry/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-telemetry">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for MicroProfile Telemetry"/>
         <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
     </props>
     <dependencies>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -4,7 +4,11 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="observability">
+    <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Aggregation of multiple monitoring functionalities"/>
+    </props>
     <dependencies>
         <layer name="microprofile-config" optional="true"/>
         <layer name="microprofile-telemetry" optional="true"/>

--- a/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/layers/standalone/opentelemetry/layer-spec.xml
@@ -6,6 +6,8 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="opentelemetry">
     <props>
+        <prop name="org.wildfly.category" value="Monitoring"/>
+        <prop name="org.wildfly.description" value="Support for OpenTelemetry"/>
         <prop name="org.wildfly.rule.annotations" value="io.opentelemetry.instrumentation.annotations"/>
         <prop name="org.wildfly.rule.class" value="io.opentelemetry.api.*,io.opentelemetry.sdk.*"/>
     </props>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -21,7 +21,7 @@
     </parent>
 
     <artifactId>wildfly-feature-pack-parent</artifactId>
-    <description>Parent for various Galleon feature pack modules</description>
+    <description>WildFly ${project.version} Galleon pack</description>
     <packaging>pom</packaging>
 
     <name>WildFly: Feature Pack Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,6 @@
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.org.jacoco>0.8.12</version.org.jacoco>
         <version.org.jboss.galleon>6.0.4.Final</version.org.jboss.galleon>
-        <version.org.jboss.wildscribe>3.1.0.Final</version.org.jboss.wildscribe>
         <version.org.owasp.dependency-check>12.1.6</version.org.owasp.dependency-check>
         <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.0.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>1.5.1.Final</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.2.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>5.1.0.Final</version.org.wildfly.plugin>


### PR DESCRIPTION
# [WFLY-21023] Feature pack documentation

Update the documentation to use the doc generated when the
wildfly-galleon-pack is built and use it instead of wildscribe.

Updated links from the guides.

This fixes https://issues.redhat.com/browse/WFLY-21024

# [WFLY-21024] Upgrade to Galleon Maven Plugin 8.0.1.Final

This fixes https://issues.redhat.com/browse/WFLY-21024

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-21023](https://issues.redhat.com/browse/WFLY-21023)
> * [WFLY-21024](https://issues.redhat.com/browse/WFLY-21024)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)