### PR TITLE
[WFLY-20864] Prefer using CDI, if available, for session beans instea…

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
@@ -8,14 +8,15 @@ package org.jboss.as.jaxrs.deployment;
 import static org.jboss.as.jaxrs.logging.JaxrsLogger.JAXRS_LOGGER;
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.ConcurrencyAttachments;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.component.ViewDescription;
-import org.jboss.as.ee.managedbean.component.ManagedBeanComponentDescription;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -23,7 +24,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.weld.WeldCapability;
 import org.jboss.modules.Module;
 import org.jboss.resteasy.util.GetRestful;
-import org.jboss.as.ee.component.ConcurrencyAttachments;
 
 /**
  * Integrates Jakarta RESTful Web Services with managed beans and Jakarta Enterprise Beans's
@@ -87,57 +87,71 @@ public class JaxrsComponentDeployer implements DeploymentUnitProcessor {
                 throw new DeploymentUnitProcessingException(e);
             }
             if (!GetRestful.isRootResource(componentClass)) continue;
-
             if (isInstanceOf(component, SESSION_BEAN_DESCRIPTION_CLASS_NAME)) {
                 if (isInstanceOf(component, STATEFUL_SESSION_BEAN_DESCRIPTION_CLASS_NAME)) {
                     //using SFSB's as Jakarta RESTful Web Services endpoints is not recommended, but if people really want to do it they can
 
                     JAXRS_LOGGER.debugf("Stateful session bean %s is being used as a Jakarta RESTful Web Services endpoint, this is not recommended", component.getComponentName());
-                    if (partOfWeldDeployment) {
-                        //if possible just let CDI handle the integration
-                        continue;
-                    }
                 }
-
-                Class<?>[] jaxrsType = GetRestful.getSubResourceClasses(componentClass);
-                final String jndiName;
-                if (component.getViews().size() == 1) {
-                    //only 1 view, just use the simple JNDI name
-                    jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName();
-                } else {
-                    boolean found = false;
-                    String foundType = null;
-                    for (final ViewDescription view : component.getViews()) {
-                        for (Class<?> subResource : jaxrsType) {
-                            if (view.getViewClassName().equals(subResource.getName())) {
-                                foundType = subResource.getName();
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (found) {
+                // If CDI is supported we should use CDI to look up the component
+                if (partOfWeldDeployment) {
+                    continue;
+                }
+            }
+            boolean found = false;
+            final Class<?>[] restResourceTypes = GetRestful.getSubResourceClasses(componentClass);
+            final Set<ViewDescription> viewDescriptions = component.getViews();
+            // If we only have a single view, we can use that
+            if (viewDescriptions.size() == 1) {
+                found = processBindings(viewDescriptions.iterator().next(), restResourceTypes, resteasy);
+            } else {
+                for (ViewDescription view : viewDescriptions) {
+                    // For beans with multiple views, find the view that corresponds to the REST resource type
+                    // (the class/interface with @Path annotations). This is typically the no-interface view
+                    // when @Path is on the bean class itself, or a specific interface view when @Path is on
+                    // an interface. We cannot safely pick an arbitrary view as it may not have the REST methods.
+                    boolean resourceMatch = false;
+                    for (Class<?> subResource : restResourceTypes) {
+                        if (view.getViewClassName().equals(subResource.getName())) {
+                            resourceMatch = true;
                             break;
                         }
                     }
-                    if (!found) {
-                        throw JAXRS_LOGGER.typeNameNotAnEjbView(Arrays.asList(jaxrsType), component.getComponentName());
+                    if (!resourceMatch) {
+                        continue;
                     }
-                    jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName() + "!" + foundType;
+                    found = processBindings(view, restResourceTypes, resteasy);
+                    if (found) {
+                        break;
+                    }
                 }
-
-                JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi jaxRsTypeName: %s", component.getComponentClassName(), jndiName);
-                resteasy.getScannedJndiComponentResources().add(jndiName + ";" + component.getComponentClassName() + ";" + "true");
-                // make sure its removed from list
-                resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
-            } else if (component instanceof ManagedBeanComponentDescription) {
-                String jndiName = "java:app/" + moduleDescription.getModuleName() + "/" + component.getComponentName();
-
-                JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi name: %s", component.getComponentClassName(), jndiName);
-                resteasy.getScannedJndiComponentResources().add(jndiName + ";" + component.getComponentClassName() + ";" + "true");
-                // make sure it's removed from list
-                resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
+            }
+            if (!found) {
+                throw JAXRS_LOGGER.typeNameNotAnEjbView(List.of(restResourceTypes), component.getComponentName());
             }
         }
+    }
+
+    private boolean processBindings(final ViewDescription view, final Class<?>[] restResourceTypes, final ResteasyDeploymentData resteasy) throws DeploymentUnitProcessingException {
+        final Set<String> bindings = view.getBindingNames();
+        if (!bindings.isEmpty()) {
+            final ComponentDescription component = view.getComponentDescription();
+            // Find a binding name for the resource. We simply use the first binding name we find that starts with java:app
+            // for the component. We assume the component will have the correct view that we need.
+            final String jndiName = bindings.stream()
+                    .filter(name -> name.startsWith("java:app"))
+                    .findFirst()
+                    .orElseThrow(() -> JAXRS_LOGGER.typeNameNotAnEjbView(List.of(restResourceTypes), component.getComponentName()));
+
+            JAXRS_LOGGER.debugf("Found Jakarta RESTful Web Services Managed Bean: %s local jndi jaxRsTypeName: %s", component.getComponentClassName(), jndiName);
+            // Resource naming is jndi-name;component-class;cache
+            resteasy.getScannedJndiComponentResources()
+                    .add(jndiName + ";" + component.getComponentClassName() + ";true");
+            // make sure it's removed from the scanned resources list
+            resteasy.getScannedResourceClasses().remove(component.getComponentClassName());
+            return true;
+        }
+        return false;
     }
 
     private boolean isInstanceOf(ComponentDescription component, String className) {

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
@@ -133,7 +133,8 @@ public interface JaxrsLogger extends BasicLogger {
      * @param ejbName The ejb
      * @return  the exception
      */
-    @Message(id = 10, value = "Jakarta RESTful Web Services resource %s does not correspond to a view on the Jakarta Enterprise Beans %s. @Path annotations can only be placed on classes or interfaces that represent a local, remote or no-interface view of a Jakarta Enterprise Beans bean.")
+    @Message(id = 10, value = "Jakarta RESTful Web Services resource %s does not correspond to a view on the Jakarta Enterprise Beans %s. @Path annotations can only be placed on classes or interfaces that represent a local, " +
+            "remote or no-interface view of a Jakarta Enterprise Beans bean. For a component with multiple views, you likely need a no-interface view registered.")
     DeploymentUnitProcessingException typeNameNotAnEjbView(List<Class<?>> type, String ejbName);
 
     @Message(id = 11, value = "Invalid value for parameter %s: %s")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/MultiViewEjbCdiTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/MultiViewEjbCdiTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.FarewellBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.GreetBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.MultiViewBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.SimpleBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.TestApplication;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class MultiViewEjbCdiTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, MultiViewEjbCdiTest.class.getSimpleName() + ".war")
+                .addClasses(
+                        FarewellBean.class,
+                        GreetBean.class,
+                        SimpleBean.class,
+                        MultiViewBean.class,
+                        TestApplication.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void checkGreet() {
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(baseUri).path("test/multiview/greet").request().get()) {
+                Assert.assertEquals(200, response.getStatus());
+                Assert.assertEquals(String.format("Hello, %sSimpleBean!", MultiViewBean.class.getName()), response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    public void checkFarewell() {
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(baseUri).path("test/multiview/farewell").request().get()) {
+                Assert.assertEquals(200, response.getStatus());
+                Assert.assertEquals(String.format("Goodbye, %sSimpleBean!", MultiViewBean.class.getName()), response.readEntity(String.class));
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/MultiViewEjbJndiTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/MultiViewEjbJndiTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.FarewellBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.GreetBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.MultiViewBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.SimpleBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.TestApplication;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class MultiViewEjbJndiTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        final String deploymentXml = """
+                <jboss-deployment-structure>
+                    <deployment>
+                        <exclude-subsystems>
+                            <subsystem name="weld" />
+                        </exclude-subsystems>
+                    </deployment>
+                </jboss-deployment-structure>
+                """;
+        return ShrinkWrap.create(WebArchive.class, MultiViewEjbJndiTest.class.getSimpleName() + ".war")
+                .addClasses(
+                        FarewellBean.class,
+                        GreetBean.class,
+                        SimpleBean.class,
+                        MultiViewBean.class,
+                        TestApplication.class)
+                .addAsWebInfResource(new StringAsset(deploymentXml), "jboss-deployment-structure.xml");
+    }
+
+    @Test
+    public void checkGreet() {
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(baseUri).path("test/multiview/greet").request().get()) {
+                Assert.assertEquals(200, response.getStatus());
+                Assert.assertEquals(String.format("Hello, %s!", MultiViewBean.class.getName()), response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    public void checkFarewell() {
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(baseUri).path("test/multiview/farewell").request().get()) {
+                Assert.assertEquals(200, response.getStatus());
+                Assert.assertEquals(String.format("Goodbye, %s!", MultiViewBean.class.getName()), response.readEntity(String.class));
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/SingleViewEjbJndiTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/SingleViewEjbJndiTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.GreetBean;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.GreetClientView;
+import org.jboss.as.test.integration.jaxrs.integration.ejb.resource.TestApplication;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class SingleViewEjbJndiTest {
+
+    @ArquillianResource
+    private URI baseUri;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        final String deploymentXml = """
+                <jboss-deployment-structure>
+                    <deployment>
+                        <exclude-subsystems>
+                            <subsystem name="weld" />
+                        </exclude-subsystems>
+                    </deployment>
+                </jboss-deployment-structure>
+                """;
+        return ShrinkWrap.create(WebArchive.class, SingleViewEjbJndiTest.class.getSimpleName() + ".war")
+                .addClasses(
+                        GreetBean.class,
+                        GreetClientView.class,
+                        TestApplication.class)
+                .addAsWebInfResource(new StringAsset(deploymentXml), "jboss-deployment-structure.xml");
+    }
+
+    @Test
+    public void checkGreet() {
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(baseUri).path("test/greet/greet").request().get()) {
+                Assert.assertEquals(200, response.getStatus());
+                Assert.assertEquals(String.format("Hello, %s!", GreetBean.class.getName()), response.readEntity(String.class));
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/FarewellBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/FarewellBean.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.ejb.Local;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Local
+public interface FarewellBean {
+
+    @Path("farewell")
+    @GET
+    String farewell();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/GreetBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/GreetBean.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.ejb.Local;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Local
+public interface GreetBean {
+
+    @Path("greet")
+    @GET
+    String greet();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/GreetClientView.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/GreetClientView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.Local;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.Path;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Stateless
+@Local(GreetBean.class)
+@Path("greet")
+public class GreetClientView implements GreetBean {
+
+    @Resource
+    private SessionContext ctx;
+
+    @Override
+    public String greet() {
+        if (ctx == null) {
+            throw new InternalServerErrorException("The SessionContext was null");
+        }
+        return String.format("Hello, %s!", ctx.getInvokedBusinessInterface().getName());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/MultiViewBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/MultiViewBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.Local;
+import jakarta.ejb.LocalBean;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.Path;
+
+/**
+ * Represents a view for multiple interfaces. It uses the {@link LocalBean} annotation to also create a no-interface
+ * view. This is the expected behavior for Jakarta REST endpoint represented by a session bean.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@Stateless
+@Local({GreetBean.class, FarewellBean.class})
+@LocalBean
+@Path("multiview")
+public class MultiViewBean implements GreetBean, FarewellBean {
+
+    @Inject
+    private SimpleBean simpleBean;
+
+    @Resource
+    private SessionContext ctx;
+
+    @Override
+    public String greet() {
+        if (ctx == null) {
+            throw new InternalServerErrorException("The SessionContext was null");
+        }
+        return String.format("Hello, %s!", name());
+    }
+
+    @Override
+    public String farewell() {
+        if (ctx == null) {
+            throw new InternalServerErrorException("The SessionContext was null");
+        }
+        return String.format("Goodbye, %s!", name());
+    }
+
+    private String name() {
+        // We check if the simpleBean is null here for the case when CDI is not available. This is purely for test
+        // re-use and not meant for anything outside of testing.
+        final String componentName = ctx.getInvokedBusinessInterface().getName();
+        return simpleBean == null ? componentName : componentName + simpleBean.name();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/SimpleBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/SimpleBean.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ApplicationScoped
+public class SimpleBean {
+
+    public String name() {
+        return "SimpleBean";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/resource/TestApplication.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.jaxrs.integration.ejb.resource;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@ApplicationPath("/test")
+public class TestApplication extends Application {
+}


### PR DESCRIPTION
…d of JNDI lookups. If CDI is not available, allow more than one component to be bound. The latter is uncommon, but should be allowed.

https://issues.redhat.com/browse/WFLY-20864
