### PR TITLE
WFLY-21243 fixup: make bumped model version the current one which eva…

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemModel.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemModel.java
@@ -23,11 +23,11 @@ public enum ModClusterSubsystemModel implements SubsystemModel {
     VERSION_6_0_0(6, 0, 0), // WildFly 14-15, EAP 7.2
 */
     VERSION_7_0_0(7, 0, 0), // WildFly 16-26, EAP 7.3-7.4
-    VERSION_8_0_0(8, 0, 0), // WildFly 27-38
+    VERSION_8_0_0(8, 0, 0), // WildFly 27-38, EAP 8.0-present
     VERSION_9_0_0(9, 0, 0), // WildFly 39-present
     ;
 
-    public static final ModClusterSubsystemModel CURRENT = VERSION_8_0_0;
+    public static final ModClusterSubsystemModel CURRENT = VERSION_9_0_0;
 
     private final ModelVersion version;
 


### PR DESCRIPTION
…ded the original change; n.b. model version 9.0.0 disallowed expressions on capability references

https://issues.redhat.com/browse/WFLY-21243

The bump was missed here: https://github.com/wildfly/wildfly/pull/19434/changes#diff-55f79afc11d2ed61e1a3c74470b3e2dcd0c281e449c0eaa25820e0f19feffbf5R27