### PR TITLE
[WFLY-21469] ContextProxyInvocationHandler should unwrap InvocationTa…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1306,7 +1306,7 @@
                             <expected-errors>
                                 <error>jakarta.naming.Context or InitialContext lookup. Enable verbose output to see the locations.</error>
                             </expected-errors>
-                            <expected-discovery>[ee-concurrency, ee-integration, ejb-lite, naming, transactions]==>ee-core-profile-server,ejb-lite</expected-discovery>
+                            <expected-discovery>[cdi, ee-concurrency, ee-integration, ejb-lite, naming, transactions]==>ee-core-profile-server,ejb-lite</expected-discovery>
                             <surefire-execution-for-included-classes>ee-concurrency-layers.surefire</surefire-execution-for-included-classes>
                         </configuration>
                     </execution>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextServiceTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for EE's context service
+ * @author emartins
+ */
+@RunWith(Arquillian.class)
+public class ContextServiceTestCase {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, ContextServiceTestCase.class.getSimpleName() + ".jar")
+                .addClasses(ContextServiceTestCase.class, ContextualProxyExceptionUnwrapBean.class, ContextualProxy.class);
+    }
+
+    @Inject
+    ContextualProxyExceptionUnwrapBean bean;
+
+    @Test
+    public void testContextualProxyDeclaredException() throws Exception {
+        bean.test();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextualProxy.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextualProxy.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+/**
+ * The interface for the test's contextual proxy.
+ * @author emartins
+ */
+public interface ContextualProxy {
+
+    class DeclaredException extends Exception {
+    }
+
+    void test() throws DeclaredException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextualProxyExceptionUnwrapBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ContextualProxyExceptionUnwrapBean.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+import static org.junit.Assert.fail;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ContextService;
+/**
+ * The bean that will do the actual test.
+ * @author emartins
+ */
+@Stateless
+public class ContextualProxyExceptionUnwrapBean {
+
+    static class UndeclaredException extends RuntimeException {
+    }
+
+    @Resource
+    private ContextService contextService;
+
+    public void test() throws Exception {
+        try {
+            contextService.createContextualProxy(this::throwDeclaredException, ContextualProxy.class).test();
+            fail("Declared exception did not propagate");
+        } catch (ContextualProxy.DeclaredException ex) {
+            // expected
+        }
+        try {
+            contextService.createContextualProxy(this::throwUndeclaredException, ContextualProxy.class).test();
+            fail("Undeclared exception did not propagate");
+        } catch (UndeclaredException ex) {
+            // expected
+        }
+    }
+
+    private void throwDeclaredException() throws ContextualProxy.DeclaredException {
+        throw new ContextualProxy.DeclaredException();
+    }
+
+    private void throwUndeclaredException() throws ContextualProxy.DeclaredException {
+        throw new UndeclaredException();
+    }
+}


### PR DESCRIPTION
…rgetException

Issue: https://issues.redhat.com/browse/WFLY-21469

Note: this fix is in Concurro 3.1, see https://github.com/eclipse-ee4j/glassfish-concurro/blob/3.1.x/src/main/java/org/glassfish/concurro/internal/ContextProxyInvocationHandler.java#L84 , so no need to add it to wildfly-concurrency-impl-31 