### PR TITLE
[WFLY-21227] Upgrade WildFly Preview to Hibernate ORM 7.1.11.Final

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -65,7 +65,7 @@
         <version.org.jboss.spec.jakarta.el.jakarta.el-api>6.0.2.Final</version.org.jboss.spec.jakarta.el.jakarta.el-api>
         <version.org.jboss.weld.weld>6.0.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
-        <version.org.hibernate>7.1.2.Final</version.org.hibernate>
+        <version.org.hibernate>7.1.11.Final</version.org.hibernate>
         <version.org.hibernate.models>1.0.1</version.org.hibernate.models>
         <version.org.hibernate.search>8.1.2.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21227

The included changes are shown here https://github.com/hibernate/hibernate-orm/compare/7.1.3...7.1.11

The included tags are:
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.11
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.10
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.9
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.8
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.7
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.6
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.5
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.4
https://github.com/hibernate/hibernate-orm/releases/tag/7.1.3
