### PR TITLE
WFLY-21297 Leverage AbstractSubsystemSchemaTest(String, Extension, S, Set<S>) constructor introduced in WFCORE-7416

### DIFF
--- a/clustering/ejb/extension/src/test/java/org/wildfly/extension/clustering/ejb/DistributableEjbSubsystemTestCase.java
+++ b/clustering/ejb/extension/src/test/java/org/wildfly/extension/clustering/ejb/DistributableEjbSubsystemTestCase.java
@@ -6,7 +6,6 @@
 package org.wildfly.extension.clustering.ejb;
 
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
-import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
@@ -41,8 +40,7 @@ public class DistributableEjbSubsystemTestCase extends AbstractSubsystemSchemaTe
     }
 
     public DistributableEjbSubsystemTestCase(DistributableEjbSubsystemSchema schema) {
-        // TODO WFCORE-7416 Eventually simplify by using this constructor AbstractSubsystemSchemaTest(String, Extension, S, Set<S>)
-        super(DistributableEjbSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new DistributableEjbExtension(), schema, Feature.map(DistributableEjbSubsystemSchema.CURRENT).get(schema.getStability()));
+        super(DistributableEjbSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new DistributableEjbExtension(), schema, DistributableEjbSubsystemSchema.CURRENT);
 
         this.schema = schema;
     }

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTestCase.java
@@ -11,7 +11,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.clustering.controller.CommonServiceDescriptor;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
-import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -48,7 +47,7 @@ public class JGroupsSubsystemTestCase extends AbstractSubsystemSchemaTest<JGroup
     private final JGroupsSubsystemSchema schema;
 
     public JGroupsSubsystemTestCase(JGroupsSubsystemSchema schema) {
-        super(JGroupsSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new JGroupsExtension(), schema, Feature.map(JGroupsSubsystemSchema.CURRENT).get(schema.getStability()));
+        super(JGroupsSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new JGroupsExtension(), schema, JGroupsSubsystemSchema.CURRENT);
         this.schema = schema;
     }
 

--- a/clustering/web/extension/src/test/java/org/wildfly/extension/clustering/web/DistributableWebSubsystemTestCase.java
+++ b/clustering/web/extension/src/test/java/org/wildfly/extension/clustering/web/DistributableWebSubsystemTestCase.java
@@ -8,7 +8,6 @@ package org.wildfly.extension.clustering.web;
 import java.util.EnumSet;
 
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
-import org.jboss.as.controller.Feature;
 import org.jboss.as.subsystem.test.AbstractSubsystemSchemaTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,8 +30,7 @@ public class DistributableWebSubsystemTestCase extends AbstractSubsystemSchemaTe
     }
 
     public DistributableWebSubsystemTestCase(DistributableWebSubsystemSchema schema) {
-        // TODO WFCORE-7416 Eventually simplify by using this constructor AbstractSubsystemSchemaTest(String, Extension, S, Set<S>)
-        super(DistributableWebSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new DistributableWebExtension(), schema, Feature.map(DistributableWebSubsystemSchema.CURRENT).get(schema.getStability()));
+        super(DistributableWebSubsystemResourceDefinitionRegistrar.REGISTRATION.getName(), new DistributableWebExtension(), schema, DistributableWebSubsystemSchema.CURRENT);
 
         this.schema = schema;
     }

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcClientSubsystemModel.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcClientSubsystemModel.java
@@ -12,12 +12,11 @@ import org.jboss.as.controller.SubsystemModel;
  * Enumeration of elytron-oidc-client subsystem model versions.
  * @author <a href="mailto:prpaul@redhat.com">Prarthona Paul</a>
  */
-
 enum ElytronOidcClientSubsystemModel implements SubsystemModel {
     VERSION_1_0_0(1, 0, 0),
     VERSION_2_0_0(2, 0, 0),
-    VERSION_3_0_0(3, 0, 0), // WildFly 32.0-present
-    VERSION_4_0_0(4, 0, 0), // WildFly 33.0-present
+    VERSION_3_0_0(3, 0, 0), // WildFly 32
+    VERSION_4_0_0(4, 0, 0), // WildFly 33-present
     ;
     static final ElytronOidcClientSubsystemModel CURRENT = VERSION_4_0_0;
 

--- a/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcSubsystemSchema.java
+++ b/elytron-oidc-client/src/main/java/org/wildfly/extension/elytron/oidc/ElytronOidcSubsystemSchema.java
@@ -87,13 +87,12 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  * Enumerated the schema versions for the elytron-oidc-client subsystem.
  * @author Prarthona Paul
  */
-
 public enum ElytronOidcSubsystemSchema implements PersistentSubsystemSchema<ElytronOidcSubsystemSchema> {
 
     VERSION_1_0(1, Stability.DEFAULT),
     VERSION_2_0(2, Stability.DEFAULT),
-    VERSION_2_0_PREVIEW(2, 0, Stability.PREVIEW), // WildFly 32.0-present
-    VERSION_3_0_PREVIEW(3, 0, Stability.PREVIEW), // WildFly 33.0-present
+    VERSION_2_0_PREVIEW(2, 0, Stability.PREVIEW), // WildFly 32
+    VERSION_3_0_PREVIEW(3, 0, Stability.PREVIEW), // WildFly 33-present
     ;
 
     static final Map<Stability, ElytronOidcSubsystemSchema> CURRENT = Feature.map(EnumSet.of(VERSION_3_0_PREVIEW, VERSION_2_0));

--- a/observability/micrometer/src/test/java/org/wildfly/extension/micrometer/SubsystemParsingTestCase.java
+++ b/observability/micrometer/src/test/java/org/wildfly/extension/micrometer/SubsystemParsingTestCase.java
@@ -7,7 +7,6 @@ package org.wildfly.extension.micrometer;
 
 import java.util.EnumSet;
 
-import org.jboss.as.controller.Feature;
 import org.jboss.as.subsystem.test.AbstractSubsystemSchemaTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -24,7 +23,6 @@ public class SubsystemParsingTestCase extends AbstractSubsystemSchemaTest<Microm
     }
 
     public SubsystemParsingTestCase(MicrometerSubsystemSchema schema) {
-        // TODO WFCORE-7416 Eventually simplify by using this constructor AbstractSubsystemSchemaTest(String, Extension, S, Set<S>)
-        super(MicrometerConfigurationConstants.NAME, new MicrometerExtension(), schema, Feature.map(MicrometerSubsystemSchema.CURRENT).get(schema.getStability()));
+        super(MicrometerConfigurationConstants.NAME, new MicrometerExtension(), schema, MicrometerSubsystemSchema.CURRENT);
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
@@ -9,6 +9,7 @@ import java.util.EnumSet;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.PersistentResourceXMLDescriptionWriter;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -48,6 +49,6 @@ public class UndertowExtension implements Extension {
         deployments.registerSubModel(new DeploymentServletDefinition());
         deployments.registerSubModel(new DeploymentWebSocketDefinition());
 
-        subsystem.registerXMLElementWriter(new PersistentResourceXMLDescriptionWriter(UndertowSubsystemSchema.CURRENT.get(context.getStability())));
+        subsystem.registerXMLElementWriter(new PersistentResourceXMLDescriptionWriter(Feature.map(UndertowSubsystemSchema.CURRENT).get(context.getStability())));
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -6,7 +6,6 @@
 package org.wildfly.extension.undertow;
 
 import java.util.EnumSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -15,7 +14,6 @@ import java.util.stream.Stream;
 
 import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.Feature;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentSubsystemSchema;
 import org.jboss.as.controller.SubsystemSchema;
@@ -64,12 +62,12 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
     VERSION_11_0(11),   // WildFly 20-22    N.B. There were no parser changes between 10.0 and 11.0 !!
     VERSION_12_0(12),   // WildFly 23-26.1, EAP 7.4
     VERSION_13_0(13),   // WildFly 27       N.B. There were no schema changes between 12.0 and 13.0!
-    VERSION_14_0(14),   // WildFly 28-32
-    VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-35
-    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY)   // WildFly 36 - present
+    VERSION_14_0(14),   // WildFly 28-present
+    VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-present
+    VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY)   // WildFly 36-present
     ;
 
-    static final Map<Stability, UndertowSubsystemSchema> CURRENT = Feature.map(EnumSet.of(VERSION_14_0, VERSION_14_0_PREVIEW, VERSION_14_0_COMMUNITY));
+    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_14_0, VERSION_14_0_PREVIEW, VERSION_14_0_COMMUNITY);
     private final VersionedNamespace<IntVersion, UndertowSubsystemSchema> namespace;
     private final PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -63,11 +63,11 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
     VERSION_12_0(12),   // WildFly 23-26.1, EAP 7.4
     VERSION_13_0(13),   // WildFly 27       N.B. There were no schema changes between 12.0 and 13.0!
     VERSION_14_0(14),   // WildFly 28-present
-    VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-present
+    VERSION_14_0_PREVIEW(14, 0, Stability.PREVIEW),   // WildFly 33-35
     VERSION_14_0_COMMUNITY(14, 0, Stability.COMMUNITY)   // WildFly 36-present
     ;
 
-    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_14_0, VERSION_14_0_PREVIEW, VERSION_14_0_COMMUNITY);
+    static final Set<UndertowSubsystemSchema> CURRENT = EnumSet.of(VERSION_14_0, VERSION_14_0_COMMUNITY);
     private final VersionedNamespace<IntVersion, UndertowSubsystemSchema> namespace;
     private final PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
 

--- a/undertow/src/main/resources/schema/wildfly-undertow_preview_14_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_preview_14_0.xsd
@@ -12,6 +12,7 @@
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
+
     <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
     <!-- The undertow subsystem root element -->
     <xs:element name="subsystem" type="undertow-subsystemType"/>
@@ -40,9 +41,9 @@
         <xs:attribute name="obfuscate-session-route" type="xs:boolean" use="optional"/>
         <xs:attribute name="default-security-domain" type="xs:string" use="optional" default="other"/>
         <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
-          <xs:annotation>
-            <xs:documentation>Whether statistics are to be gathered for undertow subsystem.</xs:documentation>
-          </xs:annotation>
+            <xs:annotation>
+                <xs:documentation>Whether statistics are to be gathered for undertow subsystem.</xs:documentation>
+            </xs:annotation>
         </xs:attribute>
     </xs:complexType>
     <xs:complexType name="serverType">
@@ -102,7 +103,7 @@
     <xs:complexType name="http-listener-type">
         <xs:complexContent>
             <xs:extension base="listener-type">
-               <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
+                <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
                     <xs:annotation>
                         <xs:documentation>
                             <![CDATA[

--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -37,7 +37,7 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
     protected final UndertowSubsystemSchema schema;
 
     AbstractUndertowSubsystemTestCase(UndertowSubsystemSchema schema) {
-        super(UndertowExtension.SUBSYSTEM_NAME, new UndertowExtension(), schema, UndertowSubsystemSchema.CURRENT.get(schema.getStability()));
+        super(UndertowExtension.SUBSYSTEM_NAME, new UndertowExtension(), schema, UndertowSubsystemSchema.CURRENT);
         this.schema = schema;
     }
 

--- a/undertow/src/test/java/org/wildfly/extension/undertow/ServerServiceTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/ServerServiceTestCase.java
@@ -39,7 +39,7 @@ public class ServerServiceTestCase extends AbstractUndertowSubsystemTestCase {
 
     @Parameters
     public static Iterable<UndertowSubsystemSchema> parameters() {
-        return UndertowSubsystemSchema.CURRENT.values();
+        return UndertowSubsystemSchema.CURRENT;
     }
 
     public ServerServiceTestCase(UndertowSubsystemSchema schema) {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServerRemovalTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServerRemovalTestCase.java
@@ -39,7 +39,7 @@ public class UndertowServerRemovalTestCase extends AbstractUndertowSubsystemTest
 
     @Parameters
     public static Iterable<UndertowSubsystemSchema> parameters() {
-        return UndertowSubsystemSchema.CURRENT.values();
+        return UndertowSubsystemSchema.CURRENT;
     }
 
     public UndertowServerRemovalTestCase(UndertowSubsystemSchema schema) {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServiceTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowServiceTestCase.java
@@ -34,7 +34,7 @@ public class UndertowServiceTestCase extends AbstractUndertowSubsystemTestCase {
 
     @Parameters
     public static Iterable<UndertowSubsystemSchema> parameters() {
-        return UndertowSubsystemSchema.CURRENT.values();
+        return UndertowSubsystemSchema.CURRENT;
     }
 
     public UndertowServiceTestCase(UndertowSubsystemSchema schema) {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
@@ -7,6 +7,7 @@ package org.wildfly.extension.undertow;
 
 import java.util.EnumSet;
 
+import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -14,6 +15,7 @@ import org.junit.runners.Parameterized.Parameters;
 /**
  * Tests subsystem against configurations for all supported subsystem schema versions.
  * @author Paul Ferraro
+ * @author Radoslav Husar
  */
 @RunWith(Parameterized.class)
 public class UndertowSubsystemTestCase extends AbstractUndertowSubsystemTestCase {
@@ -25,5 +27,13 @@ public class UndertowSubsystemTestCase extends AbstractUndertowSubsystemTestCase
 
     public UndertowSubsystemTestCase(UndertowSubsystemSchema schema) {
         super(schema);
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        // n.b. for preview:14 schema subsystem test, we automatically promote stability to a community:14 schema since they are now effectively equivalent;
+        // thus for this particular schema we need to ignore comparison of the namespace
+        boolean ignoreNamespace = schema.getStability() == Stability.PREVIEW && schema.getVersion().major() == 14;
+        super.compareXml(configId, original, marshalled, ignoreNamespace);
     }
 }


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21297

and fixup for
https://issues.redhat.com/browse/WFLY-20476 / https://issues.redhat.com/browse/WFLY-20477
____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-20476](https://issues.redhat.com/browse/WFLY-20476)
> * [WFLY-20477](https://issues.redhat.com/browse/WFLY-20477)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)