### PR TITLE
[WFLY-21448] Upgrading Jastow to 2.2.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <version.io.smallrye.smallrye-opentelemetry>2.11.2</version.io.smallrye.smallrye-opentelemetry>
         <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.30.0</version.io.smallrye.smallrye-reactive-messaging>
-        <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.2.9.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.24</version.io.vertx.vertx>
         <version.jakarta.activation.jakarta.activation-api>2.1.4</version.jakarta.activation.jakarta.activation-api>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21448