### PR TITLE
[WFLY-20349] Intermittent failures in OidcWithSubsystemConfigTest setup

### DIFF
--- a/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
+++ b/testsuite/integration/elytron-oidc-client/src/test/java/org/wildfly/test/integration/elytron/oidc/client/KeycloakContainer.java
@@ -9,6 +9,8 @@ import org.jboss.as.test.config.ContainerConfig;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
+
 /**
  * KeycloakContainer for testing.
  *
@@ -40,9 +42,12 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
         withEnv("SSO_ADMIN_PASSWORD", ADMIN_PASSWORD);
         if (isUsedRHSSOImage()) {
             waitingFor(Wait.forHttp("/auth").forPort(PORT_HTTP));
-        }else{
-            waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1));
-            withCommand("start-dev");
+        } else {
+            withCommand("start-dev", "--health-enabled=true");
+            waitingFor(Wait.forHttp("/health/ready")
+                    .forPort(PORT_HTTP)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(180)));
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20349

It seems that the log message indicates process startup, not API readiness, which could eventually create a race condition. The health endpoint verifies actual readiness.