### PR TITLE
Bump org.assertj:assertj-core to 3.27.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <version.junit>4.13.2</version.junit>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.groovy>4.0.27</version.org.apache.groovy>
-        <version.org.assertj>3.26.3</version.org.assertj>
+        <version.org.assertj>3.27.6</version.org.assertj>
         <version.org.awaitility.awaitility>4.0.3</version.org.awaitility.awaitility>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jetty>11.0.25</version.org.eclipse.jetty>


### PR DESCRIPTION
No Jira needed - test dependency only.
