### PR TITLE
[WFLY-21409] Update org.jboss.as.jpa.container.NonTxEmCloser.popCall to check for null container managed stateless session/entity manager

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/NonTxEmCloser.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/NonTxEmCloser.java
@@ -46,7 +46,7 @@ public class NonTxEmCloser {
             for (ScopedObjects scopedObjects : emStack.values()) {
                 try {
                     EntityManager entityManager = scopedObjects.getEntityManager();
-                    if (entityManager.isOpen()) {
+                    if (entityManager != null && entityManager.isOpen()) {
                         entityManager.close();
                     }
                 } catch (RuntimeException safeToIgnore) {
@@ -58,7 +58,9 @@ public class NonTxEmCloser {
                 }
                 try {
                     AutoCloseable statelessSession = scopedObjects.getStatelessSession();
-                    statelessSession.close();
+                    if (statelessSession != null) {
+                        statelessSession.close();
+                    }
                 } catch (Exception safeToIgnore) {
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.trace("Could not close (non-transactional) container managed stateless session." +


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21409

This is to address a minor (e.g. ignored) NPE that only occurs with TRACE logging enabled for Persistence:

> 2026-01-29 11:02:32,150 TRACE [org.jboss.as.jpa] (default task-2) Could not close (non-transactional) container managed stateless session. This shouldn't impact application functionality (only read operations occur in non-transactional mode): java.lang.NullPointerException: Cannot invoke "java.lang.AutoCloseable.close()" because "statelessSession" is null
> at org.jboss.as.jpa@40.0.0.Beta1-SNAPSHOT//org.jboss.as.jpa.container.NonTxEmCloser.popCall(NonTxEmCloser.java:61)

