### PR TITLE
WFLY-21156 Create clustering test case for creating a custom DefaultCacheManager (not using WF's manager), configured from an XML file and containing a <file-store>

### DIFF
--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Overview.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Overview.adoc
@@ -155,12 +155,16 @@ There are maven profiles that might come in handy for testing:
 * `ts.clustering.cluster.fullha.profile` runs tests which require `standalone-full-ha.xml` profile; e.g. tests requiring JMS subsystem
 * `ts.clustering.cluster.ha-infinispan-server.profile` runs tests against `standalone-ha.xml` profile with Infinispan Server provisioned via `@ClassRule`
 * `ts.clustering.single.profile` runs clustering tests that are using a non-HA server profile
+* `ts.clustering.single.testable.profile` runs clustering tests that use `testable=true` deployments
 * `ts.clustering.byteman.profile` runs clustering tests that require installation of byteman rules
 
 For instance, to only run tests that run against full-ha profile, activate clustering tests with `-Dts.clustering` and exclude
 the other profiles with `-P`:
 
-    $ ./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P \!ts.clustering.cluster.ha.profile,\!ts.clustering.single.profile,\!ts.clustering.byteman.profile
+[source,shell]
+----
+mvn -f testsuite/integration/clustering/pom.xml clean install -P"-ts.clustering.cluster.ha.profile,-ts.clustering.cluster.fullha.profile,-ts.clustering.cluster.ha-infinispan-server.profile,-ts.clustering.single.profile,-ts.clustering.byteman.profile"
+----
 
 If the testsuite can be run on multiple runners in parallel, the main execution (which takes the majority of the execution time)
 can be split by packages using `-Dts.surefire.clustering.ha.additionalExcludes` property.
@@ -170,11 +174,17 @@ The sub-packages at the time of writing are `affinity`, `cdi`, `dispatcher`, `ej
 For instance, to parallelize testsuite execution on two machines (e.g. when using GitHub actions scripting or alike) the following commands
 could be used to split the clustering tests into two executions of similar execution time, the first node can run the first half of the tests in sub-packages, e.g.:
 
-    $ ./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.fullha.profile,-ts.clustering.cluster.ha-infinispan-server.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dts.surefire.clustering.ha.additionalExcludes=affinity\|cdi\|dispatcher\|ejb\|ejb2\|group\|jms\|jpa
+[source,shell]
+----
+./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.fullha.profile,-ts.clustering.cluster.ha-infinispan-server.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dts.surefire.clustering.ha.additionalExcludes=affinity\|cdi\|dispatcher\|ejb\|ejb2\|group\|jms\|jpa
+----
 
 while another node can concurrently run all the other profiles and the other half of sub-packages:
 
-    $ ./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -Dts.surefire.clustering.ha.additionalExcludes=jsf\|provider\|registry\|singleton\|sso\|web\|xsite
+[source,shell]
+----
+./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -Dts.surefire.clustering.ha.additionalExcludes=jsf\|provider\|registry\|singleton\|sso\|web\|xsite
+----
 
 If the test packages get out of sync with the excludes this will result in a test running multiple times, rather than tests being omitted.
 
@@ -185,7 +195,10 @@ section of the surefire maven plugin execution. So, in case of the clustering te
 to, needs to be specified as well. For instance, to run a single test from the 'single' test execution, exclude the other
 test profiles:
 
-    $ ./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.ha.profile,-ts.clustering.cluster.fullha.profile,-ts.clustering.cluster.ha-infinispan-server.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dtest=org.jboss.as.test.clustering.single.dispatcher.CommandDispatcherTestCase
+[source,shell]
+----
+./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.ha.profile,-ts.clustering.cluster.fullha.profile,-ts.clustering.cluster.ha-infinispan-server.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dtest=org.jboss.as.test.clustering.single.dispatcher.CommandDispatcherTestCase
+----
 
 === Running Infinispan Server tests against custom distribution
 
@@ -193,7 +206,10 @@ To run the Infinispan Server-based tests against a custom distribution, a custom
 and `-Dinfinispan.server.profile.override=infinispan-13.0.xml` to use a corresponding server profile.
 The distribution is then copied over to the build directories and patched with user credentials.
 
-    $ ./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.ha.profile,-ts.clustering.cluster.fullha.profile,-ts.clustering.single.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dinfinispan.server.home.override=/Users/rhusar/Downloads/redhat-datagrid-8.3.0-server
+[source,shell]
+----
+./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -P="-ts.clustering.cluster.ha.profile,-ts.clustering.cluster.fullha.profile,-ts.clustering.single.profile,-ts.clustering.byteman.profile,-ts.clustering.single.profile" -Dinfinispan.server.home.override=/Users/rhusar/Downloads/redhat-datagrid-8.3.0-server
+----
 
 Should it be required, the Infinispan Server driver version can be also overridden by `-Dversion.org.infinispan.server.driver=13.0.0.Dev03`.
 

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -1111,7 +1111,9 @@
                                         <include>org/jboss/as/test/clustering/single/**/*TestCase.java</include>
                                     </includes>
                                     <excludes>
-                                        <exclude>org/jboss/as/test/clustering/single/infinispan/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/clustering/single/infinispan/InfinispanModulesTestSuite.java</exclude>
+                                        <exclude>org/jboss/as/test/clustering/single/infinispan/cdi/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/clustering/single/infinispan/query/**/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/clustering/single/web/NonHaWebSessionPersistenceTestCase.java</exclude>
                                     </excludes>
                                     <systemPropertyVariables combine.children="append">

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/InfinispanXMLConfigurationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/InfinispanXMLConfigurationTestCase.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.clustering.single.infinispan.xml;
+
+import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
+
+import java.io.FilePermission;
+import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.PropertyPermission;
+import javax.management.MBeanServerPermission;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.single.infinispan.xml.deployment.InfinispanXMLConfigurationServlet;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that Infinispan can be configured via an infinispan.xml file packaged directly in WEB-INF/classes.
+ *
+ * @author Radoslav Husar
+ * @see <a href="https://issues.redhat.com/browse/WFLY-21156">WFLY-21156</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class InfinispanXMLConfigurationTestCase {
+
+    private static final String MODULE_NAME = InfinispanXMLConfigurationTestCase.class.getSimpleName();
+
+
+    @Deployment(testable = false)
+    public static Archive<?> deployment() {
+        return ShrinkWrap
+                .create(WebArchive.class, MODULE_NAME + ".war")
+                .addPackage(InfinispanXMLConfigurationServlet.class.getPackage())
+                .addAsResource(InfinispanXMLConfigurationServlet.class.getPackage(), "infinispan.xml", "infinispan.xml")
+                .setWebXML(SimpleServlet.class.getPackage(), "web.xml")
+                .setManifest(new StringAsset(Descriptors.create(ManifestDescriptor.class).attribute("Dependencies", "org.infinispan").exportAsString()))
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        // n.b. Infinispan swallows this exception when parsing the XML configuration file and fails cryptically if permission is missing
+                        new FilePermission("<<ALL FILES>>", "read,write,delete"),
+                        new MBeanServerPermission("findMBeanServer"),
+                        new PropertyPermission("*", "read,write"),
+                        new ReflectPermission("suppressAccessChecks"),
+                        new RuntimePermission("accessDeclaredMembers"),
+                        new RuntimePermission("getClassLoader"),
+                        new RuntimePermission("setContextClassLoader")
+                ), "permissions.xml");
+    }
+
+    @Test
+    public void testInfinispanXmlConfiguration(@ArquillianResource URL baseURL) throws IOException, URISyntaxException {
+        URI uri = InfinispanXMLConfigurationServlet.createURI(baseURL);
+
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
+            HttpResponse response = client.execute(new HttpGet(uri));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                String content = EntityUtils.toString(response.getEntity()).trim();
+                Assert.assertEquals("", content);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/deployment/InfinispanXMLConfigurationServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/deployment/InfinispanXMLConfigurationServlet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.single.infinispan.xml.deployment;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * @author Radoslav Husar
+ */
+@WebServlet(urlPatterns = {InfinispanXMLConfigurationServlet.SERVLET_PATH})
+public class InfinispanXMLConfigurationServlet extends HttpServlet {
+
+    @Serial
+    private static final long serialVersionUID = 4455812466698420161L;
+    private static final String SERVLET_NAME = "xml";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+
+    public static URI createURI(URL baseURL) throws URISyntaxException {
+        return baseURL.toURI().resolve(SERVLET_NAME);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        new DefaultCacheManager("infinispan.xml").stop();
+    }
+
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/deployment/infinispan.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/infinispan/xml/deployment/infinispan.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:infinispan:config:15.2 https://infinispan.org/schemas/infinispan-config-15.2.xsd"
+            xmlns="urn:infinispan:config:15.2">
+    <cache-container name="test" default-cache="test">
+        <local-cache name="test">
+            <persistence>
+                <file-store path="target/infinispan-xml-test-case"/>
+            </persistence>
+        </local-cache>
+    </cache-container>
+</infinispan>
+


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21156

The primary intention of this test (apart from detecting future regressions) is to be backported downstream. 