### PR TITLE
WFLY-276 Add support for running the clustering integration tests with the JPDA debugger

### DIFF
--- a/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
@@ -270,7 +270,7 @@ your local one (typically in .m2/settings.xml).
 \2) Build EAP. You won't use the resulting EAP build, though. The
 purpose is to get the artifacts which the testsuite depends on.
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 mvn clean install -s settings.xml -Dmaven.repo.local=local-repo-eap
 ----
@@ -278,7 +278,7 @@ mvn clean install -s settings.xml -Dmaven.repo.local=local-repo-eap
 \3) Run the testsuite. Assuming that EAP is located in `/opt/eap6`, you
 would run:
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 ./integration-tests.sh -DallTests -Djboss.dist=/opt/eap6
 ----
@@ -303,7 +303,7 @@ would run:
 [[examples-1]]
 ==== Examples
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 ./integration-tests.sh install -DdebugClient -Ddebug.port.surefire=4040
 
@@ -327,12 +327,12 @@ Listening for transport dt_socket at address: 4040
 Listening for transport dt_socket at address: 5050
 ----
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 ./integration-tests.sh install -Ddebug
 ----
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 ./integration-tests.sh install -Ddebug -Das.debug.port=5005
 ----
@@ -350,13 +350,28 @@ http://jira.codehaus.org/browse/SUREFIRE-781.
 Depending on which test group(s) you run, multiple AS instances may be
 started. In that case, you need to attach the debugger multiple times.
 
+==== Debugging clustering tests
+
+With the implementation of https://issues.redhat.com/browse/WFLY-276[WFLY-276] for the clustering test suite module,
+these tests can be run with the debugger as well.
+Here are some tips on how to effectively debug:
+
+1. Prepare your IDE with 4 remote debugger sessions templates: `node1` with port 8787, `node2` with port 8788, `node3` with port 8789, and `node4` with port 8790.
+2. Using `mvn`, run a single test (`-Dtest=..`) in the debug mode (`-Ddebug` / `-Djpda`)
+3. Connect the debugger to each node as they are starting since the JVM is configured to wait for the debugger connection to proceed.
+4. Keep connecting to starting nodes as some tests change the topology during the test.
+
+NOTE: Container start timeout in Arquillian is currently set to 60 seconds,
+you may need to increase the timeout depending on your swiftness with connecting the remote debugger.
+
+
 [[running-tests-with-custom-database]]
 === Running tests with custom database
 
 To run with different database, specify the `-Dds` and use these
 properties (with the following defaults):
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 -Dds.jdbc.driver=
 -Dds.jdbc.driver.version=
@@ -381,7 +396,7 @@ http://nexus.qa.jboss.com:8081/nexus/content/repositories/thirdparty/jdbcdrivers
 
 The `ds.db` value is set depending on ds. E.g. `-Dds=mssql2005` sets
 `ds.db=mssql` (since they have the same driver). `-Dds.db` may be
-overriden to use different driver.
+overridden to use different driver.
 
 [line-through]*In case you don't want to use such driver, set just
 -Dds.db= (empty) and provide the driver to the AS manually.* +
@@ -394,7 +409,7 @@ jar._
 For WildFly continuous integration, there are some predefined values for
 some of databases, which can be set using:
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 -Dds.db=<database-identifier>
 ----
@@ -461,7 +476,7 @@ Test reports are created in the form known from EAP 5. To create them,
 simply run the testsuite, which will create Surefire XML files.
 
 Creation of the reports is bound to the `site` Maven phase, so it must
-be run separatedly afterwards. Use one of these:
+be run separately afterward. Use one of these:
 
 [source,options="nowrap"]
 ----
@@ -531,15 +546,15 @@ mvn dependency:purge-local-repository build-helper:remove-project-artifact -Dbui
 In case the build happens in a shared environment (e.g. network disk),
 it's recommended to use local repository:
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
-cp /home/hudson/.m2/settings.xml .
-sed "s|<settings>|<settings><localRepository>/home/ozizka/hudson-repos/$JOBNAME</localRepository>|" -i settings.xml
+cp /home/jenkins/.m2/settings.xml .
+sed "s|<settings>|<settings><localRepository>/home/jenkins/jenkins-repos/$JOBNAME</localRepository>|" -i settings.xml
 ----
 
 Or:
 
-[source,java,options="nowrap"]
+[source,shell,options="nowrap"]
 ----
 mvn clean install ... -Dmaven.repo.local=localrepo
 ----

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Harness_Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Harness_Developer_Guide.adoc
@@ -13,11 +13,13 @@ endif::[]
 
 *JIRA*: https://issues.redhat.com/browse/WFLY-576[WFLY-576]
 
-[[testsuite-requirements]]
-== Testsuite requirements
+// TODO - the following link is no longer available. If someone can get the content, and it is still relevant, replace this section with it.
 
-http://community.jboss.org/wiki/ASTestsuiteRequirements will probably be
-merged here later.
+// [[testsuite-requirements]]
+// == Testsuite requirements
+//
+// http://community.jboss.org/wiki/ASTestsuiteRequirements will probably be
+// merged here later.
 
 [[adding-a-new-maven-plugin]]
 == Adding a new maven plugin
@@ -64,16 +66,14 @@ TBD: https://issues.redhat.com/browse/ARQ-647
 [source,xml,options="nowrap"]
 ----
 <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
-    <surefire.jpda.args></surefire.jpda.args>
-    <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args}</surefire.system.args>
+<surefire.jpda.args></surefire.jpda.args>
+<surefire.system.args>${surefire.memory.args} ${surefire.jpda.args}</surefire.system.args>
 ----
 
 [[ip-settings]]
 === IP settings
 
-* `${ip.server.stack` *}* - used in
-`<systemPropertyVariables> / <server.jvm.args>` which is used in
-`*-arquillian.xml`.
+* `${ip.server.stack}` used in `<systemPropertyVariables>/<server.jvm.args>` which is used in `*-arquillian.xml`.
 
 [[testsuite-directories]]
 === Testsuite directories

--- a/pom.xml
+++ b/pom.xml
@@ -1624,10 +1624,6 @@
             </build>
         </profile>
 
-        <!--
-          Name: jpda
-          Descr: Enable JPDA remote debuging
-        -->
         <profile>
             <id>jpda</id>
             <activation>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -22,13 +22,27 @@
     <name>WildFly Test Suite: Integration - Clustering</name>
 
     <properties>
+        <!-- Common server configuration -->
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        <surefire.forked.process.timeout>5400</surefire.forked.process.timeout>
-        <test-group>org/jboss/as/test/clustering/cluster</test-group>
+        <!-- n.b. override ${surefire.system.args} with omitted ${surefire.jpda.args} which must be unique per node! -->
+        <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
+        <!-- n.b. override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} which must be unique per node! -->
+        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+        <surefire.jpda.args.node1/>
+        <surefire.jpda.args.node2/>
+        <surefire.jpda.args.node3/>
+        <surefire.jpda.args.node4/>
+
+        <!-- Common infinispan server configuration -->
         <version.org.infinispan.server>${version.org.infinispan}</version.org.infinispan.server>
         <version.org.infinispan.server.driver>${version.org.infinispan}</version.org.infinispan.server.driver>
+        <infinispan.server.home.override/>
+        <infinispan.server.profile.override/>
+
+        <surefire.forked.process.timeout>5400</surefire.forked.process.timeout>
+        <test-group>org/jboss/as/test/clustering/cluster</test-group>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>
         <!-- properties to enable plugins shared by various bootable jar executions -->
         <glow.phase>none</glow.phase>
@@ -38,8 +52,6 @@
         <ts.config-as.clustering.phase>test-compile</ts.config-as.clustering.phase>
         <!-- Disable the default surefire test execution. All profiles use custom executions. -->
         <surefire.default-test.phase>none</surefire.default-test.phase>
-        <infinispan.server.home.override/>
-        <infinispan.server.profile.override/>
     </properties>
 
     <dependencies>
@@ -622,6 +634,36 @@
         </plugins>
     </build>
     <profiles>
+        <!-- Override default jpda.profile which sets unique arguments per node -->
+        <!-- These are redundant in testsuite/pom.xml:553, tracker to prune one https://issues.redhat.com/browse/WFLY-21121 -->
+        <profile>
+            <id>jpda.profile</id>
+            <activation>
+                <property>
+                    <name>jpda</name>
+                </property>
+            </activation>
+            <properties>
+                <surefire.jpda.args.node1>-agentlib:jdwp=transport=dt_socket,address=*:8787,server=y,suspend=y</surefire.jpda.args.node1>
+                <surefire.jpda.args.node2>-agentlib:jdwp=transport=dt_socket,address=*:8788,server=y,suspend=y</surefire.jpda.args.node2>
+                <surefire.jpda.args.node3>-agentlib:jdwp=transport=dt_socket,address=*:8789,server=y,suspend=y</surefire.jpda.args.node3>
+                <surefire.jpda.args.node4>-agentlib:jdwp=transport=dt_socket,address=*:8790,server=y,suspend=y</surefire.jpda.args.node4>
+            </properties>
+        </profile>
+        <profile>
+            <id>debug.profile</id>
+            <activation>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
+            <properties>
+                <surefire.jpda.args.node1>-agentlib:jdwp=transport=dt_socket,address=*:8787,server=y,suspend=y</surefire.jpda.args.node1>
+                <surefire.jpda.args.node2>-agentlib:jdwp=transport=dt_socket,address=*:8788,server=y,suspend=y</surefire.jpda.args.node2>
+                <surefire.jpda.args.node3>-agentlib:jdwp=transport=dt_socket,address=*:8789,server=y,suspend=y</surefire.jpda.args.node3>
+                <surefire.jpda.args.node4>-agentlib:jdwp=transport=dt_socket,address=*:8790,server=y,suspend=y</surefire.jpda.args.node4>
+            </properties>
+        </profile>
 
         <!-- Common step to prepare servers in use by all non-Galleon tests -->
         <profile>
@@ -727,7 +769,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <execution>
                                 <id>ts.config-as.clustering</id>
                                 <phase>${ts.config-as.clustering.phase}</phase>
@@ -880,7 +922,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
-                        <executions combine.children="append">
+                        <executions>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
@@ -930,8 +972,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -957,7 +1002,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
-                        <executions combine.children="append">
+                        <executions>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.ha-infinispan-server</id>
@@ -995,8 +1040,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1022,7 +1070,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
-                        <executions combine.children="append">
+                        <executions>
                             <!-- Multi-node clustering tests -->
                             <execution>
                                 <id>ts.surefire.clustering.fullha</id>
@@ -1059,8 +1107,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3} -Djboss.messaging.cluster.password=testsuite-messaging-password</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args} -Djboss.messaging.cluster.password=testsuite-messaging-password</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1086,7 +1137,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${version.surefire.plugin}</version>
-                        <executions combine.children="append">
+                        <executions>
                             <!-- Single node clustering tests. -->
                             <execution>
                                 <id>ts.surefire.clustering.single</id>
@@ -1148,7 +1199,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <execution>
                                 <id>ts.surefire.clustering.single.testable</id>
                                 <phase>test</phase>
@@ -1168,7 +1219,8 @@
                                         <mcast>${mcast}</mcast>
                                         <arquillian.xml>arquillian-testable.xml</arquillian.xml>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1225,8 +1277,12 @@
                                         <arquillian.xml>arquillian-byteman.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Usual server JVM args plus additional Byteman args (-Djboss.modules.system.pkgs, -Xbootclasspath)-->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} ${surefire.byteman.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <!-- Append required byteman args (-Djboss.modules.system.pkgs, -Xbootclasspath) to standard ${server.jvm.args} -->
+                                        <server.jvm.args>${server.jvm.args} ${surefire.byteman.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1252,7 +1308,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <execution>
                                 <id>ts.surefire.clustering.byteman</id>
                                 <phase>none</phase>
@@ -1301,8 +1357,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1390,8 +1449,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1422,8 +1484,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -1458,8 +1523,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
@@ -2160,7 +2228,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <execution>
                                 <id>ts.config-as.clustering.mod_cluster</id>
                                 <phase>process-test-classes</phase>
@@ -2365,8 +2433,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                         <!-- Override the standard module path that points at the shared module set from dist.
@@ -2416,8 +2487,11 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
-                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
                                         <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
                                         <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                         <!-- Override the standard module path that points at the shared module set from dist.
@@ -2569,7 +2643,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <!-- Turn off the standard execution -->
                             <execution>
                                 <id>ts.config-as.clustering</id>
@@ -2868,7 +2942,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <executions combine.children="append">
+                        <executions>
                             <execution>
                                 <id>ts.config-as.clustering</id>
                                 <phase>none</phase>
@@ -2983,7 +3057,6 @@
                         <executions>
                             <execution>
                                 <id>ts.surefire.clustering.ha</id>
-                                <!--<phase>none</phase>-->
                                 <configuration>
                                     <excludes>
                                         <!-- This next section is a duplication of the usual excludes from the ts.clustering.cluster.ha.profile.
@@ -3003,7 +3076,6 @@
                             </execution>
                             <execution>
                                 <id>ts.surefire.clustering.fullha</id>
-                                <!--<phase>none</phase>-->
                                 <configuration>
                                     <excludes>
                                         <!-- Requires the /subsystem=messaging-activemq/server=default to exist for its setup tasks -->

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -631,6 +631,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Extend general surefire configuration defined in pom.xml of the integration module -->
+            <!-- This configuration is then inherited in all executions in this module providing the default, per node: -->
+            <!-- distribution directory, address, JPDA arguments and shared Infinispan server configuration -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables combine.children="append">
+                        <wildfly1>wildfly-1</wildfly1>
+                        <wildfly2>wildfly-2</wildfly2>
+                        <wildfly3>wildfly-3</wildfly3>
+                        <wildfly4>wildfly-4</wildfly4>
+                        <wildfly-load-balancer1>wildfly-load-balancer-1</wildfly-load-balancer1>
+                        <node0>${node0}</node0>
+                        <node1>${node1}</node1>
+                        <node2>${node2}</node2>
+                        <node3>${node3}</node3>
+                        <mcast>${mcast}</mcast>
+                        <mcast1>${mcast1}</mcast1>
+                        <mcast2>${mcast2}</mcast2>
+                        <mcast3>${mcast3}</mcast3>
+                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
+                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
+                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
+                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
+                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
+                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
+                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -952,33 +983,10 @@
                                         <exclude>${test-group}/**/byteman/*TestCase.java</exclude>
                                         <exclude>%regex[${test-group}/(${ts.surefire.clustering.ha.additionalExcludes})/.*TestCase.class]</exclude>
                                     </excludes>
-                                    <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <!-- required by arquillian.xml -->
-                                        <wildfly1>wildfly-1</wildfly1>
-                                        <wildfly2>wildfly-2</wildfly2>
-                                        <wildfly3>wildfly-3</wildfly3>
-                                        <wildfly4>wildfly-4</wildfly4>
-                                        <wildfly-load-balancer1>wildfly-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1022,31 +1030,9 @@
                                     </includes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <!-- required by arquillian.xml -->
-                                        <wildfly1>wildfly-1</wildfly1>
-                                        <wildfly2>wildfly-2</wildfly2>
-                                        <wildfly3>wildfly-3</wildfly3>
-                                        <wildfly4>wildfly-4</wildfly4>
-                                        <wildfly-load-balancer1>wildfly-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1089,31 +1075,10 @@
                                     </includes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <!-- required by arquillian.xml -->
-                                        <wildfly1>wildfly-1</wildfly1>
-                                        <wildfly2>wildfly-2</wildfly2>
-                                        <wildfly3>wildfly-3</wildfly3>
-                                        <wildfly4>wildfly-4</wildfly4>
-                                        <wildfly-load-balancer1>wildfly-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
+                                        <server.jvm.args>${server.jvm.args} -Djboss.messaging.cluster.password=testsuite-messaging-password</server.jvm.args>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args} -Djboss.messaging.cluster.password=testsuite-messaging-password</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1155,7 +1120,6 @@
                                         <exclude>org/jboss/as/test/clustering/single/web/NonHaWebSessionPersistenceTestCase.java</exclude>
                                     </excludes>
                                     <systemPropertyVariables combine.children="append">
-                                        <wildfly1>wildfly-1</wildfly1>
                                         <arquillian.launch>single</arquillian.launch>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
@@ -1174,7 +1138,6 @@
                                         <include>org/jboss/as/test/clustering/single/web/NonHaWebSessionPersistenceTestCase.java</include>
                                     </includes>
                                     <systemPropertyVariables combine.children="append">
-                                        <wildfly1>wildfly-1</wildfly1>
                                         <arquillian.launch>node-non-ha</arquillian.launch>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
@@ -1215,14 +1178,8 @@
                                         <classpathDependencyExclude>org.jboss.arquillian.extension:arquillian-extension-byteman</classpathDependencyExclude>
                                     </classpathDependencyExcludes>
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <mcast>${mcast}</mcast>
                                         <arquillian.xml>arquillian-testable.xml</arquillian.xml>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1266,25 +1223,11 @@
                                         <include>${test-group}/**/byteman/*TestCase.java</include>
                                     </includes>
                                     <systemPropertyVariables combine.children="append">
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
+                                        <!-- Append required byteman args (-Djboss.modules.system.pkgs, -Xbootclasspath) to standard ${server.jvm.args} -->
+                                        <server.jvm.args>${server.jvm.args} ${surefire.byteman.args}</server.jvm.args>
                                         <arquillian.xml>arquillian-byteman.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <!-- Append required byteman args (-Djboss.modules.system.pkgs, -Xbootclasspath) to standard ${server.jvm.args} -->
-                                        <server.jvm.args>${server.jvm.args} ${surefire.byteman.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1346,24 +1289,9 @@
                                     <runOrder>alphabetical</runOrder>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                     <!-- Tests to execute. -->
                                     <includes>
@@ -1438,24 +1366,9 @@
                                     </includes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1473,24 +1386,9 @@
                                     </includes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -1512,24 +1410,9 @@
                                     </excludes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2377,13 +2260,6 @@
                                         <!-- Override the standard module path that points at the shared module set from dist.
                                         Have all the servers use wildfly-1 for the modules -->
                                         <module.path>${project.build.directory}/wildfly-1/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <!-- required by arquillian.xml -->
-                                        <wildfly1>wildfly-1</wildfly1>
-                                        <wildfly2>wildfly-2</wildfly2>
-                                        <wildfly3>wildfly-3</wildfly3>
-                                        <wildfly4>wildfly-4</wildfly4>
-                                        <wildfly-load-balancer1>wildfly-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2399,13 +2275,11 @@
                                         <!-- Override the standard module path that points at the shared module set from dist.
                                         Have all the servers use wildfly-jpa-dist-1 for the modules -->
                                         <module.path>${project.build.directory}/wildfly-jpa-dist-1/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <!-- required by arquillian.xml -->
                                         <wildfly1>wildfly-jpa-dist-1</wildfly1>
                                         <wildfly2>wildfly-jpa-dist-2</wildfly2>
                                         <wildfly3>wildfly-jpa-dist-3</wildfly3>
                                         <wildfly4>wildfly-jpa-dist-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-jpa-dist-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2422,28 +2296,12 @@
                                         <include>${test-group}/**/modcluster/*TestCase.java</include>
                                     </includes>
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                         <!-- Override the standard module path that points at the shared module set from dist.
                                         Have all the servers use wildfly-clustering-mod_cluster-1 for the modules -->
                                         <module.path>${project.build.directory}/wildfly-clustering-mod_cluster-1/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <!-- arquillian.xml -->
                                         <wildfly1>wildfly-clustering-mod_cluster-1</wildfly1>
                                         <wildfly2>wildfly-clustering-mod_cluster-2</wildfly2>
                                         <wildfly3>wildfly-clustering-mod_cluster-3</wildfly3>
@@ -2476,34 +2334,17 @@
                                     </excludes>
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <node0>${node0}</node0>
-                                        <node1>${node1}</node1>
-                                        <node2>${node2}</node2>
-                                        <node3>${node3}</node3>
-                                        <mcast>${mcast}</mcast>
-                                        <mcast1>${mcast1}</mcast1>
-                                        <mcast2>${mcast2}</mcast2>
-                                        <mcast3>${mcast3}</mcast3>
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
-                                        <server.jvm.args>${server.jvm.args}</server.jvm.args>
-                                        <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
-                                        <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>
-                                        <surefire.jpda.args.node3>${surefire.jpda.args.node3}</surefire.jpda.args.node3>
-                                        <surefire.jpda.args.node4>${surefire.jpda.args.node4}</surefire.jpda.args.node4>
-                                        <infinispan.server.home>${infinispan.server.home.template}</infinispan.server.home>
-                                        <infinispan.server.profile>${infinispan.server.profile.override}</infinispan.server.profile>
                                         <!-- Override the standard module path that points at the shared module set from dist.
                                         Have all the servers use wildfly-clustering-ejb-1 for the modules -->
                                         <module.path>${project.build.directory}/wildfly-clustering-ejb-1/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <!-- required by arquillian.xml -->
                                         <wildfly1>wildfly-clustering-ejb-1</wildfly1>
                                         <wildfly2>wildfly-clustering-ejb-2</wildfly2>
                                         <wildfly3>wildfly-clustering-ejb-3</wildfly3>
                                         <wildfly4>wildfly-clustering-ejb-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-clustering-ejb-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2519,13 +2360,11 @@
                                         <!-- Override the standard module path that points at the shared module set from dist.
                                         Have all the servers use wildfly-clustering-jsf-1 for the modules -->
                                         <module.path>${project.build.directory}/wildfly-clustering-jsf-1/modules${path.separator}${basedir}/target/modules</module.path>
-                                        <!-- required by arquillian.xml -->
                                         <wildfly1>wildfly-clustering-jsf-1</wildfly1>
                                         <wildfly2>wildfly-clustering-jsf-2</wildfly2>
                                         <wildfly3>wildfly-clustering-jsf-3</wildfly3>
                                         <wildfly4>wildfly-clustering-jsf-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-clustering-jsf-load-balancer-1</wildfly-load-balancer1>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2716,14 +2555,12 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <!-- required by arquillian.xml -->
                                         <wildfly1>wildfly-mp-dist-1</wildfly1>
                                         <wildfly2>wildfly-mp-dist-2</wildfly2>
                                         <wildfly3>wildfly-mp-dist-3</wildfly3>
                                         <wildfly4>wildfly-mp-dist-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-mp-dist-load-balancer-1</wildfly-load-balancer1>
                                         <jboss.server.config.file.name>standalone-microprofile-ha.xml</jboss.server.config.file.name>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -2734,16 +2571,13 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
-                                        <!-- required by arquillian.xml -->
                                         <wildfly1>wildfly-mp-dist-1</wildfly1>
                                         <wildfly2>wildfly-mp-dist-2</wildfly2>
                                         <wildfly3>wildfly-mp-dist-3</wildfly3>
                                         <wildfly4>wildfly-mp-dist-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-mp-dist-load-balancer-1</wildfly-load-balancer1>
                                         <jboss.server.config.file.name>standalone-microprofile-ha.xml</jboss.server.config.file.name>
-                                        <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
@@ -16,12 +16,12 @@
         <configuration>
             <property name="installDir">${install.dir.1}</property>
             <property name="jarFile">${bootable.jar}</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
@@ -30,12 +30,12 @@
         <configuration>
             <property name="installDir">${install.dir.1}</property>
             <property name="jarFile">${bootable.jar}</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
@@ -46,13 +46,13 @@
                 <property name="installDir">${install.dir.1}</property>
                 <property name="jarFile">${bootable.jar}</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -60,12 +60,12 @@
             <configuration>
                 <property name="installDir">${install.dir.2}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
+                <property name="waitForPorts">8788 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -73,12 +73,12 @@
             <configuration>
                 <property name="installDir">${install.dir.3}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">${as.debug.port.node2} 10190</property>
+                <property name="waitForPorts">8789 10190</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -86,13 +86,13 @@
             <configuration>
                 <property name="installDir">${install.dir.4}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">${as.debug.port.node3} 10290</property>
+                <property name="waitForPorts">8790 10290</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
@@ -15,12 +15,12 @@
     <container qualifier="single">
         <configuration>
             <property name="jbossHome">${basedir}/target/wildfly-1</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
@@ -30,49 +30,49 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-1</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-2" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-2</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-2 -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/wildfly-2 -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
+                <property name="waitForPorts">8788 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-3" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-3</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-3 -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/wildfly-3 -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">${as.debug.port.node2} 10190</property>
+                <property name="waitForPorts">8789 10190</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         <container qualifier="node-4" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-4</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-4 -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/wildfly-4 -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">${as.debug.port.node3} 10290</property>
+                <property name="waitForPorts">8790 10290</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -80,12 +80,12 @@
         <container qualifier="node-non-ha" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-1</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">standalone.xml</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
@@ -14,12 +14,12 @@
 
     <container qualifier="default" default="true">
         <configuration>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="jbossHome">${basedir}/target/wildfly-1</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>

--- a/testsuite/integration/clustering/src/test/resources/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian.xml
@@ -15,12 +15,12 @@
     <container qualifier="single">
         <configuration>
             <property name="jbossHome">${basedir}/target/${wildfly1}</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
@@ -29,12 +29,12 @@
     <container qualifier="node-non-ha" mode="manual">
         <configuration>
             <property name="jbossHome">${basedir}/target/${wildfly1}</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
             <property name="javaHome">${container.java.home}</property>
         </configuration>
@@ -45,13 +45,13 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly1}</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <!-- AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use" -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPorts">8787 ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -59,12 +59,12 @@
         <container qualifier="node-2" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly2}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/${wildfly2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
-                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
+                <property name="waitForPorts">8788 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -72,12 +72,12 @@
         <container qualifier="node-3" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly3}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/${wildfly3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
-                <property name="waitForPorts">${as.debug.port.node2} 10190</property>
+                <property name="waitForPorts">8789 10190</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>
@@ -85,12 +85,12 @@
         <container qualifier="node-4" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly4}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/${wildfly4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/${wildfly4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
-                <property name="waitForPorts">${as.debug.port.node3} 10290</property>
+                <property name="waitForPorts">8790 10290</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
                 <property name="javaHome">${container.java.home}</property>
             </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -167,6 +167,7 @@
              a location as is practical; no more coarse-grained than the global config of
              the pom for the maven module that includes the test. -->
         <modular.jdk.testsuite.args>${modular.jdk.args}</modular.jdk.testsuite.args>
+        <!-- n.b. any updates to line below need to be mirrored in testsuite/integration/clustering/pom.xml with omitted ${surefire.jpda.args} which must be unique per node! -->
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />
         <!-- needed for arquillian-byteman-extension -->
@@ -552,14 +553,22 @@
         -->
         <profile>
             <id>jpda.profile</id>
-            <activation><property><name>jpda</name></property></activation>
+            <activation>
+                <property>
+                    <name>jpda</name>
+                </property>
+            </activation>
             <properties>
                 <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=*:${as.debug.port},server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
         <profile>
             <id>debug.profile</id>
-            <activation><property><name>debug</name></property></activation>
+            <activation>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
             <properties>
                 <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=*:${as.debug.port},server=y,suspend=y</surefire.jpda.args>
             </properties>


### PR DESCRIPTION
* setup jpda properties per node since they must be unique
* remove passing the same jpda properties to each node resulting in port conflict in multi-node tests
* fixes in the testsuite documentation section and explain caveats of running multi-node test with the debugger
* organizes properties to be grouped logically
* remove noexistent properties used in arquillian-*.xml
* cleanup duplicated ${server.jvm.arg} property override
* cleanup redundant combine children

Resolves
https://issues.redhat.com/browse/WFLY-276