### PR TITLE
WFLY-21206 Restore FD_SOCK2 to default TCP-based stacks

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -55,6 +55,9 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
                     </feature>
+                    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                        <param name="socket-binding" value="jgroups-tcp-fd"/>
+                    </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="FD_ALL3"/>
                     </feature>

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -49,6 +49,9 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
                     </feature>
+                    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                        <param name="socket-binding" value="jgroups-tcp-fd"/>
+                    </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="FD_ALL3"/>
                     </feature>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -154,6 +154,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -292,6 +295,9 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
+                        </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
@@ -433,6 +439,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -573,6 +582,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -710,6 +722,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -846,6 +861,9 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
+                        </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
@@ -17,6 +17,11 @@
         <param name="port" value="7600"/>
     </feature>
     <feature spec="domain.socket-binding-group.socket-binding">
+        <param name="socket-binding" value="jgroups-tcp-fd"/>
+        <param name="interface" value="private"/>
+        <param name="port" value="57600"/>
+    </feature>
+    <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
         <param name="interface" value="private"/>
         <param name="port" value="55200"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
@@ -17,6 +17,11 @@
         <param name="port" value="7600"/>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
+        <param name="socket-binding" value="jgroups-tcp-fd"/>
+        <param name="interface" value="private"/>
+        <param name="port" value="57600"/>
+    </feature>
+    <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
         <param name="interface" value="private"/>
         <param name="port" value="55200"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
@@ -22,6 +22,9 @@
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="MERGE3"/>
             </feature>
+            <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                <param name="socket-binding" value="jgroups-tcp-fd"/>
+            </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="FD_ALL3"/>
             </feature>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -84,6 +84,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -485,7 +485,7 @@
                         <transport type="UDP" socket-binding="jgroups-udp"/>
                         <protocol type="PING"/>
                         <protocol type="MERGE3"/>
-                        <socket-protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                        <socket-protocol type="FD_SOCK2" socket-binding="jgroups-udp-fd"/>
                         <protocol type="FD_ALL"/>
                         <protocol type="VERIFY_SUSPECT"/>
                         <protocol type="pbcast.NAKACK2"/>
@@ -500,6 +500,7 @@
                         <transport type="TCP" socket-binding="jgroups-tcp"/>
                         <socket-protocol type="MPING" socket-binding="jgroups-mping"/>
                         <protocol type="MERGE3"/>
+                        <socket-protocol type="FD_SOCK2" socket-binding="jgroups-tcp-fd"/>
                         <protocol type="FD_ALL"/>
                         <protocol type="VERIFY_SUSPECT"/>
                         <protocol type="pbcast.NAKACK2"/>
@@ -774,6 +775,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
@@ -793,6 +795,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -214,6 +214,7 @@
                         <transport type="TCP" socket-binding="jgroups-tcp"/>
                         <socket-protocol type="MPING" socket-binding="jgroups-mping"/>
                         <protocol type="MERGE3"/>
+                        <socket-protocol type="FD_SOCK2" socket-binding="jgroups-tcp-fd"/>
                         <protocol type="FD_ALL"/>
                         <protocol type="VERIFY_SUSPECT"/>
                         <protocol type="pbcast.NAKACK2"/>
@@ -570,6 +571,7 @@
                         <transport type="TCP" socket-binding="jgroups-tcp"/>
                         <socket-protocol type="MPING" socket-binding="jgroups-mping"/>
                         <protocol type="MERGE3"/>
+                        <socket-protocol type="FD_SOCK2" socket-binding="jgroups-tcp-fd"/>
                         <protocol type="FD_ALL"/>
                         <protocol type="VERIFY_SUSPECT"/>
                         <protocol type="pbcast.NAKACK2"/>
@@ -842,6 +844,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
@@ -861,6 +864,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -20,6 +20,7 @@
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
 /socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -27,6 +28,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -22,13 +22,14 @@ embed-server --server-config=standalone-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
 /socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
-
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
 /subsystem=jgroups/stack=tcp-bridge/transport=TCP:add(socket-binding=jgroups-tcp-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add
@@ -77,6 +78,7 @@ embed-server --server-config=standalone-full-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
 /socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -84,6 +86,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -22,6 +22,7 @@ embed-server --server-config=standalone-microprofile-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
 /socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -29,6 +30,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/partition/PartitionServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/partition/PartitionServlet.java
@@ -6,6 +6,7 @@
 package org.jboss.as.test.clustering.cluster.singleton.partition;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -36,7 +37,7 @@ import org.jgroups.stack.ProtocolStack;
  * {@link DISCARD} protocol and passing MERGE event up the stack.
  * <p>
  * Note that while it would be desirable for the tests to leave splitting and merging to the servers themselves, this is not practical in a
- * test suite. While FD/VERIFY_SUSPECT/GMS can be be configured to detect partitions quickly the MERGE3 handles merges within randomized
+ * test suite. While FD/VERIFY_SUSPECT/GMS can be configured to detect partitions quickly the MERGE3 handles merges within randomized
  * intervals and uses unreliable channel which can easily take several minutes for merge to actually happen. Also, speeds up the test
  * significantly.
  *
@@ -44,6 +45,7 @@ import org.jgroups.stack.ProtocolStack;
  */
 @WebServlet(urlPatterns = {PartitionServlet.PARTITION})
 public class PartitionServlet extends HttpServlet {
+    @Serial
     private static final long serialVersionUID = 3034138469210308974L;
 
     private static final long VIEWS_TIMEOUT = 3_000;
@@ -73,7 +75,7 @@ public class PartitionServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        boolean partition = Boolean.valueOf(request.getParameter(PARTITION));
+        boolean partition = Boolean.parseBoolean(request.getParameter(PARTITION));
 
         this.log("Simulating network partitions? " + partition);
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
@@ -56,13 +56,12 @@ public class DomainAdjuster740 extends DomainAdjuster {
     }
 
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {
-        // Remove protocols that do not exist in EAP 7.4, but don't bother replacing
-        operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", "udp").append("protocol", "FD_SOCK2")));
         for (String stack : Arrays.asList("tcp", "udp")) {
-            for (String protocol : Arrays.asList("RED", "FD_ALL3", "FRAG4", "VERIFY_SUSPECT2", "NAKACK4", "UNICAST4")) {
+            // Remove protocols that do not exist in EAP 7.4, but don't bother replacing
+            for (String protocol : Arrays.asList("RED", "FD_SOCK2", "FD_ALL3", "FRAG4", "VERIFY_SUSPECT2", "NAKACK4", "UNICAST4")) {
                 operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", protocol)));
             }
-            // Remote GMS too - this requires reliable unicast/multicast
+            // Remove GMS too - this requires reliable unicast/multicast
             operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", "pbcast.GMS")));
         }
     }

--- a/testsuite/mixed-domain/src/test/resources/primary-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/primary-config/domain-minimal.xml
@@ -77,6 +77,7 @@
             <socket-binding name="jgroups-diagnostics" port="0" multicast-address="224.0.75.75" multicast-port="7500"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21206
https://issues.redhat.com/browse/WFLY-21180

WFLY-21206 Add back configuration parts of WFLY-20710 while keeping auto-enabling suspect events if the stack does not otherwise contain a socket-based failure-detection protocol
Revert "WFLY-20710 Auto-enable transport-based failure detection if protocol stack does not contain a socket-based failure detection protocol. Drop FD_SOCK2 from default TCP protocol stack."
This reverts commit 6e8e451ecc0eec60e53521e691c68042984beeb4.

Opening as draft to confirm whether this does actually fix the problem.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20710](https://issues.redhat.com/browse/WFLY-20710)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)