### PR TITLE
[WFLY-19393][WFLY-19694] default bytecode enhancement on and implement equivalent of having a PersistenceProvider.getClassTransformer() to allow entity enhancement and bootstrap of the persistence unit to occur in two phases without well known chicken + egg initialization problems.

### DIFF
--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/HibernatePersistenceProviderAdaptor.java
@@ -214,6 +214,11 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
         hibernateExtendedBeanManager.beanManagerIsAvailableForUse();
     }
 
+    @Override
+    public void addClassFileTransformer(PersistenceUnitMetadata pu) {
+        pu.addTransformer(new WildFlyClassTransformer());
+    }
+
     /* start of TwoPhaseBootstrapCapable methods */
 
     public EntityManagerFactoryBuilder getBootstrap(final PersistenceUnitInfo info, final Map map) {
@@ -221,5 +226,6 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
     }
 
     /* end of TwoPhaseBootstrapCapable methods */
+
 }
 

--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.jpa.hibernate;
+
+import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
+import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
+
+/**
+ * WildFlyClassTransformer is simple wrapper of Hibernate ORM EnhancingClassTransformerImpl that provides
+ * bytecode enhancing of application deployment classes (e.g. entity classes).
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
+
+    public WildFlyClassTransformer() {
+        super(new DefaultEnhancementContext() {
+
+            @Override
+            public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {
+                // return false to disable extended enhancement so that non-entity classes are not enhanced.
+                return false;
+            }
+
+        });
+    }
+}
+

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/HibernatePersistenceProviderAdaptor.java
@@ -218,6 +218,11 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
         hibernateExtendedBeanManager.beanManagerIsAvailableForUse();
     }
 
+    @Override
+    public void addClassFileTransformer(PersistenceUnitMetadata pu) {
+        pu.addTransformer(new WildFlyClassTransformer());
+    }
+
     /* start of TwoPhaseBootstrapCapable methods */
 
     public EntityManagerFactoryBuilder getBootstrap(final PersistenceUnitInfo info, final Map map) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.persistence.jipijapa.hibernate7;
+
+import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
+import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
+
+/**
+ * WildFlyClassTransformer is simple wrapper of Hibernate ORM EnhancingClassTransformerImpl that provides
+ * bytecode enhancing of application deployment classes (e.g. entity classes).
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
+
+    public WildFlyClassTransformer() {
+        super(new DefaultEnhancementContext() {
+
+            @Override
+            public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {
+                // return false to disable extended enhancement so that non-entity classes are not enhanced.
+                return false;
+            }
+
+        });
+    }
+}
+

--- a/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderAdaptor.java
+++ b/jpa/spi/src/main/java/org/jipijapa/plugin/spi/PersistenceProviderAdaptor.java
@@ -94,5 +94,8 @@ public interface PersistenceProviderAdaptor {
     Object beanManagerLifeCycle(BeanManager beanManager);
 
     void markPersistenceUnitAvailable(Object wrapperBeanManagerLifeCycle);
+
+    default void addClassFileTransformer(PersistenceUnitMetadata pu) {
+    }
 }
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -7,7 +7,6 @@ package org.jboss.as.jpa.config;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.persistence.EntityManagerFactory;
 
@@ -272,34 +271,7 @@ public class Configuration {
         if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
             return Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
         }
-        if (isHibernateProvider(pu.getPersistenceProviderClassName())) {
-
-            return isAnyHibernateEnhancerPropertySpecified(pu);
-        }
         return true;
-    }
-
-    /**
-     * Consider jboss.as.jpa.classtransformer to be set to true if any hibernate.enhancer properties are set to true.
-     *
-     * @param pu
-     * @return true if any hibernate.enhancer property is detected otherwise return false
-     */
-    private static boolean isAnyHibernateEnhancerPropertySpecified(PersistenceUnitMetadata pu) {
-
-        Set<String> set = pu.getProperties().stringPropertyNames();
-        for (String key : set) {
-            if (key.startsWith(HIBERNATE_ENHANCER) &&
-                    (true == Boolean.parseBoolean(pu.getProperties().getProperty(key)))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isHibernateProvider(String provider) {
-        // If the persistence provider is not specified (null case), Hibernate ORM will be used as the persistence provider.
-        return provider == null || provider.contains(HIBERNATE);
     }
 
     // key = provider class name, value = adapter module name

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -1062,9 +1062,9 @@ public class PersistenceUnitServiceHandler {
                     final PersistenceProviderAdaptor adaptor = getPersistenceProviderAdaptor(pu, persistenceProviderDeploymentHolder, phaseContext.getDeploymentUnit(), provider, platform);
                     final boolean twoPhaseBootStrapCapable = (adaptor instanceof TwoPhaseBootstrapCapable) && Configuration.allowTwoPhaseBootstrap(pu);
                     // only add the next phase dependency, if the persistence unit service is starting early.
-                    if( !Configuration.allowApplicationDefinedDatasource(pu) && !Configuration.allowDefaultDataSourceUse(pu) && twoPhaseBootStrapCapable ) {
+                    if( Configuration.needClassFileTransformer(pu) && !Configuration.allowApplicationDefinedDatasource(pu) && !Configuration.allowDefaultDataSourceUse(pu) ) {
                         // wait until the persistence unit service is started before starting the next deployment phase
-                        phaseContext.addToAttachmentList(Attachments.NEXT_PHASE_DEPS, puServiceName.append(FIRST_PHASE) );
+                        phaseContext.addToAttachmentList(Attachments.NEXT_PHASE_DEPS, twoPhaseBootStrapCapable ? puServiceName.append(FIRST_PHASE) : puServiceName);
                     }
                 }
             }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformerdisabledtest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformerdisabledtest/persistence.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="mypc">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="SecondPU">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="ThirdPU">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-19393 - `Persistence container bytecode enhancement must be enabled by default to ensure better performance.`
https://issues.redhat.com/browse/WFLY-19694 - `Implement equivalent of having a PersistenceProvider.getClassTransformer() to allow entity enhancement and bootstrap of the persistence unit to occur in two phases without well known chicken + egg initialization problems.`

