### PR TITLE
WFLY-21369 idle-threshold test cases fail when running on a container…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/stateful/passivation/IdleThresholdStatefulSessionBeanPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/stateful/passivation/IdleThresholdStatefulSessionBeanPassivationTestCase.java
@@ -27,8 +27,8 @@ import org.jboss.as.test.clustering.single.ejb.stateful.bean.Result;
 import org.jboss.as.test.clustering.single.ejb.stateful.passivation.bean.PassivatingIncrementor;
 import org.jboss.as.test.clustering.single.ejb.stateful.passivation.bean.PassivatingIncrementorBean;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
-import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -45,8 +45,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
-        SnapshotRestoreSetupTask.class, // MUST be first!
-        IdleThresholdStatefulSessionBeanPassivationTestCase.ServerSetupTask.class
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        IdleThresholdStatefulSessionBeanPassivationTestCase.ServerSetupTask.class,
 })
 public class IdleThresholdStatefulSessionBeanPassivationTestCase {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/passivation/IdleThresholdTimerPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/passivation/IdleThresholdTimerPassivationTestCase.java
@@ -22,8 +22,8 @@ import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.single.ejb.timer.passivation.bean.TimerTracker;
 import org.jboss.as.test.clustering.single.ejb.timer.passivation.bean.TimerTrackerBean;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
-import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -40,8 +40,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
-        SnapshotRestoreSetupTask.class, // MUST be first
-        IdleThresholdTimerPassivationTestCase.ServerSetupTask.class
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        IdleThresholdTimerPassivationTestCase.ServerSetupTask.class,
 })
 public class IdleThresholdTimerPassivationTestCase {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdCoarseSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdCoarseSessionPassivationTestCase.java
@@ -7,8 +7,10 @@ package org.jboss.as.test.clustering.single.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Validates the correctness of session passivation events for a distributed session manager using a local,
@@ -18,6 +20,7 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
+@ServerSetup(StabilityServerSetupSnapshotRestoreTasks.Community.class)
 public class LocalIdleThresholdCoarseSessionPassivationTestCase extends LocalIdleThresholdSessionPassivationTestCase {
 
     private static final String MODULE_NAME = LocalIdleThresholdCoarseSessionPassivationTestCase.class.getSimpleName();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.java
@@ -9,9 +9,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
-import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Validates the correctness of session passivation events for a distributed session manager using a local,
@@ -21,8 +21,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
-        SnapshotRestoreSetupTask.class, // MUST be first!
-        LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.ServerSetupTask.class
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+        LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.ServerSetupTask.class,
 })
 public class LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase extends LocalIdleThresholdSessionPassivationTestCase {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdFineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdFineSessionPassivationTestCase.java
@@ -7,8 +7,10 @@ package org.jboss.as.test.clustering.single.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
+import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 
 /**
  * Validates the correctness of session passivation events for a distributed session manager using a local,
@@ -18,6 +20,7 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
+@ServerSetup(StabilityServerSetupSnapshotRestoreTasks.Community.class)
 public class LocalIdleThresholdFineSessionPassivationTestCase extends LocalIdleThresholdSessionPassivationTestCase {
 
     private static final String MODULE_NAME = LocalIdleThresholdFineSessionPassivationTestCase.class.getSimpleName();


### PR DESCRIPTION
… that does not support 'community' stability

Resolves
https://issues.redhat.com/browse/WFLY-21369