### PR TITLE
Fix for WFLY-21406, Remove tmp directory created by Galleon at provisioning time

### DIFF
--- a/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/domain/model.xml
@@ -25,6 +25,7 @@
         <package name="cleanup.domain.servers.dir" optional="true"/>
         <package name="cleanup.domain.log.dir" optional="true"/>
         <package name="cleanup.domain.data.dir" optional="true"/>
+        <package name="cleanup.domain.tmp.dir" optional="true"/>
         <!-- Unstable API Annotation Index -->
         <package name="unstable-api-annotation-index.wildfly-ee-feature-pack" optional="true" valid-for-stability="preview"/>
         <package name="org.wildfly.unstable.annotation.api.indexer" optional="true" valid-for-stability="preview" />

--- a/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -28,7 +28,7 @@
         <package name="cleanup.standalone.config.history.dir" optional="true"/>
         <package name="cleanup.standalone.log.dir" optional="true"/>
         <package name="cleanup.standalone.data.dir" optional="true"/>
-        <package name="cleanup.standalone.tmp.vfs" optional="true"/>
+        <package name="cleanup.standalone.tmp" optional="true"/>
 
         <package name="org.wildfly.bootable-jar" optional="true"/>
         <package name="org.wildfly.embedded"/>

--- a/preview/galleon-local/src/main/resources/configs/domain/model.xml
+++ b/preview/galleon-local/src/main/resources/configs/domain/model.xml
@@ -25,6 +25,7 @@
         <package name="cleanup.domain.servers.dir" optional="true"/>
         <package name="cleanup.domain.log.dir" optional="true"/>
         <package name="cleanup.domain.data.dir" optional="true"/>
+        <package name="cleanup.domain.tmp.dir" optional="true"/>
 
         <package name="org.wildfly.deployment.transformation"/>
 

--- a/preview/galleon-local/src/main/resources/configs/standalone/model.xml
+++ b/preview/galleon-local/src/main/resources/configs/standalone/model.xml
@@ -25,7 +25,7 @@
         <package name="cleanup.standalone.config.history.dir" optional="true"/>
         <package name="cleanup.standalone.log.dir" optional="true"/>
         <package name="cleanup.standalone.data.dir" optional="true"/>
-        <package name="cleanup.standalone.tmp.vfs" optional="true"/>
+        <package name="cleanup.standalone.tmp" optional="true"/>
 
         <package name="org.wildfly.bootable-jar" optional="true"/>
         <package name="org.wildfly.embedded"/>


### PR DESCRIPTION
ISSUE: https://issues.redhat.com/browse/WFLY-21406