### PR TITLE
[39.x] WFLY-21415 Bump version.io.vertx.vertx from 4.5.23 to 4.5.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.30.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
-        <version.io.vertx.vertx>4.5.23</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.5.24</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21415
https://github.com/wildfly/wildfly/pull/19557