### PR TITLE
WFLY-21191 Overhaul README.md at the root of the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,63 @@
 # Contributing guide
 
-**First of all, thank you for taking the time to contribute to WildFly!** The below contents will help you through the steps for getting started with WildFly. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions.
+**First of all, thank you for taking the time to contribute to WildFly!**
+The below contents will help you through the steps for getting started with WildFly.
+Please make sure to read the relevant section before making your contribution.
+It will make it a lot easier for us maintainers and smooth out the experience for all involved.
+The community looks forward to your contributions.
 
-* Git Setup: https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_hacking/github_setup.adoc
+* Git setup: https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_hacking/github_setup.adoc
 * Contributing: https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_hacking/contributing.adoc
 * Pull request standard: https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_hacking/pullrequest_standards.adoc
 
-If you like our project, but just don’t have time to contribute, that’s fine. There are other easy ways to support the project and show your appreciation.
+[//]: # ( TODO Replace these links with published version of the documents once we do publish it with a permalink)
+
+If you like our project, but just don’t have time to contribute, that’s fine.
+There are other easy ways to support the project and show your appreciation.
 
 * Mention the project at local meetups and tell your friends/colleagues.
-* Tweet about it and also check out our [twitter page](https://twitter.com/WildFlyAS) and [mastodon page](https://fosstodon.org/@wildflyas).
-* Check out our [youtube](https://www.youtube.com/@WildFlyAS) contents.
+* Post about it and also check out our [X.com (Twitter) page](https://x.com/WildFlyAS) and [Mastodon page](https://fosstodon.org/@wildflyas).
+* Check out our [YouTube](https://www.youtube.com/@WildFlyAS) videos.
 
 # Issues
 
 ---
 
-WildFly uses JIRA to manage issues. All issues can be found [here](https://issues.redhat.com/projects/WFLY/issues/).
+WildFly uses Jira to manage issues.
+All issues can be found [here](https://issues.redhat.com/projects/WFLY/issues/).
 
-To create a new issue, comment on an existing issue, or assign an issue to yourself, you'll need to first [create a JIRA account](https://issues.redhat.com/).
+To create a new issue, comment on an existing issue, or assign an issue to yourself, you'll need to first [create a Jira account](https://issues.redhat.com/).
 
 # Good First Issues
 
 ---
 
-Check out our issues with the `good-first-issue` label. These are a triaged set of issues that are great for getting started on our project. These can be found [here](https://issues.redhat.com/issues/?filter=12403174).
+Check out our issues with the `good-first-issue` label.
+These are a triaged set of issues that are great for getting started on our project.
+These can be found [here](https://issues.redhat.com/issues/?filter=12403174).
 
-Once you have selected an issue you'd like to work on, make sure it's not already assigned to someone else. To assign an issue to yourself, simply click on "Start Progress". This will automatically assign the issue to you. If you're not able to assign it to yourself that way, post a message in the [wildfly-developers Zulip stream](https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers) and someone will help get it assigned to you.
+Once you have selected an issue you'd like to work on, make sure it's not already assigned to someone else.
+To assign an issue to yourself, simply click on "Start Progress".
+This will automatically assign the issue to you.
+If you're not able to assign it to yourself that way, post a message in the [wildfly-developers Zulip stream](https://wildfly.zulipchat.com/#narrow/stream/174184-wildfly-developers) and someone will help get it assigned to you.
 
-Lastly, this project is an open source project. Please act responsibly, be nice, polite and enjoy!
+Lastly, this project is an open source project.
+Please act responsibly, be nice, polite and enjoy!
+
+---
+
+# Using Eclipse
+
+1. Install the latest version of eclipse
+2. Make sure Xmx in eclipse.ini is at least 1280M, and it's using JDK 17
+3. Launch eclipse and install the m2e plugin, make sure it uses your repo configs
+   (get it from: http://www.eclipse.org/m2e/
+   or install "Maven Integration for Eclipse" from the Eclipse Marketplace)
+4. In eclipse preferences Java->Compiler->Errors/Warnings->Deprecated and restricted
+   set forbidden reference to WARNING
+5. In eclipse preferences Java->Code Style, import the cleanup, templates, and
+   formatter configs in [ide-configs/eclipse](https://github.com/wildfly/wildfly-core/tree/main/ide-configs) in the wildfly-core repository.
+6. In eclipse preferences Java->Editor->Save Actions enable "Additional Actions",
+   and deselect all actions except for "Remove trailing whitespace"
+7. Use import on the root pom, which will pull in all modules
+8. Wait (m2e takes a while on initial import)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing guide
 
 **First of all, thank you for taking the time to contribute to WildFly!**
-The below contents will help you through the steps for getting started with WildFly.
+The contents below will help you through the steps for getting started with WildFly.
 Please make sure to read the relevant section before making your contribution.
 It will make it a lot easier for us maintainers and smooth out the experience for all involved.
 The community looks forward to your contributions.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <p align="center">
   <a href="https://wildfly.org">
-      <img src="logo/wildfly_logo.svg" alt="wildfly logo" title="wildlfy" width="600"/>
+      <img src="logo/wildfly_logo.svg" alt="wildfly logo" title="WildFly" width="600"/>
   </a>
 </p>
 
-WildFly Application Server
-========================
+# WildFly Application Server
 https://wildfly.org
 
 * Fast Startup
@@ -15,8 +14,11 @@ https://wildfly.org
 
 And of course Jakarta EE and MicroProfile!
 
-Building
--------------------
+# Documentation
+
+* https://docs.wildfly.org/
+
+# Building
 
 Prerequisites:
 
@@ -38,12 +40,11 @@ On Windows
 
     mvnw install
 
+# Starting and Stopping WildFly
 
-Starting and Stopping WildFly
-------------------------------------------
 Change to the bin directory after a successful build
 
-$ cd build/target/wildfly-\[version\]/bin
+    $ cd build/target/wildfly-\[version\]/bin
 
 Start the server in domain mode
 
@@ -59,17 +60,7 @@ To stop the server, press Ctrl + C, or use the admin console
 
 Check 'Getting Started Guide' in the WildFly documentation for more information about how to start and stop WildFly.
 
-Documentation
-------------------------------------------
-
-* https://docs.wildfly.org/
-
-Contributing
-------------------
-Please see the instructions available in the [contribution guide](CONTRIBUTING.md).
-
-Build vs. Dist directories
---------------------------
+# `build` vs. `dist` directories
 
 After running `mvn install`, WildFly will be available in two distinct directories, `build` and `dist`.
 
@@ -80,16 +71,7 @@ Using the `build` directory makes iterating with subsystem or module development
 
 The `dist` directory is better suited when a full build of WildFly is needed for development or test purposes.
 
-Running the Testsuite
---------------------
-The testsuite module contains several submodules including the following:
-
-* "smoke" -- core tests that should be run as part of every build of the AS. Failures here will fail the build.
-* "api" -- tests of features that involve end user use of the public JBoss AS 8 API. Should be run with no failures before any major commits.
-* "cluster" -- tests of the WildFly HA clustering features. Should be run with no failures before any major commits.
-* "domain" -- tests of the domain management features. Should be run with no failures before any major commits.
-* "integration" -- tests of a WildFly standalone server's internals. Should be run with no failures before any major commits.
-* "spec" -- tests of features that only involve end user use of the Jakarta EE spec APIs. Should be run with no failures before any major commits.
+# Running the Testsuite
 
 For basic smoke tests, simply: `mvn test`
 
@@ -97,23 +79,17 @@ To run all the tests
 
     mvn install -DallTests
 
-Using Eclipse
--------------
-1. Install the latest version of eclipse
-2. Make sure Xmx in eclipse.ini is at least 1280M, and it's using JDK 17
-3. Launch eclipse and install the m2e plugin, make sure it uses your repo configs
-   (get it from: http://www.eclipse.org/m2e/
-   or install "Maven Integration for Eclipse" from the Eclipse Marketplace)
-4. In eclipse preferences Java->Compiler->Errors/Warnings->Deprecated and restricted
-   set forbidden reference to WARNING
-5. In eclipse preferences Java->Code Style, import the cleanup, templates, and
-   formatter configs in [ide-configs/eclipse](https://github.com/wildfly/wildfly-core/tree/main/ide-configs) in the wildfly-core repository.
-6. In eclipse preferences Java->Editor->Save Actions enable "Additional Actions",
-   and deselect all actions except for "Remove trailing whitespace"
-7. Use import on the root pom, which will pull in all modules
-8. Wait (m2e takes a while on initial import)
+The testsuite module contains several submodules which can be run individually as needed to speed up development.
+Refer to our documentation section that describes the testsuite in details.
 
-License
--------
+https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+
+[//]: # ( TODO Replace this link with published version of the document section once we do publish it with a permalink)
+
+# Contributing
+
+Please see the instructions available in the [contributing guide](CONTRIBUTING.md).
+
+# License
+
 * [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-


### PR DESCRIPTION
* remove outdated testsuite section and replace it with links to documentation proper (which is still somewhat out of date, but more on that later in the next PR)
* fix spelling of the WildFly project name in image alt description
* fix name of the contribution guide to contributing guide
* reorder sections by importance and relevance
* replace legacy markdown title notation with proper one
* move Eclipse information to contributing guide
* use single sentence per SCM line
* fix code blocks not rendered as code blocks
* fix linked services names
* fix legacy services URLs

Resolves
https://issues.redhat.com/browse/WFLY-21191
