### PR TITLE
WFLY-21389 - Upgrade Eclipse Mojarra in WildFly Preview to 4.1.6

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -59,7 +59,7 @@
         <version.org.bytebuddy>1.17.8</version.org.bytebuddy>
         <version.org.glassfish.concurro>3.1.0</version.org.glassfish.concurro>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
-        <version.org.glassfish.jakarta.faces>4.1.5</version.org.glassfish.jakarta.faces>
+        <version.org.glassfish.jakarta.faces>4.1.6</version.org.glassfish.jakarta.faces>
         <version.org.glassfish.soteria>4.0.2</version.org.glassfish.soteria>
         <version.org.jboss.resteasy>7.0.1.Final</version.org.jboss.resteasy>
         <version.org.jboss.spec.jakarta.el.jakarta.el-api>6.0.2.Final</version.org.jboss.spec.jakarta.el.jakarta.el-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21389

Bump version