### PR TITLE
[WFLY-21213] Broken docs.jboss.org links to Arquillian content

### DIFF
--- a/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Testsuite_Test_Developer_Guide.adoc
@@ -95,15 +95,6 @@ public void test() {
 @ArquillianResource Deployer deployer;
 ----
 
-See
-https://docs.jboss.org/author/display/ARQ/Resource+injection[Arquillian's
-Resource Injection docs] for more info,
-https://github.com/arquillian/arquillian-examples for examples.
-
-See also
-https://docs.jboss.org/author/display/ARQ/Reference+Guide[Arquillian
-Reference].
-
 Note to @ServerSetup annotation: It works as expected only on non-manual
 containers. In case of manual mode containers it calls setup() method
 after each server start up which is right (or actually before


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-21213

`https://docs.jboss.org/author/display/ARQ/JBoss+AS+7.1%2C+JBoss+EAP+6.0+-+Managed[AS..` was deleted in the https://github.com/wildfly/wildfly/pull/19456 PR.