### PR TITLE
[WFLY-21188] Fix Hibernate runtime bytecode enhancement not working in EJB JAR module in EAR deployment.  This reverts the WFLY-20393 change that previously ensured that only one bytecode transformer is added for each Persistence Unit.

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.ValidationMode;
@@ -97,7 +96,6 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     private volatile ClassLoader cachedTempClassLoader;
 
-    private final AtomicBoolean onlyCheckIfClassFileTransformerIsNeededOnce = new AtomicBoolean(false);
     private volatile String scopeAnnotationName="";
     private volatile List<String> qualifierAnnotationNames = List.of();
     private volatile boolean isDuplicate;
@@ -373,11 +371,7 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     @Override
     public boolean needsJPADelegatingClassFileTransformer() {
-        // WFLY-20393 Ensure that only one internal JPADelegatingClassFileTransformer bytecode transformer is configured for each Persistence Unit
-        if (onlyCheckIfClassFileTransformerIsNeededOnce.compareAndSet(false, true)) {
-            return Configuration.needClassFileTransformer(this);
-        }
-        return false;
+        return Configuration.needClassFileTransformer(this);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.earbytecodeenhancement;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * Test that an EJB jar can reference the persistence provider classes
+ */
+@RunWith(Arquillian.class)
+public class EJBJarPackagingTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "scopedToEar.ear");
+
+        JavaArchive ejbjar = ShrinkWrap.create(JavaArchive.class, "ejbjar.jar");
+        ejbjar.addAsManifestResource(emptyEjbJar(), "ejb-jar.xml");
+        ejbjar.addAsManifestResource(EJBJarPackagingTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        ejbjar.addClasses(EmployeeBean.class, EJBJarPackagingTestCase.class);
+        ejbjar.addClasses(Employee.class);
+        ear.addAsModule(ejbjar);        // add ejbjar to root of ear
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "lib.jar");
+        lib.addClasses(Organisation.class);
+        ear.addAsLibrary(lib);          // add entity jar to ear/lib
+
+
+
+
+        return ear;
+    }
+
+    @ArquillianResource
+    private static InitialContext iniCtx;
+
+    /**
+     * Test that bean in ejbjar can access persistence provider class
+     */
+    @Test
+    public void testBeanInEJBJarCanAccessPersistenceProviderClass() throws Exception {
+        EmployeeBean bean = (EmployeeBean) iniCtx.lookup("java:app/ejbjar/EmployeeBean");
+        Class sessionClass = bean.getPersistenceProviderClass("org.hibernate.Session");
+        assertNotNull("was able to load 'org.hibernate.Session' class from persistence provider", sessionClass);
+    }
+
+    @Test
+    public void testEntityByteCodeIsEnhanced() throws Exception {
+            EmployeeBean bean = (EmployeeBean) iniCtx.lookup("java:app/ejbjar/EmployeeBean");
+            assertTrue("Employee entity class needs to be bytecode enhanced",
+                    bean.isEmployeeClassByteCodeEnhanced());
+            assertTrue("Organisation entity class (that resides in ear/lib/lib.jar) needs to be bytecode enhanced",
+                    bean.isOrganisationClassByteCodeEnhanced());
+        }
+
+    private static StringAsset emptyEjbJar() {
+        return new StringAsset(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<ejb-jar xmlns=\"http://java.sun.com/xml/ns/javaee\" \n" +
+                        "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+                        "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd\"\n" +
+                        "         version=\"3.0\">\n" +
+                        "   \n" +
+                        "</ejb-jar>");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
@@ -44,24 +44,11 @@ public class EJBJarPackagingTestCase {
         lib.addClasses(Organisation.class);
         ear.addAsLibrary(lib);          // add entity jar to ear/lib
 
-
-
-
         return ear;
     }
 
     @ArquillianResource
     private static InitialContext iniCtx;
-
-    /**
-     * Test that bean in ejbjar can access persistence provider class
-     */
-    @Test
-    public void testBeanInEJBJarCanAccessPersistenceProviderClass() throws Exception {
-        EmployeeBean bean = (EmployeeBean) iniCtx.lookup("java:app/ejbjar/EmployeeBean");
-        Class sessionClass = bean.getPersistenceProviderClass("org.hibernate.Session");
-        assertNotNull("was able to load 'org.hibernate.Session' class from persistence provider", sessionClass);
-    }
 
     @Test
     public void testEntityByteCodeIsEnhanced() throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EJBJarPackagingTestCase.java
@@ -5,14 +5,12 @@
 
 package org.jboss.as.test.integration.jpa.earbytecodeenhancement;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import javax.naming.InitialContext;
+import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -47,12 +45,10 @@ public class EJBJarPackagingTestCase {
         return ear;
     }
 
-    @ArquillianResource
-    private static InitialContext iniCtx;
+    private @Inject EmployeeBean bean;
 
     @Test
     public void testEntityByteCodeIsEnhanced() throws Exception {
-            EmployeeBean bean = (EmployeeBean) iniCtx.lookup("java:app/ejbjar/EmployeeBean");
             assertTrue("Employee entity class needs to be bytecode enhanced",
                     bean.isEmployeeClassByteCodeEnhanced());
             assertTrue("Organisation entity class (that resides in ear/lib/lib.jar) needs to be bytecode enhanced",

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/Employee.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.earbytecodeenhancement;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EmployeeBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EmployeeBean.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.earbytecodeenhancement;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.ejb.Stateless;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+
+import org.hibernate.bytecode.enhance.spi.EnhancementInfo;
+
+/**
+ * stateful session bean
+ *
+ * @author Stuart Douglas
+ */
+@Stateless
+public class EmployeeBean {
+
+    @PersistenceUnit(unitName = "mainPu")
+    EntityManagerFactory entityManagerFactory;
+
+    // AS7-2275 requires each PU reference to specify a persistence unit name, if there are
+    // multiple persistence unit definitions.
+    // as a workaround, specified the pu name
+    @PersistenceUnit(unitName = "mainPu")
+    EntityManagerFactory defaultEntityManagerFactory;
+
+    public EntityManagerFactory getEntityManagerFactory() {
+        return entityManagerFactory;
+    }
+
+    public EntityManagerFactory getDefaultEntityManagerFactory() {
+        return defaultEntityManagerFactory;
+    }
+
+    // AS7-2829 bean in ejbjar should be able to access class in persistence provider
+    public Class getPersistenceProviderClass(String classname) {
+        Class result = null;
+        try {
+            result = EmployeeBean.class.getClassLoader().loadClass(classname);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        return result;
+    }
+
+    public boolean isEmployeeClassByteCodeEnhanced() {
+        for(Annotation annotation: Employee.class.getDeclaredAnnotations())
+            if(annotation instanceof EnhancementInfo) {
+                return true;
+            }
+        return false;
+    }
+
+    public boolean isOrganisationClassByteCodeEnhanced() {
+        for(Annotation annotation: Organisation.class.getDeclaredAnnotations())
+            if(annotation instanceof EnhancementInfo) {
+                return true;
+            }
+        return false;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EmployeeBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/EmployeeBean.java
@@ -10,7 +10,6 @@ import java.lang.annotation.Annotation;
 import jakarta.ejb.Stateless;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceUnit;
-
 import org.hibernate.bytecode.enhance.spi.EnhancementInfo;
 
 /**
@@ -23,31 +22,6 @@ public class EmployeeBean {
 
     @PersistenceUnit(unitName = "mainPu")
     EntityManagerFactory entityManagerFactory;
-
-    // AS7-2275 requires each PU reference to specify a persistence unit name, if there are
-    // multiple persistence unit definitions.
-    // as a workaround, specified the pu name
-    @PersistenceUnit(unitName = "mainPu")
-    EntityManagerFactory defaultEntityManagerFactory;
-
-    public EntityManagerFactory getEntityManagerFactory() {
-        return entityManagerFactory;
-    }
-
-    public EntityManagerFactory getDefaultEntityManagerFactory() {
-        return defaultEntityManagerFactory;
-    }
-
-    // AS7-2829 bean in ejbjar should be able to access class in persistence provider
-    public Class getPersistenceProviderClass(String classname) {
-        Class result = null;
-        try {
-            result = EmployeeBean.class.getClassLoader().loadClass(classname);
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
-        return result;
-    }
 
     public boolean isEmployeeClassByteCodeEnhanced() {
         for(Annotation annotation: Employee.class.getDeclaredAnnotations())

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/Organisation.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/Organisation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jpa.earbytecodeenhancement;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Organisation {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/earbytecodeenhancement/persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="mainPu">
+        <description>Persistence Unit.</description>
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <class>org.jboss.as.test.integration.jpa.earbytecodeenhancement.Organisation</class>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <property name="jboss.as.jpa.classtransformer" value="true"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21188
The previous change we made to reduce the number of threads trying to enhance the same class from multiple threads caused other problems.  Will open a new issue to replace how we solve WFLY-20393.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20393](https://issues.redhat.com/browse/WFLY-20393)
> * [WFLY-21260](https://issues.redhat.com/browse/WFLY-21260)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)