### PR TITLE
[WFLY-21317] Allow misc services to declare they should start before …

### DIFF
--- a/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
+++ b/weld/bean-validation/src/main/java/org/jboss/as/weld/deployment/processor/CdiBeanValidationFactoryProcessor.java
@@ -5,6 +5,7 @@
 package org.jboss.as.weld.deployment.processor;
 
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
+import static org.jboss.as.weld.deployment.AttachmentKeys.START_COMPLETION_DEPENDENCIES;
 
 import java.util.function.Supplier;
 
@@ -61,5 +62,8 @@ public class CdiBeanValidationFactoryProcessor implements DeploymentUnitProcesso
         sb.requires(weldStartService);
         sb.setInstance(new CdiValidatorFactoryService(deploymentUnit, beanManagerSupplier));
         sb.install();
+
+        // Make sure CdiValidatorFactoryService is started before WeldStartCompletionService sends out lifecycle events
+        deploymentUnit.addToAttachmentList(START_COMPLETION_DEPENDENCIES, serviceName);
     }
 }

--- a/weld/common/src/main/java/org/jboss/as/weld/deployment/AttachmentKeys.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/deployment/AttachmentKeys.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.weld.deployment;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.AttachmentList;
+import org.jboss.msc.service.ServiceName;
+
+public final class AttachmentKeys {
+
+    /** Names of misc services that should start before WeldStartCompletionService. */
+    public static final AttachmentKey<AttachmentList<ServiceName>> START_COMPLETION_DEPENDENCIES = AttachmentKey.createList(ServiceName.class);
+
+}


### PR DESCRIPTION
…Weld emits application started events

https://issues.redhat.com/browse/WFLY-21317

Note there may be other services where the same thing should happen; the CdiValidatorFactoryService touched here is just the one that's observable via a test failure. AIUI the basic idea is services where ExtensionObserverMethodImpl is going to be delivering extension lifecycle events should be started before WeldStartCompletionServices begins emitting lifecycle events to applications.

I don't know if this is right so it definitely needs a review from @manovotn 