### PR TITLE
[39.x]  WFLY-21392 Bump org.assertj:assertj-bom from 3.27.6 to 3.27.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <version.junit>4.13.2</version.junit>
         <version.org.apache.ds>2.0.0.AM26</version.org.apache.ds>
         <version.org.apache.groovy>4.0.27</version.org.apache.groovy>
-        <version.org.assertj>3.26.3</version.org.assertj>
+        <version.org.assertj>3.27.7</version.org.assertj>
         <version.org.awaitility.awaitility>4.0.3</version.org.awaitility.awaitility>
         <version.org.codehaus.plexus.plexus-utils>3.5.1</version.org.codehaus.plexus.plexus-utils>
         <version.org.eclipse.jetty>11.0.25</version.org.eclipse.jetty>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21392

Bumps [org.assertj:assertj-bom](https://github.com/assertj/assertj) from 3.27.6 to 3.27.7.
- [Release notes](https://github.com/assertj/assertj/releases)
- [Commits](https://github.com/assertj/assertj/compare/assertj-build-3.27.6...assertj-build-3.27.7)

Upstream: #19555

---
updated-dependencies:
- dependency-name: org.assertj:assertj-bom dependency-version: 3.27.7 dependency-type: direct:production update-type: version-update:semver-patch ...

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

If this PR is not for the 'main' branch you must add a link to the equivalent change in 'main'.

Remember to use the Jira issue ID in the PR title and any commits.
