### PR TITLE
[WFLY-21525] Promote 'reuseXForwarded and rewriteHost' to default stability

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ReverseProxyTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ReverseProxyTestCase.java
@@ -46,7 +46,6 @@ public class ReverseProxyTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
-    private static ManagementClient mc;
     private AutoCloseable serverSnapshot;
 
     @Before

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
@@ -4,11 +4,10 @@
  */
 package org.jboss.as.test.integration.web.reverseproxy.headers;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
 
 import org.apache.http.HttpResponse;
@@ -27,10 +26,11 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.ServerSnapshot;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -47,50 +47,49 @@ public class ReverseProxyForwardedForTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
-    private static ManagementClient mc;
+    private AutoCloseable serverSnapshot;
 
     @Before
     public void setup() throws Exception {
-        if (mc == null) {
-            mc = managementClient;
-            //add the reverse proxy
-            ModelNode op = new ModelNode();
-            ModelNode addr = new ModelNode();
-            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-            addr.add("configuration", "handler");
-            addr.add("reverse-proxy", "myproxy");
-            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get("max-request-time").set(60000);
-            op.get("connection-idle-timeout").set(60000);
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        serverSnapshot = ServerSnapshot.takeSnapshot(managementClient);
+        // add the reverse proxy
+        ModelNode op = new ModelNode();
+        ModelNode addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        op.get("max-request-time").set(60000);
+        op.get("connection-idle-timeout").set(60000);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
-            //add the hosts
-            ModelNode addSocketBindingOp = getOutboundSocketBinding(managementClient.getWebUri().getHost(), managementClient.getWebUri().getPort());
-            ManagementOperations.executeOperation(managementClient.getControllerClient(),addSocketBindingOp);
+        // add the hosts
+        ModelNode addSocketBindingOp = getOutboundSocketBinding(managementClient.getWebUri().getHost(),
+                managementClient.getWebUri().getPort());
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), addSocketBindingOp);
 
-            op = new ModelNode();
-            addr = new ModelNode();
-            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-            addr.add("configuration", "handler");
-            addr.add("reverse-proxy", "myproxy");
-            addr.add("host", "server1");
-            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get("outbound-socket-binding").set("proxy-host");
-            op.get("path").set("/server1");
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-            op = new ModelNode();
-            addr = new ModelNode();
-            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-            addr.add("server", "default-server");
-            addr.add("host", "default-host");
-            addr.add("location", "/proxy");
-            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-            op.get("handler").set("myproxy");
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-        }
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        addr.add("host", "server1");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        op.get("outbound-socket-binding").set("proxy-host");
+        op.get("path").set("/server1");
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("server", "default-server");
+        addr.add("host", "default-host");
+        addr.add("location", "/proxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get("handler").set("myproxy");
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
     }
 
     private static ModelNode getOutboundSocketBinding(String address, int port) {
@@ -100,44 +99,9 @@ public class ReverseProxyForwardedForTestCase {
         return op;
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
-
-        ModelNode op = new ModelNode();
-        ModelNode addr = new ModelNode();
-
-        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-        addr.add("configuration", "handler");
-        addr.add("reverse-proxy", "myproxy");
-        addr.add("host", "server1");
-        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
-        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        ManagementOperations.executeOperation(mc.getControllerClient(), op);
-
-        op = new ModelNode();
-        addr = new ModelNode();
-        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-        addr.add("server", "default-server");
-        addr.add("host", "default-host");
-        addr.add("location", "/proxy");
-        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
-        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        ManagementOperations.executeOperation(mc.getControllerClient(), op);
-
-        op = new ModelNode();
-        addr = new ModelNode();
-        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
-        addr.add("configuration", "handler");
-        addr.add("reverse-proxy", "myproxy");
-        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
-        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        ManagementOperations.executeOperation(mc.getControllerClient(), op);
-
-        op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy-host", "remove");
-        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+    @After
+    public void tearDown() throws Exception {
+        serverSnapshot.close();
     }
 
     @ArquillianResource
@@ -163,24 +127,30 @@ public class ReverseProxyForwardedForTestCase {
     @Test
     public void testNoForwarded() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            setReuseForawrdedTo(false);// thats default
+            setReuseForwardedTo(false);// thats default
             final String result = performCall(httpclient, "name?header=X_Forwarded_For");
-            Assert.assertEquals(url.getHost(), result);
+            final InetAddress resultAddress = InetAddress.getByName(result);
+            final InetAddress hostAddress = InetAddress.getByName(url.getHost());
+            Assert.assertEquals(hostAddress, resultAddress);
         }
     }
 
     @Test
     public void testWithForwarded() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            setReuseForawrdedTo(true);
+            setReuseForwardedTo(true);
             final String result = performCall(httpclient, "name?header=X_Forwarded_For");
-            Assert.assertEquals("1.1.1.1,"+url.getHost(), result);
+            final String[] parts = result.split(",");
+            Assert.assertEquals(parts.length, 2);
+            final InetAddress resultAddress = InetAddress.getByName(parts[1]);
+            final InetAddress hostAddress = InetAddress.getByName(url.getHost());
+            Assert.assertEquals("1.1.1.1,"+hostAddress.toString(), parts[0]+","+resultAddress.toString());
         } finally {
-            setReuseForawrdedTo(false);
+            setReuseForwardedTo(false);
         }
     }
 
-    private void setReuseForawrdedTo(final boolean value) throws IOException, MgmtOperationException {
+    private void setReuseForwardedTo(final boolean value) throws IOException, MgmtOperationException {
         ModelNode op = new ModelNode();
         ModelNode addr = new ModelNode();
         addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.reverseproxy.headers;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+/**
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ReverseProxyForwardedForTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+    private static ManagementClient mc;
+
+    @Before
+    public void setup() throws Exception {
+        if (mc == null) {
+            mc = managementClient;
+            //add the reverse proxy
+            ModelNode op = new ModelNode();
+            ModelNode addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("configuration", "handler");
+            addr.add("reverse-proxy", "myproxy");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get("max-request-time").set(60000);
+            op.get("connection-idle-timeout").set(60000);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+            //add the hosts
+            ModelNode addSocketBindingOp = getOutboundSocketBinding(managementClient.getWebUri().getHost(), managementClient.getWebUri().getPort());
+            ManagementOperations.executeOperation(managementClient.getControllerClient(),addSocketBindingOp);
+
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("configuration", "handler");
+            addr.add("reverse-proxy", "myproxy");
+            addr.add("host", "server1");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get("outbound-socket-binding").set("proxy-host");
+            op.get("path").set("/server1");
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("server", "default-server");
+            addr.add("host", "default-host");
+            addr.add("location", "/proxy");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get("handler").set("myproxy");
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+    }
+
+    private static ModelNode getOutboundSocketBinding(String address, int port) {
+        ModelNode op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy-host", "add");
+        op.get("host").set(address);
+        op.get("port").set(port);
+        return op;
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+
+        ModelNode op = new ModelNode();
+        ModelNode addr = new ModelNode();
+
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        addr.add("host", "server1");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("server", "default-server");
+        addr.add("host", "default-host");
+        addr.add("location", "/proxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy-host", "remove");
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+    }
+
+    @ArquillianResource
+    @OperateOnDeployment("server1")
+    private URL url;
+
+    @Deployment(name = "server1", testable = false)
+    public static WebArchive server1() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "server1.war");
+        war.addClasses(ServerNameServlet.class);
+        war.addAsWebInfResource(ReverseProxyForwardedForTestCase.class.getPackage(), "web-server1.xml", "web.xml");
+        return war;
+    }
+
+    private String performCall(CloseableHttpClient httpclient, String urlPattern) throws Exception {
+        HttpGet get = new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/" + urlPattern);
+        get.addHeader("X-Forwarded-For", "1.1.1.1");
+        HttpResponse res =  httpclient.execute(get);
+        Assert.assertEquals(200, res.getStatusLine().getStatusCode());
+        return EntityUtils.toString(res.getEntity());
+    }
+
+    @Test
+    public void testNoForwarded() throws Exception {
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            setReuseForawrdedTo(false);// thats default
+            final String result = performCall(httpclient, "name?header=X_Forwarded_For");
+            Assert.assertEquals(url.getHost(), result);
+        }
+    }
+
+    @Test
+    public void testWithForwarded() throws Exception {
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            setReuseForawrdedTo(true);
+            final String result = performCall(httpclient, "name?header=X_Forwarded_For");
+            Assert.assertEquals("1.1.1.1,"+url.getHost(), result);
+        } finally {
+            setReuseForawrdedTo(false);
+        }
+    }
+
+    private void setReuseForawrdedTo(final boolean value) throws IOException, MgmtOperationException {
+        ModelNode op = new ModelNode();
+        ModelNode addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION);
+        op.get(ModelDescriptionConstants.NAME).set("reuse-x-forwarded-header");
+        op.get(ModelDescriptionConstants.VALUE).set(value);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
+    }
+
+    public void testReverseProxyMaxRequestTime2() throws Exception {
+        // set the max-request-time to a lower value than the wait
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/name?wait=50");
+            get.addHeader("X-Forwarded-For", "1.1.1.1");
+            HttpResponse res = httpclient.execute(get);
+            // With https://issues.redhat.com/browse/UNDERTOW-1459 fix, status code should be 504
+            // FIXME: after undertow 2.2.13.Final integrated into WildFly, this should be updated to 504 only
+            Assert.assertTrue("Service Unaviable expected because max-request-time is set to 10ms", res.getStatusLine().getStatusCode() == 504 || res.getStatusLine().getStatusCode() == 503);
+        }
+    }
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyForwardedForTestCase.java
@@ -33,16 +33,14 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 /**
+ * Test if reuse-x-forwarded-header attribute work properly.
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ReverseProxyForwardedForTestCase {
 
     @ContainerResource
@@ -141,12 +139,10 @@ public class ReverseProxyForwardedForTestCase {
             setReuseForwardedTo(true);
             final String result = performCall(httpclient, "name?header=X_Forwarded_For");
             final String[] parts = result.split(",");
-            Assert.assertEquals(parts.length, 2);
+            Assert.assertEquals(2, parts.length);
             final InetAddress resultAddress = InetAddress.getByName(parts[1]);
             final InetAddress hostAddress = InetAddress.getByName(url.getHost());
             Assert.assertEquals("1.1.1.1,"+hostAddress.toString(), parts[0]+","+resultAddress.toString());
-        } finally {
-            setReuseForwardedTo(false);
         }
     }
 
@@ -162,17 +158,5 @@ public class ReverseProxyForwardedForTestCase {
         op.get(ModelDescriptionConstants.VALUE).set(value);
         ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
         ServerReload.executeReloadAndWaitForCompletion(managementClient);
-    }
-
-    public void testReverseProxyMaxRequestTime2() throws Exception {
-        // set the max-request-time to a lower value than the wait
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            HttpGet get = new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/name?wait=50");
-            get.addHeader("X-Forwarded-For", "1.1.1.1");
-            HttpResponse res = httpclient.execute(get);
-            // With https://issues.redhat.com/browse/UNDERTOW-1459 fix, status code should be 504
-            // FIXME: after undertow 2.2.13.Final integrated into WildFly, this should be updated to 504 only
-            Assert.assertTrue("Service Unaviable expected because max-request-time is set to 10ms", res.getStatusLine().getStatusCode() == 504 || res.getStatusLine().getStatusCode() == 503);
-        }
     }
 }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyRewriteHostTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyRewriteHostTestCase.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.reverseproxy.headers;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+/**
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ReverseProxyRewriteHostTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+    private static ManagementClient mc;
+
+    @Before
+    public void setup() throws Exception {
+        if (mc == null) {
+            mc = managementClient;
+            //add the reverse proxy
+            ModelNode op = new ModelNode();
+            ModelNode addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("configuration", "handler");
+            addr.add("reverse-proxy", "myproxy");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get("max-request-time").set(60000);
+            op.get("connection-idle-timeout").set(60000);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+            //add the hosts
+            ModelNode addSocketBindingOp = getOutboundSocketBinding(managementClient.getWebUri().getHost(), managementClient.getWebUri().getPort());
+            ManagementOperations.executeOperation(managementClient.getControllerClient(),addSocketBindingOp);
+
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("configuration", "handler");
+            addr.add("reverse-proxy", "myproxy");
+            addr.add("host", "server1");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get("outbound-socket-binding").set("proxy-host");
+            op.get("path").set("/server1");
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+            addr.add("server", "default-server");
+            addr.add("host", "default-host");
+            addr.add("location", "/proxy");
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get("handler").set("myproxy");
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+    }
+
+    private static ModelNode getOutboundSocketBinding(String address, int port) {
+        ModelNode op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy-host", "add");
+        op.get("host").set(address);
+        op.get("port").set(port);
+        return op;
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+
+        ModelNode op = new ModelNode();
+        ModelNode addr = new ModelNode();
+
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        addr.add("host", "server1");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("server", "default-server");
+        addr.add("host", "default-host");
+        addr.add("location", "/proxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+
+        op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy-host", "remove");
+        ManagementOperations.executeOperation(mc.getControllerClient(), op);
+    }
+
+    @ArquillianResource
+    @OperateOnDeployment("server1")
+    private URL url;
+
+    @Deployment(name = "server1", testable = false)
+    public static WebArchive server1() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "server1.war");
+        war.addClasses(ServerNameServlet.class);
+        war.addAsWebInfResource(ReverseProxyRewriteHostTestCase.class.getPackage(), "web-server1.xml", "web.xml");
+        return war;
+    }
+
+    private String performCall(CloseableHttpClient httpclient, String urlPattern) throws Exception {
+        HttpGet get = new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/" + urlPattern);
+        HttpResponse res =  httpclient.execute(get);
+        Assert.assertEquals(200, res.getStatusLine().getStatusCode());
+        return EntityUtils.toString(res.getEntity());
+    }
+
+    @Test
+    public void testNoRewrite() throws Exception {
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            setReuseForawrdedTo(false);// thats default
+            final String result = performCall(httpclient, "name?header=X_Forwarded_Host"); //this is side effect, but Host header is localhost in both, so checking it makes sense
+            Assert.assertEquals(url.getHost(), result);
+        }
+    }
+
+    @Test
+    public void testWithRewrite() throws Exception {
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            setReuseForawrdedTo(true);
+            final String result = performCall(httpclient, "name?header=X_Forwarded_Host");
+            Assert.assertEquals(url.getHost()+":"+url.getPort(), result);
+        } finally {
+            setReuseForawrdedTo(false);
+        }
+    }
+
+    private void setReuseForawrdedTo(final boolean value) throws IOException, MgmtOperationException {
+        ModelNode op = new ModelNode();
+        ModelNode addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        addr.add("configuration", "handler");
+        addr.add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION);
+        op.get(ModelDescriptionConstants.NAME).set("rewrite-host-header");
+        op.get(ModelDescriptionConstants.VALUE).set(value);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
+    }
+
+    public void testReverseProxyMaxRequestTime2() throws Exception {
+        // set the max-request-time to a lower value than the wait
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/name?wait=50");
+            get.addHeader("X-Forwarded-For", "1.1.1.1");
+            HttpResponse res = httpclient.execute(get);
+            // With https://issues.redhat.com/browse/UNDERTOW-1459 fix, status code should be 504
+            // FIXME: after undertow 2.2.13.Final integrated into WildFly, this should be updated to 504 only
+            Assert.assertTrue("Service Unaviable expected because max-request-time is set to 10ms", res.getStatusLine().getStatusCode() == 504 || res.getStatusLine().getStatusCode() == 503);
+        }
+    }
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyRewriteHostTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ReverseProxyRewriteHostTestCase.java
@@ -33,16 +33,14 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 /**
+ * Test if rewrite-host-header attribute work properly
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ReverseProxyRewriteHostTestCase {
 
     @ContainerResource
@@ -127,7 +125,7 @@ public class ReverseProxyRewriteHostTestCase {
     @Test
     public void testNoRewrite() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            setReuseForwardedTo(false);// thats default
+            setRewriteHostHeader(false);// thats default
             final String result = performCall(httpclient, "name?header=X_Forwarded_Host"); //this is side effect, but Host header is localhost in both, so checking it makes sense
             final InetAddress resultAddress = InetAddress.getByName(result);
             final InetAddress hostAddress = InetAddress.getByName(url.getHost());
@@ -138,7 +136,7 @@ public class ReverseProxyRewriteHostTestCase {
     @Test
     public void testWithRewrite() throws Exception {
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            setReuseForwardedTo(true);
+            setRewriteHostHeader(true);
             final String result = performCall(httpclient, "name?header=X_Forwarded_Host");
             final int lastInd = result.lastIndexOf(":"); //ipv6 will have more :, we cant split on it.
             Assert.assertNotEquals(-1, lastInd);
@@ -147,12 +145,10 @@ public class ReverseProxyRewriteHostTestCase {
             final InetAddress hostAddress = InetAddress.getByName(url.getHost());
             Assert.assertEquals(hostAddress.toString(), resultAddress.toString());
             Assert.assertEquals(url.getPort()+"", parts[1]);
-        } finally {
-            setReuseForwardedTo(false);
         }
     }
 
-    private void setReuseForwardedTo(final boolean value) throws IOException, MgmtOperationException {
+    private void setRewriteHostHeader(final boolean value) throws IOException, MgmtOperationException {
         ModelNode op = new ModelNode();
         ModelNode addr = new ModelNode();
         addr.add(ModelDescriptionConstants.SUBSYSTEM, "undertow");

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ServerNameServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/ServerNameServlet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.reverseproxy.headers;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+
+/**
+ */
+@WebServlet(name = "ServerNameServlet", urlPatterns = {"/name"})
+public class ServerNameServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().write(req.getHeader(req.getParameter("header").replaceAll("_", "-")));
+        resp.getWriter().close();
+    }
+
+
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/web-server1.xml
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/web-server1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <servlet>
+        <servlet-name>ServerNameServlet</servlet-name>
+    </servlet>
+
+</web-app>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/web-server1.xml
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/headers/web-server1.xml
@@ -4,10 +4,10 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-    version="3.0">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <servlet>
         <servlet-name>ServerNameServlet</servlet-name>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemSchema.java
@@ -273,7 +273,7 @@ public enum UndertowSubsystemSchema implements PersistentSubsystemSchema<Underto
         builder.addChild(this.factory.builder(FileHandlerDefinition.PATH_ELEMENT).addAttributes(FileHandlerDefinition.ATTRIBUTES.stream()).build());
 
         Stream<AttributeDefinition> reverseProxyHandlerAttributes = ReverseProxyHandlerDefinition.ATTRIBUTES.stream();
-        if (!this.since(VERSION_14_0_COMMUNITY)) {
+        if (!this.since(VERSION_15_0) && !this.since(VERSION_14_0_COMMUNITY)) {
             reverseProxyHandlerAttributes = reverseProxyHandlerAttributes.filter(Predicate.not(Set.of(ReverseProxyHandlerDefinition.REUSE_X_FORWARDED_HEADER, ReverseProxyHandlerDefinition.REWRITE_HOST_HEADER)::contains));
         }
         if (!this.since(UndertowSubsystemSchema.VERSION_4_0)) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerDefinition.java
@@ -18,7 +18,6 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.version.Stability;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.undertow.Constants;
@@ -96,7 +95,6 @@ public class ReverseProxyHandlerDefinition extends HandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
-            .setStability(Stability.COMMUNITY)
             .build();
 
     public static final AttributeDefinition REWRITE_HOST_HEADER = new SimpleAttributeDefinitionBuilder(Constants.REWRITE_HOST_HEADER, ModelType.BOOLEAN)
@@ -104,7 +102,6 @@ public class ReverseProxyHandlerDefinition extends HandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setDefaultValue(ModelNode.FALSE)
-            .setStability(Stability.COMMUNITY)
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(CONNECTIONS_PER_THREAD, SESSION_COOKIE_NAMES, PROBLEM_SERVER_RETRY, REQUEST_QUEUE_SIZE, MAX_REQUEST_TIME, CACHED_CONNECTIONS_PER_THREAD, CONNECTION_IDLE_TIMEOUT, MAX_RETRIES,REUSE_X_FORWARDED_HEADER, REWRITE_HOST_HEADER);

--- a/undertow/src/main/resources/schema/wildfly-undertow_15_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_15_0.xsd
@@ -757,6 +757,8 @@
         <xs:attribute name="cached-connections-per-thread" use="optional" type="xs:integer" default="5"/>
         <xs:attribute name="connection-idle-timeout" use="optional" type="xs:integer" default="60000"/>
         <xs:attribute name="max-retries" type="xs:int" use="optional" default="1"/>
+        <xs:attribute name="reuse-x-forwarded-header" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="rewrite-host-header" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="reverse-proxy-hostType">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-15.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-15.0.xml
@@ -72,7 +72,7 @@
    </servlet-container>
    <handlers>
       <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
-      <reverse-proxy connection-idle-timeout="60000" max-request-time="60000" connections-per-thread="30" max-retries="10" name="reverse-proxy">
+      <reverse-proxy connection-idle-timeout="60000" max-request-time="60000" connections-per-thread="30" max-retries="10" name="reverse-proxy" reuse-x-forwarded-header="true" rewrite-host-header="false">
          <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
          <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
       </reverse-proxy>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-21525
Related Issue: https://redhat.atlassian.net/browse/WFLY-14255
Ref: https://redhat.atlassian.net/browse/EAP7-1837
Depends: https://redhat.atlassian.net/browse/UNDERTOW-2713 
Doc PR: https://github.com/wildfly/wildfly/pull/19728


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21525](https://issues.redhat.com/browse/WFLY-21525)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)