### PR TITLE
[WFLY-21508] Override the inherited organization setting and the mail…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
     <description>WildFly: Parent Aggregator</description>
     <url>https://wildfly.org</url>
 
+    <organization>
+        <name>WildFly</name>
+        <url>https://wildfly.org</url>
+    </organization>
+
     <licenses>
         <license>
             <name>Apache License 2.0</name>
@@ -50,6 +55,15 @@
             <organizationUrl>https://wildfly.org</organizationUrl>
         </developer>
     </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>WildFly</name>
+            <subscribe>https://groups.google.com/forum/#!forum/wildfly</subscribe>
+            <unsubscribe>https://groups.google.com/forum/#!forum/wildfly</unsubscribe>
+            <archive>https://groups.google.com/forum/#!forum/wildfly</archive>
+        </mailingList>
+    </mailingLists>
 
     <properties>
         <!-- Release Info.

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <mailingLists>
         <mailingList>
-            <name>WildFly</name>
+            <name>WildFly User Forum</name>
             <subscribe>https://groups.google.com/forum/#!forum/wildfly</subscribe>
             <unsubscribe>https://groups.google.com/forum/#!forum/wildfly</unsubscribe>
             <archive>https://groups.google.com/forum/#!forum/wildfly</archive>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <unsubscribe>https://groups.google.com/forum/#!forum/wildfly</unsubscribe>
             <archive>https://groups.google.com/forum/#!forum/wildfly</archive>
         </mailingList>
+        <mailingList>
+            <name>WildFly Development</name>
+            <subscribe>https://lists.jboss.org/admin/lists/wildfly-dev.lists.jboss.org/</subscribe>
+            <unsubscribe>https://lists.jboss.org/admin/lists/wildfly-dev.lists.jboss.org/</unsubscribe>
+            <archive>https://lists.jboss.org/archives/list/wildfly-dev@lists.jboss.org/</archive>
+        </mailingList>
     </mailingLists>
 
     <properties>


### PR DESCRIPTION
…ing list setting.

https://issues.redhat.com/browse/WFLY-21508

The `mailingList` directing to the forum, I wasn't sure about. I couldn't get lists.jboss.org to come up so I could get a good link to the real mailing list. That said, on https://wildfly.org the only links are for the Google Group. If we want the mailing lists to be something different, I can change that.

WildFly Core PR: https://github.com/wildfly/wildfly-core/pull/6677
