### PR TITLE
WFLY-21381 - Add support for SECURE_PROTOCOL tag to ExchangeAttributeDefinitions

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/ConsoleAccessLogTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/ConsoleAccessLogTestCase.java
@@ -95,6 +95,7 @@ public class ConsoleAccessLogTestCase {
             "response-reason-phrase",
             "response-time",
             "secure-exchange",
+            "secure-protocol",
             "ssl-cipher",
             "ssl-client-cert",
             "ssl-session-id",

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ExchangeAttributeDefinitions.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ExchangeAttributeDefinitions.java
@@ -52,6 +52,7 @@ import io.undertow.attribute.ResponseHeaderAttribute;
 import io.undertow.attribute.ResponseReasonPhraseAttribute;
 import io.undertow.attribute.ResponseTimeAttribute;
 import io.undertow.attribute.SecureExchangeAttribute;
+import io.undertow.attribute.SecureProtocolAttribute;
 import io.undertow.attribute.SslCipherAttribute;
 import io.undertow.attribute.SslClientCertAttribute;
 import io.undertow.attribute.SslSessionIdAttribute;
@@ -536,6 +537,16 @@ class ExchangeAttributeDefinitions {
                 }
             });
 
+    private static final SimpleAttributeDefinition SECURE_PROTOCOL_KEY = createKey("secureProtocol");
+    public static final ObjectTypeAttributeDefinition SECURE_PROTOCOL = create(
+            ObjectTypeAttributeDefinition.create("secure-protocol", SECURE_PROTOCOL_KEY),
+            new ExceptionBiFunction<>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(SECURE_PROTOCOL_KEY, context, model, SecureProtocolAttribute.INSTANCE);
+                }
+            });
+
     private static final SimpleAttributeDefinition SSL_CIPHER_KEY = createKey("sslCipher");
     private static final ObjectTypeAttributeDefinition SSL_CIPHER = create(
             ObjectTypeAttributeDefinition.create("ssl-cipher", SSL_CIPHER_KEY),
@@ -626,6 +637,7 @@ class ExchangeAttributeDefinitions {
             RESPONSE_TIME,
             SECURE_EXCHANGE,
             SSL_CIPHER,
+            SECURE_PROTOCOL,
             SSL_CLIENT_CERT,
             SSL_SESSION_ID,
             STORED_RESPONSE,

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
@@ -6,6 +6,7 @@
 package org.wildfly.extension.undertow;
 
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.ModelVersion;
@@ -66,6 +67,15 @@ public class UndertowExtensionTransformerRegistration implements ExtensionTransf
                 ajpListenerAttributeTransformationDescriptionBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN)
                 .end();
+
+                RejectAttributeChecker.ObjectFieldsRejectAttributeChecker attributeChecker = new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(
+                    Map.of(ExchangeAttributeDefinitions.SECURE_PROTOCOL.getName(), RejectAttributeChecker.DEFINED)
+                );
+                server.addChildResource(HostDefinition.PATH_ELEMENT)
+                    .addChildResource(ConsoleAccessLogDefinition.PATH_ELEMENT)
+                    .getAttributeBuilder()
+                    .addRejectCheck(attributeChecker, ExchangeAttributeDefinitions.ATTRIBUTES)
+                ;
 
                 if (UndertowSubsystemModel.VERSION_13_0_0.requiresTransformation(version)) {
                     final ResourceTransformationDescriptionBuilder servletContainer = subsystem.addChildResource(ServletContainerDefinition.PATH_ELEMENT);

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -149,6 +149,7 @@ undertow.console-access-log.attributes.response-reason-phrase=The text reason fo
 undertow.console-access-log.attributes.response-time=The time used to process the request.
 undertow.console-access-log.attributes.time-unit=The unit of time used for the response time.
 undertow.console-access-log.attributes.secure-exchange=Indicates whether or not the exchange was secure.
+undertow.console-access-log.attributes.secure-protocol=The name of the secure protocol used for the request.
 undertow.console-access-log.attributes.ssl-cipher=The SSL cipher.
 undertow.console-access-log.attributes.ssl-client-cert=The SSL client certificate.
 undertow.console-access-log.attributes.ssl-session-id=The SSL session id.

--- a/undertow/src/main/resources/schema/wildfly-undertow_15_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_15_0.xsd
@@ -665,6 +665,11 @@
                     <xs:attribute name="key" type="xs:string"/>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="secure-protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="ssl-cipher" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="key" type="xs:string"/>

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTransformerTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTransformerTestCase.java
@@ -142,10 +142,14 @@ public class UndertowSubsystemTransformerTestCase extends AbstractSubsystemTest 
         PathAddress subsystemAddress = PathAddress.pathAddress(UndertowRootDefinition.PATH_ELEMENT);
 
         if (UndertowSubsystemModel.VERSION_15_0_0.requiresTransformation(this.modelVersion)) {
-            PathAddress ajpListenerAddress = subsystemAddress.append(PathElement.pathElement(ServerDefinition.PATH_ELEMENT.getKey(), "default-server"))
-                    .append(PathElement.pathElement(AjpListenerResourceDefinition.PATH_ELEMENT.getKey(), "ajp"));
+            PathAddress serverAddress = subsystemAddress.append(PathElement.pathElement(ServerDefinition.PATH_ELEMENT.getKey(), "default-server"));
 
+            PathAddress ajpListenerAddress = serverAddress.append(PathElement.pathElement(AjpListenerResourceDefinition.PATH_ELEMENT.getKey(), "ajp"));
             config.addFailedAttribute(ajpListenerAddress, new FailedOperationTransformationConfig.NewAttributesConfig(AjpListenerResourceDefinition.ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
+
+            PathAddress consoleAccessLogAddress = serverAddress.append(PathElement.pathElement(HostDefinition.PATH_ELEMENT.getKey(), "default-host"))
+                .append(PathElement.pathElement(ConsoleAccessLogDefinition.PATH_ELEMENT.getKey(), "console-access-log"));
+            config.addFailedAttribute(consoleAccessLogAddress, new SecureProtocolAttributeConfig(ExchangeAttributeDefinitions.ATTRIBUTES.getName()));
         }
         if (UndertowSubsystemModel.VERSION_13_0_0.requiresTransformation(this.modelVersion)) {
             PathAddress servletContainerAddress = subsystemAddress.append(PathElement.pathElement(ServletContainerDefinition.PATH_ELEMENT.getKey(), "rejected-container"));
@@ -158,5 +162,29 @@ public class UndertowSubsystemTransformerTestCase extends AbstractSubsystemTest 
 
         List<ModelNode> operations = builder.parseXmlResource("undertow-transform-reject.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(services, this.modelVersion, operations, config);
+    }
+
+    private static class SecureProtocolAttributeConfig
+            extends FailedOperationTransformationConfig.AttributesPathAddressConfig<SecureProtocolAttributeConfig> {
+
+        SecureProtocolAttributeConfig(String attributeName) {
+            super(attributeName);
+        }
+
+        @Override
+        protected boolean isAttributeWritable(String attributeName) {
+            return true;
+        }
+
+        @Override
+        protected boolean checkValue(String attrName, ModelNode attribute, boolean isGeneratedWriteAttribute) {
+            return attribute.hasDefined(ExchangeAttributeDefinitions.SECURE_PROTOCOL.getName());
+        }
+
+        @Override
+        protected ModelNode correctValue(ModelNode toResolve, boolean isGeneratedWriteAttribute) {
+            toResolve.remove(ExchangeAttributeDefinitions.SECURE_PROTOCOL.getName());
+            return toResolve;
+        }
     }
 }

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-15.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-15.0.xml
@@ -37,6 +37,7 @@
                </request-header>
                <response-code/>
                <response-time time-unit="MICROSECONDS"/>
+               <secure-protocol/>
             </attributes>
             <metadata>
                <property name="@version" value="1"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform-reject.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform-reject.xml
@@ -7,7 +7,14 @@
     <byte-buffer-pool name="default" thread-local-cache-size="45" buffer-size="1000" direct="false" leak-detection-percent="50" max-pool-size="1000"/>
     <server name="default-server" default-host="default-host">
         <ajp-listener name="ajp" allowed-request-attributes-pattern="test" socket-binding="ajp"/>
-        <host name="default-host"/>
+        <host name="default-host">
+            <console-access-log>
+                <attributes>
+                    <bytes-sent/>
+                    <secure-protocol/>
+                </attributes>
+            </console-access-log>
+        </host>
     </server>
     <servlet-container name="default-container"/>
     <servlet-container name="rejected-container" allow-orphan-session="true"/>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21381

Add new exchange attribute
Update test

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21381](https://issues.redhat.com/browse/WFLY-21381)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)