### PR TITLE
[WFLY-21403] Upgrade WildFly Core to 32.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>32.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>32.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21403

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/32.0.0.Beta2
Diff: https://github.com/wildfly/wildfly-core/compare/32.0.0.Beta1...32.0.0.Beta2

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7478'>WFCORE-7478</a>] -         wildfly-subsystem requires jboss-modules
</li>
</ul>
                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7467'>WFCORE-7467</a>] -         Upgrade smallrye-common to 2.15.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7480'>WFCORE-7480</a>] -         Upgrade Installation Manager API to 1.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7481'>WFCORE-7481</a>] -         Bump version.ch.qos.logback from 1.5.25 to 1.5.26
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7482'>WFCORE-7482</a>] -         Upgrade JBoss Logging to 3.6.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7483'>WFCORE-7483</a>] -         Upgrade Commons Logging JBoss Logging to 2.0.0.Final
</li>
</ul>
</details>

