### PR TITLE
WFLY-21286 Upgrade smallrye-open-api to 4.2.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <version.io.prometheus>1.3.3</version.io.prometheus>
         <version.io.reactivex.rxjava2>2.2.21</version.io.reactivex.rxjava2>
         <version.io.reactivex.rxjava3>3.1.12</version.io.reactivex.rxjava3>
-        <version.io.smallrye.open-api>4.2.1</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>4.2.3</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-config>3.13.4</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>6.10.0</version.io.smallrye.smallrye-fault-tolerance>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21286