### PR TITLE
[WFLY-21355] Upgrade WildFly Core to 31.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>31.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>31.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/WFLY-21355

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/31.0.1.Final
Diff: https://github.com/wildfly/wildfly-core/compare/31.0.0.Final...31.0.1.Final

---

<details>
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7464'>WFCORE-7464</a>] -         Upgrade Undertow to 2.3.22.Final
</li>
</ul>
</details>
