### PR TITLE
WFLY-21158 Model descriptions for expiration parameters are out-of-date.

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -190,9 +190,9 @@ infinispan.memory.evictions=The number of cache eviction operations.
 infinispan.component.expiration=The cache expiration configuration.
 infinispan.component.expiration.add=Adds an expiration configuration element to the cache.
 infinispan.component.expiration.remove=Removes an expiration configuration element from the cache.
-infinispan.component.expiration.max-idle=Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.
-infinispan.component.expiration.lifespan=Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.
-infinispan.component.expiration.interval=Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set wakeupInterval to -1.
+infinispan.component.expiration.interval=Specifies the duration of time (in milliseconds) between expiration processing, during which expired cache entries will be purged from memory and stores.  If zero, asynchronous expiration processing is disabled.
+infinispan.component.expiration.lifespan=When defined, specifies the default duration of time (in milliseconds) since creation after which cache entries will auto-expire. When undefined, cache entries will not auto-expire due to age by default.
+infinispan.component.expiration.max-idle=When defined, specifies the default duration of time (in milliseconds) since last access after which idle cache entries will auto-expire. When undefined, idle cache entries will not auto-expire by default.
 
 infinispan.store.custom=The cache store configuration.
 infinispan.store.custom.add=Adds a basic cache store configuration element to the cache.

--- a/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/infinispan/Infinispan_Subsystem.adoc
@@ -351,8 +351,6 @@ e.g. To configure expiration of entries older than 1 day, or that have not been 
 /subsystem=infinispan/cache-container=foo/local-cache=bar/component=expiration(lifespan=86400000, max-idle=3600000)
 ----
 
-CAUTION: max-idle based expiration is not generally safe for use with clustered caches, as the meta data of a cache entry is not replicated by cache read operations
-
 For a complete list of expiration attributes, refer to the link:feature-pack/doc/reference/index.html[WildFly management model documentation^]
 
 ==== Persistence


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21158

Also, remove out-dated documentation WRT max-idle, which has been safe for use with clustered caches since Infinispan 13.