### PR TITLE
WFLY-21390 Fix memory leak of ComponentConfiguration after deployment being retained due to lambdas

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
@@ -244,8 +244,10 @@ public class ViewDescription {
             boolean appclient = context.getDeploymentUnit().getAttachment(Attachments.EE_MODULE_DESCRIPTION).isAppClient();
             // Create view bindings
             final List<BindingConfiguration> bindingConfigurations = configuration.getBindingConfigurations();
+            // WFLY-21390 Extract the class loader before the lambda to avoid capturing the entire ComponentConfiguration
+            final ClassLoader moduleClassLoader = componentConfiguration.getModuleClassLoader();
             for (String bindingName : description.getBindingNames()) {
-                bindingConfigurations.add(new BindingConfiguration(bindingName, description.createInjectionSource(description.getServiceName(), () -> componentConfiguration.getModuleClassLoader(), appclient)));
+                bindingConfigurations.add(new BindingConfiguration(bindingName, description.createInjectionSource(description.getServiceName(), () -> moduleClassLoader, appclient)));
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -191,6 +191,8 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
         }
         addStatefulSessionSynchronizationInterceptor();
 
+        // WFLY-21390 Extract component name before the lambda to avoid capturing the entire ComponentConfiguration
+        final String componentName = statefulComponentConfiguration.getComponentName();
         this.getConfigurators().add(new ComponentConfigurator() {
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
@@ -200,7 +202,7 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
                 ServiceInstaller installer = new ServiceInstaller() {
                     @Override
                     public ServiceController<?> install(RequirementServiceTarget target) {
-                        for (ServiceInstaller factoryInstaller : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription, statefulComponentConfiguration)) {
+                        for (ServiceInstaller factoryInstaller : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription, componentName)) {
                             factoryInstaller.install(target);
                         }
                         return null;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
@@ -5,8 +5,8 @@
 
 package org.jboss.as.ejb3.component.stateful.cache;
 
-import org.jboss.as.ee.component.ComponentConfiguration;
-import org.jboss.as.ee.component.EEModuleConfiguration;
+import java.util.Set;
+
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
@@ -25,18 +25,19 @@ public interface StatefulSessionBeanCacheProvider {
     /**
      * Returns configurators for services to be installed for the specified deployment.
      * @param unit a deployment unit
+     * @param beanClasses the set of stateful session bean classes in the deployment
      * @return a collection of service configurators
      */
-    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, EEModuleConfiguration moduleConfiguration);
+    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses);
 
     /**
      * Returns a configurator for a service supplying a cache factory.
      * @param unit the deployment unit containing this EJB component.
      * @param description the EJB component description
-     * @param configuration the component configuration
+     * @param componentName the component name
      * @return a service configurator
      */
-    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, ComponentConfiguration configuration);
+    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName);
 
     /**
      * Indicates whether or not cache factories provides by this object can support passivation.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
@@ -5,12 +5,11 @@
 package org.jboss.as.ejb3.subsystem;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.ee.component.ComponentConfiguration;
-import org.jboss.as.ee.component.EEModuleConfiguration;
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.component.stateful.cache.StatefulSessionBeanCacheProvider;
 import org.jboss.as.ejb3.component.stateful.cache.simple.SimpleStatefulSessionBeanCacheFactoryServiceInstallerFactory;
@@ -36,12 +35,12 @@ public class SimpleStatefulSessionBeanCacheProviderResourceDefinition extends St
     public ServiceDependency<StatefulSessionBeanCacheProvider> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
         return ServiceDependency.of(new StatefulSessionBeanCacheProvider() {
             @Override
-            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, EEModuleConfiguration moduleConfiguration) {
+            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses) {
                 return List.of();
             }
 
             @Override
-            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, ComponentConfiguration configuration) {
+            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName) {
                 return List.of(new SimpleStatefulSessionBeanCacheFactoryServiceInstallerFactory<>().apply(description));
             }
 


### PR DESCRIPTION
ComponentConfiguration objects were being retained after deployment due to lambda expressions capturing entire configuration objects when they only needed specific values.
Since these lambdas were stored in long-lived MSC services (e.g., BinderService), the deployment-time configuration remained in memory indefinitely.

Fix lambda captures in ViewDescription and EjbJndiBindingsDeploymentUnitProcessor
Refactor StatefulSessionBeanCacheProvider SPI to avoid retaining configuration.

Resolves
https://issues.redhat.com/browse/WFLY-21390