### PR TITLE
[WFLY-20999] Revert "WFLY-16576 Remove org.bouncycastle main module"

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.bouncycastle">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="org.bouncycastle.bcpkix" export="true" services="export"/>
+        <module name="org.bouncycastle.bcprov" export="true" services="export"/>
+        <module name="org.bouncycastle.bcmail" export="true" services="export"/>
+    </dependencies>
+
+    <provides>
+        <service name="java.security.Provider">
+            <with-class name="org.bouncycastle.jce.provider.BouncyCastleProvider"/>
+            <with-class name="org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider"/>
+        </service>
+    </provides>
+</module>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/LayersTestBase.java
@@ -299,6 +299,8 @@ public abstract class LayersTestBase {
             // Appclient support is not provided by a layer
             "org.jboss.as.appclient",
             "org.jboss.metadata.appclient",
+            // TODO WFLY-16576 -- cruft?
+            "org.bouncycastle",
             // This was brought in as part an RFE, WFLY-10632 & WFLY-10636. While the module is currently marked as private,
             // for now we should keep this module.
             "org.jboss.resteasy.resteasy-rxjava2",


### PR DESCRIPTION
This reverts commit 0f37321356454ed6d43a833f4512cbac6a29456c. This reverts commit 3f2190cf73786847a4f8157f71bfb175f0dacecd.

https://issues.redhat.com/browse/WFLY-20999

For WF 39 we'll try and revert this revert, once we know the keycloak-saml-adapter-feature-pack no longer uses this module

____

<--- THIS SECTION IS AUTOMATICALLY GENERATED BY WILDFLY GITHUB BOT. ANY MANUAL CHANGES WILL BE LOST. --->

> WildFly issue links:
> * [WFLY-16576](https://issues.redhat.com/browse/WFLY-16576)

<--- END OF WILDFLY GITHUB BOT REPORT --->

More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)