### PR TITLE
WFLY-21025 Fix remaining non-HTTPS links to wildfly.org

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -171,7 +171,7 @@ we'll focus on the common approach of installing the download zip of standard Wi
 
 WildFly {wildflyVersion} distributions can be obtained from:
 
-http://www.wildfly.org/downloads/[wildfly.org/downloads]
+https://www.wildfly.org/downloads/[wildfly.org/downloads]
 
 Standard WildFly {wildflyVersion} provides a single distribution available in zip or tar file
 formats.

--- a/docs/src/main/asciidoc/Installation_Guide.adoc
+++ b/docs/src/main/asciidoc/Installation_Guide.adoc
@@ -41,7 +41,7 @@ but if you'd like a technical preview look at what's coming in the future, try o
 [[Zipped_Installation]]
 = Installing WildFly from a zipped distribution
 
-http://www.wildfly.org/downloads[Downloading the WildFly release zip] and unzipping it is the traditional way to install
+https://www.wildfly.org/downloads/[Downloading the WildFly release zip] and unzipping it is the traditional way to install
 a complete WildFly server with support for both standalone and managed domain operating modes. A WildFly distribution
 contains a large number of default configurations allowing you to select the server features and operating modes.
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Batch.adoc
@@ -12,7 +12,7 @@ endif::[]
 [abstract]
 
 The batch subsystem is used to configure an environment for running
-batch applications. http://wildfly.org[WildFly] uses
+batch applications. https://wildfly.org[WildFly] uses
 https://github.com/jberet/jsr352[JBeret] for its Jakarta Batch implementation.
 Specific information about JBeret can be found in the
 http://jberet.gitbooks.io/jberet-user-guide/content/[user guide]. The
@@ -90,7 +90,7 @@ job executions from the backing storage mechanism.
 
 There are no deployment descriptors for configuring a batch environment
 defined by the https://www.jcp.org/en/jsr/detail?id=352[JSR-352
-specification]. In http://wildfly.org[WildFly] you can use a
+specification]. In https://wildfly.org[WildFly] you can use a
 `jboss-all.xml` deployment descriptor to define aspects of the batch
 environment for your deployment.
 
@@ -130,7 +130,7 @@ deployment descriptor.
 [[deployment-resources]]
 == Deployment Resources
 
-Some subsystems in http://wildfly.org[WildFly] register runtime
+Some subsystems in https://wildfly.org[WildFly] register runtime
 resources for deployments. The batch subsystem registers jobs and
 executions. The jobs are registered using the job name, this is _not_
 the job XML name. Executions are registered using the execution id.

--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -440,7 +440,7 @@ The final two elements are mutually exclusive and define how the SASL mechanism 
 
 == <net-authenticator />
 
-This element contains no specific configuration, however if present the [org.wildfly.security.auth.util.ElytronAuthenticator|http://wildfly-security.github.io/wildfly-elytron/1.1.x/org/wildfly/security/auth/util/ElytronAuthenticator.html] will be registered with [java.net.Authenticator.setDefault(Authenticator)|https://docs.oracle.com/javase/8/docs/api/java/net/Authenticator.html#setDefault-java.net.Authenticator-] meaning that the WildFly Elytron authentication client configuration can be used for authentication where the JDK APIs are used for HTTP calls which require authentication.
+This element contains no specific configuration, however if present the [org.wildfly.security.auth.util.ElytronAuthenticator|https://wildfly-security.github.io/wildfly-elytron/documentation/api/upstream/org/wildfly/security/auth/util/ElytronAuthenticator.html] will be registered with [java.net.Authenticator.setDefault(Authenticator)|https://docs.oracle.com/javase/8/docs/api/java/net/Authenticator.html#setDefault-java.net.Authenticator-] meaning that the WildFly Elytron authentication client configuration can be used for authentication where the JDK APIs are used for HTTP calls which require authentication.
 
 There are some limitations within this integration as the JDK will cache the authentication JVM wide from the first call so is better used in stand alone processes that don't require different credentials for different calls to the same URI,
 

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -76,7 +76,7 @@ move on and you will get the points step by step.
 [[download-wildfly]]
 == Download WildFly
 
-First we should download WildFly from the http://wildfly.org/downloads/[WildFly website].
+First we should download WildFly from the https://wildfly.org/downloads/[WildFly website].
 
 Then I unzipped the package to the primary host and try to make a test run:
 

--- a/ee-feature-pack/galleon-shared/src/main/resources/content/README.txt
+++ b/ee-feature-pack/galleon-shared/src/main/resources/content/README.txt
@@ -1,5 +1,5 @@
 Welcome to WildFly (formerly known as JBoss Application Server)
-http://www.wildfly.org/
+https://www.wildfly.org/
 
 Go to the above link for documentation, and additional downloads.
 
@@ -21,7 +21,7 @@ Release Notes
 -------------
 You can obtain release notes here:
 
-http://wildfly.org/releases
+https://wildfly.org/releases/
 
 Getting Started
 ---------------

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <id>wildfly.org</id>
             <name>WildFly Community</name>
             <organization>wildfly.org</organization>
-            <organizationUrl>http://wildfly.org</organizationUrl>
+            <organizationUrl>https://wildfly.org</organizationUrl>
         </developer>
     </developers>
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/url/URLConnectionFactoryResourceInjectionTestEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/url/URLConnectionFactoryResourceInjectionTestEJB.java
@@ -17,10 +17,10 @@ import java.net.URL;
 @Stateless
 public class URLConnectionFactoryResourceInjectionTestEJB {
 
-    @Resource(name = "overrideLookupURL", lookup = "http://www.wildfly.org")
+    @Resource(name = "overrideLookupURL", lookup = "https://www.wildfly.org")
     private URL url1;
 
-    @Resource(name = "lookupURL", lookup = "http://www.wildfly.org")
+    @Resource(name = "lookupURL", lookup = "https://www.wildfly.org")
     private URL url2;
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/FacesConverterInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/injection/FacesConverterInjectionTestCase.java
@@ -110,11 +110,11 @@ public class FacesConverterInjectionTestCase {
 
     @Test
     public void testConverterSuccess() throws Exception {
-        test("http://wildfly.org/index.html", "Valid URL.");
+        test("https://wildfly.org/index.html", "Valid URL.");
     }
 
     @Test
     public void testConverterError() throws Exception {
-        test("http://wildfly.org:wrong/index.html", "Invalid URL:");
+        test("https://wildfly.org:wrong/index.html", "Invalid URL:");
     }
 }


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21025

n.b.  with these changes

```
[rhusar@puglia wildfly]$ git grep "http://www.wildfly" | wc -l
       0
[rhusar@puglia wildfly]$ git grep "http://wildfly" | wc -l
       0
```