### PR TITLE
WFLY-21065 - Micrometer subsystem does not register system metrics

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -19,8 +19,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
@@ -80,13 +80,16 @@ public class MicrometerOtelIntegrationTestCase {
     @InSequence(4)
     public void getMetrics() throws InterruptedException {
         List<String> metricsToTest = Arrays.asList(
+                "classloader_loaded_classes_count",
+                "cpu_available_processors",
+                "cpu_system_load_average",
                 "demo_counter",
                 "demo_timer",
-                "memory_used_heap",
-                "cpu_available_processors",
-                "classloader_loaded_classes_count",
-                "cpu_system_load_average",
                 "gc_time",
+                "jvm_classes_loaded",
+                "memory_commited_heap_bytes",
+                "memory_used_heap",
+                "system_cpu_count",
                 "thread_count",
                 "undertow_bytes_received"
         );


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21065

Register system metrics using Micrometer's API
Add a sampling of system metrics to the test
Update test utility to log last know state when checks fail

