### PR TITLE
[WFLY-21215] Broken docs.jboss.org links to Developer Guide content

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Jakarta_Transactions_Reference.adoc
@@ -354,9 +354,7 @@ or `@TransactionScoped` then class loading handling is done automatically.
 There is one limitation with the CDI with this approach.
 If your application adds the transactional annotations dynamically
 (you adds the annotations dynamically during runtime) then the
-transaction module has to be
-https://docs.jboss.org/author/display/WFLY/Class+Loading+in+WildFly[explicitly added]
-to the application classpath.
+transaction module has to be <<Class_Loading_in_WildFly, explicitly added>> to the application classpath.
 
 This can be done with creating `META-INF/MANIFEST.MF` or
 with use of `jboss-deployment-structure.xml` descriptor. The `MANIFEST.MF`

--- a/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Spring_applications_development_and_migration_guide.adoc
@@ -20,8 +20,7 @@ WildFly {wildflyVersion} has a modular class loading strategy, different from pr
 versions of JBoss AS, which enforces a better class loading isolation
 between deployments and the application server itself. A detailed
 description can be found in the documentation dedicated to
-https://docs.jboss.org/author/display/AS7/Class+Loading+in+AS7[class
-loading in WildFly {wildflyVersion}].
+<<Class_Loading_in_WildFly, class loading in WildFly {wildflyVersion}>>.
 
 This reduces significantly the risk of running into a class loading
 conflict and allows applications to package their own dependencies if
@@ -32,7 +31,7 @@ persistence providers to run on WildFly {wildflyVersion}.
 At the same time, this does not mean that duplications and conflicts
 cannot exist on the classpath. Some module dependencies are implicit,
 depending on the type of deployment as shown
-https://docs.jboss.org/author/display/AS7/Implicit+module+dependencies+for+deployments[here].
+<<Implicit_module_dependencies_for_deployments, here>>
 
 [[persistence-usage-guide]]
 == Persistence usage guide


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-21215

`Spring_applications_development_and_migration_guide.adoc` seem to link the old version (AS7 instead of WFLY).