### PR TITLE
WFLY-21341 ironjacamar.xml files in testsuite are failing XML schema validation and are missing schema declaration

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/archive/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/archive/ironjacamar.xml
@@ -4,4 +4,6 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar/>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-ao.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-ao.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <config-property name="raProperty">5</config-property>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-cf.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-cf.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <config-property name="raProperty">5</config-property>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-ra.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar-wrong-ra.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <config-property name="raProperty">1</config-property>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/ironjacamar.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <config-property name="raProperty">4</config-property>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/ironjacamar.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bootstrap-context>customContext</bootstrap-context>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/ironjacamar-2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/ironjacamar-2.xml
@@ -4,14 +4,16 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
-    <bootstrap-context>default</bootstrap-context>
-    <transaction-support>XATransaction</transaction-support>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bean-validation-groups>
         <bean-validation-group>org.jboss.as.test.integration.jca.beanvalidation.ra.ValidGroup</bean-validation-group>
         <bean-validation-group>org.jboss.as.test.integration.jca.beanvalidation.ra.ValidGroup1</bean-validation-group>
     </bean-validation-groups>
+    <bootstrap-context>default</bootstrap-context>
     <config-property name="raProperty">4</config-property>
+    <transaction-support>XATransaction</transaction-support>
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.beanvalidation.ra.ValidManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/ironjacamar.xml
@@ -4,14 +4,16 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
-    <bootstrap-context>default</bootstrap-context>
-    <transaction-support>XATransaction</transaction-support>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bean-validation-groups>
         <bean-validation-group>org.jboss.as.test.integration.jca.beanvalidation.ra.ValidGroup</bean-validation-group>
         <bean-validation-group>org.jboss.as.test.integration.jca.beanvalidation.ra.ValidGroup1</bean-validation-group>
     </bean-validation-groups>
+    <bootstrap-context>default</bootstrap-context>
     <config-property name="raProperty">4</config-property>
+    <transaction-support>XATransaction</transaction-support>
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.beanvalidation.ra.ValidManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-default.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-default.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-enlistmentfalse.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-enlistmentfalse.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-sharablefalse.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-sharablefalse.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-xa-default.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-xa-default.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ironjacamar.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition
                 class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar1.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1"
                                jndi-name="java:jboss/ConnectionFactory1"></connection-definition>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar2.xml
@@ -4,9 +4,11 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory2"
-                               jndi-name="java:jboss/ConnectionFactory2"></connection-definition>
+                               jndi-name="java:jboss/ConnectionFactory2"/>
     </connection-definitions>
 </ironjacamar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/ironjacamar3.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1"
                                jndi-name="java:jboss/ConnectionFactory3"></connection-definition>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/ironjacamar1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/ironjacamar1.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bootstrap-context>customContext1</bootstrap-context>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/ironjacamar2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/ironjacamar2.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bootstrap-context>customContext2</bootstrap-context>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ironjacamar-distributed-1.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ironjacamar-distributed-1.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <bootstrap-context>customContext1</bootstrap-context>
     <connection-definitions>
         <connection-definition

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/activation/ironjacamar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/activation/ironjacamar.xml
@@ -4,7 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"
                                pool-name="ij_Pool1"></connection-definition>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/ironjacamar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/ironjacamar.xml
@@ -4,12 +4,14 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"
-                               pool-name="ij_Pool1"></connection-definition>
+                               pool-name="ij_Pool1"/>
     </connection-definitions>
     <admin-objects>
-        <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl" jndi-name="java:jboss/Name3" pool-name="ij_Pool3"></admin-object>
+        <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl" jndi-name="java:jboss/Name3" pool-name="ij_Pool3"/>
     </admin-objects>
 </ironjacamar>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/ironjacamar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/ironjacamar.xml
@@ -1,16 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:noNamespaceSchemaLocation="../../../../../../common/src/main/resources/schema/ironjacamar_1_0.xsd">
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1"
-                               jndi-name="java:jboss/name3" pool-name="Pool1"></connection-definition>
+                               jndi-name="java:jboss/name3" pool-name="Pool1"/>
     </connection-definitions>
     <admin-objects>
         <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl"
-                      jndi-name="java:jboss/Name5" pool-name="Pool3"></admin-object>
+                      jndi-name="java:jboss/Name5" pool-name="Pool3"/>
     </admin-objects>
 </ironjacamar>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/ironjacamar2.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/ironjacamar2.xml
@@ -1,16 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:noNamespaceSchemaLocation="../../../../../../common/src/main/resources/schema/ironjacamar_1_0.xsd">
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
     <connection-definitions>
         <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory2"
-                               jndi-name="java:jboss/name2" pool-name="Pool2"></connection-definition>
+                               jndi-name="java:jboss/name2" pool-name="Pool2"/>
     </connection-definitions>
     <admin-objects>
         <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject2Impl"
-                      jndi-name="java:jboss/Name4" pool-name="Pool4"></admin-object>
+                      jndi-name="java:jboss/Name4" pool-name="Pool4"/>
     </admin-objects>
 </ironjacamar>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/inflow/ironjacamar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/inflow/ironjacamar.xml
@@ -1,11 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright The WildFly Authors
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar xmlns="http://www.jboss.org/ironjacamar/schema"
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema 
-             http://www.jboss.org/ironjacamar/schema/ironjacamar_1_0.xsd">
-
-</ironjacamar>
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd"/>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/rar/ironjacamar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/rar/ironjacamar.xml
@@ -5,7 +5,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<ironjacamar>
+<ironjacamar xmlns="http://www.ironjacamar.org/doc/schema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.ironjacamar.org/doc/schema https://www.ironjacamar.org/doc/schema/ironjacamar_1_3.xsd">
 
    <connection-definitions>
      <connection-definition class-name="org.jboss.as.test.smoke.rar.HelloWorldManagedConnectionFactory"


### PR DESCRIPTION
The ironjacamar.xml descriptor files across the WildFly testsuite are either missing proper XML schema declarations or are using outdated/incorrect schema references.

Fixing the declaration causes schema validation failures and prevents proper validation of the deployment descriptors.

1. Missing or incomplete XML schema declarations (no xmlns/xsi:schemaLocation)
2. Incorrect namespace: Using http://www.jboss.org/ironjacamar/schema instead of http://www.ironjacamar.org/doc/schema
3. Outdated schema version: Referencing ironjacamar_1_2.xsd instead of ironjacamar_1_3.xsd
4. Incorrect element ordering causing schema validation failures (elements not ordered according to XSD sequence requirements)

Resolves
https://issues.redhat.com/browse/WFLY-21341