### PR TITLE
WFLY-21450 Add SHA-256 checksum validation for Maven Wrapper distribution

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21450

Follow up on WFLY-21411

Currently, the project uses the Maven Wrapper (mvnw), but it does not explicitly verify the integrity of the downloaded Maven binary. To ensure we are executing a legitimate distribution, we need to configure the wrapper to check the SHA-256 hash upon download.


This can be used for cross-check of the sum: https://github.com/quarkusio/quarkus/blob/main/.mvn/wrapper/maven-wrapper.properties#L4

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21411](https://issues.redhat.com/browse/WFLY-21411)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)