### PR TITLE
WFLY-21199 - Upgrade SmallRye-OpenTelemetry to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
         <version.io.smallrye.smallrye-mutiny>2.8.0</version.io.smallrye.smallrye-mutiny>
         <version.io.smallrye.smallrye-mutiny-vertx>3.17.1</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.1</version.io.smallrye.smallrye-mutiny-zero>
-        <version.io.smallrye.smallrye-opentelemetry>2.10.1</version.io.smallrye.smallrye-opentelemetry>
+        <version.io.smallrye.smallrye-opentelemetry>2.11.0</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.30.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>

--- a/testsuite/integration/expansion/pom.xml
+++ b/testsuite/integration/expansion/pom.xml
@@ -220,7 +220,7 @@
             <scope>test</scope>
         </dependency>
         <!--
-            smallrye-reactive-messaging-kafka-test-companion doesn't pull in the kafka server dependencies
+            smallrye-reactive-messaging-kafka-test-companion doesn't pull in the kafka server dependencies,
             so we need to add them here
         -->
         <dependency>

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -6,7 +6,13 @@
 package org.wildfly.test.integration.observability.opentelemetry;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 import org.arquillian.testcontainers.api.Testcontainer;
 import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.junit.Arquillian;
@@ -17,6 +23,7 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerResponse;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.JaxRsActivator;
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelMetricResource;
@@ -49,5 +56,15 @@ public abstract class BaseOpenTelemetryTest {
 
     protected String getDeploymentUrl(String deploymentName) throws MalformedURLException {
         return TestSuiteEnvironment.getHttpUrl() + "/" + deploymentName + "/";
+    }
+
+    protected void makeRequests(URL url, int count, int expectedStatus) throws URISyntaxException {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(url.toURI());
+            for (int i = 0; i < count; i++) {
+                Response response = target.request().get();
+                Assert.assertEquals(expectedStatus, response.getStatus());
+            }
+        }
     }
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryLogsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryLogsTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.test.integration.observability.opentelemetry;
+
+import java.net.URL;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+
+@RunAsClient
+@ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
+public class OpenTelemetryLogsTestCase extends BaseOpenTelemetryTest {
+    private static final String DEPLOYMENT_NAME = "otel-logs-test";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static Archive<?> getDeployment() {
+        return buildBaseArchive(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void testLogs() throws Exception {
+        makeRequests(new URL(url, "logging/hello"), 1, Response.noContent().build().getStatus());
+
+        String expectedLogEntry = "This is a test message: hello";
+        otelCollector.assertOpenTelemetryLogs(logEntries ->
+                Assert.assertTrue("Missing log entry: '" + expectedLogEntry + "'",
+                        logEntries.stream().anyMatch(entry ->
+                                entry.body().contains(expectedLogEntry))));
+    }
+}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/application/OtelService1.java
@@ -14,6 +14,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Client;
@@ -21,10 +22,13 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import org.jboss.logging.Logger;
 
 @RequestScoped
 @Path("/")
 public class OtelService1 {
+    private final Logger logger = Logger.getLogger(OtelService1.class.getName());
+
     @Context
     private UriInfo uriInfo;
 
@@ -41,6 +45,14 @@ public class OtelService1 {
         }
 
         return "Hello, " + name;
+    }
+
+    @GET
+    @Path("logging/{message}")
+    public Response log(@PathParam("message") String message) {
+        logger.infof("This is a test message: %s", message);
+
+        return Response.noContent().build();
     }
 
     @GET

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/CollectorLogRecordParser.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/CollectorLogRecordParser.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.shared.observability.signals.logs;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to parse a list of strings from the Collector log file and return a list of OpenTelemetryLogRecord instances.
+ */
+public class CollectorLogRecordParser {
+    // Pattern for parsing key-value fields (e.g., "Field: Value")
+    private static final Pattern FIELD_PATTERN = Pattern.compile("^([A-Za-z]+[\\sA-Za-z]*):\\s*(.*)$");
+    // Pattern for extracting the numerical severity number from text like "Info(9)"
+    private static final Pattern SEVERITY_NUMBER_PATTERN = Pattern.compile("(\\d+)");
+    // Pattern for parsing attributes like " -> bridge.name: Str(...)"
+    private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("^\\s*->\\s*([^:]+):\\s*Str\\((.*)\\)$");
+    // Formatter to parse the specific date format: 2025-11-26 22:23:39.754885 +0000 UTC
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS Z");
+
+    public List<OpenTelemetryLogRecord> retrieveLogRecords(String[] lines) {
+        // Strip unneeded metadata from the start of each line
+        List<String> cleaned = Arrays.stream(lines).map(line ->
+                        line.replace("[OpenTelemetryCollector] ", "")
+                                .replaceAll("\\d{4}-\\d{2}-\\d{2}T.*Z\t", "")
+                                .trim())
+                .toList();
+        var iterator = cleaned.iterator();
+        var logRecords = new ArrayList<OpenTelemetryLogRecord>();
+
+        var logLines = new ArrayList<String>();
+        while (iterator.hasNext()) {
+            var line = iterator.next();
+            // Iterate through log entries until a LogRecord is found, and then start processing the text
+            if (line.startsWith("LogRecord")) {
+                var end = false;
+                logLines.add(line);
+                while (!end && iterator.hasNext()) {
+                    line = iterator.next();
+                    // A new LogRecord is starting, so process what we have and start building a new record
+                    if (line.startsWith("LogRecord")) {
+                        logRecords.add(buildLogRecord(logLines));
+                        logLines.clear();
+                        logLines.add(line);
+                    } else if (line.startsWith("{\"resource\":")) {
+                        // LogRecord publishing is terminated by a JSON object, so we need to process what we've collected
+                        logRecords.add(buildLogRecord(logLines));
+                        logLines.clear();
+                        end = true;
+                    } else {
+                        logLines.add(line);
+                    }
+                }
+            }
+        }
+
+        return logRecords;
+    }
+
+    /**
+     * Parses the List<String> log entry into an OpenTelemetryLogRecord instance.
+     *
+     * @param logLines The list of strings containing the log record data.
+     * @return A fully populated OpenTelemetryLogRecord.
+     */
+    private OpenTelemetryLogRecord buildLogRecord(List<String> logLines) {
+        Map<String, String> parsedFields = new HashMap<>();
+        Map<String, String> attributes = new HashMap<>();
+
+        boolean inAttributesSection = false;
+
+        for (String line : logLines) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.isEmpty() || trimmedLine.startsWith("LogRecord #")) {
+                continue;
+            }
+
+            // 1. Detect the start of the Attributes section
+            if (trimmedLine.startsWith("Attributes:")) {
+                inAttributesSection = true;
+                continue;
+            }
+
+            if (inAttributesSection) {
+                // 2. Parse attributes until a new top-level field is detected
+                if (trimmedLine.startsWith("->")) {
+                    Matcher attributeMatcher = ATTRIBUTE_PATTERN.matcher(trimmedLine);
+                    if (attributeMatcher.matches()) {
+                        attributes.put(attributeMatcher.group(1).trim(), attributeMatcher.group(2).trim());
+                    }
+                } else {
+                    // This line is no longer an attribute, check if it's a new top-level field
+                    inAttributesSection = false;
+                }
+            }
+
+            // 3. Parse top-level fields
+            if (!inAttributesSection) {
+                Matcher fieldMatcher = FIELD_PATTERN.matcher(trimmedLine);
+                if (fieldMatcher.matches()) {
+                    parsedFields.put(fieldMatcher.group(1).trim(), fieldMatcher.group(2).trim());
+                }
+            }
+        }
+
+        // Extract severity number from "Info(9)" or similar
+        int severityNumber = 0;
+        Matcher severityMatcher = SEVERITY_NUMBER_PATTERN.matcher(
+                parsedFields.getOrDefault("SeverityNumber", "0"));
+        if (severityMatcher.find()) {
+            try {
+                severityNumber = Integer.parseInt(severityMatcher.group(1));
+            } catch (NumberFormatException e) {
+                // Keep default of 0
+            }
+        }
+
+        // Build the final record instance
+        return new OpenTelemetryLogRecord(
+                parseDateToUnixNano(parsedFields.getOrDefault("Timestamp", "")),
+                parseDateToUnixNano(parsedFields.getOrDefault("ObservedTimestamp", "")),
+                severityNumber,
+                parsedFields.getOrDefault("SeverityText", ""),
+                parsedFields.getOrDefault("Body", "Str()")
+                        .replaceAll("^Str\\(|\\)$", ""), // Removes "Str(" and ")"
+                attributes,
+                Integer.parseInt(parsedFields.getOrDefault("Flags", "0")), // Flags is simple int
+                parsedFields.getOrDefault("Trace ID", ""),
+                parsedFields.getOrDefault("Span ID", "")
+        );
+    }
+
+    /**
+     * Parses the date string (e.g., "2025-11-26 22:23:39.755362 +0000 UTC")
+     * into a Unix timestamp in nanoseconds as a String.
+     *
+     * @param dateString The observed date string.
+     * @return The Unix time in nanoseconds as a String.
+     */
+    private String parseDateToUnixNano(String dateString) {
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return "0"; // Default to 0 if missing
+        }
+        try {
+            // Remove the ' UTC' suffix as it's handled by the 'Z' pattern
+            OffsetDateTime odt = OffsetDateTime.parse(dateString.replace(" UTC", "").trim(), DATE_FORMATTER);
+
+            // Calculate nanoseconds: seconds * 10^9 + nanoseconds part of the second
+            long nanoSeconds = odt.toInstant().getEpochSecond() * 1_000_000_000L + odt.toInstant().getNano();
+
+            return String.valueOf(nanoSeconds);
+        } catch (Exception e) {
+            System.err.println("Error parsing date '" + dateString + "'. Returning 0. Error: " + e.getMessage());
+            return "0";
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/OpenTelemetryLogRecord.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/OpenTelemetryLogRecord.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.shared.observability.signals.logs;
+
+import java.util.Map;
+
+public record OpenTelemetryLogRecord(
+        String timeUnixNano,
+        String observedTimeUnixNano,
+        int severityNumber,
+        String severityText,
+        String body,
+        Map<String, String> attributes,
+        int flags,
+        String traceId,
+        String spanId
+) {
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21199

- Update component version
- Add test to verify fix for WFLY-20251 - OpenTelemetry logs capture messages before formatting
- Add methods to OpenTelemetryCollectorContainer for retrieving log entries from Collector container logs
- Add model class to wrap log entry output file

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20251](https://issues.redhat.com/browse/WFLY-20251)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)