### PR TITLE
[WFLY-21247] Don't import standard boms into preview boms; use common

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -76,11 +76,11 @@
         <dependencies>
 
             <!--
-                Re-expose the standard-ee deps.
+                Re-expose the common-ee deps.
              -->
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
-                <artifactId>wildfly-standard-ee-bom</artifactId>
+                <artifactId>wildfly-common-ee-dependency-management</artifactId>
                 <version>${ee.maven.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/boms/preview-expansion/pom.xml
+++ b/boms/preview-expansion/pom.xml
@@ -44,11 +44,11 @@
             </dependency>
 
             <!--
-                Re-expose the standard-expansion deps.
+                Re-expose the common-expansion deps.
              -->
             <dependency>
                 <groupId>${full.maven.groupId}</groupId>
-                <artifactId>wildfly-standard-expansion-bom</artifactId>
+                <artifactId>wildfly-common-expansion-dependency-management</artifactId>
                 <version>${full.maven.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -836,11 +836,6 @@
             <artifactId>wsdl4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.jakarta.el</groupId>
-            <artifactId>jboss-el-api_5.0_spec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
             <scope>test</scope>
@@ -3755,22 +3750,40 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Profile that can be activated in combination with -Dts.layers and -Dts.galleon
-             to execute the tests activated by those profiles, but using the wildfly-preview feature pack
-             based variant of wildfly-test-galleon-pack.
-        -->
+        <!-- Dependencies only to be used when testing WildFly Preview -->
         <profile>
-            <id>test.feature.pack.preview.profile</id>
+            <id>preview-server-tests-deps</id>
             <activation>
                 <property>
-                    <name>testsuite.ee.galleon.pack.artifactId</name>
-                    <value>wildfly-preview-feature-pack</value>
+                    <name>preview-server-tests</name>
                 </property>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>jakarta.enterprise</groupId>
                     <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.spec.jakarta.el</groupId>
+                    <artifactId>jakarta.el-api</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <!-- Dependencies only to be used when NOT testing WildFly Preview -->
+        <profile>
+            <id>standard-server-tests-deps</id>
+            <activation>
+                <property>
+                    <name>!preview-server-tests</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.jakarta.el</groupId>
+                    <artifactId>jboss-el-api_5.0_spec</artifactId>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -503,46 +503,17 @@
             Plugin execution configuration profiles. DO NOT ACTIVATE MODULES VIA THESE PROFILES
         -->
 
+        <!-- Settings applicable to all execution modes for testing WFP (ts.preview, -Dts.bootable.preview, -Dts.layers, -Dts.galleon) -->
         <profile>
-            <id>preview.profile</id>
-            <activation><property><name>ts.preview</name></property></activation>
+            <id>preview-server-tests-config</id>
+            <activation><property><name>preview-server-tests</name></property></activation>
             <properties>
+                <!-- Use the WFP dependencies -->
                 <dependency.management.import.artifact>wildfly-preview-expansion-bom</dependency.management.import.artifact>
                 <dependency.management.import.test.artifact>wildfly-preview-test-expansion-bom</dependency.management.import.test.artifact>
-                <!-- For WFP, if there are EE-version-specific test sources, uses the ee11 ones -->
-                <additional.ee.test.source>ee11</additional.ee.test.source>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>bootablejar.preview.profile</id>
-            <activation>
-                <property>
-                    <name>ts.bootable.preview</name>
-                </property>
-            </activation>
-            <properties>
-                <!-- For WFP, if there are EE-version-specific test sources, uses the ee11 ones -->
-                <additional.ee.test.source>ee11</additional.ee.test.source>
-            </properties>
-        </profile>
-        <!-- Profile that can be activated in combination with -Dts.layers and -Dts.galleon
-             to execute the tests activated by those profiles, but using the wildfly-preview feature pack
-             based variant of wildfly-test-galleon-pack.
-        -->
-        <profile>
-            <id>test.feature.pack.preview.profile</id>
-            <activation>
-                <property>
-                    <name>testsuite.ee.galleon.pack.artifactId</name>
-                    <value>wildfly-preview-feature-pack</value>
-                </property>
-            </activation>
-            <properties>
-                <dependency.management.import.artifact>wildfly-preview-expansion-bom</dependency.management.import.artifact>
-                <dependency.management.import.test.artifact>wildfly-preview-test-expansion-bom</dependency.management.import.test.artifact>
+                <!-- Use the WFP test-feature-pack -->
                 <testsuite.test.feature.pack.artifactId>wildfly-test-feature-pack-preview</testsuite.test.feature.pack.artifactId>
-                <!-- For WFP, if there are EE-version-specific test sources, uses the ee11 ones -->
+                <!-- If there are EE-version-specific test sources, uses the ee11 ones -->
                 <additional.ee.test.source>ee11</additional.ee.test.source>
             </properties>
         </profile>


### PR DESCRIPTION
This requires some refactoring of how the testsuite controls which boms to use and how ts/int/basic declares some deps that vary between WFP and std WF

https://issues.redhat.com/browse/WFLY-21247

#19441 but against the EE11 branch to exercise the WFP tests that are significantly impacted by the change.