### PR TITLE
WFLY-21402 Add the galleon-core artifact into generated manifests

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -270,6 +270,11 @@
             <artifactId>wildfly-producers</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.galleon</groupId>
+            <artifactId>galleon-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- module and copy artifact dependencies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -904,6 +904,11 @@
                 <artifactId>wildfly-producers</artifactId>
                 <version>${version.org.jboss.universe.producer.wildfly}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.galleon</groupId>
+                <artifactId>galleon-core</artifactId>
+                <version>${version.org.jboss.galleon}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -290,6 +290,11 @@
             <artifactId>wildfly-producers</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.galleon</groupId>
+            <artifactId>galleon-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- module and copy artifact dependencies -->
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-21402

This adds the galleon-core artifact into Wildfly Channel manifests for ee and preview galleon packs.