### PR TITLE
[39.x] [WFLY-21415] Upgrade vertx to 4.5.24 for [CVE-2026-1002]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.30.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
-        <version.io.vertx.vertx>4.5.23</version.io.vertx.vertx>
+        <version.io.vertx.vertx>4.5.24</version.io.vertx.vertx>
         <version.io.vertx.vertx-kafka-client>4.4.9</version.io.vertx.vertx-kafka-client>
         <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>


### PR DESCRIPTION
Upstream PR: https://github.com/wildfly/wildfly/pull/19557
https://issues.redhat.com/browse/WFLY-21415


Bumps `version.io.vertx.vertx` from 4.5.23 to 4.5.24.

Updates `io.vertx:vertx-core` from 4.5.23 to 4.5.24
- [Commits](https://github.com/eclipse/vert.x/compare/4.5.23...4.5.24)

Updates `io.vertx:vertx-amqp-client` from 4.5.23 to 4.5.24
- [Commits](https://github.com/vert-x3/vertx-amqp-client/compare/4.5.23...4.5.24)

Updates `io.vertx:vertx-grpc-client` from 4.5.23 to 4.5.24
- [Commits](https://github.com/eclipse-vertx/vertx-grpc/compare/4.5.23...4.5.24)

Updates `io.vertx:vertx-grpc-common` from 4.5.23 to 4.5.24
- [Commits](https://github.com/eclipse-vertx/vertx-grpc/compare/4.5.23...4.5.24)

Updates `io.vertx:vertx-proton` from 4.5.23 to 4.5.24
- [Commits](https://github.com/vert-x3/vertx-proton/compare/4.5.23...4.5.24)

---
updated-dependencies:
- dependency-name: io.vertx:vertx-core dependency-version: 4.5.24 dependency-type: direct:development update-type: version-update:semver-patch
- dependency-name: io.vertx:vertx-amqp-client dependency-version: 4.5.24 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.vertx:vertx-grpc-client dependency-version: 4.5.24 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.vertx:vertx-grpc-common dependency-version: 4.5.24 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.vertx:vertx-proton dependency-version: 4.5.24 dependency-type: direct:production update-type: version-update:semver-patch ...