### PR TITLE
Ignore LegacyJMSTestCase on Windows until WFLY-21350 is fixed

### DIFF
--- a/testsuite/integration/legacy/src/test/java/org/jboss/as/test/integration/messaging/jms/legacy/LegacyJMSTestCase.java
+++ b/testsuite/integration/legacy/src/test/java/org/jboss/as/test/integration/messaging/jms/legacy/LegacyJMSTestCase.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 
 import javax.jms.ConnectionFactory;
@@ -36,15 +37,17 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Test that a legacy (HornetQ) clients can lookup Jakarta Messaging resources managed by the messaging-activemq subsystem
- * when they lookup a legacy entry.
+ * Test that a legacy (HornetQ) clients can look up Jakarta Messaging resources managed by the messaging-activemq subsystem
+ * when they look up a legacy entry.
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
@@ -71,6 +74,14 @@ public class LegacyJMSTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
+
+    @BeforeClass
+    public static void ignoreOnWindows() {
+        if (System.getProperty("os.name", null).toLowerCase(Locale.ENGLISH).contains("windows")) {
+            // this isn't actually an intermittent failure, but might as well allow it to be enabled via the IntermittentFailure sys prop
+            IntermittentFailure.thisTestIsFailingIntermittently("WFLY-21350");
+        }
+    }
 
     @Before
     public void setUp() throws IOException {


### PR DESCRIPTION


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21350](https://issues.redhat.com/browse/WFLY-21350)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)