### PR TITLE
WFLY-21311 Upgrade io.github.resilience4j:resilience4j-core to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.de.dentrassi.crypto>2.4.0</version.de.dentrassi.crypto>
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.io.agroal>2.0</version.io.agroal>
-        <version.io.github.resilience4j>2.2.0</version.io.github.resilience4j>
+        <version.io.github.resilience4j>2.3.0</version.io.github.resilience4j>
         <version.io.grpc>1.70.0</version.io.grpc>
         <version.io.micrometer>1.15.7</version.io.micrometer>
         <version.io.netty>4.1.130.Final</version.io.netty>


### PR DESCRIPTION
Jira
https://issues.redhat.com/browse/WFLY-21311