### PR TITLE
[WFLY-21052] Fix Non-Idempotent-Outcome flaky test in AddDataSourceOperationsUnitTestCase

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.as.connector.subsystems.datasources.DataSourcesExtension;
 import org.jboss.as.connector.subsystems.datasources.Namespace;
 import org.jboss.as.test.integration.management.jca.DsMgmtTestBase;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,7 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 public class AddDataSourceOperationsUnitTestCase extends DsMgmtTestBase{
 
-    private static final String JDBC_DRIVER_NAME = "test-jdbc-" + System.currentTimeMillis() + ".jar";
+    private static final String JDBC_DRIVER_NAME = "test-jdbc.jar";
 
     @Deployment(testable = false)
     public static Archive<?> getDeployment() {
@@ -77,6 +78,8 @@ public class AddDataSourceOperationsUnitTestCase extends DsMgmtTestBase{
         List<ModelNode> newList = marshalAndReparseDsResources("data-source");
 
         remove(address);
+
+        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
 
         Assertions.assertNotNull(newList,"Reparsing failed:");
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 public class AddDataSourceOperationsUnitTestCase extends DsMgmtTestBase{
 
-    private static final String JDBC_DRIVER_NAME = "test-jdbc.jar";
+    private static final String JDBC_DRIVER_NAME = "test-jdbc-" + System.currentTimeMillis() + ".jar";
 
     @Deployment(testable = false)
     public static Archive<?> getDeployment() {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-21052

Use timestamp-based deployment name to avoid conflicts between test classes:

```java
private static final String JDBC_DRIVER_NAME = "test-jdbc-" + System.currentTimeMillis() + ".jar";
```