### PR TITLE
WFLY-21130 Clustering test suite: nodes are not being shutdown gracefully + WFLY-21083 Continued intermittent failures in JSFFailoverTestCase

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -648,10 +648,6 @@
                         <node1>${node1}</node1>
                         <node2>${node2}</node2>
                         <node3>${node3}</node3>
-                        <mcast>${mcast}</mcast>
-                        <mcast1>${mcast1}</mcast1>
-                        <mcast2>${mcast2}</mcast2>
-                        <mcast3>${mcast3}</mcast3>
                         <server.jvm.args>${server.jvm.args}</server.jvm.args>
                         <surefire.jpda.args.node1>${surefire.jpda.args.node1}</surefire.jpda.args.node1>
                         <surefire.jpda.args.node2>${surefire.jpda.args.node2}</surefire.jpda.args.node2>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -81,16 +81,16 @@ public final class NodeUtil {
         return controller.isStarted(container);
     }
 
-    public static void stop(WildFlyContainerController controller, Set<String> containers, int timeout) {
+    public static void stop(WildFlyContainerController controller, Set<String> containers, int suspendTimeout) {
         for (String container : containers) {
-            stop(controller, container, timeout);
+            stop(controller, container, suspendTimeout);
         }
     }
 
-    public static void stop(WildFlyContainerController controller, String container, int timeout) {
+    public static void stop(WildFlyContainerController controller, String container, int suspendTimeout) {
         if (controller.isStarted(container)) {
             log.tracef("Stopping container %s", container);
-            controller.stop(container, timeout);
+            controller.stop(container, suspendTimeout);
             log.tracef("Stopped container %s", container);
         } else {
             log.tracef("Container %s was already stopped", container);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -131,8 +131,26 @@ public abstract class AbstractClusteringTestCase {
     }
 
     public AbstractClusteringTestCase(Set<String> containers, Set<String> deployments) {
-        this.containers = containers;
-        this.deployments = deployments;
+        this.containers = Set.copyOf(containers);
+        this.deployments = Set.copyOf(deployments);
+    }
+
+    /**
+     * Returns an unmodifiable set of container names available for this clustering test.
+     *
+     * @return an unmodifiable set of container names available for this clustering test.
+     */
+    public Set<String> getContainers() {
+        return this.containers;
+    }
+
+    /**
+     * Returns an unmodifiable set of deployment names available for this clustering test.
+     *
+     * @return an unmodifiable set of deployment names available for this clustering test.
+     */
+    public Set<String> getDeployments() {
+        return this.deployments;
     }
 
     /**

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -34,7 +34,7 @@ import org.junit.Before;
  * may be overridden.
  * <p>
  * Furthermore, this base class provides common constants for node/instance-id, deployment/deployment helpers, timeouts and provides
- * convenience methods for managing container and deployment lifecycle ({@link #start(String...)}, {@link #deploy(String...)}, etc).
+ * convenience methods for managing container and deployment lifecycle ({@link #start(Set)}, {@link #deploy(Set)}, etc.).
  *
  * @author Radoslav Husar
  */
@@ -47,12 +47,9 @@ public abstract class AbstractClusteringTestCase {
     public static final String NODE_2 = "node-2";
     public static final String NODE_3 = "node-3";
     public static final String NODE_4 = "node-4";
-    @Deprecated public static final String[] TWO_NODES = new String[] { NODE_1, NODE_2 };
-    @Deprecated public static final String[] THREE_NODES = new String[] { NODE_1, NODE_2, NODE_3 };
-    @Deprecated public static final String[] FOUR_NODES = new String[] { NODE_1, NODE_2, NODE_3, NODE_4 };
-    public static final Set<String> NODE_1_2 = Set.of(TWO_NODES);
-    public static final Set<String> NODE_1_2_3 = Set.of(THREE_NODES);
-    public static final Set<String> NODE_1_2_3_4 = Set.of(FOUR_NODES);
+    public static final Set<String> NODE_1_2 = Set.of(NODE_1, NODE_2);
+    public static final Set<String> NODE_1_2_3 = Set.of(NODE_1, NODE_2, NODE_3);
+    public static final Set<String> NODE_1_2_3_4 = Set.of(NODE_1, NODE_2, NODE_3, NODE_4);
     public static final String NODE_NAME_PROPERTY = "jboss.node.name";
 
     // Test deployment names
@@ -60,22 +57,18 @@ public abstract class AbstractClusteringTestCase {
     public static final String DEPLOYMENT_2 = "deployment-2";
     public static final String DEPLOYMENT_3 = "deployment-3";
     public static final String DEPLOYMENT_4 = "deployment-4";
-    @Deprecated public static final String[] TWO_DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2 };
-    @Deprecated public static final String[] THREE_DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3 };
-    @Deprecated public static final String[] FOUR_DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3, DEPLOYMENT_4 };
-    public static final Set<String> DEPLOYMENT_1_2 = Set.of(TWO_DEPLOYMENTS);
-    public static final Set<String> DEPLOYMENT_1_2_3 = Set.of(THREE_DEPLOYMENTS);
-    public static final Set<String> DEPLOYMENT_1_2_3_4 = Set.of(FOUR_DEPLOYMENTS);
+    public static final Set<String> DEPLOYMENT_1_2 = Set.of(DEPLOYMENT_1, DEPLOYMENT_2);
+    public static final Set<String> DEPLOYMENT_1_2_3 = Set.of(DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3);
+    public static final Set<String> DEPLOYMENT_1_2_3_4 = Set.of(DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3, DEPLOYMENT_4);
 
     // Helper deployment names
     public static final String DEPLOYMENT_HELPER_1 = "deployment-helper-0";
     public static final String DEPLOYMENT_HELPER_2 = "deployment-helper-1";
     public static final String DEPLOYMENT_HELPER_3 = "deployment-helper-2";
     public static final String DEPLOYMENT_HELPER_4 = "deployment-helper-3";
-    @Deprecated public static final String[] TWO_DEPLOYMENT_HELPERS = new String[] { DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2 };
-    @Deprecated public static final String[] FOUR_DEPLOYMENT_HELPERS = new String[] { DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2, DEPLOYMENT_HELPER_3, DEPLOYMENT_HELPER_4 };
-    public static final Set<String> DEPLOYMENT_HELPER_1_2 = Set.of(TWO_DEPLOYMENT_HELPERS);
-    public static final Set<String> DEPLOYMENT_HELPER_1_2_3_4 = Set.of(FOUR_DEPLOYMENT_HELPERS);
+    public static final Set<String> DEPLOYMENT_HELPER_1_2 = Set.of(DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2);
+    public static final Set<String> DEPLOYMENT_HELPER_1_2_3 = Set.of(DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2, DEPLOYMENT_HELPER_3);
+    public static final Set<String> DEPLOYMENT_HELPER_1_2_3_4 = Set.of(DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2, DEPLOYMENT_HELPER_3, DEPLOYMENT_HELPER_4);
 
     // Infinispan Server
     public static final String INFINISPAN_SERVER_HOME = System.getProperty("infinispan.server.home");
@@ -95,7 +88,7 @@ public abstract class AbstractClusteringTestCase {
     // Timeouts
     public static final int GRACE_TIME_TO_REPLICATE = TimeoutUtil.adjust(4000);
     public static final int GRACE_TIME_TOPOLOGY_CHANGE = TimeoutUtil.adjust(3000);
-    public static final int GRACEFUL_SHUTDOWN_TIMEOUT = TimeoutUtil.adjust(15);
+    public static final int SUSPEND_TIMEOUT_S = TimeoutUtil.adjust(60);
     public static final int GRACE_TIME_TO_MEMBERSHIP_CHANGE = TimeoutUtil.adjust(10000);
     public static final int WAIT_FOR_PASSIVATION_MS = TimeoutUtil.adjust(5);
     public static final int HTTP_REQUEST_WAIT_TIME_S = TimeoutUtil.adjust(5);
@@ -105,10 +98,6 @@ public abstract class AbstractClusteringTestCase {
     public static final String TESTSUITE_NODE1 = System.getProperty("node1", "127.0.0.1");
     public static final String TESTSUITE_NODE2 = System.getProperty("node2", "127.0.0.1");
     public static final String TESTSUITE_NODE3 = System.getProperty("node3", "127.0.0.1");
-    public static final String TESTSUITE_MCAST = System.getProperty("mcast", "230.0.0.4");
-    public static final String TESTSUITE_MCAST1 = System.getProperty("mcast1", "230.0.0.5");
-    public static final String TESTSUITE_MCAST2 = System.getProperty("mcast2", "230.0.0.6");
-    public static final String TESTSUITE_MCAST3 = System.getProperty("mcast3", "230.0.0.7");
 
     protected static final Logger log = Logger.getLogger(AbstractClusteringTestCase.class);
     private static final Map<String, String> CONTAINER_TO_DEPLOYMENT = Map.of(NODE_1, DEPLOYMENT_1, NODE_2, DEPLOYMENT_2, NODE_3, DEPLOYMENT_3, NODE_4, DEPLOYMENT_4);
@@ -137,18 +126,8 @@ public abstract class AbstractClusteringTestCase {
         this(NODE_1_2);
     }
 
-    @Deprecated
-    public AbstractClusteringTestCase(String[] nodes) {
-        this(Set.of(nodes));
-    }
-
     public AbstractClusteringTestCase(Set<String> containers) {
         this(containers, toDeployments(containers));
-    }
-
-    @Deprecated
-    public AbstractClusteringTestCase(String[] nodes, String[] deployments) {
-        this(Set.of(nodes), Set.of(deployments));
     }
 
     public AbstractClusteringTestCase(Set<String> containers, Set<String> deployments) {
@@ -160,7 +139,7 @@ public abstract class AbstractClusteringTestCase {
      * Guarantees that prior to test method execution
      * (1) all containers that are not used in the test are stopped and,
      * (2) all requested containers are running and,
-     * (3) all requested deployments are deployed thus allowing all necessary test resources injection.
+     * (3) all requested deployments are deployed thus allowing all necessary test resource injection.
      */
     @Before
     public void beforeTestMethod() throws Exception {
@@ -188,12 +167,10 @@ public abstract class AbstractClusteringTestCase {
 
     // Node and deployment lifecycle management convenience methods
 
-    /**
-     * @deprecated Use {@link AbstractClusteringTestCase#start(String)} and {@link AbstractClusteringTestCase#start(Set)} instead.
-     */
-    @Deprecated
-    protected void start(String... containers) {
-        start(Set.of(containers));
+    // Container.start(..) methods
+
+    protected boolean isStarted(String container) {
+        return NodeUtil.isStarted(this.controller, container);
     }
 
     protected void start() {
@@ -208,53 +185,50 @@ public abstract class AbstractClusteringTestCase {
         NodeUtil.start(this.controller, containers);
     }
 
-    /**
-     * @deprecated Use {@link AbstractClusteringTestCase#stop(String)} and {@link AbstractClusteringTestCase#stop(Set)} instead.
-     */
-    @Deprecated
-    protected void stop(String... containers) {
-        stop(Set.of(containers));
-    }
+    // Container.stop(..) methods
 
+    // n.b. all stop methods for the purposes of clustering tests by default use a suspend-timeout;
+    // use 0 explicitly to not wait for active sessions to finish
+
+    /**
+     * Gracefully stops all containers configured for this test case with default suspend timeout of 60 seconds (adjusted).
+     * To stop the containers without waiting for all requests to finish, use {@link #stop(java.lang.String, int)} with suspend timeout of 0.
+     */
     protected void stop() {
-        this.stop(this.containers);
+        this.stop(this.containers, SUSPEND_TIMEOUT_S);
     }
 
+    /**
+     * Gracefully stops given container with default suspend timeout of 60 seconds (adjusted).
+     * To stop the container without waiting for all requests to finish, use {@link #stop(java.lang.String, int)} with suspend timeout of 0.
+     */
     protected void stop(String container) {
-        NodeUtil.stop(this.controller, container);
+        NodeUtil.stop(this.controller, container, SUSPEND_TIMEOUT_S);
     }
 
+    /**
+     * Sequentially gracefully stops given set of containers with default suspend timeout of 60 seconds (adjusted).
+     * To stop the containers without waiting for all requests to finish, use {@link #stop(java.lang.String, int)} with suspend timeout of 0.
+     */
     protected void stop(Set<String> containers) {
-        NodeUtil.stop(this.controller, containers);
-    }
-
-    protected boolean isStarted(String container) {
-        return NodeUtil.isStarted(this.controller, container);
+        this.stop(containers, SUSPEND_TIMEOUT_S);
     }
 
     /**
-     * @deprecated Use {@link AbstractClusteringTestCase#stop(String, int)} and {@link AbstractClusteringTestCase#stop(Set, int)} instead.
+     * Gracefully stops given container with a given suspend timeout.
      */
-    @Deprecated
-    protected void stop(int timeout, String... containers) {
-        stop(Set.of(containers), timeout);
-    }
-
-    protected void stop(String container, int timeout) {
-        NodeUtil.stop(this.controller, container, timeout);
-    }
-
-    protected void stop(Set<String> containers, int timeout) {
-        NodeUtil.stop(this.controller, containers, timeout);
+    protected void stop(String container, int suspendTimeout) {
+        NodeUtil.stop(this.controller, container, suspendTimeout);
     }
 
     /**
-     * @deprecated Use {@link AbstractClusteringTestCase#deploy(String)} and {@link AbstractClusteringTestCase#deploy(Set)} instead.
+     * Gracefully stops given set of containers with a given suspend timeout.
      */
-    @Deprecated
-    protected void deploy(String... deployments) {
-        deploy(Set.of(deployments));
+    protected void stop(Set<String> containers, int suspendTimeout) {
+        NodeUtil.stop(this.controller, containers, suspendTimeout);
     }
+
+    // Container deployment methods
 
     protected void deploy() {
         this.deploy(this.deployments);
@@ -266,14 +240,6 @@ public abstract class AbstractClusteringTestCase {
 
     protected void deploy(Set<String> deployments) {
         NodeUtil.deploy(this.deployer, deployments);
-    }
-
-    /**
-     * @deprecated Use {@link AbstractClusteringTestCase#undeploy(String)} and {@link AbstractClusteringTestCase#undeploy(Set)} instead.
-     */
-    @Deprecated
-    protected void undeploy(String... deployments) {
-        undeploy(Set.of(deployments));
     }
 
     protected void undeploy() {
@@ -297,18 +263,13 @@ public abstract class AbstractClusteringTestCase {
     }
 
     public static int getPortOffsetForNode(String node) {
-        switch (node) {
-            case NODE_1:
-                return 0;
-            case NODE_2:
-                return 100;
-            case NODE_3:
-                return 200;
-            case NODE_4:
-                return 300;
-            default:
-                throw new IllegalArgumentException();
-        }
+        return switch (node) {
+            case NODE_1 -> 0;
+            case NODE_2 -> 100;
+            case NODE_3 -> 200;
+            case NODE_4 -> 300;
+            default -> throw new IllegalArgumentException();
+        };
     }
 
     static Set<String> toDeployments(Set<String> containers) {
@@ -340,14 +301,14 @@ public abstract class AbstractClusteringTestCase {
 
         @Override
         public void stop(Set<String> containers) {
-            AbstractClusteringTestCase.this.stop(containers);
+            AbstractClusteringTestCase.this.stop(containers, 0);
         }
     }
 
     public class GracefulRestartLifecycle extends RestartLifecycle {
         @Override
         public void stop(Set<String> containers) {
-            AbstractClusteringTestCase.this.stop(containers, GRACEFUL_SHUTDOWN_TIMEOUT);
+            AbstractClusteringTestCase.this.stop(containers);
         }
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
@@ -158,7 +158,7 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             client.assertNoExceptions("at the beginning of the test");
 
             logger.debugf("------ Shutdown clusterA-node0 -----");
-            stop(NODE_1, GRACEFUL_SHUTDOWN_TIMEOUT);
+            stop(NODE_1);
             Thread.sleep(SERVER_DOWN_TIME);
             client.assertNoExceptions("after clusterA-node0 was shut down");
 
@@ -168,7 +168,7 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             client.assertNoExceptions("after clusterA-node0 was brought up");
 
             logger.debug("----- Shutdown clusterA-node1 -----");
-            stop(NODE_2, GRACEFUL_SHUTDOWN_TIMEOUT);
+            stop(NODE_2);
             Thread.sleep(SERVER_DOWN_TIME);
 
             logger.debug("------ Startup clusterA-node1 -----");
@@ -177,7 +177,7 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             client.assertNoExceptions("after clusterA-node1 was brought back up");
 
             logger.debug("----- Shutdown clusterB-node0 -----");
-            stop(NODE_3, GRACEFUL_SHUTDOWN_TIMEOUT);
+            stop(NODE_3);
             Thread.sleep(SERVER_DOWN_TIME);
             client.assertNoExceptions("after clusterB-node0 was shut down");
 
@@ -187,7 +187,7 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             client.assertNoExceptions("after clusterB-node0 was brought back up");
 
             logger.debug("----- Shutdown clusterB-node1 -----");
-            stop(NODE_4, GRACEFUL_SHUTDOWN_TIMEOUT);
+            stop(NODE_4);
             Thread.sleep(SERVER_DOWN_TIME);
 
             logger.debug("------ Startup clusterB-node1 -----");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
@@ -77,9 +77,9 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                     Thread.sleep(INVOCATION_WAIT);
                 }
 
-                for (String node : TWO_NODES) {
+                for (String node : NODE_1_2) {
                     int frequency = Collections.frequency(results, node);
-                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                    assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
                 }
 
                 undeploy(DEPLOYMENT_1);
@@ -104,9 +104,9 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                     Thread.sleep(INVOCATION_WAIT);
                 }
 
-                for (String node : TWO_NODES) {
+                for (String node : NODE_1_2) {
                     int frequency = Collections.frequency(results, node);
-                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                    assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
                 }
 
                 stop(NODE_2);
@@ -131,9 +131,9 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Abstrac
                     Thread.sleep(INVOCATION_WAIT);
                 }
 
-                for (String node : TWO_NODES) {
+                for (String node : NODE_1_2) {
                     int frequency = Collections.frequency(results, node);
-                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                    assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
                 }
             }
             return null;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientClusterNodeSelectorTestCase.java
@@ -74,7 +74,7 @@ public class ClientClusterNodeSelectorTestCase extends AbstractClusteringTestCas
     }
 
     public ClientClusterNodeSelectorTestCase() {
-        super(FOUR_NODES);
+        super(NODE_1_2_3_4);
     }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
@@ -51,7 +51,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
  * Test for WFLY-13871.
  * <p>
  * This test will set up an EJB client interacting with a cluster of two nodes and verify that when
- * one of the nodes is suspended, invovations no longer are sent to the suspended node; and that when the node is resumed,
+ * one of the nodes is suspended, invocations no longer are sent to the suspended node; and that when the node is resumed,
  * invocations return to the resumed node.
  *
  * @author Richard Achmatowicz
@@ -98,7 +98,7 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
     // time between invocations
     static final long INV_WAIT_DURATION_MSECS = 10;
     // time that the server remains suspended (or resumed) during continuous invocations
-    static final long SUSPEND_RESUME_DURATION_MSECS = 1 * 1000;
+    static final long SUSPEND_RESUME_DURATION_MSECS = 1000;
 
     // the set of nodes available, according to suspend/resume
     private final Set<String> nodesAvailable = new TreeSet<>(NODE_1_2);
@@ -127,12 +127,10 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
      * in the case that the proxy is created before the server is suspended.
      * <p>
      * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
-     *
-     * @throws Exception
      */
     @Test
     @InSequence(1)
-    public void testSuspendResumeAfterProxyInit() throws Exception {
+    public void testSuspendResumeAfterProxyInit() {
         LOGGER.info("testSuspendResumeAfterProxyInit() - start");
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             Heartbeat bean = directory.lookupStateless(HeartbeatBean.class, Heartbeat.class);
@@ -165,12 +163,10 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
      * in the case that the proxy is created after the server is suspended.
      * <p>
      * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
-     *
-     * @throws Exception
      */
     @Test
     @InSequence(2)
-    public void testSuspendResumeBeforeProxyInit() throws Exception {
+    public void testSuspendResumeBeforeProxyInit() {
         LOGGER.info("testSuspendResumeBeforeProxyInit() - start");
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
 
@@ -200,12 +196,10 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
      * in the case that the proxy is created after the server is suspended.
      * <p>
      * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
-     *
-     * @throws Exception
      */
     @Test
     @InSequence(3)
-    public void testSuspendResumeContinuous() throws Exception {
+    public void testSuspendResumeContinuous() {
         LOGGER.info("testSuspendResumeContinuous() - start");
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
 
@@ -268,7 +262,7 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
                     performInvocation(this.bean);
                 }
             } catch (Throwable e) {
-                LOGGER.info("ContinousInvoker: caught exception while performing invocation: e = " + e.getMessage());
+                LOGGER.info("ContinuousInvoker: caught exception while performing invocation: e = " + e.getMessage());
             }
         }
     }
@@ -355,7 +349,7 @@ public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
      * Check if a server is suspended by reading the server attribute "suspend-state"
      *
      * @param node the node to be checked
-     * @return true if the server is suspended
+     * @return server suspend state
      */
     private String getSuspendState(String node) throws IOException {
         ModelNode op = Util.createOperation("read-attribute", PathAddress.EMPTY_ADDRESS);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
@@ -111,7 +111,7 @@ public class TransactionalRemoteStatefulEJBFailoverTestCase extends AbstractClus
                 tx.rollback();
 
                 // TODO remove workaround for WFLY-12128
-                undeploy(TWO_DEPLOYMENTS);
+                undeploy(DEPLOYMENT_1_2);
                 ServerReload.executeReloadAndWaitForCompletion(client1);
                 ServerReload.executeReloadAndWaitForCompletion(client2);
                 // Workaround the above yielding "DeploymentException: Cannot deploy StatefulFailoverTestCase.war: WFLYCTL0379: System boot is in process; execution of remote management operations is not currently available"

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
@@ -70,8 +70,8 @@ import static org.junit.Assert.assertNull;
 @RunWith(Arquillian.class)
 public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase {
 
-    public LastNodeToLeaveRemoteEJBTestCase() throws Exception {
-        super(THREE_NODES);
+    public LastNodeToLeaveRemoteEJBTestCase() {
+        super(NODE_1_2_3);
     }
 
     static final Logger LOGGER = Logger.getLogger(LastNodeToLeaveRemoteEJBTestCase.class);
@@ -278,7 +278,7 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
      * can keep track of them.
      */
     private Set<String> getStartedNodes() {
-        List<String> nodes = Arrays.asList(THREE_NODES);
+        List<String> nodes = NODE_1_2_3.stream().toList();
         Set<String> startedNodes = new HashSet<>();
         for (String node : nodes) {
             if (isStarted(node)) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
@@ -47,13 +47,12 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNull;
 
 /**
  *
- * Tests the ability of the the RemoteEJBDiscoveryProvider to detect the condition when a last node left in a cluster has crashed
+ * Tests the ability of the RemoteEJBDiscoveryProvider to detect the condition when a last node left in a cluster has crashed
  * and to remove that cluster from the discovered node registry (DNR).
  * The condition is as follows: if we get a ConnectException when trying to connect to a node X in cluster Y, and the DNR shows
  * X as being the only member of Y, then remove cluster Y from the DNR.
@@ -106,11 +105,11 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
                 ;
     }
 
-    public class CustomClusterNodeSelector implements ClusterNodeSelector {
+    public static class CustomClusterNodeSelector implements ClusterNodeSelector {
         @Override
         public String selectNode(String clusterName, String[] connectedNodes, String[] totalAvailableNodes) {
-            Set<String> connectedNodesSet = Arrays.asList(connectedNodes).stream().collect(Collectors.toSet());
-            Set<String> totalNodesSet = Arrays.asList(totalAvailableNodes).stream().collect(Collectors.toSet());
+            Set<String> connectedNodesSet = new HashSet<>(Arrays.asList(connectedNodes));
+            Set<String> totalNodesSet = new HashSet<>(Arrays.asList(totalAvailableNodes));
             LOGGER.debugf("Calling ClusterNodeSelector.selectNode(%s,%s,%s)", clusterName, connectedNodesSet, totalNodesSet);
             return ClusterNodeSelector.DEFAULT.selectNode(clusterName, connectedNodes, totalAvailableNodes);
         }
@@ -278,9 +277,8 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
      * can keep track of them.
      */
     private Set<String> getStartedNodes() {
-        List<String> nodes = NODE_1_2_3.stream().toList();
         Set<String> startedNodes = new HashSet<>();
-        for (String node : nodes) {
+        for (String node : this.getContainers()) {
             if (isStarted(node)) {
                 startedNodes.add(node);
             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -120,14 +120,14 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends AbstractCl
                 deployer.undeploy(DEPLOYMENT_1);
                 deployer.undeploy(DEPLOYMENT_HELPER_1);
             } else {
-                stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_1);
+                stop(NODE_1);
             }
         } else {
             if (undeployOnly) {
                 deployer.undeploy(DEPLOYMENT_2);
                 deployer.undeploy(DEPLOYMENT_HELPER_2);
             } else {
-                stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_2);
+                stop(NODE_2);
             }
         }
         // invoke again

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -134,7 +134,7 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends AbstractCl
         CounterResult resultAfterShuttingDownANode = remoteCounter.increment();
         Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
         Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", totalCountBeforeShuttingDownANode + 1, resultAfterShuttingDownANode.getCount());
-        Assert.assertFalse("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName.equals(resultAfterShuttingDownANode.getNodeName()));
+        Assert.assertNotEquals("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName, resultAfterShuttingDownANode.getNodeName());
 
         // repeat invocations
         final int countBeforeDecrementing = resultAfterShuttingDownANode.getCount();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -176,7 +176,7 @@ public class RemoteStatelessFailoverTestCase {
             StatelessRemoteHome home = directory.lookupHome(StatelessBean.class, StatelessRemoteHome.class);
             StatelessRemote bean = home.create();
 
-            assertEquals("The only " + TWO_NODES[0] + " is active. Bean had to be invoked on it but it wasn't.", TWO_NODES[0], bean.getNodeName());
+            assertEquals("The only " + NODE_1 + " is active. Bean had to be invoked on it but it wasn't.", NODE_1, bean.getNodeName());
 
             this.start(NODE_2);
             this.deploy(NODE_2, deployment2);
@@ -187,9 +187,9 @@ public class RemoteStatelessFailoverTestCase {
                 this.undeploy(NODE_1, deployment1);
             }
 
-            assertEquals("Only " + TWO_NODES[1] + " is active. The bean had to be invoked on it but it wasn't.", TWO_NODES[1], bean.getNodeName());
+            assertEquals("Only " + NODE_2 + " is active. The bean had to be invoked on it but it wasn't.", NODE_2, bean.getNodeName());
         } finally {
-            // need to have the container started to undeploy deployment afterwards
+            // need to have the container started to undeploy deployment afterward
             this.start(NODE_1);
             // shutdown the containers
             undeployAll();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jms/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jms/ClusteredMessagingTestCase.java
@@ -12,6 +12,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
@@ -52,7 +53,7 @@ public class ClusteredMessagingTestCase extends AbstractClusteringTestCase {
     private static final String jmsTopicLookup = "jms/" + jmsTopicName;
 
     public ClusteredMessagingTestCase() {
-        super(TWO_NODES, new String[] {});
+        super(NODE_1_2, Set.of());
     }
 
     protected static ModelControllerClient createClient1() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/custom/ClusteredJPA2LCCustomRegionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/custom/ClusteredJPA2LCCustomRegionTestCase.java
@@ -285,7 +285,7 @@ public class ClusteredJPA2LCCustomRegionTestCase extends AbstractClusteringTestC
 
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
-            this.builder.node(TWO_NODES)
+            this.builder.node(NODE_1_2.toArray(new String[0]))
                     .setup("/subsystem=infinispan/cache-container=hibernate/replicated-cache=entity-replicated-template:add()")
                     .teardown("/subsystem=infinispan/cache-container=hibernate/replicated-cache=entity-replicated-template:remove()")
                     ;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
@@ -117,7 +117,7 @@ public class SingletonPartitionTestCase extends AbstractClusteringTestCase {
         checkSingletonNode(baseURL2, SingletonServiceActivator.SERVICE_B_NAME, SingletonServiceActivator.SERVICE_B_PREFERRED_NODE);
 
 
-        // 2. Simulate network partition; each having it's own provider
+        // 2. Simulate network partition; each having its own provider
 
         partition(true, baseURL1, baseURL2);
         waitForView(baseURL1, Set.of(NODE_1));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ElytronSSOServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ElytronSSOServerSetupTask.java
@@ -14,7 +14,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
 public class ElytronSSOServerSetupTask extends CLIServerSetupTask {
     public ElytronSSOServerSetupTask() {
 
-        NodeBuilder nb = this.builder.node(AbstractClusteringTestCase.TWO_NODES)
+        NodeBuilder nb = this.builder.node(AbstractClusteringTestCase.NODE_1_2.toArray(new String[0]))
                 .setup("/subsystem=elytron/filesystem-realm=sso:add(path=sso-realm, relative-to=jboss.server.data.dir)")
                 .setup("/subsystem=elytron/security-domain=sso:add(default-realm=sso, permission-mapper=default-permission-mapper,realms=[{realm=sso, role-decoder=groups-to-roles}])");
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/IdentityServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/IdentityServerSetupTask.java
@@ -14,7 +14,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
 
 public class IdentityServerSetupTask extends CLIServerSetupTask {
     public IdentityServerSetupTask() {
-        this.builder.node(AbstractClusteringTestCase.TWO_NODES)
+        this.builder.node(AbstractClusteringTestCase.NODE_1_2.toArray(new String[0]))
                 .setup("/subsystem=elytron/filesystem-realm=sso:add-identity(identity=user1)")
                 .setup("/subsystem=elytron/filesystem-realm=sso:add-identity-attribute(identity=user1, name=groups, value=[Users])")
                 .setup("/subsystem=elytron/filesystem-realm=sso:set-password(identity=user1, clear={password=password1})")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/InfinispanServerSetupTask.java
@@ -18,7 +18,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
  */
 public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
-        this.builder.node(AbstractClusteringTestCase.TWO_NODES)
+        this.builder.node(AbstractClusteringTestCase.NODE_1_2.toArray(new String[0]))
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
                 .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, marshaller=PROTOSTREAM, modules=[org.wildfly.clustering.web.hotrod], properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s})", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD)
                 .setup("/subsystem=infinispan/remote-cache-container=sso/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/RemoteElytronSingleSignOnTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/remote/RemoteElytronSingleSignOnTestCase.java
@@ -48,7 +48,7 @@ public class RemoteElytronSingleSignOnTestCase extends AbstractSingleSignOnTestC
 
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
-            this.builder.node(TWO_NODES)
+            this.builder.node(NODE_1_2.toArray(new String[0]))
                     .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=other:add(remote-cache-container=sso, cache-configuration=default)")
                     .teardown("/subsystem=distributable-web/hotrod-single-sign-on-management=other:remove")
             ;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractSessionActivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractSessionActivationTestCase.java
@@ -38,7 +38,7 @@ public abstract class AbstractSessionActivationTestCase extends AbstractClusteri
     private final boolean transactional;
 
     protected AbstractSessionActivationTestCase(boolean transactional) {
-        super(THREE_NODES);
+        super(NODE_1_2_3);
         this.transactional = transactional;
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/EnableUndertowStatisticsSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/EnableUndertowStatisticsSetupTask.java
@@ -15,7 +15,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
 public class EnableUndertowStatisticsSetupTask extends CLIServerSetupTask {
 
     public EnableUndertowStatisticsSetupTask() {
-        this.builder.node(AbstractClusteringTestCase.FOUR_NODES)
+        this.builder.node(AbstractClusteringTestCase.NODE_1_2_3_4.toArray(new String[0]))
                 .setup("/subsystem=undertow:write-attribute(name=statistics-enabled, value=true)")
                 .teardown("/subsystem=undertow:undefine-attribute(name=statistics-enabled)")
                 ;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonTransactionalSessionServerSetup.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonTransactionalSessionServerSetup.java
@@ -5,7 +5,8 @@
 
 package org.jboss.as.test.clustering.cluster.web;
 
-import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.NODE_1_2_3;
+
 import org.jboss.as.test.shared.CLIServerSetupTask;
 
 /**
@@ -13,7 +14,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
  */
 public class NonTransactionalSessionServerSetup extends CLIServerSetupTask {
     public NonTransactionalSessionServerSetup() {
-        this.builder.node(AbstractClusteringTestCase.THREE_NODES)
+        this.builder.node(NODE_1_2_3.toArray(new String[0]))
                 .setup("/subsystem=infinispan/cache-container=web/distributed-cache=concurrent:add()")
                 .setup("/subsystem=infinispan/cache-container=web/distributed-cache=concurrent/store=file:add(passivation=true, purge=true)")
                 .teardown("/subsystem=infinispan/cache-container=web/distributed-cache=concurrent:remove()")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
@@ -102,7 +102,7 @@ public class AsyncServletTestCase extends AbstractClusteringTestCase {
 
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
-            this.builder.node(AbstractClusteringTestCase.THREE_NODES)
+            this.builder.node(NODE_1_2_3.toArray(new String[0]))
                     .setup("/subsystem=distributable-web/infinispan-session-management=attribute:add(cache-container=web, granularity=ATTRIBUTE)")
                     .teardown("/subsystem=distributable-web/infinispan-session-management=attribute:remove()")
             ;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -9,8 +9,8 @@ import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.IN
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_APPLICATION_USER;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_ADDRESS;
 import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.INFINISPAN_SERVER_PORT;
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.NODE_1_2_3;
 
-import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.shared.CLIServerSetupTask;
 
 /**
@@ -19,7 +19,7 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
  */
 public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
-        this.builder.node(AbstractClusteringTestCase.THREE_NODES)
+        this.builder.node(NODE_1_2_3.toArray(new String[0]))
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=%d,host=%s)", INFINISPAN_SERVER_PORT, INFINISPAN_SERVER_ADDRESS)
                 .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, tcp-keep-alive=true, marshaller=PROTOSTREAM, modules=[org.wildfly.clustering.web.hotrod], properties={infinispan.client.hotrod.auth_username=%s, infinispan.client.hotrod.auth_password=%s}, statistics-enabled=true)", INFINISPAN_APPLICATION_USER, INFINISPAN_APPLICATION_PASSWORD)
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/NonHaWebSessionPersistenceTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -88,11 +89,11 @@ public class NonHaWebSessionPersistenceTestCase {
             try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
-                Assert.assertFalse(Boolean.valueOf(response.getFirstHeader("serialized").getValue()));
+                Assert.assertFalse(Boolean.parseBoolean(response.getFirstHeader("serialized").getValue()));
                 Assert.assertEquals(sessionId, response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             }
 
-            NodeUtil.stop(this.controller, CONTAINER_SINGLE);
+            NodeUtil.stop(this.controller, CONTAINER_SINGLE, AbstractClusteringTestCase.SUSPEND_TIMEOUT_S);
             NodeUtil.start(this.controller, CONTAINER_SINGLE);
             if (isBootableJar()) {
                 NodeUtil.deploy(this.deployer, DEPLOYMENT_1);
@@ -102,7 +103,7 @@ public class NonHaWebSessionPersistenceTestCase {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session passivation was configured but session was lost after restart.",
                         3, Integer.parseInt(response.getFirstHeader("value").getValue()));
-                Assert.assertTrue(Boolean.valueOf(response.getFirstHeader("serialized").getValue()));
+                Assert.assertTrue(Boolean.parseBoolean(response.getFirstHeader("serialized").getValue()));
                 Assert.assertEquals(sessionId, response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             }
 

--- a/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-bootable.xml
@@ -16,7 +16,7 @@
         <configuration>
             <property name="installDir">${install.dir.1}</property>
             <property name="jarFile">${bootable.jar}</property>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
@@ -30,7 +30,7 @@
         <configuration>
             <property name="installDir">${install.dir.1}</property>
             <property name="jarFile">${bootable.jar}</property>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
@@ -46,7 +46,7 @@
                 <property name="installDir">${install.dir.1}</property>
                 <property name="jarFile">${bootable.jar}</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
@@ -60,7 +60,7 @@
             <configuration>
                 <property name="installDir">${install.dir.2}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
@@ -73,7 +73,7 @@
             <configuration>
                 <property name="installDir">${install.dir.3}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node2}</property>
@@ -86,7 +86,7 @@
             <configuration>
                 <property name="installDir">${install.dir.4}</property>
                 <property name="jarFile">${bootable.jar}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-byteman.xml
@@ -15,7 +15,7 @@
     <container qualifier="single">
         <configuration>
             <property name="jbossHome">${basedir}/target/wildfly-1</property>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
@@ -30,7 +30,7 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-1</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
@@ -43,7 +43,7 @@
         <container qualifier="node-2" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-2</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/wildfly-2 -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/wildfly-2 -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
@@ -55,7 +55,7 @@
         <container qualifier="node-3" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-3</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/wildfly-3 -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/wildfly-3 -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
@@ -67,7 +67,7 @@
         <container qualifier="node-4" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-4</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/wildfly-4 -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/wildfly-4 -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
@@ -80,7 +80,7 @@
         <container qualifier="node-non-ha" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/wildfly-1</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">standalone.xml</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>

--- a/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian-testable.xml
@@ -14,7 +14,7 @@
 
     <container qualifier="default" default="true">
         <configuration>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/wildfly-1 -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="jbossHome">${basedir}/target/wildfly-1</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/clustering/src/test/resources/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/resources/arquillian.xml
@@ -15,7 +15,7 @@
     <container qualifier="single">
         <configuration>
             <property name="jbossHome">${basedir}/target/${wildfly1}</property>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
@@ -29,7 +29,7 @@
     <container qualifier="node-non-ha" mode="manual">
         <configuration>
             <property name="jbossHome">${basedir}/target/${wildfly1}</property>
-            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+            <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
@@ -45,7 +45,7 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly1}</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-1</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node1} -Djboss.inst=${basedir}/target/${wildfly1} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.node.name=node-1</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
@@ -59,7 +59,7 @@
         <container qualifier="node-2" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly2}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/${wildfly2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node2} -Djboss.inst=${basedir}/target/${wildfly2} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.private=${node1} -Djboss.node.name=node-2 -Djboss.socket.binding.port-offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
@@ -72,7 +72,7 @@
         <container qualifier="node-3" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly3}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/${wildfly3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node3} -Djboss.inst=${basedir}/target/${wildfly3} -Djboss.bind.address=${node2} -Djboss.bind.address.management=${node2} -Djboss.bind.address.private=${node2} -Djboss.node.name=node-3 -Djboss.socket.binding.port-offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
@@ -85,7 +85,7 @@
         <container qualifier="node-4" mode="custom">
             <configuration>
                 <property name="jbossHome">${basedir}/target/${wildfly4}</property>
-                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/${wildfly4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.default.multicast.address=${mcast} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
+                <property name="javaVmArguments">${server.jvm.args} ${surefire.jpda.args.node4} -Djboss.inst=${basedir}/target/${wildfly4} -Djboss.bind.address=${node3} -Djboss.bind.address.management=${node3} -Djboss.bind.address.private=${node3} -Djboss.node.name=node-4 -Djboss.socket.binding.port-offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21130 Clustering testsuite: nodes are not being shutdown gracefully
https://issues.redhat.com/browse/WFLY-21083 Continued intermittent failures in JSFFailoverTestCase / ProtoStreamJSFFailoverTestCase
https://issues.redhat.com/browse/WFLY-21129 Clustering testsuite: remove unused multicast configuration options

WFLY-21130 Clustering testsuite: nodes are not being shutdown gracefully
- Make stop(..) be graceful by default and immediate shutdown without waiting be opt-in.
- Fix tests that are not using graceful shutdown to explicity do (i.e. NonHA-variants).
- Remove deprecated methods and replace usage.
- Code cleanup.