### PR TITLE
[WFLY-21379] Upgrade WildFly Core to 32.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>31.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>32.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21379

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/32.0.0.Beta1
Diff: https://github.com/wildfly/wildfly-core/compare/31.0.1.Final...32.0.0.Beta1

---

<details>
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7440'>WFCORE-7440</a>] -         Port DurationAttributeDefinition to wildfly-subsystem.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7441'>WFCORE-7441</a>] -         Port EnumAttributeDefinition to wildfly-subsystem.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7442'>WFCORE-7442</a>] -         Port ModuleAttributeDefinition to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7443'>WFCORE-7443</a>] -         Port ModuleListAttributeDefinition to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7444'>WFCORE-7444</a>] -         Port PropertiesAttributeDefinition to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7445'>WFCORE-7445</a>] -         Port StatisticsEnabledAttributeDefinition to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7446'>WFCORE-7446</a>] -         Port generic BoundedParameterValidator to wildfly-controller
</li>
</ul>
                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7471'>WFCORE-7471</a>] -         deployment-overlay high level command do not validate the deployment runtime names
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7472'>WFCORE-7472</a>] -         launch.sh systemd script incorrectly overrides JAVA_OPTS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7473'>WFCORE-7473</a>] -         Interactive CLI does not work on Windows with WildFly 39
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7383'>WFCORE-7383</a>] -         Bump the kernel management API version to 33.0.0
</li>
</ul>
                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7460'>WFCORE-7460</a>] -         Upgrade org.wildfly.galleon-plugins to 8.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7464'>WFCORE-7464</a>] -         Upgrade Undertow to 2.3.22.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7474'>WFCORE-7474</a>] -         Upgrade jansi to 2.4.2
</li>
</ul>
        
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-6893'>WFCORE-6893</a>] -         Add channel manifest versions information to the installer history and product-info operations
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7436'>WFCORE-7436</a>] -         Improve the log message reporting channel manifest versions used in the installation
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7439'>WFCORE-7439</a>] -         Port attribute definition implementations from wildfly-clustering-common to wildfly-subsystem
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7476'>WFCORE-7476</a>] -         Align jboss.require-java-version with compiler target i.e. JDK 17
</li>
</ul>
</details>

