### PR TITLE
WFLY-16653 Fix race condition in SuspendBatchletTestCase: JobOperator…

### DIFF
--- a/testsuite/integration/manualmode-expansion/pom.xml
+++ b/testsuite/integration/manualmode-expansion/pom.xml
@@ -35,7 +35,7 @@
         <byteman.port>17091</byteman.port>
         <!-- JVM args -->
         <microprofile.server.jvm.args>${server.jvm.args} -Djboss.node.name=microprofile</microprofile.server.jvm.args>
-        <!-- This module tests expanded funtionality, so use a bom that includes expansion dependencies -->
+        <!-- This module tests expanded functionality, so use a bom that includes expansion dependencies -->
         <dependency.management.import.artifact>wildfly-standard-expansion-bom</dependency.management.import.artifact>
         <dependency.management.import.test.artifact>wildfly-standard-test-expansion-bom</dependency.management.import.test.artifact>
         <channel.provisioning.phase>process-test-resources</channel.provisioning.phase>


### PR DESCRIPTION
….start() is asynchronous, so wait for the Batchlet to actually begin executing before suspending the server to avoid the race condition that caused "The job execution has no steps" failures

Included suggestions for future improvements of the test logic.

Resolves
https://issues.redhat.com/browse/WFLY-16653