### PR TITLE
WFLY-21437 Disable FILE_PING and its subclasses' register_shutdown_hook as its leaking resources

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -27,6 +27,16 @@
         port_range="0"
         use_virtual_threads="false"
     />
+    <!-- Disable register_shutdown_hook for all *loadable* FILE_PING-based discovery protocols -->
+    <FILE_PING
+        register_shutdown_hook="false"
+    />
+    <JDBC_PING
+        register_shutdown_hook="false"
+    />
+    <JDBC_PING2
+        register_shutdown_hook="false"
+    />
     <TCPPING
         port_range="0"
         num_discovery_runs="3"

--- a/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
@@ -18,7 +18,7 @@ The following minimal example updates the existing `tcp` stack to use this disco
 ----
 batch
 /subsystem=jgroups/stack=tcp/protocol=MPING:remove()
-/subsystem=jgroups/stack=tcp/protocol=org.jgroups.protocols.aws.S3_PING:add(add-index=1, module="org.jgroups.aws", properties={region_name="eu-central-1", bucket_name="jgroups-s3"})
+/subsystem=jgroups/stack=tcp/protocol=org.jgroups.protocols.aws.S3_PING:add(add-index=1, module="org.jgroups.aws", properties={region_name="eu-central-1", bucket_name="jgroups-s3", register_shutdown_hook="false"})
 run-batch
 ----
 

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -50,7 +50,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
@@ -95,7 +95,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -44,7 +44,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
@@ -89,7 +89,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -428,7 +428,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -473,7 +473,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -568,7 +568,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -613,7 +613,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -149,7 +149,7 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="azure.AZURE_PING"/>
-                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;}"/>
+                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -193,7 +193,7 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="azure.AZURE_PING"/>
-                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;}"/>
+                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -288,7 +288,7 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="azure.AZURE_PING"/>
-                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;}"/>
+                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -332,7 +332,7 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="azure.AZURE_PING"/>
-                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;}"/>
+                            <param name="properties" value="{storage_account_name=&quot;${jboss.jgroups.azure_ping.storage_account_name}&quot;,storage_access_key=&quot;${jboss.jgroups.azure_ping.storage_access_key}&quot;,container=&quot;${jboss.jgroups.azure_ping.container}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>


### PR DESCRIPTION
Resolves two issues – shutdown hook leak https://issues.redhat.com/browse/JGRP-2976 workaround and the fact that these should never be registered in WF https://issues.redhat.com/browse/WFLY-21437

WFLY-21437 Disable FILE_PING and its subclasses' register_shutdown_hook as its leaking resources

WildFly already handles JVM shutdown gracefully so it should be default disable register_shutdown_hook which defaults to true in vanilla JGroups.

This impl is problematic as it cases memory leak.

Follow up on JGRP-2976:

FILE_PING registers a JVM shutdown hook in init() but doesn't keep a reference to it, so the hook cannot be removed when the protocol stops.

The shutdown hook to remain registered even after the channel is closed
Memory leaks when channels are repeatedly created and destroyed - Thread is anonymous class and keeps reference to the stack via up/down protocol references
Errors when closing gracefully and then shutdown hook operates on closed resources
This also affects subclasses such as JDBC_PING, S3_PING, etc.

Also submitted a fix to upstream https://github.com/belaban/JGroups/pull/986