### PR TITLE
[WFLY-21455] Upgrade WildFly Core to 31.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>31.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>31.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21455

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/31.0.2.Final
Diff: https://github.com/wildfly/wildfly-core/compare/31.0.1.Final...31.0.2.Final

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7473'>WFCORE-7473</a>] -         Interactive CLI does not work on Windows with WildFly 39
</li>
</ul>
                                                                                                                                                        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7474'>WFCORE-7474</a>] -         Upgrade jansi to 2.4.2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7488'>WFCORE-7488</a>] -         Upgrade WildFly Elytron to 2.8.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7497'>WFCORE-7497</a>] -         Upgrade Undertow to 2.3.23.Final
</li>
</ul>
</details>
