### PR TITLE
[WFLY-21313] Upgrade Hibernate ORM to 6.6.40, ByteBuddy to 1.17.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
         <version.org.apache.wss4j>3.0.5</version.org.apache.wss4j>
         <version.org.apache.ws.xmlschema>2.3.0</version.org.apache.ws.xmlschema>
         <version.org.bitbucket.jose4j>0.9.6</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.15.11</version.org.bytebuddy>
+        <version.org.bytebuddy>1.17.5</version.org.bytebuddy>
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>
@@ -506,7 +506,7 @@
         <version.org.glassfish.soteria>3.0.3</version.org.glassfish.soteria>
         <version.org.glassfish.web.jakarta.servlet.jsp.jstl>3.0.1-jbossorg-1</version.org.glassfish.web.jakarta.servlet.jsp.jstl>
         <version.org.hibernate.commons.annotations>7.0.3.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate>6.6.37.Final</version.org.hibernate>
+        <version.org.hibernate>6.6.40.Final</version.org.hibernate>
         <version.org.hibernate.search>7.2.4.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21313

Allows SE 25 support when doing bytecode enhancement of entitites