### PR TITLE
[WFLY-21334] Add jakarta.enterprise.concurrent.api module

### DIFF
--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
@@ -25,6 +25,9 @@
 
     <!-- lra-client -->
     <module name="jakarta.enterprise.api"/>
+    <!-- Setting the cuncurrent.api optional prevents it being provisioned in a slimmed server whose provisioning config doesn't include the actual Jakarta Concurrency integration -->
+    <module name="jakarta.enterprise.concurrent.api" optional="true"/>
+
     <!-- lra-proxy-api -->
     <module name="io.smallrye.jandex"/>
     <!-- narayana-lra -->


### PR DESCRIPTION
Make jakarta.enterprise.concurrent.api optional

https://issues.redhat.com/browse/WFLY-21334

