### PR TITLE
WFLY-21369 Fix-up of server setup for "Idle time-based eviction confiuration test cases fail when running on a container that does not support 'community' stability"

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/stateful/passivation/IdleThresholdStatefulSessionBeanPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/stateful/passivation/IdleThresholdStatefulSessionBeanPassivationTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.as.test.clustering.single.ejb.stateful.bean.Result;
 import org.jboss.as.test.clustering.single.ejb.stateful.passivation.bean.PassivatingIncrementor;
 import org.jboss.as.test.clustering.single.ejb.stateful.passivation.bean.PassivatingIncrementorBean;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 import org.jboss.shrinkwrap.api.Archive;
@@ -45,6 +46,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
+        SnapshotRestoreSetupTask.class, // MUST be first!
         StabilityServerSetupSnapshotRestoreTasks.Community.class,
         IdleThresholdStatefulSessionBeanPassivationTestCase.ServerSetupTask.class,
 })

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/passivation/IdleThresholdTimerPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/ejb/timer/passivation/IdleThresholdTimerPassivationTestCase.java
@@ -22,6 +22,7 @@ import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.single.ejb.timer.passivation.bean.TimerTracker;
 import org.jboss.as.test.clustering.single.ejb.timer.passivation.bean.TimerTrackerBean;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
 import org.jboss.shrinkwrap.api.Archive;
@@ -40,6 +41,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
+        SnapshotRestoreSetupTask.class, // MUST be first!
         StabilityServerSetupSnapshotRestoreTasks.Community.class,
         IdleThresholdTimerPassivationTestCase.ServerSetupTask.class,
 })

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdCoarseSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdCoarseSessionPassivationTestCase.java
@@ -8,6 +8,7 @@ package org.jboss.as.test.clustering.single.web.passivation;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
@@ -20,7 +21,10 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@ServerSetup(StabilityServerSetupSnapshotRestoreTasks.Community.class)
+@ServerSetup({
+        SnapshotRestoreSetupTask.class, // MUST be first!
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+})
 public class LocalIdleThresholdCoarseSessionPassivationTestCase extends LocalIdleThresholdSessionPassivationTestCase {
 
     private static final String MODULE_NAME = LocalIdleThresholdCoarseSessionPassivationTestCase.class.getSimpleName();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
@@ -21,6 +22,7 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({
+        SnapshotRestoreSetupTask.class, // MUST be first!
         StabilityServerSetupSnapshotRestoreTasks.Community.class,
         LocalIdleThresholdDefaultSessionManagerSessionPassivationTestCase.ServerSetupTask.class,
 })

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdFineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/passivation/LocalIdleThresholdFineSessionPassivationTestCase.java
@@ -8,6 +8,7 @@ package org.jboss.as.test.clustering.single.web.passivation;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.runner.RunWith;
 import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
@@ -20,7 +21,10 @@ import org.wildfly.test.stabilitylevel.StabilityServerSetupSnapshotRestoreTasks;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@ServerSetup(StabilityServerSetupSnapshotRestoreTasks.Community.class)
+@ServerSetup({
+        SnapshotRestoreSetupTask.class, // MUST be first!
+        StabilityServerSetupSnapshotRestoreTasks.Community.class,
+})
 public class LocalIdleThresholdFineSessionPassivationTestCase extends LocalIdleThresholdSessionPassivationTestCase {
 
     private static final String MODULE_NAME = LocalIdleThresholdFineSessionPassivationTestCase.class.getSimpleName();


### PR DESCRIPTION
The StabilityServerSetupSnapshotRestoreTasks.Community.class does not always restore a snapshot despite the call in tearDown if the server was already in the desired stability; which it always is in WildFly main.

Fix-up of https://github.com/wildfly/wildfly/pull/19665

Jira https://issues.redhat.com/browse/WFLY-21369