### PR TITLE
[WFLY-21457] Upgrade WildFly Core to 31.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>31.0.2.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>31.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21457

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/31.0.3.Final
Diff: https://github.com/wildfly/wildfly-core/compare/31.0.2.Final...31.0.3.Final

---

<details>
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7192'>WFCORE-7192</a>] -         CVE-2025-23368 WildFly Elytron Brute Force Authentication Attack
</li>
</ul>
                                                                                                                                                                
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7502'>WFCORE-7502</a>] -         Upgrade WildFly Elytron to 2.8.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7503'>WFCORE-7503</a>] -         Upgrade WildFly Elytron to 2.8.2.Final
</li>
</ul>
</details>

