### PR TITLE
WFLY-21099 JGroups protocols with defined module=".." still does not attempt to load with 'org.jgroups.protocols' prefix

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -85,8 +85,8 @@ public interface JGroupsLogger extends BasicLogger {
 //    @Message(id = 9, value = "A node named %s already exists in this cluster. Perhaps there is already a server running on this host? If so, restart this server with a unique node name, via -Djboss.node.name=<node-name>")
 //    IllegalStateException duplicateNodeName(String name);
 
-    @Message(id = 10, value = "Transport for stack %s is not defined. Please specify both a transport and protocol list, either as optional parameters to add() or via batching.")
-    OperationFailedException transportNotDefined(String stackName);
+//    @Message(id = 10, value = "Transport for stack %s is not defined. Please specify both a transport and protocol list, either as optional parameters to add() or via batching.")
+//    OperationFailedException transportNotDefined(String stackName);
 
 //    @Message(id = 11, value = "Protocol list for stack %s is not defined. Please specify both a transport and protocol list, either as optional parameters to add() or via batching.")
 //    OperationFailedException protocolListNotDefined(String stackName);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolChildResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolChildResourceDefinitionRegistrar.java
@@ -4,18 +4,28 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.ModuleAttributeDefinition;
 import org.jboss.as.clustering.controller.PropertiesAttributeDefinition;
 import org.jboss.as.clustering.controller.StatisticsEnabledAttributeDefinition;
+import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.ResourceRegistration;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleLoadException;
+import org.jgroups.Global;
 import org.jgroups.JChannel;
+import org.jgroups.stack.Protocol;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrar;
 import org.wildfly.subsystem.resource.ManagementResourceRegistrationContext;
@@ -23,7 +33,9 @@ import org.wildfly.subsystem.resource.ResourceDescriptor;
 
 /**
  * Registers a resource definition for a typed JGroups protocol component.
+ *
  * @author Paul Ferraro
+ * @author Radoslav Husar
  */
 public class ProtocolChildResourceDefinitionRegistrar implements ChildResourceDefinitionRegistrar, UnaryOperator<ResourceDescriptor.Builder> {
     static final ModuleAttributeDefinition MODULE = new ModuleAttributeDefinition.Builder().setDefaultValue(Module.forClass(JChannel.class)).build();
@@ -66,5 +78,55 @@ public class ProtocolChildResourceDefinitionRegistrar implements ChildResourceDe
     @Override
     public ResourceDescriptor.Builder apply(ResourceDescriptor.Builder builder) {
         return builder.addAttributes(List.of(MODULE, PROPERTIES, STATISTICS_ENABLED));
+    }
+
+    static Class<? extends Protocol> findProtocolClass(ExpressionResolver context, String protocolName, ModelNode protocolModel) throws OperationFailedException {
+        String moduleName = MODULE.resolveModelAttribute(context, protocolModel).asString();
+
+        ModuleClassLoader classLoader;
+        try {
+            classLoader = Module.getContextModuleLoader().loadModule(moduleName).getClassLoader();
+        } catch (ModuleLoadException e) {
+            throw JGroupsLogger.ROOT_LOGGER.unableToLoadProtocolModule(moduleName, protocolName);
+        }
+
+        try {
+            return findProtocolClass(classLoader, protocolName);
+        } catch (ClassNotFoundException e) {
+            throw JGroupsLogger.ROOT_LOGGER.unableToLoadProtocolClass(protocolName);
+        }
+    }
+
+    static Class<? extends Protocol> findProtocolClass(ClassLoader classLoader, String protocolName) throws ClassNotFoundException {
+        List<String> candidateClassNames = new ArrayList<>(2);
+
+        if (protocolName.startsWith(Global.PREFIX)) {
+            // Protocol name is already a jgroups protocol class name
+            candidateClassNames.add(protocolName);
+        } else {
+            boolean isDefaultModule = Protocol.class.getClassLoader().equals(classLoader);
+
+            // If using non-default module, try loading protocol name as class name first
+            if (!isDefaultModule) {
+                candidateClassNames.add(protocolName);
+            }
+            // Compose class name using standard prefix
+            // e.g. "raft.RAFT" akin to standalone jgroups classloading
+            candidateClassNames.add(Global.PREFIX + protocolName);
+        }
+
+        Iterator<String> classNames = candidateClassNames.iterator();
+        ClassNotFoundException firstException = null;
+        while (classNames.hasNext()) {
+            try {
+                return classLoader.loadClass(classNames.next()).asSubclass(Protocol.class);
+            } catch (ClassNotFoundException e) {
+                // Retry with next
+                if (firstException == null) {
+                    firstException = e;
+                }
+            }
+        }
+        throw firstException;
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolConfigurationResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolConfigurationResourceDefinitionRegistrar.java
@@ -20,7 +20,6 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
-import org.jgroups.Global;
 import org.jgroups.stack.Protocol;
 import org.jgroups.util.StackType;
 import org.jgroups.util.Util;
@@ -76,10 +75,7 @@ public abstract class ProtocolConfigurationResourceDefinitionRegistrar<P extends
                         @Override
                         public P createProtocol(ChannelFactoryConfiguration configuration) {
                             try {
-                                // A "native" protocol is one that is not specified as a class name
-                                boolean nativeProtocol = module.get().getName().equals(MODULE.getDefaultValue().asString()) && !name.startsWith(Global.PREFIX);
-                                String className = nativeProtocol ? (Global.PREFIX + name) : name;
-                                Class<? extends Protocol> protocolClass = module.get().getClassLoader().loadClass(className).asSubclass(Protocol.class);
+                                Class<? extends Protocol> protocolClass = findProtocolClass(context, name, model);
                                 Map<String, String> protocolProperties = new HashMap<>(repository.get().getProperties(protocolClass));
                                 protocolProperties.putAll(properties);
                                 PrivilegedExceptionAction<Protocol> action = new PrivilegedExceptionAction<>() {


### PR DESCRIPTION


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21099](https://issues.redhat.com/browse/WFLY-21099)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)