### PR TITLE
[WFLY-21240] [CVE-2025-12183] Upgrade lz4-java to 1.8.1

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -1408,9 +1408,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.lz4</groupId>
+                <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
-                <version>${version.org.lz4.lz4-java}</version>
+                <version>${version.at.yawk.lz4.lz4-java}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -491,7 +491,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
         </dependency>
 

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/at/yawk/lz4/lz4-java/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/at/yawk/lz4/lz4-java/main/module.xml
@@ -5,12 +5,12 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<module xmlns="urn:jboss:module:1.9" name="org.lz4.lz4-java">
+<module xmlns="urn:jboss:module:1.9" name="at.yawk.lz4.lz4-java">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${org.lz4:lz4-java}"/>
+        <artifact name="${at.yawk.lz4:lz4-java}"/>
     </resources>
 </module>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/kafka/client/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/apache/kafka/client/main/module.xml
@@ -20,7 +20,7 @@
         <module name="java.management"/>
         <module name="java.security.jgss"/>
         <module name="java.security.sasl"/>
-        <module name="org.lz4.lz4-java"/>
+        <module name="at.yawk.lz4.lz4-java"/>
         <module name="org.slf4j"/>
         <module name="org.xerial.snappy.snappy-java"/>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,7 @@
             Properties for dependencies that solely relate to tests go in the test code section above.
          -->
         <version.antlr>4.13.0</version.antlr>
+        <version.at.yawk.lz4.lz4-java>1.8.1</version.at.yawk.lz4.lz4-java>
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.20.1</version.com.fasterxml.jackson>
@@ -547,7 +548,6 @@
         <version.org.jvnet.staxex>2.1.0</version.org.jvnet.staxex>
         <version.org.keycloak.keycloak-saml-wildfly-subsystem>18.0.2</version.org.keycloak.keycloak-saml-wildfly-subsystem>
         <version.org.kohsuke.metainf-services>1.11</version.org.kohsuke.metainf-services>
-        <version.org.lz4.lz4-java>1.8.0</version.org.lz4.lz4-java>
         <version.org.opensaml.opensaml>4.3.2</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>

--- a/testsuite/integration/expansion/pom.xml
+++ b/testsuite/integration/expansion/pom.xml
@@ -284,7 +284,7 @@
         </dependency>
         <dependency>
             <!-- Needed if people use compression.type=lz4 in their Kafka config -->
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This includes moving to at.yawk.lz4:lz4-java which is a continuation of the project.

https://issues.redhat.com/browse/WFLY-21240

[CVE-2025-12183](https://ossindex.sonatype.org/vulnerability/CVE-2025-12183?component-type=maven&component-name=org.lz4%2Flz4-java&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.0)

A little context around the project change:

https://github.com/lz4/lz4-java/issues/230
https://github.com/lz4/lz4-java/issues/217

New home of lz4-java https://github.com/yawkat/lz4-java