### PR TITLE
WFLY-21125 Upgrade SmallRye Health from 4.2.0 to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-config>3.13.4</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.9.3</version.io.smallrye.smallrye-fault-tolerance>
-        <version.io.smallrye.smallrye-health>4.2.0</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>4.3.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>2.8.0</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>3.17.1</version.io.smallrye.smallrye-mutiny-vertx>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21125