### PR TITLE
[WFLY-21037] Update documentation copyright

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -57,12 +57,14 @@
                         <revdate>${maven.build.timestamp}</revdate>
                         <organization>${project.organization.name}</organization>
                         <!-- end TODO -->
+                        <nofooter>true</nofooter>
+                        <docinfo>shared</docinfo>
                         <!-- Attributes to use in the asciidoc source files. Please leave in alphabetical order -->
                         <appservername>${full.dist.product.release.name}</appservername>
                         <oracle-javadoc>https://docs.oracle.com/en/java/javase/17/docs/api</oracle-javadoc>
                         <resteasyversion>${version.org.jboss.resteasy}</resteasyversion>
                         <wildflyversion>${product.docs.server.version}</wildflyversion>
-
+                        <copyright-blurb>${wildfly.copyright}</copyright-blurb>
                         <!-- Default asciidoc setting attributes -->
                         <linkcss>false</linkcss>
                         <sectanchors/>

--- a/docs/src/main/asciidoc/Admin_Guide.adoc
+++ b/docs/src/main/asciidoc/Admin_Guide.adoc
@@ -1,6 +1,6 @@
 [[Admin_Guide]]
 = WildFly Admin Guide
-WildFly developer team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -25,8 +25,6 @@ endif::[]
 
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 

--- a/docs/src/main/asciidoc/Bootable_Guide.adoc
+++ b/docs/src/main/asciidoc/Bootable_Guide.adoc
@@ -1,6 +1,6 @@
 [[Bootable_Guide]]
 = Bootable JAR Guide
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -19,8 +19,6 @@ ifdef::env-github[]
 endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Client_Guide.adoc
+++ b/docs/src/main/asciidoc/Client_Guide.adoc
@@ -1,5 +1,6 @@
 [[Client_Guide]]
 = WildFly Client Configuration
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro

--- a/docs/src/main/asciidoc/Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/Developer_Guide.adoc
@@ -1,6 +1,6 @@
 [[Developer_Guide]]
 = Developer Guide
-WildFly developer team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -20,8 +20,6 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Extending_WildFly.adoc
+++ b/docs/src/main/asciidoc/Extending_WildFly.adoc
@@ -1,6 +1,6 @@
 [[Extending_WildFly]]
 = Extending WildFly
-WildFly code development team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro

--- a/docs/src/main/asciidoc/Galleon_Guide.adoc
+++ b/docs/src/main/asciidoc/Galleon_Guide.adoc
@@ -1,6 +1,6 @@
 [[Galleon_Guide]]
 = Galleon Provisioning Guide
-WildFly developer team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -24,8 +24,6 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 

--- a/docs/src/main/asciidoc/Getting_Started_Developing_Applications_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Developing_Applications_Guide.adoc
@@ -1,6 +1,6 @@
 [[Getting_Started_Developing_Applications_Guide]]
 = Getting Started Developing Applications Guide
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -20,8 +20,6 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -1,6 +1,6 @@
 [[Getting_Started_Guide]]
 = Getting Started Guide
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -19,8 +19,6 @@ ifdef::env-github[]
 endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Hacking_On_WildFly.adoc
+++ b/docs/src/main/asciidoc/Hacking_On_WildFly.adoc
@@ -1,6 +1,6 @@
 [[Hacking_On_WildFly]]
 = Hacking on WildFly
-WildFly developer team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -24,8 +24,6 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 

--- a/docs/src/main/asciidoc/Installation_Guide.adoc
+++ b/docs/src/main/asciidoc/Installation_Guide.adoc
@@ -1,6 +1,6 @@
 [[Installation_Guide]]
 = Installation Guide
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -22,8 +22,6 @@ endif::[]
 :leveloffset: +1
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Migration_Guide.adoc
+++ b/docs/src/main/asciidoc/Migration_Guide.adoc
@@ -1,6 +1,6 @@
 [[Admin_Guide]]
 = WildFly Migration Guide
-WildFly developer team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -24,8 +24,6 @@ ifdef::env-github[]
 endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 

--- a/docs/src/main/asciidoc/Quickstarts.adoc
+++ b/docs/src/main/asciidoc/Quickstarts.adoc
@@ -1,6 +1,6 @@
 [[Quickstarts]]
 = Quickstarts
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -17,8 +17,6 @@ ifdef::env-github[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 endif::[]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/Testsuite.adoc
+++ b/docs/src/main/asciidoc/Testsuite.adoc
@@ -1,6 +1,6 @@
 [[Testsuite]]
 = WildFly Testsuite
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -22,8 +22,6 @@ endif::[]
 :leveloffset: +1
 
 ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/WildFly_Elytron_Security.adoc
+++ b/docs/src/main/asciidoc/WildFly_Elytron_Security.adoc
@@ -1,5 +1,6 @@
 [[WildFly_Elytron_Security]]
 = WildFly Elytron Security
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro

--- a/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
+++ b/docs/src/main/asciidoc/WildFly_Maven_Plugin_Guide.adoc
@@ -1,6 +1,6 @@
 [[WildFly_Maven_Plugin_Guide]]
 = WildFly Maven Plugin Guide
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -19,8 +19,6 @@ ifdef::env-github[]
 endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
+++ b/docs/src/main/asciidoc/WildFly_and_WildFly_Preview.adoc
@@ -1,6 +1,6 @@
 [[WildFly_and_WildFly_Preview]]
 = WildFly and WildFly Preview
-WildFly team;
+WildFly authors;
 :revnumber: {version}
 :revdate: {localdate}
 :toc: macro
@@ -19,8 +19,6 @@ ifdef::env-github[]
 endif::[]
 
 // ifndef::ebook-format[:leveloffset: 1]
-
-(C) The WildFly Authors.
 
 ifdef::basebackend-html[toc::[]]
 :numbered:

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Elytron_OIDC_Client.adoc
@@ -313,7 +313,7 @@ across the deployment. No further managed configuration is required.
 [NOTE]
 ====
 To propagate an identity from a virtual security domain, additional configuration might be required
-depending on your use case. See <<identity_propagation, Identity Propagation>> for more details.
+depending on your use case. See <<Identity_Propagation, Identity Propagation>> for more details.
 ====
 
 == OpenID Providers

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -519,7 +519,7 @@ We define the module in `module.xml`:
 </module>
 ----
 
-[[configuration]]
+[[messaging.configuration]]
 === Configuration
 
 A Jakarta Messaging bridge is defined inside a `jms-bridge` section of the

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_JWT.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_JWT.adoc
@@ -127,8 +127,5 @@ As the deployment is configured entirely within the MicroProfile Config properti
 [NOTE]
 ====
 To propagate an identity from a virtual security domain, additional configuration might be required
-depending on your use case. See <<identity_propagation, Identity Propagation>> for more details.
+depending on your use case. See <<Identity_Propagation, Identity Propagation>> for more details.
 ====
-
-include::Identity_Propagation.adoc[]
-

--- a/docs/src/main/asciidoc/_developer-guide/JNDI_Local_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JNDI_Local_Reference.adoc
@@ -179,7 +179,7 @@ the Naming subsystem configuration.
 == Retrieving entries from JNDI
 
 [[resource-injection]]
-==== Resource Injection
+=== Resource Injection
 
 For Jakarta EE applications the recommended way to lookup a JNDI entry is
 to use `@Resource` injection:
@@ -227,7 +227,7 @@ the default instance of a managed executor service, the value in
 Concurrency Utilities 1.0 Specification (JSR 236).
 
 [[standard-java-se-jndi-api]]
-==== Standard Java SE JNDI API
+=== Standard Java SE JNDI API
 
 Jakarta EE applications may use, without any additional configuration
 needed, the standard JNDI API to lookup an entry from JNDI:

--- a/docs/src/main/asciidoc/_elytron/Keycloak_SAML_Integration.adoc
+++ b/docs/src/main/asciidoc/_elytron/Keycloak_SAML_Integration.adoc
@@ -181,7 +181,7 @@ selected but the Keycloak feature pack requires the complete `groupId`, `artifac
 specified.
 ====
 
-[[identity-propagation]]
+[[saml-identity-propagation]]
 == Propagating the Security Context to EJBs
 
 The sample configuration in the above sections has referenced the `keycloak-client-saml` layer.

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -285,7 +285,7 @@ link:#gal.naming[naming] +
 |
 link:#gal.base-server[base-server] +
 
-|[[gal.jaxrs-core]]jakarta-data
+|[[gal.jakarta-data]]jakarta-data
 |Support for Jakarta Data. (xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability]) The _link:#gal.jpa[jpa]_ dependency can be excluded and _link:#gal.jpa-distributed[jpa-distributed]_ used instead.
 |
 link:#gal.jpa[jpa] OR +

--- a/docs/src/main/asciidoc/_high-availability/index.adoc
+++ b/docs/src/main/asciidoc/_high-availability/index.adoc
@@ -22,8 +22,6 @@ endif::[]
 
 ifndef::ebook-format[:leveloffset: 1]
 
-(C) The WildFly Authors.
-
 ifdef::basebackend-html[toc::[]]
 :numbered:
 

--- a/docs/src/main/asciidoc/docinfo-footer.html
+++ b/docs/src/main/asciidoc/docinfo-footer.html
@@ -1,0 +1,4 @@
+<hr />
+<div id="footer" style="background: white; text-align: center">
+  <p>{copyright-blurb}</p>
+</div>

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,7 +1,7 @@
 [[index]]
 = WildFly {wildflyVersion} Documentation
+WildFly authors;
 :ext-relative: {outfilesuffix}
-:wildflyVersion: 37
 
 ifdef::env-github[]
 :tip-caption: :bulb:

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,16 @@
              still being easily disabled in profiles where it is not wanted. -->
         <surefire.default-test.phase>test</surefire.default-test.phase>
 
+        <!-- Copyright footer for generated documentation -->
+
+        <wildfly.copyright><![CDATA[
+            <img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/project/svg/CF_logo_wildFly_default.svg" style="height: 120px;"/>
+            <br />
+            Copyright &copy; <a href="https://wildfly.org">WildFly</a>.<br />
+            All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>.<br />
+            Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.
+        ]]></wildfly.copyright>
+
         <!-- Base wildfly version used by testsuite/galleon/update test to install a server that gets updated to the SNAPSHOT version -->
         <wildfly.test.galleon.update.base.version>26.1.1.Final</wildfly.test.galleon.update.base.version>
 


### PR DESCRIPTION
Add a docinfo-footer that adds the same copyright footer to all the generated doc based on Commonhaus template.

The copyright blurb is a HTML snippet stored in the "wildfly.copyright" property in the root pom.xml

Consistently use "WildFly authors" as the author of the documentation

This fixes https://issues.redhat.com/browse/WFLY-21037
