### PR TITLE
[WFLY-21337] Add load balancer-based failover tests for clustering testsuite.

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
+
+import java.util.PropertyPermission;
+import java.util.Set;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateful EJB behind a load balancer.
+ *
+ * The test scenario is as follows:
+ * - an EJB/HTTP client
+ * - an Undertow-based modcluster load balancer
+ * - two clustered Wildfly servers with Stateful EJBs deployed
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.ServerSetupTask.class)
+public abstract class AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
+    protected static final Logger log = Logger.getLogger(AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.class);
+
+    protected static final int LB_OFFSET = 500;
+    private static final int COUNT = 20;
+    private static final long LOAD_BALANCER_WAIT = TimeoutUtil.adjust(5000);
+    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+
+    static Archive<?> createDeployment(String moduleName) {
+        return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, StatefulIncrementorBean.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    private final ExceptionSupplier<EJBDirectory, Exception> directoryProvider;
+
+    /**
+     * Constructs a clustering test case consisting of a load balancer and two backend nodes.
+     *
+     * The load balancer and its two backend nodes are configured in the inner class ServerSetupTask.
+     * The directory provider must provide a proxy that is configured for EJB/HTTP and which points to the load balancer.
+     *
+     * @param directoryProvider a provider for the EJBDirectory instance used to create the test case proxies.
+     */
+    protected AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) {
+        super(Set.of(LOAD_BALANCER_1, NODE_1, NODE_2), Set.of(DEPLOYMENT_1, DEPLOYMENT_2));
+        this.directoryProvider = directoryProvider;
+    }
+
+    @Test
+    public void test() throws Exception {
+        log.info("Running test case test()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+
+            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+
+            Result<Integer> result = bean.increment();
+            String target = result.getNode();
+            int count = 1;
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            undeploy(this.findDeployment(target));
+
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            String failoverTarget = result.getNode();
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+            Assert.assertNotEquals(target, failoverTarget);
+
+            deploy(this.findDeployment(target));
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            String failbackTarget = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            Assert.assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            stop(target);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            failoverTarget = result.getNode();
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+            Assert.assertNotEquals(target, failoverTarget);
+
+            start(target);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            failbackTarget = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            Assert.assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            bean.remove();
+        }
+    }
+
+    /**
+     * A server setup script to configure each backend node to register with the load balancer.
+     */
+    static class ServerSetupTask extends ManagementServerSetupTask {
+        public ServerSetupTask() {
+            super(NODE_1_2, createContainerConfigurationBuilder()
+                    .setupScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=false)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:add(host=localhost, port=8590)")
+                            .add("/subsystem=modcluster/proxy=default:list-add(name=proxies, value=proxy1)")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:add(class-name=\"io.undertow.server.handlers.RequestDumpingHandler\", module=\"io.undertow.core\")")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:add")
+                            .endBatch()
+                            .build()
+                    )
+                    .tearDownScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:list-remove(name=proxies, value=proxy1)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:remove")
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=true)")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:remove")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:remove")
+                            .endBatch()
+                            .build()
+                    )
+                    .build()
+            );
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
@@ -73,8 +73,68 @@ public abstract class AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase exte
     }
 
     @Test
-    public void test() throws Exception {
-        log.info("Running test case test()");
+    public void testFailoverForStopStart() throws Exception {
+        log.info("Running test case testFailoverForStopStart()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+
+            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+
+            Result<Integer> result = bean.increment();
+            String target = result.getNode();
+            int count = 1;
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            stop(target);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            String failoverTarget = result.getNode();
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+            Assert.assertNotEquals(target, failoverTarget);
+
+            start(target);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            String failbackTarget = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            Assert.assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            bean.remove();
+        }
+    }
+
+    @Test
+    public void testFailoverForUndeployDeploy() throws Exception {
+        log.info("Running test case testFailoverForUndeployDeploy()");
 
         // Allow sufficient time for the load balancer + cluster configuration to initialise
         Thread.sleep(LOAD_BALANCER_WAIT);
@@ -118,53 +178,10 @@ public abstract class AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase exte
             // Bean should retain weak affinity for this node
             Assert.assertEquals(failoverTarget, failbackTarget);
 
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
-                Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
-
-            stop(target);
-
-            result = bean.increment();
-            // Bean should failover to other node
-            failoverTarget = result.getNode();
-
-            Assert.assertEquals(count++, result.getValue().intValue());
-            Assert.assertNotEquals(target, failoverTarget);
-
-            start(target);
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            failbackTarget = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-            // Bean should retain weak affinity for this node
-            Assert.assertEquals(failoverTarget, failbackTarget);
-
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
-                Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
-
             bean.remove();
         }
     }
+
 
     /**
      * A server setup script to configure each backend node to register with the load balancer.

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.common.function.ExceptionSupplier;
+
+import java.util.PropertyPermission;
+import java.util.Set;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateful EJB behind a load balancer.
+ *
+ * The test scenario is as follows:
+ * - an EJB/HTTP client
+ * - an Undertow-based modcluster load balancer
+ * - two clustered Wildfly servers with Stateful EJBs deployed
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+@ExtendWith(ArquillianExtension.class)
+@ServerSetup(AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.ServerSetupTask.class)
+public abstract class AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
+    protected static final Logger log = Logger.getLogger(AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase.class);
+
+    protected static final int LB_OFFSET = 500;
+    private static final int COUNT = 20;
+    private static final long LOAD_BALANCER_WAIT = TimeoutUtil.adjust(5000);
+    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+
+    static Archive<?> createDeployment(String moduleName) {
+        return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, StatefulIncrementorBean.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    private final ExceptionSupplier<EJBDirectory, Exception> directoryProvider;
+
+    /**
+     * Constructs a clustering test case consisting of a load balancer and two backend nodes.
+     *
+     * The load balancer and its two backend nodes are configured in the inner class ServerSetupTask.
+     * The directory provider must provide a proxy that is configured for EJB/HTTP and which points to the load balancer.
+     *
+     * @param directoryProvider a provider for the EJBDirectory instance used to create the test case proxies.
+     */
+    protected AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) {
+        super(Set.of(LOAD_BALANCER_1, NODE_1, NODE_2), Set.of(DEPLOYMENT_1, DEPLOYMENT_2));
+        this.directoryProvider = directoryProvider;
+    }
+
+    @Test
+    public void testFailoverForStopStart() throws Exception {
+        log.info("Running test case testFailoverForStopStart()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+
+            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+
+            Result<Integer> result = bean.increment();
+            String target = result.getNode();
+            int count = 1;
+
+            assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                // expected, actual
+                assertEquals(count++, result.getValue().intValue());
+                assertEquals(target, result.getNode(), "error on iteration" + String.valueOf(i));
+            }
+
+            stop(target);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            String failoverTarget = result.getNode();
+
+            assertEquals(count++, result.getValue().intValue());
+            assertNotEquals(target, failoverTarget);
+
+            start(target);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            String failbackTarget = result.getNode();
+            assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                assertEquals(count++, result.getValue().intValue());
+                assertEquals(target, result.getNode(), "error on iteration" + String.valueOf(i));
+            }
+
+            bean.remove();
+        }
+    }
+
+    @Test
+    public void testFailoverForUndeployDeploy() throws Exception {
+        log.info("Running test case testFailoverForUndeployDeploy()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+
+            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+
+            Result<Integer> result = bean.increment();
+            String target = result.getNode();
+            int count = 1;
+
+            assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                assertEquals(count++, result.getValue().intValue());
+                assertEquals(target, result.getNode(), "error on iteration" + String.valueOf(i));
+            }
+
+            undeploy(this.findDeployment(target));
+
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            String failoverTarget = result.getNode();
+
+            assertEquals(count++, result.getValue().intValue());
+            assertNotEquals(target, failoverTarget);
+
+            deploy(this.findDeployment(target));
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            String failbackTarget = result.getNode();
+            assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            assertEquals(failoverTarget, failbackTarget);
+
+            bean.remove();
+        }
+    }
+
+
+    /**
+     * A server setup script to configure each backend node to register with the load balancer.
+     */
+    static class ServerSetupTask extends ManagementServerSetupTask {
+        public ServerSetupTask() {
+            super(NODE_1_2, createContainerConfigurationBuilder()
+                    .setupScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=false)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:add(host=localhost, port=8590)")
+                            .add("/subsystem=modcluster/proxy=default:list-add(name=proxies, value=proxy1)")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:add(class-name=\"io.undertow.server.handlers.RequestDumpingHandler\", module=\"io.undertow.core\")")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:add")
+                            .endBatch()
+                            .build()
+                    )
+                    .tearDownScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:list-remove(name=proxies, value=proxy1)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:remove")
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=true)")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:remove")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:remove")
+                            .endBatch()
+                            .build()
+                    )
+                    .build()
+            );
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SecureStatelessIncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementorBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PropertyPermission;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateless EJB behind a load balancer.
+ *
+ * The test scenario is as follows:
+ * - an EJB/HTTP client
+ * - an Undertow-based modcluster load balancer
+ * - two clustered Wildfly servers with Stateless EJBs deployed
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.ServerSetupTask.class)
+public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase extends AbstractClusteringTestCase {
+
+    protected static final Logger log = Logger.getLogger(AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.class.getSimpleName());
+
+    protected static final int LB_OFFSET = 500;
+    private static final int COUNT = 20;
+    private static final long LOAD_BALANCER_WAIT = TimeoutUtil.adjust(5000);
+    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+    private static final long INVOCATION_WAIT = TimeoutUtil.adjust(10);
+
+    static Archive<?> createDeployment(String moduleName) {
+        return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, StatelessIncrementorBean.class, SecureStatelessIncrementorBean.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    private final ExceptionSupplier<EJBDirectory, Exception> directoryProvider;
+
+    AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) {
+        super(Set.of(LOAD_BALANCER_1, NODE_1, NODE_2), Set.of(DEPLOYMENT_1, DEPLOYMENT_2));
+        this.directoryProvider = directoryProvider;
+    }
+
+    @Test
+    public void test() throws Exception {
+        log.info("Running test case test()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+            Incrementor bean = directory.lookupStateless(StatelessIncrementorBean.class, Incrementor.class);
+
+            // Allow sufficient time for client to receive full topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            List<String> results = new ArrayList<>(COUNT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.add(result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
+            }
+
+            undeploy(DEPLOYMENT_1);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            Assert.assertEquals(0, Collections.frequency(results, NODE_1));
+            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_2));
+
+            deploy(DEPLOYMENT_1);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
+            }
+
+            stop(NODE_2);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
+            Assert.assertEquals(0, Collections.frequency(results, NODE_2));
+
+            start(NODE_2);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
+            }
+        }
+    }
+
+    /**
+     * A server setup script to configure each backend node to register with the load balancer.
+     */
+    static class ServerSetupTask extends ManagementServerSetupTask {
+        public ServerSetupTask() {
+            super(NODE_1_2, createContainerConfigurationBuilder()
+                    .setupScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=false)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:add(host=localhost, port=8590)")
+                            .add("/subsystem=modcluster/proxy=default:list-add(name=proxies, value=proxy1)")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:add(class-name=\"io.undertow.server.handlers.RequestDumpingHandler\", module=\"io.undertow.core\")")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:add")
+                            .endBatch()
+                            .build()
+                    )
+                    .tearDownScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:list-remove(name=proxies, value=proxy1)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:remove")
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=true)")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:remove")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:remove")
+                            .endBatch()
+                            .build()
+                    )
+                    .build()
+            );
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
@@ -73,8 +73,8 @@ public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase ext
     }
 
     @Test
-    public void test() throws Exception {
-        log.info("Running test case test()");
+    public void testFailoverForStopStart() throws Exception {
+        log.info("Running test case testFailoverForStopStart()");
 
         // Allow sufficient time for the load balancer + cluster configuration to initialise
         Thread.sleep(LOAD_BALANCER_WAIT);
@@ -93,6 +93,65 @@ public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase ext
                 Thread.sleep(INVOCATION_WAIT);
             }
 
+            log.infof("load balancing results before stop: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
+            }
+
+            stop(NODE_2);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after stop: %s", results);
+            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
+            Assert.assertEquals(0, Collections.frequency(results, NODE_2));
+
+            start(NODE_2);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after restart: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
+            }
+        }
+    }
+
+    @Test
+    public void testFailoverForUndeployDeploy() throws Exception {
+        log.info("Running test case testFailoverForUndeployDeploy()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+            Incrementor bean = directory.lookupStateless(StatelessIncrementorBean.class, Incrementor.class);
+
+            // Allow sufficient time for client to receive full topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            List<String> results = new ArrayList<>(COUNT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.add(result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results before undeploy: %s", results);
             for (String node : NODE_1_2) {
                 int frequency = Collections.frequency(results, node);
                 assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
@@ -109,6 +168,7 @@ public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase ext
                 Thread.sleep(INVOCATION_WAIT);
             }
 
+            log.infof("load balancing results after undeploy: %s", results);
             Assert.assertEquals(0, Collections.frequency(results, NODE_1));
             Assert.assertEquals(COUNT, Collections.frequency(results, NODE_2));
 
@@ -123,38 +183,12 @@ public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase ext
                 Thread.sleep(INVOCATION_WAIT);
             }
 
+            log.infof("load balancing results after redeploy: %s", results);
             for (String node : NODE_1_2) {
                 int frequency = Collections.frequency(results, node);
                 assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
             }
-
-            stop(NODE_2);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
-            Assert.assertEquals(0, Collections.frequency(results, NODE_2));
-
-            start(NODE_2);
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            for (String node : NODE_1_2) {
-                int frequency = Collections.frequency(results, node);
-                assertTrue(frequency + " invocations were routed to " + node, frequency > 0);
-            }
-        }
+       }
     }
 
     /**

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SecureStatelessIncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementorBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.common.function.ExceptionSupplier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PropertyPermission;
+import java.util.Set;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateless EJB behind a load balancer.
+ *
+ * The test scenario is as follows:
+ * - an EJB/HTTP client
+ * - an Undertow-based modcluster load balancer
+ * - two clustered Wildfly servers with Stateless EJBs deployed
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+@ExtendWith(ArquillianExtension.class)
+@ServerSetup(AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.ServerSetupTask.class)
+public abstract class AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase extends AbstractClusteringTestCase {
+
+    protected static final Logger log = Logger.getLogger(AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase.class.getSimpleName());
+
+    protected static final int LB_OFFSET = 500;
+    private static final int COUNT = 20;
+    private static final long LOAD_BALANCER_WAIT = TimeoutUtil.adjust(5000);
+    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+    private static final long INVOCATION_WAIT = TimeoutUtil.adjust(10);
+
+    static Archive<?> createDeployment(String moduleName) {
+        return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, StatelessIncrementorBean.class, SecureStatelessIncrementorBean.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    private final ExceptionSupplier<EJBDirectory, Exception> directoryProvider;
+
+    AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) {
+        super(Set.of(LOAD_BALANCER_1, NODE_1, NODE_2), Set.of(DEPLOYMENT_1, DEPLOYMENT_2));
+        this.directoryProvider = directoryProvider;
+    }
+
+    @Test
+    public void testFailoverForStopStart() throws Exception {
+        log.info("Running test case testFailoverForStopStart()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+            Incrementor bean = directory.lookupStateless(StatelessIncrementorBean.class, Incrementor.class);
+
+            // Allow sufficient time for client to receive full topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            List<String> results = new ArrayList<>(COUNT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.add(result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results before stop: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency > 0, frequency + " invocations were routed to " + node);
+            }
+
+            stop(NODE_2);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after stop: %s", results);
+            // asertEquals(expected, actual)
+            assertEquals(COUNT, Collections.frequency(results, NODE_1));
+            assertEquals(0, Collections.frequency(results, NODE_2));
+
+            start(NODE_2);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after restart: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency > 0, frequency + " invocations were routed to " + node);
+            }
+        }
+    }
+
+    @Test
+    public void testFailoverForUndeployDeploy() throws Exception {
+        log.info("Running test case testFailoverForUndeployDeploy()");
+
+        // Allow sufficient time for the load balancer + cluster configuration to initialise
+        Thread.sleep(LOAD_BALANCER_WAIT);
+
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+            Incrementor bean = directory.lookupStateless(StatelessIncrementorBean.class, Incrementor.class);
+
+            // Allow sufficient time for client to receive full topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            List<String> results = new ArrayList<>(COUNT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.add(result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results before undeploy: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency > 0, frequency + " invocations were routed to " + node);
+            }
+
+            undeploy(DEPLOYMENT_1);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after undeploy: %s", results);
+            assertEquals(0, Collections.frequency(results, NODE_1));
+            assertEquals(COUNT, Collections.frequency(results, NODE_2));
+
+            deploy(DEPLOYMENT_1);
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            for (int i = 0; i < COUNT; ++i) {
+                Result<Integer> result = bean.increment();
+                results.set(i, result.getNode());
+                Thread.sleep(INVOCATION_WAIT);
+            }
+
+            log.infof("load balancing results after redeploy: %s", results);
+            for (String node : NODE_1_2) {
+                int frequency = Collections.frequency(results, node);
+                assertTrue(frequency > 0, frequency + " invocations were routed to " + node);
+            }
+       }
+    }
+
+    /**
+     * A server setup script to configure each backend node to register with the load balancer.
+     */
+    static class ServerSetupTask extends ManagementServerSetupTask {
+        public ServerSetupTask() {
+            super(NODE_1_2, createContainerConfigurationBuilder()
+                    .setupScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=false)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:add(host=localhost, port=8590)")
+                            .add("/subsystem=modcluster/proxy=default:list-add(name=proxies, value=proxy1)")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:add(class-name=\"io.undertow.server.handlers.RequestDumpingHandler\", module=\"io.undertow.core\")")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:add")
+                            .endBatch()
+                            .build()
+                    )
+                    .tearDownScript(createScriptBuilder()
+                            .startBatch()
+                            .add("/subsystem=modcluster/proxy=default:list-remove(name=proxies, value=proxy1)")
+                            .add("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1:remove")
+                            .add("/subsystem=modcluster/proxy=default:write-attribute(name=advertise, value=true)")
+                            .add("/subsystem=undertow/server=default-server/host=default-host/filter-ref=request-dumper:remove")
+                            .add("/subsystem=undertow/configuration=filter/custom-filter=request-dumper:remove")
+                            .endBatch()
+                            .build()
+                    )
+                    .build()
+            );
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/LoadBalancedRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/LoadBalancedRemoteStatefulEJBFailoverTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+
+import javax.naming.Context;
+import java.util.Properties;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateful EJB behind a load balancer.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public class LoadBalancedRemoteStatefulEJBFailoverTestCase extends AbstractLoadBalancedRemoteStatefulEJBFailoverTestCase {
+    private static final String MODULE_NAME = LoadBalancedRemoteStatefulEJBFailoverTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment(MODULE_NAME);
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment(MODULE_NAME);
+    }
+
+    public LoadBalancedRemoteStatefulEJBFailoverTestCase() {
+        super(() -> new RemoteEJBDirectory(MODULE_NAME, getInitialContextProperties()));
+    }
+
+    /**
+     * Provide a configured Properties file which will be used to initialise the JNDI InitialContext used for
+     * EJB proxy lookup. This specific configuration does two things:
+     * - it causes the EJB client code to use the EJB/HTTP transport, as the scheme is http and the context path
+     * is /wildfly-services
+     * - it causes the EJB client to bypass discovery, and use only the target nodes identified in the PROVIDER_URL
+     * in the case of retry of a failed invocation.
+     *
+     * @return an InitialContext properties file configured for EJB/HTTP
+     */
+    private static Properties getInitialContextProperties() {
+        Properties properties = new Properties();
+        // the load balancer is started at a process sharing the same IP with an offset port
+        String lbAddress = TestSuiteEnvironment.getHttpAddress();
+        int lbPort = TestSuiteEnvironment.getHttpPort() + LB_OFFSET;
+        String providerURL = String.format("http://%s:%s/wildfly-services", lbAddress, lbPort);
+        log.info("Setting PROVIDER_URL in InitialContext: " + providerURL);
+
+        properties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        properties.put(Context.PROVIDER_URL, providerURL);
+        properties.put(Context.SECURITY_PRINCIPAL, "remoteejbuser");
+        properties.put(Context.SECURITY_CREDENTIALS, "rem@teejbpasswd1");
+        return properties;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/LoadBalancedRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/LoadBalancedRemoteStatelessEJBFailoverTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+
+import javax.naming.Context;
+import java.util.Properties;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateless EJB behind a load balancer.
+ *
+ * @author Paul Ferraro
+ * @author Richard Achmatowicz
+ */
+public class LoadBalancedRemoteStatelessEJBFailoverTestCase extends AbstractLoadBalancedRemoteStatelessEJBFailoverTestCase {
+    private static final String MODULE_NAME = LoadBalancedRemoteStatelessEJBFailoverTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment(MODULE_NAME);
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment(MODULE_NAME);
+    }
+
+    public LoadBalancedRemoteStatelessEJBFailoverTestCase() {
+        super(() -> new RemoteEJBDirectory(MODULE_NAME, getInitialContextProperties()));
+    }
+
+    /**
+     * Provide a configured Properties file which will be used to initialise the JNDI InitialContext used for
+     * EJB proxy lookup. This specific configuration does two things:
+     * - it causes the EJB client code to use the EJB/HTTP transport, as the scheme is http and the context path
+     * is /wildfly-services
+     * - it causes the EJB client to bypass discovery, and use only the target nodes identified in the PROVIDER_URL
+     * in the case of retry of a failed invocation.
+     *
+     * @return an InitialContext properties file configured for EJB/HTTP
+     */
+    private static Properties getInitialContextProperties() {
+        Properties properties = new Properties();
+        // the load balancer is started at a process sharing the same IP with an offset port
+        String lbAddress = TestSuiteEnvironment.getHttpAddress();
+        int lbPort = TestSuiteEnvironment.getHttpPort() + LB_OFFSET;
+        String providerURL = String.format("http://%s:%s/wildfly-services", lbAddress, lbPort);
+        log.info("Setting PROVIDER_URL in InitialContext: " + providerURL);
+
+        properties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        properties.put(Context.PROVIDER_URL, providerURL);
+        properties.put(Context.SECURITY_PRINCIPAL, "remoteejbuser");
+        properties.put(Context.SECURITY_CREDENTIALS, "rem@teejbpasswd1");
+        return properties;
+    }
+}


### PR DESCRIPTION

This PR does the following:
- adds load balancing counterparts to RemoteStatefulEJBFailoverTestCase and RemoteStatelessEJBFailoverTestCase 
- these tests will make use of clients using EJB/HTTP as opposed to EJB/Remoting

For more details see:  https://issues.redhat.com/browse/WFLY-21337