### PR TITLE
WFLY-21060 Make OpenTelemetry tests more resilient in resource-constrained CI environments

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -49,8 +49,8 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-            // Lower the interval from 60 seconds to 100 millis
-            "otel.metric.export.interval=100";
+            // Lower the interval from 60 seconds to 2 seconds
+            "otel.metric.export.interval=2000";
 
     @Deployment(testable = false)
     public static Archive<?> deploy() {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -29,8 +29,8 @@ public abstract class BaseOpenTelemetryTest {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-            // Lower the interval from 60 seconds to 100 millis
-            "otel.metric.export.interval=100";
+            // Lower the interval from 60 seconds to 2 seconds
+            "otel.metric.export.interval=2000";
 
     static WebArchive buildBaseArchive(String name) {
         return ShrinkWrap

--- a/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/preview/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -30,8 +30,8 @@ public abstract class BaseOpenTelemetryTest {
     protected OpenTelemetryCollectorContainer otelCollector;
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
-            // Lower the interval from 60 seconds to 100 millis
-            "otel.metric.export.interval=100";
+            // Lower the interval from 60 seconds to 2 seconds
+            "otel.metric.export.interval=2000";
 
     static WebArchive buildBaseArchive(String name) {
         return ShrinkWrap

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -33,7 +33,7 @@ import org.testcontainers.utility.MountableFile;
  */
 public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetryCollectorContainer> {
     public static final String IMAGE_NAME = "otel/opentelemetry-collector";
-    public static final String IMAGE_VERSION = "0.115.1";
+    public static final String IMAGE_VERSION = "0.138.0";
     public static final int OTLP_GRPC_PORT = 4317;
     public static final int OTLP_HTTP_PORT = 4318;
     public static final int PROMETHEUS_PORT = 1234;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetryWithCollectorSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetryWithCollectorSetupTask.java
@@ -26,9 +26,11 @@ public class OpenTelemetryWithCollectorSetupTask extends OpenTelemetrySetupTask 
 
     @Override
     public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
-        otelCollectorContainer.stop();
         super.tearDown(managementClient, containerId);
 
         ServerReload.executeReloadAndWaitForCompletion(managementClient);
+
+        // Stop the container last to avoid spurious connection errors from the GrpcExporter
+        otelCollectorContainer.stop();
     }
 }

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/shared/observability/containers/otel-collector-config.yaml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/shared/observability/containers/otel-collector-config.yaml
@@ -10,6 +10,7 @@ receivers:
 
 processors:
   batch:
+    timeout: 0
 
 exporters:
   debug:


### PR DESCRIPTION
Changes

* reduce export interval to 2s as to not overwhelm the collector container
* essentially disable batching in the collector
* bump the collector container version to 0.138.0
* stop the container last to avoid spurious connection errors from the GrpcExporter

https://issues.redhat.com/browse/WFLY-21060