### PR TITLE
WFLY-21123 Upgrade jboss-parent from 50 to 51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
         <!-- The empty relativePath makes Maven lookup it in the repository. Missing tag default is ../pom.xml. -->
         <relativePath/>
     </parent>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21123

Tag: https://github.com/jboss/jboss-parent-pom/releases/tag/jboss-parent-51
Changelog: https://github.com/jboss/jboss-parent-pom/compare/jboss-parent-50...jboss-parent-51

Here is WF effective pom diff: https://gist.github.com/rhusar/05cb81cd51b0e3453f7e700d77024cb8/revisions