### PR TITLE
[WFLY-20695] Naming: ServiceBasedNamingStore - don't skip delegating to boundServices if initial lookup fails

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
@@ -112,7 +112,7 @@ public class ServiceBasedNamingStore implements NamingStore {
             final ServiceController<?> controller = serviceRegistry.getService(lookupName);
             if (controller != null) {
                 if (!State.UP.equals(controller.getState())) {
-                    // the controller is registered but there is not outcome yet. 
+                    // the controller is registered but there is not outcome yet.
                     // If we try to get value at this point it will fail so it is not resolvable
                     // due to a race condition.
                     return new ResolveResult(null, name);

--- a/naming/src/test/java/org/jboss/as/naming/ServiceBasedNamingStoreTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/ServiceBasedNamingStoreTestCase.java
@@ -20,7 +20,6 @@ import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.spi.ResolveResult;
 
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
 import org.jboss.msc.service.Service;
@@ -36,7 +35,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
based on @bstansberry
comments https://github.com/wildfly/wildfly/pull/18984#issuecomment-2960501152

issue https://issues.redhat.com/browse/WFLY-20695

probably it would be better to rename the issue is resolving as ResolveResult while the service is still starting.
It does exists but it did not produce any value yet. 