### PR TITLE
[WFLY-21044]: Not recovered transactions after crash of server with MDB.

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
@@ -477,8 +477,6 @@ public class ExternalPooledConnectionFactoryService implements Service<ExternalP
 
             configureCredential(properties);
 
-            WildFlyRecoveryRegistry.container = container;
-
             OutboundResourceAdapter outbound = createOutbound(outboundProperties);
             InboundResourceAdapter inbound = createInbound(inboundProperties);
             ResourceAdapter ra = createResourceAdapter15(properties, outbound, inbound);
@@ -514,6 +512,7 @@ public class ExternalPooledConnectionFactoryService implements Service<ExternalP
                                     activator.getCcmInjector());
             sb.requires(NamingService.SERVICE_NAME);
             sb.requires(capabilityServiceSupport.getCapabilityServiceName(MessagingServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY));
+            WildFlyRecoveryRegistry.supplier = sb.requires(capabilityServiceSupport.getCapabilityServiceName(MessagingServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY));
             sb.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
             sb.setInitialMode(ServiceController.Mode.PASSIVE).install();
 

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -416,8 +416,6 @@ public class PooledConnectionFactoryService implements Service<Void> {
             inboundProperties.add(simpleProperty15("queuePrefix", String.class.getName(), JMS_QUEUE_PREFIX));
             inboundProperties.add(simpleProperty15("topicPrefix", String.class.getName(), JMS_TOPIC_PREFIX));
 
-            WildFlyRecoveryRegistry.container = container;
-
             OutboundResourceAdapter outbound = createOutbound(outboundProperties);
             InboundResourceAdapter inbound = createInbound(inboundProperties);
             ResourceAdapter ra = createResourceAdapter15(properties, outbound, inbound);
@@ -454,6 +452,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
             sb.requires(ActiveMQActivationService.getServiceName(getActiveMQServiceName(serverName)));
             sb.requires(NamingService.SERVICE_NAME);
             sb.requires(MessagingServices.getCapabilityServiceName(MessagingServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY));
+            WildFlyRecoveryRegistry.supplier = sb.requires(MessagingServices.getCapabilityServiceName(MessagingServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY));
             sb.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
             sb.setInitialMode(ServiceController.Mode.PASSIVE).install();
             // Mock the deployment service to allow it to start

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
@@ -5,13 +5,9 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 
+import java.util.function.Supplier;
 import org.jboss.activemq.artemis.wildfly.integration.recovery.WildFlyActiveMQRegistry;
-import org.jboss.as.controller.ServiceNameFactory;
-import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.tm.XAResourceRecoveryRegistry;
-import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
 
 /**
@@ -19,7 +15,7 @@ import org.wildfly.extension.messaging.activemq._private.MessagingLogger;
  *         9/22/11
  */
 public class WildFlyRecoveryRegistry extends WildFlyActiveMQRegistry {
-    static volatile ServiceContainer container;
+    static volatile Supplier<XAResourceRecoveryRegistry> supplier;
 
     private XAResourceRecoveryRegistry registry;
 
@@ -38,9 +34,6 @@ public class WildFlyRecoveryRegistry extends WildFlyActiveMQRegistry {
         // This parsing isn't 100% ideal as it's somewhat 'internal' knowledge of the relationship between
         // capability names and service names. But at this point that relationship really needs to become
         // a contract anyway
-        ServiceName serviceName = ServiceNameFactory.parseServiceName(MessagingServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY);
-        @SuppressWarnings("unchecked")
-        ServiceController<XAResourceRecoveryRegistry> service = (ServiceController<XAResourceRecoveryRegistry>) container.getService(serviceName);
-        return service == null ? null : service.getValue();
+        return supplier == null ? null : supplier.get();
     }
 }

--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
@@ -31,9 +31,6 @@ public class WildFlyRecoveryRegistry extends WildFlyActiveMQRegistry {
     }
 
     private static XAResourceRecoveryRegistry getXAResourceRecoveryRegistry() {
-        // This parsing isn't 100% ideal as it's somewhat 'internal' knowledge of the relationship between
-        // capability names and service names. But at this point that relationship really needs to become
-        // a contract anyway
         return supplier == null ? null : supplier.get();
     }
 }


### PR DESCRIPTION
 * Fixing how WildFly provides the recovery manager to Artemis
 * Removing the old MSC API usage to get the RecoveryService

Jira: https://issues.redhat.com/browse/WFLY-21044
Upstream: https://github.com/wildfly/wildfly/pull/19303