### PR TITLE
WFLY-21293 Don't bypass Session.invalidate(...) if we know session was already invalidated.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ControlPointDeploymentInfoConfigurator.java
@@ -406,9 +406,8 @@ public class ControlPointDeploymentInfoConfigurator implements UnaryOperator<Dep
 
         @Override
         public void invalidate(HttpServerExchange exchange) {
-            if (this.valid.compareAndSet(true, false)) {
-                this.session.invalidate(exchange);
-            }
+            this.valid.set(false);
+            this.session.invalidate(exchange);
         }
 
         @Override


### PR DESCRIPTION
Allows decorated session to throw an ISE for duplicate invocations as expected by servlet specification.

Follows up on https://issues.redhat.com/browse/WFLY-21293