### PR TITLE
[WFLY-21408] Apply workaround for dependabot pom.xml parsing issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,9 @@
              By default, if channels drive the provisioning we use the 'wildfly' channel.
              Profiles that focus on wildfly-preview or wildfly-ee can change that.
          -->
-        <channels.maven.groupId>${project.groupId}.channels</channels.maven.groupId>
+        <!-- TODO WFLY-21408 Apply workaround for dependabot pom.xml parsing issue "ERROR: Invalid expression: /project/groupId}.channel" -->
+        <!-- <channels.maven.groupId>${project.groupId}.channels</channels.maven.groupId> -->
+        <channels.maven.groupId>org.wildfly.channels</channels.maven.groupId>
         <channels.maven.artifactId>wildfly</channels.maven.artifactId>
         <channels.maven.version>${full.maven.version}</channels.maven.version>
 


### PR DESCRIPTION
Replace ${project.groupId}.channels with hardcoded org.wildfly.channels to work around dependabot's bug to parse this specific expression correctly.

Manifests as "ERROR: Invalid expression: /project/groupId}.channel"

Jira
https://issues.redhat.com/browse/WFLY-21408 (created a Jira as a placeholder for the context why we are doing it and what needs to happen)