### PR TITLE
WFLY-21370 TLS support to JGroups TCP-based transports test cases fai…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSTCP_NIO2CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSTCP_NIO2CommandDispatcherTestCase.java
@@ -7,13 +7,18 @@ package org.jboss.as.test.clustering.cluster.jgroups.tls;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.cluster.dispatcher.CommandDispatcherTestCase;
 import org.jboss.as.test.clustering.cluster.jgroups.TCP_NIO2ServerSetupTask;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Variant of the {@link CommandDispatcherTestCase} with TLS-secured TCP_NIO2 transport protocol.
  *
  * @author Radoslav Husar
  */
-@ServerSetup({TCP_NIO2ServerSetupTask.class, TLSServerSetupTasks.SharedStoreSecureJGroupsTCP_NIO2TransportServerSetupTask_NODE_1_2.class})
+@ServerSetup({
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        TCP_NIO2ServerSetupTask.class,
+        TLSServerSetupTasks.SharedStoreSecureJGroupsTCP_NIO2TransportServerSetupTask_NODE_1_2.class,
+})
 public class TLSTCP_NIO2CommandDispatcherTestCase extends CommandDispatcherTestCase {
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSUnsharedKeyCommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSUnsharedKeyCommandDispatcherTestCase.java
@@ -13,6 +13,7 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Variation of the standard {@link CommandDispatcherTestCase} that uses SSL/TLS-secured JGroups communication channel,
@@ -23,7 +24,11 @@ import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
  *
  * @author Radoslav Husar
  */
-@ServerSetup({TLSServerSetupTasks.PhysicalKeyStoresServerSetupTask_NODE_1_2.class, TLSServerSetupTasks.UnsharedSecureJGroupsTransportServerSetupTask_NODE_1_2.class})
+@ServerSetup({
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        TLSServerSetupTasks.PhysicalKeyStoresServerSetupTask_NODE_1_2.class,
+        TLSServerSetupTasks.UnsharedSecureJGroupsTransportServerSetupTask_NODE_1_2.class,
+})
 public class TLSUnsharedKeyCommandDispatcherTestCase extends CommandDispatcherTestCase {
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jgroups/tls/TLSWebFailoverTestCase.java
@@ -6,13 +6,18 @@ package org.jboss.as.test.clustering.cluster.jgroups.tls;
 
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.cluster.web.CoarseWebFailoverTestCase;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Variation of the standard {@link CoarseWebFailoverTestCase} that uses TLS/SSL-secured JGroups communication channel.
  *
  * @author Radoslav Husar
  */
-@ServerSetup({TLSServerSetupTasks.SharedPhysicalKeyStoresServerSetupTask.class, TLSServerSetupTasks.SharedStoreSecureJGroupsTransportServerSetupTask_NODE_1_2_3.class})
+@ServerSetup({
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        TLSServerSetupTasks.SharedPhysicalKeyStoresServerSetupTask.class,
+        TLSServerSetupTasks.SharedStoreSecureJGroupsTransportServerSetupTask_NODE_1_2_3.class,
+})
 public class TLSWebFailoverTestCase extends CoarseWebFailoverTestCase {
 
     // No changes to the tests are necessary, securing the channel is transparent to the underlying test.


### PR DESCRIPTION
…l when running on a container that does not support 'community' stability

Resolves
https://issues.redhat.com/browse/WFLY-21370