### PR TITLE
WFLY-21480 - Warning WFLYMMTREXT0015 in log when registering micrometer Timer using Builder pattern

### DIFF
--- a/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/registry/ApplicationRegistry.java
+++ b/observability/micrometer/src/main/java/org/wildfly/extension/micrometer/registry/ApplicationRegistry.java
@@ -139,7 +139,11 @@ public class ApplicationRegistry extends SimpleMeterRegistry {
 
     @Override
     public Config config() {
-        MicrometerExtensionLogger.MICROMETER_LOGGER.configNotSupported();
+        // Micrometer calls this internally, but if application code does, the returned Config cannot be used normally
+        // since this isn't the real MeterRegistry
+        if (!StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass().getName().startsWith("io.micrometer")) {
+            MicrometerExtensionLogger.MICROMETER_LOGGER.configNotSupported();
+        }
         return super.config();
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21480

The MeterRegistry.Config class does not expose any problematic APIs, so we need not warn about its use in ApplicationRegstiry. Removing log message.
