### PR TITLE
[WFLY-21505] Upgrade WildFly Core to 32.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -567,7 +567,7 @@
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->
-        <version.org.wildfly.core>32.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>32.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.http-client>2.1.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.launcher>1.0.2.Final</version.org.wildfly.launcher>
         <version.org.wildfly.mvc.krazo>2.0.1.Final</version.org.wildfly.mvc.krazo>


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/WFLY-21505

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/32.0.0.Beta4
Diff: https://github.com/wildfly/wildfly-core/compare/32.0.0.Beta3...32.0.0.Beta4

---

<details>
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7335'>WFCORE-7335</a>] -         Block deployments if the security manager subsystem has invalid config and the security manager is enabled.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7463'>WFCORE-7463</a>] -         InterfaceUploadLimitTestCase fails intermittently on Windows - Bootable JAR Job
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7511'>WFCORE-7511</a>] -         Distinguish between lifecycle termination and stop behaviour via [Non]BlockingLifecycle
</li>
</ul>
                                                                                                                                                    
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7510'>WFCORE-7510</a>] -         Upgrade Galleon to 7.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-7513'>WFCORE-7513</a>] -         Upgrade WildFly Elytron to 2.8.3.Final
</li>
</ul>
</details>

