### PR TITLE
WFLY-20824 Description in the XSD of attribute segmented for infinispan file-store is wrong

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -205,7 +205,7 @@ infinispan.store.fetch-state=If true, fetch persistent state when joining a clus
 infinispan.store.fetch-state.deprecated=Deprecated. Persistent state will always be fetched if store is not shared.
 infinispan.store.purge=If true, purges this cache store when it starts up.
 infinispan.store.max-batch-size=The maximum size of a batch to be inserted/deleted from the store. If the value is less than one, then no upper limit is placed on the number of operations in a batch.
-infinispan.store.segmented=Indicates whether or not this cache store should be segment aware.
+infinispan.store.segmented=Indicates whether or not the cache store is segmented. The number of segments is defined by the segments attribute of the associated cache resource.
 infinispan.store.properties=A list of cache store properties.
 infinispan.store.write=The write behavior of the cache store.
 

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_14_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_14_0.xsd
@@ -504,7 +504,7 @@
         </xs:attribute>
         <xs:attribute name="segmented" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
+                <xs:documentation>Indicates whether or not the cache store is segmented. The number of segments is defined by the segments attribute of the associated cache resource.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_15_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_15_0.xsd
@@ -504,7 +504,7 @@
         </xs:attribute>
         <xs:attribute name="segmented" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
+                <xs:documentation>Indicates whether or not the cache store is segmented. The number of segments is defined by the segments attribute of the associated cache resource.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
@@ -374,6 +374,10 @@ purge::
     Indicates whether the cache store should be purged on cache start.
     Purge should never be enabled on a shared store.
     Default is true.
+segmented::
+    Indicates whether or not the cache store is segmented.
+    The number of segments is defined by the segments attribute of the associated cache resource.
+    Default is true.
 shared::
     Indicates that the same cache store endpoint (e.g. database, data grid, etc.) is used by all members of the cluster.
     When using a shared cache store, cache entries are only persisted by the primary owner of a given cache entry.


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-20824

Replacement of original https://github.com/wildfly/wildfly/pull/19108 with more wording cleanup, XSD fixes and rebase.