### PR TITLE
[38.x][WFLY-21062] Upgrade org.wildfly:mvc-krazo-* to 2.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
         <version.org.wildfly.core>30.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
-        <version.org.wildfly.mvc.krazo>2.0.0.Final</version.org.wildfly.mvc.krazo>
+        <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>
         <version.org.wildfly.vertx>1.0.2.Final</version.org.wildfly.vertx>
         <version.org.wildfly.naming-client>2.0.1.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-tests-common>2.4.2.Final</version.org.wildfly.security.elytron-tests-common>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21062
Upstream: #19347

This is to bring in https://github.com/wildfly/mvc-krazo-feature-pack/pull/140/files for the catalog. Otherwise there are no changes beyond pom stuff to allow the project to deploy to updated Nexus.