### PR TITLE
[WFLY-14980] Add test to check if listener types conform to R/W timeo…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ActionSequence.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ActionSequence.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+public enum ActionSequence {
+
+    MSG_RECEIVED, MSG_SENT, IO_EXCEPTION;
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/HttpListenerTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/HttpListenerTimeoutTestCase.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+
+public class HttpListenerTimeoutTestCase extends ListenerTimeoutTestCaseBase{
+    private static final PathAddress ADDRESS_HTTP_LISTENER = PathAddress.pathAddress(
+            PathElement.pathElement(SUBSYSTEM, "undertow"), PathElement.pathElement(SERVER, "default-server"),
+            PathElement.pathElement("http-listener", "default"));
+    @Override
+    protected PathAddress getListenerAddress() {
+        return ADDRESS_HTTP_LISTENER;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ListenerTimeoutTestCaseBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ListenerTimeoutTestCaseBase.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.ServerSnapshot;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class ListenerTimeoutTestCaseBase {
+    public static final String DEPLOYMENT_NAME = "sockettimeout";
+    public static final String DEPLOYMENT_NAME_WAR = DEPLOYMENT_NAME+".war";
+    public static final String READ_SERVLET_PATH = "/read";
+    public static final String WRITE_SERVLET_PATH = "/write";
+    public static final int SMALL_TIMEOUT = 10;
+
+    private AutoCloseable serverSnapshot;
+    @ArquillianResource
+    protected ManagementClient managementClient;
+    @ArquillianResource
+    protected URL url;
+
+    @Deployment
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME_WAR);
+        war.addClass(ReadServlet.class);
+        war.addClass(WriteServlet.class);
+        war.addClass(TimeoutLog.class);
+        war.addClass(TimeoutLogBean.class);
+        war.addClass(ActionSequence.class);
+        return war;
+    }
+
+    @Before
+    public void before() throws Exception {
+        serverSnapshot = ServerSnapshot.takeSnapshot(managementClient);
+    }
+
+    @After
+    public void after() throws Exception {
+        serverSnapshot.close();
+    }
+
+    @Test
+    public void testReadTimeout() throws IOException, InterruptedException {
+        final PathAddress listenerAddress = getListenerAddress();
+        final ModelNode setTimeoutOperation = Operations.createWriteAttributeOperation(listenerAddress.toModelNode(), "read-timeout", SMALL_TIMEOUT);
+        final ModelControllerClient controllerClient = managementClient.getControllerClient();
+        final ModelNode response = controllerClient.execute(setTimeoutOperation);
+        Assert.assertTrue(Operations.isSuccessfulOutcome(response));
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        final String message = "POST /"+DEPLOYMENT_NAME+READ_SERVLET_PATH+" HTTP/1.1\r\n" +
+                "JSESSIONID: MY_ID\r\n" +
+                "Expect: 100-continue\r\n" +
+                "Content-Length: 16\r\n" +
+                "Content-Type: text/plain; charset=ISO-8859-1\r\n" +
+                "Host: "+getServerAddress()+":"+getServerPort()+"\r\n" +
+                "Connection: Keep-Alive\r\n\r\nMy HTTP Request!";
+        try(Socket socket = new Socket()){
+            socket.connect(new InetSocketAddress(getServerAddress(), getServerPort()), 5000);
+            sendMessageToServer(socket, message, true);
+            //TOs are opportunistic, it need another OP to trigger TO and than another to see if pipe is broken.
+            Thread.sleep(SMALL_TIMEOUT+SMALL_TIMEOUT/2);
+            sendMessageToServer(socket, message, false);
+            Thread.sleep(SMALL_TIMEOUT/3);
+
+            assertThrows(SocketException.class, () -> {sendMessageToServer(socket, message, false);});
+
+        }
+    }
+
+    @Test
+    public void testWriteTimeout() throws IOException, InterruptedException, NamingException {
+        final TimeoutLog log = lookupEJB();
+        Assert.assertNotNull(log);
+        final PathAddress listenerAddress = getListenerAddress();
+        final ModelNode setTimeoutOperation = Operations.createWriteAttributeOperation(listenerAddress.toModelNode(), "write-timeout", SMALL_TIMEOUT);
+        final ModelControllerClient controllerClient = managementClient.getControllerClient();
+        final ModelNode response = controllerClient.execute(setTimeoutOperation);
+        Assert.assertTrue(Operations.isSuccessfulOutcome(response));
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        //trigger other side and read what we get and wait for bean to get info
+        final String message = "POST /"+DEPLOYMENT_NAME+WRITE_SERVLET_PATH+" HTTP/1.1\r\n" +
+                "JSESSIONID: MY_ID2\r\n" +
+                "Expect: 100-continue\r\n" +
+                "Content-Length: 16\r\n" +
+                "Content-Type: text/plain; charset=ISO-8859-1\r\n" +
+                "Host: "+getServerAddress()+":"+getServerPort()+"\r\n" +
+                "Connection: Keep-Alive\r\n\r\nMy HTTP Request!";
+        try(Socket socket = new Socket()){
+            socket.connect(new InetSocketAddress(getServerAddress(), getServerPort()), 5000);
+            sendMessageToServer(socket, message, false);
+            Thread.sleep(SMALL_TIMEOUT*2);
+            sendMessageToServer(socket, message, false);
+            final List<ActionSequence> expectedResult = new ArrayList<ActionSequence>();
+            expectedResult.add(ActionSequence.MSG_RECEIVED);
+            expectedResult.add(ActionSequence.MSG_SENT);
+            expectedResult.add(ActionSequence.MSG_RECEIVED);
+            expectedResult.add(ActionSequence.IO_EXCEPTION);
+            final List<ActionSequence> result = log.getTestResult();
+            Assert.assertEquals(expectedResult.size(), result.size());
+            for(int index = 0; index < expectedResult.size() ; index++) {
+                Assert.assertEquals(expectedResult+":"+result,expectedResult.get(index), result.get(index));
+            }
+        }
+    }
+
+    protected TimeoutLog lookupEJB() throws NamingException {
+        final Context context = getInitialContext();
+        return (TimeoutLog) context.lookup("ejb:/sockettimeout/TimeoutLogBean!org.jboss.as.test.integration.web.timeout.TimeoutLog");
+    }
+
+    private InitialContext getInitialContext() throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.as.naming.InitialContextFactory");
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        return new InitialContext(jndiProperties);
+    }
+    protected void sendMessageToServer(final Socket socket, final String message, final boolean failOnNOReturn) throws IOException, InterruptedException {
+        socket.getOutputStream().write(message.getBytes(StandardCharsets.UTF_8));
+        socket.getOutputStream().flush();
+        doRead(socket,failOnNOReturn);
+    }
+
+    protected String readStream(final InputStream stream) throws IOException {
+
+        byte[] buf = new byte[100];
+        StringBuilder sb = new StringBuilder();
+        while(stream.available() > 0) {
+            int r = stream.read(buf);
+            sb.append(new String(buf, 0, r));
+        }
+        return sb.toString();
+    }
+
+    protected void doRead(final Socket socket, final boolean failOnNoMessage) throws InterruptedException, IOException {
+        final CountDownLatch latch = new CountDownLatch(10);
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (socket.getInputStream().available() <= 0) {
+                        latch.countDown();
+                        Thread.sleep(200);
+                    }
+                } catch (Exception e) {
+                    Assert.assertNull(e.getMessage());
+                }
+            }
+        };
+        new Thread(r).start();
+        latch.await(TimeoutUtil.adjust(1000), TimeUnit.MILLISECONDS);
+        if(socket.getInputStream().available() > 0) {
+            final String httpResponse = readStream(socket.getInputStream());
+            Assert.assertTrue(httpResponse, httpResponse.contains("100"));
+        } else {
+            if(failOnNoMessage) {
+                Assert.assertNull("Failed to receive response");
+            }
+        }
+    }
+
+    protected String getServerAddress() {
+        return url.getHost();
+    }
+
+    protected int getServerPort() {
+        return url.getPort();
+    }
+
+    protected abstract PathAddress getListenerAddress();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ReadServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/ReadServlet.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = ListenerTimeoutTestCaseBase.READ_SERVLET_PATH)
+public class ReadServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+        //Do we need more here?
+        resp.setStatus(100);
+        resp.flushBuffer();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/TimeoutLog.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/TimeoutLog.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+import java.util.List;
+
+import jakarta.ejb.Remote;
+
+@Remote
+public interface TimeoutLog {
+
+    void receivedMessage();
+
+    void sentResponse();
+
+    void failedIO();
+
+    List<ActionSequence> getTestResult();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/TimeoutLogBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/TimeoutLogBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.web.timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.ejb.Singleton;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@Singleton
+@ApplicationScoped
+public class TimeoutLogBean implements TimeoutLog{
+
+    List<ActionSequence> lst =  new ArrayList<ActionSequence>();
+    @Override
+    public void receivedMessage() {
+        lst.add(ActionSequence.MSG_RECEIVED);
+    }
+
+    @Override
+    public void sentResponse() {
+        lst.add(ActionSequence.MSG_SENT);
+    }
+
+    @Override
+    public void failedIO() {
+        lst.add(ActionSequence.IO_EXCEPTION);
+    }
+
+    @Override
+    public List<ActionSequence> getTestResult() {
+        return lst;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/WriteServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/timeout/WriteServlet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.test.integration.web.timeout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.Collectors;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = ListenerTimeoutTestCaseBase.WRITE_SERVLET_PATH)
+public class WriteServlet extends HttpServlet {
+    @EJB(mappedName = "java:global/sockettimeout/TimeoutLogBean!org.jboss.as.test.integration.web.timeout.TimeoutLog")
+    private TimeoutLog bean;
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        //TOs are opportunistic.
+        //FLOW:
+        //1. incomming message - timestamp taken
+        //2. 100-Confinue sent back to keep session alive
+        //3. wait over timestamp+RW TO
+        //4. subsequent request on the same session
+        //5. Receive header, terminate writes/socket, deliver to servlet - yep, its a hack.
+        bean.receivedMessage();
+        try {
+            req.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
+            resp.setStatus(100);
+            resp.flushBuffer();
+            bean.sentResponse();
+        } catch (UncheckedIOException cce) {
+            bean.failedIO();
+        }
+    }
+
+}


### PR DESCRIPTION
…ut values

Test requested via https://issues.redhat.com/browse/EAP7-1835

Remember to use the Jira issue ID in the PR title and any commits.


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-14980](https://issues.redhat.com/browse/WFLY-14980)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)