### PR TITLE
[WFLY-21154] Default Hibernate ORM compatibility setting for UUID to char

### DIFF
--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
@@ -12,6 +12,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.spi.PersistenceUnitInfo;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.MappingSettings;
 import org.jipijapa.cache.spi.Classification;
 import org.jipijapa.event.impl.internal.Notification;
 import org.jipijapa.plugin.spi.EntityManagerFactoryBuilder;
@@ -80,6 +81,9 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
 
         // Enable JPA Compliance mode
         putPropertyIfAbsent(pu, properties, AvailableSettings.JPA_COMPLIANCE, true);
+        // Default to CHAR type for UUID column mapping.
+        // Applications can override by setting "hibernate.type.preferred_uuid_jdbc_type" to "uuid"
+        putPropertyIfAbsent(pu, properties, MappingSettings.PREFERRED_UUID_JDBC_TYPE, "CHAR");
     }
 
     private void failOnIncompatibleSetting(PersistenceUnitMetadata pu, Map properties) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21154

Pass EE 11 Persistence tests:
- ee.jakarta.tck.persistence.core.types.field.ClientPmservletTest#testCreateUUIDType
- ee.jakarta.tck.persistence.core.types.field.ClientPuservletTest#testCreateUUIDType

I believe that we will soon pass the other Persistence tests mentioned in https://issues.redhat.com/browse/WFLY-21154 pending  TCK challenge https://github.com/jakartaee/platform-tck/issues/2593 (e.g. needs to be approved or rejected or questioned).