### PR TITLE
[WFLY-21349] Deprecate require-host-http11 and ignore its setting

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AbstractHttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AbstractHttpListenerResourceDefinition.java
@@ -14,6 +14,7 @@ import io.undertow.protocols.http2.Http2Channel;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -98,6 +99,7 @@ abstract class AbstractHttpListenerResourceDefinition extends ListenerResourceDe
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
+            .setDeprecated(ModelVersion.create(14, 0, 0))
             .build();
 
     static final SimpleAttributeDefinition PROXY_PROTOCOL = new SimpleAttributeDefinitionBuilder(Constants.PROXY_PROTOCOL, ModelType.BOOLEAN)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -29,7 +29,6 @@ class HttpListenerAdd extends ListenerAdd<HttpListenerService> {
         final boolean proxyAddressForwarding = AbstractHttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING.resolveModelAttribute(context, model).asBoolean();
         OptionMap.Builder listenerBuilder = OptionMap.builder().addAll(listenerOptions);
         AbstractHttpListenerResourceDefinition.ENABLE_HTTP2.resolveOption(context, model,listenerBuilder);
-        AbstractHttpListenerResourceDefinition.REQUIRE_HOST_HTTP11.resolveOption(context, model,listenerBuilder);
 
         handleHttp2Options(context, model, listenerBuilder);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -30,6 +30,8 @@ class HttpListenerAdd extends ListenerAdd<HttpListenerService> {
         OptionMap.Builder listenerBuilder = OptionMap.builder().addAll(listenerOptions);
         AbstractHttpListenerResourceDefinition.ENABLE_HTTP2.resolveOption(context, model,listenerBuilder);
 
+        logRequireHostHttp1Ineffective(context, model);
+
         handleHttp2Options(context, model, listenerBuilder);
 
         return new HttpListenerService(serviceConsumer, context.getCurrentAddress(), serverName, listenerBuilder.getMap(), socketOptions, certificateForwarding, proxyAddressForwarding, proxyProtocol);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -43,6 +43,7 @@ class HttpsListenerAdd extends ListenerAdd<HttpsListenerService> {
         AbstractHttpListenerResourceDefinition.ENABLE_HTTP2.resolveOption(context, model, listenerBuilder);
         HttpListenerAdd.handleHttp2Options(context, model, listenerBuilder);
 
+        logRequireHostHttp1Ineffective(context, model);
 
         final boolean certificateForwarding = AbstractHttpListenerResourceDefinition.CERTIFICATE_FORWARDING.resolveModelAttribute(context, model).asBoolean();
         final boolean proxyAddressForwarding = AbstractHttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING.resolveModelAttribute(context, model).asBoolean();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -43,7 +43,6 @@ class HttpsListenerAdd extends ListenerAdd<HttpsListenerService> {
         AbstractHttpListenerResourceDefinition.ENABLE_HTTP2.resolveOption(context, model, listenerBuilder);
         HttpListenerAdd.handleHttp2Options(context, model, listenerBuilder);
 
-        AbstractHttpListenerResourceDefinition.REQUIRE_HOST_HTTP11.resolveOption(context, model,listenerBuilder);
 
         final boolean certificateForwarding = AbstractHttpListenerResourceDefinition.CERTIFICATE_FORWARDING.resolveModelAttribute(context, model).asBoolean();
         final boolean proxyAddressForwarding = AbstractHttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING.resolveModelAttribute(context, model).asBoolean();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -429,4 +429,8 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 111, value = "The annotation: '%s' will have no effect on Servlet: '%s'")
     void badAnnotationOnServlet(String annotation, String servlet);
 
+    @Message(id = 112, value = "The value '%s' attribute in the '%s' resource is 'false', which will be ignored. " +
+            "The server now always enforces the RFC 9112 requirement that HTTP/1.1 request messages include a Host header.")
+    String http11HostHeaderRequired(String attribute, String resource);
+
 }

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -261,6 +261,7 @@ undertow.listener.http2-max-header-list-size=The maximum size of request headers
 undertow.listener.http2-initial-window-size=The flow control window size that controls how quickly the client can send data to the server
 undertow.listener.http2-header-table-size=The size of the header table used for HPACK compression, in bytes. This amount of memory will be allocated per connection for compression. Larger values use more memory but may give better compression.
 undertow.listener.require-host-http11=Require that all HTTP/1.1 requests have a 'Host' header, as per the RFC. IF the request does not include this header it will be rejected with a 403.
+undertow.listener.require-host-http11.deprecated=This attribute is ignored in a current version server. A Host header is required for HTTP/1.1 and above. For older protocols is it optional.
 undertow.listener.allowed-request-attributes-pattern=Pattern(regex) which specifies allowed custom AJP request attributes.
 undertow.host=An Undertow host
 undertow.host.add=Adds a new host


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21349

Ported from downstream EAP.

Undertow no longer supports this setting and logs if it is set.