### PR TITLE
[39.x] WFLY-21390 Fix memory leak of ComponentConfiguration after deployment being retained due to lambdas + Cleanup StatefulSessionBeanCacheProvider SPI following WFLY-21390

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
@@ -244,8 +244,10 @@ public class ViewDescription {
             boolean appclient = context.getDeploymentUnit().getAttachment(Attachments.EE_MODULE_DESCRIPTION).isAppClient();
             // Create view bindings
             final List<BindingConfiguration> bindingConfigurations = configuration.getBindingConfigurations();
+            // WFLY-21390 Extract the class loader before the lambda to avoid capturing the entire ComponentConfiguration
+            final ClassLoader moduleClassLoader = componentConfiguration.getModuleClassLoader();
             for (String bindingName : description.getBindingNames()) {
-                bindingConfigurations.add(new BindingConfiguration(bindingName, description.createInjectionSource(description.getServiceName(), () -> componentConfiguration.getModuleClassLoader(), appclient)));
+                bindingConfigurations.add(new BindingConfiguration(bindingName, description.createInjectionSource(description.getServiceName(), () -> moduleClassLoader, appclient)));
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
@@ -7,7 +7,6 @@ package org.jboss.as.ejb3.component.stateful;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.jboss.as.clustering.msc.InjectedValueDependency;
 import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ComponentStartService;
@@ -19,7 +18,7 @@ import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.subsystem.DefaultStatefulBeanSessionTimeoutWriteHandler;
 import org.jboss.ejb.client.SessionID;
 import org.jboss.msc.service.ServiceBuilder;
-import org.wildfly.clustering.service.SupplierDependency;
+import org.wildfly.service.ServiceDependency;
 
 /**
  * User: jpai
@@ -40,11 +39,11 @@ public class StatefulComponentCreateServiceFactory extends EJBComponentCreateSer
             }
         });
         StatefulComponentDescription description = (StatefulComponentDescription) configuration.getComponentDescription();
-        SupplierDependency<StatefulSessionBeanCacheFactory<SessionID, StatefulSessionComponentInstance>> cacheFactory = new InjectedValueDependency<>(description.getCacheFactoryServiceName(), (Class<StatefulSessionBeanCacheFactory<SessionID, StatefulSessionComponentInstance>>) (Class<?>) StatefulSessionBeanCacheFactory.class);
+        ServiceDependency<StatefulSessionBeanCacheFactory<SessionID, StatefulSessionComponentInstance>> cacheFactory = ServiceDependency.on(description.getCacheFactoryServiceName());
         configuration.getStartDependencies().add(new DependencyConfigurator<ComponentStartService>() {
             @Override
             public void configureDependency(ServiceBuilder<?> builder, ComponentStartService service) {
-                cacheFactory.register(builder);
+                cacheFactory.accept(builder);
             }
         });
         return new StatefulSessionComponentCreateService(configuration, this.ejbJarConfiguration, cacheFactory);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -191,6 +191,8 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
         }
         addStatefulSessionSynchronizationInterceptor();
 
+        // WFLY-21390 Extract component name before the lambda to avoid capturing the entire ComponentConfiguration
+        final String componentName = statefulComponentConfiguration.getComponentName();
         this.getConfigurators().add(new ComponentConfigurator() {
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
@@ -200,7 +202,7 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
                 ServiceInstaller installer = new ServiceInstaller() {
                     @Override
                     public ServiceController<?> install(RequirementServiceTarget target) {
-                        for (ServiceInstaller factoryInstaller : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription, statefulComponentConfiguration)) {
+                        for (ServiceInstaller factoryInstaller : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription, componentName)) {
                             factoryInstaller.install(target);
                         }
                         return null;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -16,6 +16,7 @@ import jakarta.ejb.EJBObject;
 import jakarta.ejb.TransactionManagementType;
 
 import org.jboss.as.controller.RequirementServiceTarget;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentConfiguration;
@@ -191,32 +192,23 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
         }
         addStatefulSessionSynchronizationInterceptor();
 
-        // WFLY-21390 Extract component name before the lambda to avoid capturing the entire ComponentConfiguration
-        final String componentName = statefulComponentConfiguration.getComponentName();
         this.getConfigurators().add(new ComponentConfigurator() {
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
                 DeploymentUnit unit = context.getDeploymentUnit();
+                CapabilityServiceSupport support = unit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
                 StatefulComponentDescription statefulDescription = (StatefulComponentDescription) description;
-                ServiceDependency<StatefulSessionBeanCacheProvider> provider = this.getStatefulSessionBeanCacheProvider(statefulDescription);
+                ServiceDependency<StatefulSessionBeanCacheProvider> provider = ServiceDependency.on(statefulDescription.getCacheProviderServiceName(support));
                 ServiceInstaller installer = new ServiceInstaller() {
                     @Override
                     public ServiceController<?> install(RequirementServiceTarget target) {
-                        for (ServiceInstaller factoryInstaller : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription, componentName)) {
-                            factoryInstaller.install(target);
+                        for (ServiceInstaller installer : provider.get().getStatefulBeanCacheFactoryServiceInstallers(unit, statefulDescription)) {
+                            installer.install(target);
                         }
                         return null;
                     }
                 };
-                ServiceInstaller.builder(installer, unit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT)).requires(provider).build().install(context);
-            }
-
-            private ServiceDependency<StatefulSessionBeanCacheProvider> getStatefulSessionBeanCacheProvider(StatefulComponentDescription description) {
-                if (!description.isPassivationApplicable()) {
-                    return ServiceDependency.on(StatefulSessionBeanCacheProvider.PASSIVATION_DISABLED_SERVICE_DESCRIPTOR);
-                }
-                CacheInfo cache = description.getCache();
-                return (cache != null) ? ServiceDependency.on(StatefulSessionBeanCacheProvider.SERVICE_DESCRIPTOR, cache.getName()) : ServiceDependency.on(StatefulSessionBeanCacheProvider.DEFAULT_SERVICE_DESCRIPTOR);
+                ServiceInstaller.builder(installer, support).requires(provider).build().install(context);
             }
         });
 
@@ -434,6 +426,11 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
 
     public ServiceName getDeploymentUnitServiceName() {
         return this.deploymentUnitServiceName;
+    }
+
+    public ServiceName getCacheProviderServiceName(CapabilityServiceSupport support) {
+        if (!this.passivationApplicable) return support.getCapabilityServiceName(StatefulSessionBeanCacheProvider.PASSIVATION_DISABLED_SERVICE_DESCRIPTOR);
+        return (this.cache != null) ? support.getCapabilityServiceName(StatefulSessionBeanCacheProvider.SERVICE_DESCRIPTOR, this.cache.getName()) : support.getCapabilityServiceName(StatefulSessionBeanCacheProvider.DEFAULT_SERVICE_DESCRIPTOR);
     }
 
     public ServiceName getCacheFactoryServiceName() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
@@ -5,8 +5,8 @@
 
 package org.jboss.as.ejb3.component.stateful.cache;
 
-import org.jboss.as.ee.component.ComponentConfiguration;
-import org.jboss.as.ee.component.EEModuleConfiguration;
+import java.util.Set;
+
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
@@ -25,18 +25,19 @@ public interface StatefulSessionBeanCacheProvider {
     /**
      * Returns configurators for services to be installed for the specified deployment.
      * @param unit a deployment unit
+     * @param beanClasses the set of stateful session bean classes in the deployment
      * @return a collection of service configurators
      */
-    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, EEModuleConfiguration moduleConfiguration);
+    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses);
 
     /**
      * Returns a configurator for a service supplying a cache factory.
      * @param unit the deployment unit containing this EJB component.
      * @param description the EJB component description
-     * @param configuration the component configuration
+     * @param componentName the component name
      * @return a service configurator
      */
-    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, ComponentConfiguration configuration);
+    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName);
 
     /**
      * Indicates whether or not cache factories provides by this object can support passivation.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/cache/StatefulSessionBeanCacheProvider.java
@@ -5,9 +5,9 @@
 
 package org.jboss.as.ejb3.component.stateful.cache;
 
-import java.util.Set;
-
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.AttachmentList;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.wildfly.service.descriptor.NullaryServiceDescriptor;
 import org.wildfly.service.descriptor.UnaryServiceDescriptor;
@@ -22,22 +22,22 @@ public interface StatefulSessionBeanCacheProvider {
     NullaryServiceDescriptor<StatefulSessionBeanCacheProvider> DEFAULT_SERVICE_DESCRIPTOR = NullaryServiceDescriptor.of("org.wildfly.ejb.stateful.default-cache", StatefulSessionBeanCacheProvider.class);
     UnaryServiceDescriptor<StatefulSessionBeanCacheProvider> SERVICE_DESCRIPTOR = UnaryServiceDescriptor.of("org.wildfly.ejb.stateful.cache", DEFAULT_SERVICE_DESCRIPTOR);
 
-    /**
-     * Returns configurators for services to be installed for the specified deployment.
-     * @param unit a deployment unit
-     * @param beanClasses the set of stateful session bean classes in the deployment
-     * @return a collection of service configurators
-     */
-    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses);
+    AttachmentKey<AttachmentList<StatefulSessionBeanCacheProvider>> ATTACHMENT_KEY = AttachmentKey.createList(StatefulSessionBeanCacheProvider.class);
 
     /**
-     * Returns a configurator for a service supplying a cache factory.
-     * @param unit the deployment unit containing this EJB component.
-     * @param description the EJB component description
-     * @param componentName the component name
-     * @return a service configurator
+     * Returns zero or more service installers required to support SFSB caching for a deployment.
+     * @param unit a deployment unit
+     * @return zero or more service installers
      */
-    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName);
+    Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit);
+
+    /**
+     * Returns zero or more service installers required to support caching for the specified SFSB component.
+     * @param unit the deployment unit containing the SFSB component.
+     * @param description the description of the SFSB component
+     * @return zero or more service installers
+     */
+    Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description);
 
     /**
      * Indicates whether or not cache factories provides by this object can support passivation.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/CacheDependenciesProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/CacheDependenciesProcessor.java
@@ -5,31 +5,14 @@
 
 package org.jboss.as.ejb3.deployment.processors;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import org.jboss.as.controller.RequirementServiceTarget;
-import org.jboss.as.controller.capability.CapabilityServiceSupport;
-import org.jboss.as.ee.component.Attachments;
-import org.jboss.as.ee.component.ComponentConfiguration;
-import org.jboss.as.ee.component.ComponentDescription;
-import org.jboss.as.ee.component.EEModuleConfiguration;
-import org.jboss.as.ee.component.EEModuleDescription;
-import org.jboss.as.ejb3.cache.CacheInfo;
-import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.component.stateful.cache.StatefulSessionBeanCacheProvider;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-import org.jboss.msc.service.ServiceController;
-import org.wildfly.subsystem.service.ServiceDependency;
 import org.wildfly.subsystem.service.ServiceInstaller;
 
 /**
+ * Installs services required for stateful session bean caches.
  * @author Paul Ferraro
  */
 public class CacheDependenciesProcessor implements DeploymentUnitProcessor {
@@ -37,53 +20,11 @@ public class CacheDependenciesProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext context) {
         DeploymentUnit unit = context.getDeploymentUnit();
-        EEModuleDescription moduleDescription = unit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
-        if (moduleDescription == null) {
-            return;
-        }
-
-        final CapabilityServiceSupport support = unit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
-
-        Set<ServiceDependency<StatefulSessionBeanCacheProvider>> dependencies = new HashSet<>();
-        for (ComponentDescription description : moduleDescription.getComponentDescriptions()) {
-            if (description instanceof StatefulComponentDescription) {
-                StatefulComponentDescription statefulDescription = (StatefulComponentDescription) description;
-                dependencies.add(getStatefulSessionBeanCacheProviderDependency(statefulDescription));
+        // Attachments may contain duplicates (if providers were referenced via an alias ServiceName)
+        for (StatefulSessionBeanCacheProvider provider : context.getAttachmentList(StatefulSessionBeanCacheProvider.ATTACHMENT_KEY).stream().distinct().toList()) {
+            for (ServiceInstaller installer : provider.getDeploymentServiceInstallers(unit)) {
+                installer.install(context);
             }
         }
-
-        // WFLY-21390 Compute bean classes before the lambda to avoid capturing EEModuleConfiguration
-        EEModuleConfiguration moduleConfiguration = unit.getAttachment(Attachments.EE_MODULE_CONFIGURATION);
-        Set<Class<?>> beanClasses = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (ComponentConfiguration configuration : moduleConfiguration.getComponentConfigurations()) {
-            if (configuration.getComponentDescription() instanceof StatefulComponentDescription) {
-                Class<?> componentClass = configuration.getComponentClass();
-                while (componentClass != Object.class) {
-                    beanClasses.add(componentClass);
-                    componentClass = componentClass.getSuperclass();
-                }
-            }
-        }
-
-        ServiceInstaller installer = new ServiceInstaller() {
-            @Override
-            public ServiceController<?> install(RequirementServiceTarget target) {
-                // Cache provider dependencies might still contain duplicates (if referenced via alias), so ensure we collect only distinct instances.
-                Set<StatefulSessionBeanCacheProvider> providers = dependencies.stream().map(Supplier::get).distinct().collect(Collectors.toSet());
-                for (StatefulSessionBeanCacheProvider provider : providers) {
-                    for (ServiceInstaller deploymentInstaller : provider.getDeploymentServiceInstallers(unit, beanClasses)) {
-                        deploymentInstaller.install(target);
-                    }
-                }
-                return null;
-            }
-        };
-        ServiceInstaller.builder(installer, support).requires(dependencies).build().install(context);
-    }
-
-    private static ServiceDependency<StatefulSessionBeanCacheProvider> getStatefulSessionBeanCacheProviderDependency(StatefulComponentDescription description) {
-        if (!description.isPassivationApplicable()) return ServiceDependency.on(StatefulSessionBeanCacheProvider.PASSIVATION_DISABLED_SERVICE_DESCRIPTOR);
-        CacheInfo cache = description.getCache();
-        return (cache != null) ? ServiceDependency.on(StatefulSessionBeanCacheProvider.SERVICE_DESCRIPTOR, cache.getName()) : ServiceDependency.on(StatefulSessionBeanCacheProvider.DEFAULT_SERVICE_DESCRIPTOR);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
@@ -5,7 +5,6 @@
 package org.jboss.as.ejb3.subsystem;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.OperationContext;
@@ -35,12 +34,12 @@ public class SimpleStatefulSessionBeanCacheProviderResourceDefinition extends St
     public ServiceDependency<StatefulSessionBeanCacheProvider> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
         return ServiceDependency.of(new StatefulSessionBeanCacheProvider() {
             @Override
-            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses) {
+            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit) {
                 return List.of();
             }
 
             @Override
-            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName) {
+            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description) {
                 return List.of(new SimpleStatefulSessionBeanCacheFactoryServiceInstallerFactory<>().apply(description));
             }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SimpleStatefulSessionBeanCacheProviderResourceDefinition.java
@@ -5,12 +5,11 @@
 package org.jboss.as.ejb3.subsystem;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.ee.component.ComponentConfiguration;
-import org.jboss.as.ee.component.EEModuleConfiguration;
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.component.stateful.cache.StatefulSessionBeanCacheProvider;
 import org.jboss.as.ejb3.component.stateful.cache.simple.SimpleStatefulSessionBeanCacheFactoryServiceInstallerFactory;
@@ -36,12 +35,12 @@ public class SimpleStatefulSessionBeanCacheProviderResourceDefinition extends St
     public ServiceDependency<StatefulSessionBeanCacheProvider> resolve(OperationContext context, ModelNode model) throws OperationFailedException {
         return ServiceDependency.of(new StatefulSessionBeanCacheProvider() {
             @Override
-            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, EEModuleConfiguration moduleConfiguration) {
+            public Iterable<ServiceInstaller> getDeploymentServiceInstallers(DeploymentUnit unit, Set<Class<?>> beanClasses) {
                 return List.of();
             }
 
             @Override
-            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, ComponentConfiguration configuration) {
+            public Iterable<ServiceInstaller> getStatefulBeanCacheFactoryServiceInstallers(DeploymentUnit unit, StatefulComponentDescription description, String componentName) {
                 return List.of(new SimpleStatefulSessionBeanCacheFactoryServiceInstallerFactory<>().apply(description));
             }
 


### PR DESCRIPTION
Jira
https://issues.redhat.com/browse/WFLY-21390

Backport of https://github.com/wildfly/wildfly/pull/19551 + https://github.com/wildfly/wildfly/pull/19570