### PR TITLE
Fix for WFLY-21463, galleon-core dependency should exclude dependencies

### DIFF
--- a/ee-feature-pack/galleon-feature-pack/pom.xml
+++ b/ee-feature-pack/galleon-feature-pack/pom.xml
@@ -273,6 +273,12 @@
         <dependency>
             <groupId>org.jboss.galleon</groupId>
             <artifactId>galleon-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
 

--- a/preview/feature-pack/pom.xml
+++ b/preview/feature-pack/pom.xml
@@ -293,6 +293,12 @@
         <dependency>
             <groupId>org.jboss.galleon</groupId>
             <artifactId>galleon-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-21463
