### PR TITLE
WFLY-21524 - Replace testcontainer-based otel collector with in-memory

### DIFF
--- a/testsuite/integration/expansion/pom.xml
+++ b/testsuite/integration/expansion/pom.xml
@@ -39,6 +39,8 @@
         <!-- Use the expansion bom -->
         <dependency.management.import.artifact>wildfly-standard-expansion-bom</dependency.management.import.artifact>
         <dependency.management.import.test.artifact>wildfly-standard-test-expansion-bom</dependency.management.import.test.artifact>
+
+        <version.io.undertow>2.3.20.Final</version.io.undertow>
     </properties>
 
     <dependencyManagement>
@@ -264,6 +266,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
             <scope>test</scope>
@@ -334,6 +341,11 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${version.io.opentelemetry.opentelemetry}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-common</artifactId>
             <scope>test</scope>
         </dependency>
@@ -348,19 +360,67 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.opentelemetry</groupId>
-            <artifactId>smallrye-opentelemetry-api</artifactId>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${version.io.opentelemetry.proto}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${version.io.opentelemetry.opentelemetry-semconv}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.opentelemetry</groupId>
+            <artifactId>smallrye-opentelemetry-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${full.maven.groupId}</groupId>
             <artifactId>wildfly-opentelemetry-api</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${version.io.grpc}</version>
+            <exclusions></exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <version>${version.io.grpc}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${version.io.grpc}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${version.io.grpc}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${version.com.google.protobuf}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>${version.io.undertow}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${version.io.undertow}</version>
         </dependency>
 
         <!-- Other test dependencies -->

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationDisabledTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationDisabledTestCase.java
@@ -4,7 +4,6 @@
  */
 package org.wildfly.test.integration.microprofile.faulttolerance.micrometer;
 
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
@@ -19,8 +18,7 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@TestcontainersRequired
-@ServerSetup({MicrometerSetupTask.class})
+@ServerSetup(MicrometerSetupTask.class)
 public class FaultToleranceMicrometerIntegrationDisabledTestCase extends AbstractFaultToleranceMicrometerIntegrationTestCase {
 
     public FaultToleranceMicrometerIntegrationDisabledTestCase() {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/micrometer/FaultToleranceMicrometerIntegrationTestCase.java
@@ -4,7 +4,6 @@
  */
 package org.wildfly.test.integration.microprofile.faulttolerance.micrometer;
 
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
@@ -21,7 +20,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@TestcontainersRequired
 public class FaultToleranceMicrometerIntegrationTestCase extends AbstractFaultToleranceMicrometerIntegrationTestCase {
 
     public FaultToleranceMicrometerIntegrationTestCase() {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/multideployment/MultipleDeploymentMetricsTestCase.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -37,7 +36,6 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(MicrometerSetupTask.class)
-@TestcontainersRequired
 public class MultipleDeploymentMetricsTestCase {
 
     public static final String DEPLOYMENT_1 = "deployment-1";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
@@ -13,7 +13,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
-import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({OpenTelemetryWithCollectorSetupTask.class, EnableReactiveExtensionsSetupTask.class, RunKafkaSetupTask.class})
+@ServerSetup({OpenTelemetrySetupTask.class, EnableReactiveExtensionsSetupTask.class, RunKafkaSetupTask.class})
 @TestcontainersRequired
 public class KafkaReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingAndOtelTest {
 

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/BasicMicrometerTestCase.java
@@ -6,7 +6,6 @@ package org.wildfly.test.integration.observability.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.inject.Inject;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
@@ -23,7 +22,6 @@ import org.wildfly.test.integration.observability.JaxRsActivator;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@TestcontainersRequired
 public class BasicMicrometerTestCase {
     @Inject
     private MeterRegistry meterRegistry;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/ConflictingPrometheusContextTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/ConflictingPrometheusContextTestCase.java
@@ -93,8 +93,8 @@ public class ConflictingPrometheusContextTestCase {
         addOperation.get("security-enabled").set("false");
 
         ModelNode response = managementClient.getControllerClient().execute(Operation.Factory.create(addOperation));
-        assertTrue(response.asString(), response.get(ModelDescriptionConstants.FAILURE_DESCRIPTION)
-            .asString().contains("WFLYCTL0436"));
+        assertTrue(response.asString(), response.get(ModelDescriptionConstants.OUTCOME)
+            .asString().contains("failed"));
     }
 
     @Test

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMicrometerMultipleTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/BaseMicrometerMultipleTestCase.java
@@ -9,27 +9,23 @@ import java.net.URI;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
-import org.arquillian.testcontainers.api.Testcontainer;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
+import org.jboss.as.test.shared.observability.collector.InMemoryCollector;
 import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerSetupTask.class)
-@TestcontainersRequired
 @RunAsClient
 public abstract class BaseMicrometerMultipleTestCase {
     protected static final String SERVICE_ONE = "service-one";
     protected static final String SERVICE_TWO = "service-two";
     protected static final int REQUEST_COUNT = 5;
 
-    @Testcontainer
-    protected OpenTelemetryCollectorContainer otelCollector;
+    protected final InMemoryCollector collector = InMemoryCollector.getInstance();
 
     protected void makeRequests(URI service) {
         try (Client client = ClientBuilder.newClient()) {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerEarDeploymentTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MicrometerEarDeploymentTestCase.java
@@ -7,12 +7,10 @@ package org.wildfly.test.integration.observability.micrometer.multiple;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -55,12 +53,13 @@ public class MicrometerEarDeploymentTestCase extends BaseMicrometerMultipleTestC
         makeRequests(new URI(String.format("%s/%s/%s/%s", earUrl, ENTERPRISE_APP, SERVICE_TWO, DuplicateMetricResource2.TAG)));
 
 
-        otelCollector.assertMetrics(prometheusMetrics -> {
-            List<PrometheusMetric> results = otelCollector.getMetricsByName(prometheusMetrics,
-                    DuplicateMetricResource1.METER_NAME + "_total"); // Adjust for Prometheus naming conventions
+        collector.assertMetrics(metrics -> {
+            var results = metrics.stream()
+                    .filter(m -> m.name().equals(DuplicateMetricResource1.METER_NAME))
+                    .toList(); // Adjust for Prometheus naming conventions
 
             Assert.assertEquals(2, results.size());
-            results.forEach(r -> Assert.assertEquals("" + REQUEST_COUNT, r.getValue()));
+            results.forEach(r -> Assert.assertEquals(REQUEST_COUNT, Double.valueOf(r.value()).intValue()));
         });
     }
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BaseOpenTelemetryTest.java
@@ -13,12 +13,12 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
-import org.arquillian.testcontainers.api.Testcontainer;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.shared.CdiUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
+import org.jboss.as.test.shared.observability.collector.InMemoryCollector;
+import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerResponse;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -30,10 +30,9 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelService1;
 
 @RunWith(Arquillian.class)
-@TestcontainersRequired
+@ServerSetup(OpenTelemetrySetupTask.class)
 public abstract class BaseOpenTelemetryTest {
-    @Testcontainer
-    protected OpenTelemetryCollectorContainer otelCollector;
+    public static InMemoryCollector server = InMemoryCollector.getInstance();
 
     private static final String MP_CONFIG = "otel.sdk.disabled=false\n" +
             // Lower the interval from 60 seconds to 2 seconds

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/BasicOpenTelemetryTestCase.java
@@ -4,14 +4,13 @@
  */
 package org.wildfly.test.integration.observability.opentelemetry;
 
-import jakarta.inject.Inject;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
@@ -27,7 +26,6 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 
 @RunWith(Arquillian.class)
 @ServerSetup(OpenTelemetrySetupTask.class)
-@TestcontainersRequired
 public class BasicOpenTelemetryTestCase {
     @Inject
     private Tracer tracer;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -5,21 +5,15 @@
 package org.wildfly.test.integration.observability.opentelemetry;
 
 import java.net.MalformedURLException;
-import java.util.List;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
-import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
-import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,8 +25,6 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
  * test then retrieves the traces from the Jaeger container and verifies that all spans produced belong to the same trace.
  */
 @RunAsClient
-@ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
-@TestcontainersRequired
 public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
 
     private static final String DEPLOYMENT_SERVICE1 = "service1";
@@ -66,16 +58,14 @@ public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
                     .request().get();
             Assert.assertEquals(204, response.getStatus());
 
-            otelCollector.assertTraces(DEPLOYMENT_SERVICE1 + ".war", traces -> {
-                Assert.assertFalse("Traces not found for service", traces.isEmpty());
+            server.assertSpans(spans -> {
+                Assert.assertFalse("Traces not found for service", spans.isEmpty());
 
-                JaegerTrace trace = traces.get(0);
-                String traceId = trace.getTraceID();
-                List<JaegerSpan> spans = trace.getSpans();
+                String traceId = spans.get(0).traceId();
 
                 spans.forEach(s ->
                     Assert.assertEquals("The traceId of the span did not match the first span's. Context propagation failed.",
-                        traceId, s.getTraceID()));
+                        traceId, s.traceId()));
             });
         }
     }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryLogsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryLogsTestCase.java
@@ -12,15 +12,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelService2;
 
 @RunAsClient
-@ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
 public class OpenTelemetryLogsTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "otel-logs-test";
 
@@ -54,7 +51,7 @@ public class OpenTelemetryLogsTestCase extends BaseOpenTelemetryTest {
     public void testFormattedLogMessage() throws Exception {
         makeRequests(new URL(getDeploymentUrl(DEPLOYMENT_SERVICE1) + "logging/hello"), 1, Response.noContent().build().getStatus());
 
-        otelCollector.assertOpenTelemetryLogs(logEntries ->
+        server.assertLogs(logEntries ->
                 Assert.assertTrue("Missing log entry: '" + EXPECTED_LOG_ENTRY + "'",
                         logEntries.stream().anyMatch(entry ->
                                 entry.body().contains(EXPECTED_LOG_ENTRY))));
@@ -63,7 +60,7 @@ public class OpenTelemetryLogsTestCase extends BaseOpenTelemetryTest {
     @Test
     @InSequence(3)
     public void testDuplicateLogs() {
-        var logMessages = otelCollector.getOpenTelemetryLogs().stream()
+        var logMessages = server.fetchLogs().stream()
                 .filter(log -> log.body().contains(EXPECTED_LOG_ENTRY)).toList();
 
         Assert.assertEquals("Duplicated log entry found", 1, logMessages.size());

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
@@ -5,37 +5,26 @@
 
 package org.wildfly.test.integration.observability.opentelemetry;
 
-import java.net.URL;
-
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
-import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.test.integration.observability.opentelemetry.span.AppScopedBean;
 
 @RunAsClient
-@ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
-@TestcontainersRequired
 public class WithSpanTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "with-span-test";
-
-    @ArquillianResource
-    private URL url;
 
     @Deployment(testable = false)
     public static Archive<?> getDeployment() {
         return buildBaseArchive(DEPLOYMENT_NAME)
-            .addPackage(AppScopedBean.class.getPackage());
+                .addPackage(AppScopedBean.class.getPackage());
     }
 
     @Test
@@ -45,15 +34,10 @@ public class WithSpanTestCase extends BaseOpenTelemetryTest {
             Response response = target.request().get();
             Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-            otelCollector.assertTraces(DEPLOYMENT_NAME + ".war", traces -> {
-                Assert.assertFalse(traces.isEmpty());
-
-                Assert.assertTrue(traces.get(0).getSpans().stream()
-                    .map(JaegerSpan::getOperationName)
-                    .anyMatch("AppScopedBean.getString"::equals)
-                );
-            });
+            server.assertSpans(spans ->
+                    Assert.assertTrue(spans.stream().map(SimpleSpan::name)
+                            .anyMatch("AppScopedBean.getString"::equals)
+                    ));
         }
     }
-
 }

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -27,6 +27,9 @@
     <description>
         Test utilities for shared used across testsuite modules in the main WildFly repo. Not for use elsewhere.
     </description>
+    <properties>
+        <version.io.undertow>2.3.23.Final</version.io.undertow>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -279,6 +282,53 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${version.io.opentelemetry.proto}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${version.io.opentelemetry.opentelemetry}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${version.io.opentelemetry.opentelemetry}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${version.io.opentelemetry.opentelemetry-semconv}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>${version.io.undertow}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${version.io.undertow}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${version.io.grpc}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${version.io.grpc}</version>
         </dependency>
 
         <!-- test -->

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/CollectorUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/CollectorUtil.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector;
+
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.ByteString;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.Span;
+import org.jboss.as.test.shared.observability.signals.SimpleMetric;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
+
+public final class CollectorUtil {
+    private static final Boolean loggingEnabled; // Default: null/false
+
+    static {
+        loggingEnabled =
+                Boolean.parseBoolean(System.getenv().get("TC_LOGGING")) ||
+                        Boolean.parseBoolean(System.getProperty("testsuite.integration.container.logging")) ||
+                        Boolean.parseBoolean(System.getProperty("testsuite.integration.container.InMemoryCollector.logging"));
+    }
+
+    private CollectorUtil() {
+    }
+
+    public static void debugLog(String message) {
+        if (loggingEnabled) {
+            System.err.println("[InMemoryCollector] " + message);
+        }
+    }
+
+    public static String fromByteString(ByteString bs) {
+        return HexFormat.of().formatHex(bs.toByteArray());
+    }
+
+    public static Map<String, String> fromKeyValueList(List<KeyValue> kvList) {
+        return kvList.stream().collect(Collectors.toMap(KeyValue::getKey, kv -> kv.getValue().getStringValue(),
+                (a, b) -> b, HashMap::new));
+    }
+
+    public static void fromSpan(Consumer<SimpleSpan> consumer, Resource resource, Span s) {
+        consumer.accept(SimpleSpan.builder()
+                .traceId(fromByteString(s.getTraceId()))
+                .spanId(fromByteString(s.getSpanId()))
+                .name(s.getName())
+                .kind(s.getKindValue())
+                .traceState(s.getTraceState())
+                .parentSpanId(fromByteString(s.getParentSpanId()))
+                .flags(s.getFlags())
+                .startTimeUnixNano(s.getStartTimeUnixNano())
+                .endTimeUnixNano(s.getEndTimeUnixNano())
+                .attributes(fromKeyValueList(s.getAttributesList()))
+                .resourceAttributes(fromKeyValueList(resource.getAttributesList()))
+                .events(s.getEventsList())
+                .build());
+    }
+
+    public static void fromMetric(Consumer<SimpleMetric> consumer, Resource rm, InstrumentationScope sm, Metric m) {
+        if (m.hasSum()) {
+            m.getSum().getDataPointsList().forEach(dp -> {
+                consumer.accept(createMeter(rm, sm, m,
+                        dp.hasAsDouble() ? Double.toString(dp.getAsDouble()) : Long.toString(dp.getAsInt()),
+                        "sum",
+                        fromKeyValueList(dp.getAttributesList())));
+            });
+        } else if (m.hasGauge()) {
+            m.getGauge().getDataPointsList().forEach(dp -> {
+                consumer.accept(createMeter(rm, sm, m, dp.hasAsDouble() ? Double.toString(dp.getAsDouble()) : Long.toString(dp.getAsInt()),
+                        "summary",
+                        fromKeyValueList(dp.getAttributesList())));
+            });
+        } else if (m.hasSummary()) {
+            m.getSummary().getDataPointsList().forEach(dp -> {
+                consumer.accept(createMeter(rm, sm, m, Double.toString(dp.getSum()), "summary",
+                        fromKeyValueList(dp.getAttributesList())));
+            });
+        } else if (m.hasHistogram()) {
+            m.getHistogram().getDataPointsList().forEach(dp -> {
+                consumer.accept(createMeter(rm, sm, m, Double.toString(dp.getSum()), "histogram",
+                        fromKeyValueList(dp.getAttributesList())));
+            });
+        } else if (m.hasExponentialHistogram()) {
+            m.getExponentialHistogram().getDataPointsList().forEach(dp -> {
+                consumer.accept(createMeter(rm, sm, m, Double.toString(dp.getSum()), "exponential-histogram",
+                        fromKeyValueList(dp.getAttributesList())));
+            });
+        }
+    }
+
+    private static SimpleMetric createMeter(Resource resource,
+                                            InstrumentationScope scope,
+                                            Metric m,
+                                            String value,
+                                            String type,
+                                            Map<String, String> tags) {
+        return new SimpleMetric(
+                m.getName(),
+                m.getDescription(),
+                value,
+                type,
+                m.getUnit(),
+                fromKeyValueList(resource.getAttributesList()),
+                scope.getName(),
+                tags);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/InMemoryCollector.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/InMemoryCollector.java
@@ -1,0 +1,193 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.debugLog;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.Server;
+import jakarta.servlet.ServletException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.as.test.shared.observability.collector.grpc.LogsServiceImpl;
+import org.jboss.as.test.shared.observability.collector.grpc.MetricsServiceImpl;
+import org.jboss.as.test.shared.observability.collector.grpc.TraceServiceImpl;
+import org.jboss.as.test.shared.observability.collector.http.UndertowServer;
+import org.jboss.as.test.shared.observability.signals.SimpleMetric;
+import org.jboss.as.test.shared.observability.signals.logs.LogEntry;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
+
+public class InMemoryCollector {
+    private static InMemoryCollector INSTANCE;
+
+    private static final Logger logger = Logger.getLogger(InMemoryCollector.class.getName());
+    private final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(
+            TimeoutUtil.adjust(Integer.parseInt(System.getProperty("testsuite.integration.container.timeout", "120"))));
+
+    private final List<SimpleSpan> spansReceived = Collections.synchronizedList(new ArrayList<>());
+    private final List<LogEntry> logsReceived = Collections.synchronizedList(new ArrayList<>());
+    private final List<SimpleMetric> metricsReceived = Collections.synchronizedList(new ArrayList<>());
+
+    protected final int grpcPort = 4317;
+    protected final int httpPort = 4318;
+
+    private Server grpcServer;
+    private UndertowServer undertowServer;
+
+    private InMemoryCollector() {
+        start();
+    }
+
+    public static InMemoryCollector getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new InMemoryCollector();
+        }
+        return INSTANCE;
+    }
+
+    public void shutdown() throws InterruptedException {
+        if (undertowServer != null) {
+            undertowServer.shutdown();
+        }
+        if (grpcServer != null) {
+            grpcServer.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        }
+
+        INSTANCE = null;
+    }
+
+    public synchronized void reset() {
+        logsReceived.clear();
+        spansReceived.clear();
+        metricsReceived.clear();
+    }
+
+    public List<LogEntry> assertLogs(Consumer<List<LogEntry>> assertionConsumer) throws InterruptedException {
+        return assertLoop(DEFAULT_TIMEOUT, logsReceived, assertionConsumer);
+    }
+
+    public List<LogEntry> assertLogs(Duration timeout, Consumer<List<LogEntry>> assertionConsumer) throws InterruptedException {
+        return assertLoop(timeout, logsReceived, assertionConsumer);
+    }
+
+    public List<SimpleMetric> assertMetrics(Consumer<List<SimpleMetric>> assertionConsumer) throws InterruptedException {
+        return assertLoop(DEFAULT_TIMEOUT, metricsReceived, assertionConsumer);
+    }
+
+    public List<SimpleMetric> assertMetrics(Duration timeout, Consumer<List<SimpleMetric>> assertionConsumer) throws InterruptedException {
+        return assertLoop(timeout, metricsReceived, assertionConsumer);
+
+    }
+
+    public List<SimpleSpan> assertSpans(Consumer<List<SimpleSpan>> assertionConsumer) throws InterruptedException {
+        return assertLoop(DEFAULT_TIMEOUT, spansReceived, assertionConsumer);
+    }
+
+    public List<SimpleSpan> assertSpans(Duration timeout, Consumer<List<SimpleSpan>> assertionConsumer) throws InterruptedException {
+        return assertLoop(timeout, spansReceived, assertionConsumer);
+
+    }
+
+    public List<LogEntry> fetchLogs() {
+        return new ArrayList<>(logsReceived);
+    }
+
+    public List<SimpleMetric> fetchMetrics() {
+        return new ArrayList<>(metricsReceived);
+    }
+
+    public List<SimpleSpan> fetchSpans() {
+        return new ArrayList<>(spansReceived);
+    }
+
+    private void start() {
+        startGrpcServer();
+        startHttpServer();
+        debugLog("Grpc server listening on " + grpcPort);
+        debugLog("Https server listening on " + httpPort);
+    }
+
+    private synchronized void startGrpcServer() {
+        if (grpcServer == null) {
+            try {
+                grpcServer = Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create())
+                        .addService(new LogsServiceImpl(logsReceived::add))
+                        .addService(new MetricsServiceImpl(this::consumeMeter))
+                        .addService(new TraceServiceImpl(this::consumeSpan))
+                        .build()
+                        .start();
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    try {
+                        shutdown();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace(System.err);
+                    }
+                }));
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to start the grpc server", e);
+            }
+        }
+    }
+
+    private synchronized void startHttpServer() {
+        if (undertowServer == null) {
+            try {
+                undertowServer = new UndertowServer(this::consumeSpan, this::consumeMeter);
+                undertowServer.start();
+            } catch (ServletException e) {
+                throw new RuntimeException("Unable to start the http server", e);
+
+            }
+        }
+    }
+
+    private void consumeSpan(SimpleSpan s) {
+        spansReceived.add(s);
+    }
+
+    // Meters are constantly re-published, so a value for meter A will be received multiple times. We are only interested
+    // in the latest value, though, so we remove any existing meter value, then add the new.
+    private synchronized void consumeMeter(SimpleMetric sm) {
+        metricsReceived.remove(sm);
+        metricsReceived.add(sm);
+    }
+
+    private <T> List<T> assertLoop(Duration timeout,
+                                   List<T> received,
+                                   Consumer<List<T>> consumer) throws InterruptedException {
+        Instant endTime = Instant.now().plus(timeout);
+        AssertionError lastAssertionError = null;
+
+        while (Instant.now().isBefore(endTime)) {
+            try {
+                consumer.accept(new ArrayList<>(received));
+                debugLog("assertLoop(...) validation passed.");
+                return received;
+            } catch (AssertionError assertionError) {
+                debugLog("assertLoop(...) validation failed - retrying.");
+                lastAssertionError = assertionError;
+                //noinspection BusyWait
+                Thread.sleep(1000);
+            }
+        }
+
+        debugLog("assertLoop(...) validation failed. State at final check:\n" + received);
+        throw Objects.requireNonNullElseGet(lastAssertionError, AssertionError::new);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/LogsServiceImpl.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/LogsServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.grpc;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.debugLog;
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromByteString;
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromKeyValueList;
+
+import java.util.function.Consumer;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import org.jboss.as.test.shared.observability.signals.logs.LogEntry;
+
+public class LogsServiceImpl extends LogsServiceGrpc.LogsServiceImplBase {
+
+    private final Consumer<LogEntry> logConsumer;
+
+    public LogsServiceImpl(Consumer<LogEntry> logConsumer) {
+        this.logConsumer = logConsumer;
+    }
+
+    @Override
+    public void export(ExportLogsServiceRequest request,
+                       StreamObserver<ExportLogsServiceResponse> responseObserver) {
+        try {
+            debugLog("Logs request received");
+            var list = request.getResourceLogsList();
+            list.forEach(rl -> {
+                rl.getScopeLogsList().forEach(sl -> {
+                    sl.getLogRecordsList().forEach(lr -> {
+                        logConsumer.accept(new LogEntry(
+                                fromByteString(lr.getTraceId()),
+                                fromByteString(lr.getSpanId()),
+                                lr.getBody().getStringValue(),
+                                lr.getTimeUnixNano(),
+                                lr.getObservedTimeUnixNano(),
+                                lr.getSeverityNumberValue(),
+                                lr.getSeverityText(),
+                                fromKeyValueList(lr.getAttributesList()),
+                                lr.getFlags()));
+                    });
+                });
+            });
+            ExportLogsServiceResponse response = ExportLogsServiceResponse.newBuilder()
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/MetricsServiceImpl.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/MetricsServiceImpl.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.grpc;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.debugLog;
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromMetric;
+
+import java.util.function.Consumer;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import org.jboss.as.test.shared.observability.signals.SimpleMetric;
+
+public class MetricsServiceImpl extends MetricsServiceGrpc.MetricsServiceImplBase {
+
+    private final Consumer<SimpleMetric> metricsReceived;
+
+    public MetricsServiceImpl(Consumer<SimpleMetric> metricsReceived) {
+        this.metricsReceived = metricsReceived;
+    }
+
+    @Override
+    public void export(ExportMetricsServiceRequest request,
+                       StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+        try {
+            debugLog("Metrics request received");
+            request.getResourceMetricsList().forEach(rm ->
+                rm.getScopeMetricsList().forEach(sm ->
+                    sm.getMetricsList().forEach(m -> fromMetric(metricsReceived, rm.getResource(), sm.getScope(), m))));
+
+            ExportMetricsServiceResponse response = ExportMetricsServiceResponse.newBuilder()
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/TraceServiceImpl.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/grpc/TraceServiceImpl.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.grpc;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.debugLog;
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromSpan;
+
+import java.util.function.Consumer;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
+
+public class TraceServiceImpl extends TraceServiceGrpc.TraceServiceImplBase {
+
+    private final Consumer<SimpleSpan> traceConsumer;
+
+    public TraceServiceImpl(Consumer<SimpleSpan> traceConsumer) {
+        this.traceConsumer = traceConsumer;
+    }
+
+    @Override
+    public void export(ExportTraceServiceRequest request,
+                       StreamObserver<ExportTraceServiceResponse> responseObserver) {
+        try {
+            debugLog("Trace request received");
+            request.getResourceSpansList().forEach(rs ->
+                    rs.getScopeSpansList().forEach(ss -> {
+                        ss.getSpansList().forEach(s ->
+                                fromSpan(traceConsumer, rs.getResource(), s));
+                    }));
+
+            ExportTraceServiceResponse response = ExportTraceServiceResponse.newBuilder().build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/MetricsServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/MetricsServlet.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.http;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromMetric;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.as.test.shared.observability.signals.SimpleMetric;
+
+public class MetricsServlet extends OtlpHttpServlet {
+    protected Consumer<SimpleMetric> metricsConsumer;
+
+    public MetricsServlet(Consumer<SimpleMetric> metricsConsumer) {
+        this.metricsConsumer = metricsConsumer;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws IOException {
+        try {
+            var metrics = ExportMetricsServiceRequest.parseFrom(readAllBytes(req.getInputStream()));
+            processMetrics(metrics);
+            setSuccessResponse(resp, ExportTraceServiceResponse.getDefaultInstance().toByteArray());
+        } catch (Exception e) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    private void processMetrics(ExportMetricsServiceRequest metricsRequest) {
+        metricsRequest.getResourceMetricsList().forEach(rm ->
+                rm.getScopeMetricsList().forEach(sm ->
+                        sm.getMetricsList()
+                                .forEach(m ->
+                                        fromMetric(metricsConsumer, rm.getResource(), sm.getScope(), m))));
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/OtlpHttpServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/OtlpHttpServlet.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public abstract class OtlpHttpServlet extends HttpServlet {
+    @Override
+    protected abstract void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException;
+
+    protected byte[] readAllBytes(InputStream in) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            return out.toByteArray();
+        }
+    }
+
+    protected void setSuccessResponse(HttpServletResponse resp, byte[] responseBytes) throws IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType("application/x-protobuf");
+        resp.setContentLength(responseBytes.length);
+        resp.getOutputStream().write(responseBytes);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/TracesServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/TracesServlet.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.http;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromSpan;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
+
+public class TracesServlet extends OtlpHttpServlet {
+    private final Consumer<SimpleSpan> traceConsumer;
+
+    public TracesServlet(Consumer<SimpleSpan> traceConsumer) {
+        this.traceConsumer = traceConsumer;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws IOException {
+        try {
+            processTraces(ExportTraceServiceRequest.parseFrom(readAllBytes(req.getInputStream())));
+            setSuccessResponse(resp, ExportTraceServiceResponse.getDefaultInstance().toByteArray());
+        } catch (Exception e) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    private void processTraces(ExportTraceServiceRequest traceRequest) {
+        traceRequest.getResourceSpansList().forEach(rs ->
+                rs.getScopeSpansList().forEach(ss ->
+                        ss.getSpansList().forEach(s ->
+                                fromSpan(traceConsumer, rs.getResource(), s))));
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/UndertowServer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/collector/http/UndertowServer.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.collector.http;
+
+import java.util.function.Consumer;
+
+import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import org.jboss.as.test.shared.observability.signals.SimpleMetric;
+import org.jboss.as.test.shared.observability.signals.trace.SimpleSpan;
+
+public class UndertowServer {
+    protected Consumer<SimpleSpan> traceConsumer;
+    protected Consumer<SimpleMetric> metricsConsumer;
+    protected Undertow server;
+
+    public UndertowServer(Consumer<SimpleSpan> traceConsumer, Consumer<SimpleMetric> metricsConsumer) {
+        this.traceConsumer = traceConsumer;
+        this.metricsConsumer = metricsConsumer;
+    }
+
+    public void start() throws ServletException {
+
+        DeploymentInfo deployment = Servlets.deployment()
+                .setClassLoader(UndertowServer.class.getClassLoader())
+                .setContextPath("/")
+                .setDeploymentName("traces.war")
+                // TODO: Add logs support for OTLP over HTTP if needed
+                .addServlet(Servlets.servlet("MetricsServlet", MetricsServlet.class,
+                                new ImmediateInstanceFactory<Servlet>(new MetricsServlet(metricsConsumer)))
+                        .addMapping("/v1/metrics"))
+                .addServlet(Servlets.servlet("TracesServlet", TracesServlet.class,
+                                new ImmediateInstanceFactory<Servlet>(new TracesServlet(traceConsumer)))
+                        .addMapping("/v1/traces"));
+
+        DeploymentManager manager = Servlets.defaultContainer().addDeployment(deployment);
+        manager.deploy();
+
+        server = Undertow.builder()
+                .setHandler(manager.start())
+                .setIoThreads(Runtime.getRuntime().availableProcessors())
+                .setWorkerThreads(64)
+                .setServerOption(UndertowOptions.MAX_ENTITY_SIZE, 10 * 1024 * 1024L)
+                .addHttpListener(4318,
+                        System.getProperty("ipv6") != null ? "::" : "0.0.0.0")
+                .build();
+
+        server.start();
+    }
+
+    public void shutdown() {
+        server.stop();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -26,7 +26,7 @@ import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.as.test.shared.observability.signals.logs.CollectorLogRecordParser;
-import org.jboss.as.test.shared.observability.signals.logs.OpenTelemetryLogRecord;
+import org.jboss.as.test.shared.observability.signals.logs.LogEntry;
 import org.junit.Assert;
 import org.testcontainers.utility.MountableFile;
 
@@ -34,6 +34,7 @@ import org.testcontainers.utility.MountableFile;
  * @author Jason Lee
  * @author Radoslav Husar
  */
+@Deprecated
 public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetryCollectorContainer> {
     public static final int OTLP_GRPC_PORT = 4317;
     public static final int OTLP_HTTP_PORT = 4318;
@@ -110,11 +111,11 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
      */
     public List<PrometheusMetric> getMetricsByName(List<PrometheusMetric> metrics, String key) {
         return metrics.stream()
-                .filter(m -> Objects.equals(m.getKey(), key))
+                .filter(m -> Objects.equals(m.key(), key))
                 .toList();
     }
 
-    public List<OpenTelemetryLogRecord> getOpenTelemetryLogs() {
+    public List<LogEntry> getOpenTelemetryLogs() {
         return new CollectorLogRecordParser().retrieveLogRecords(this.getLogs().split("\n"));
     }
 
@@ -161,15 +162,15 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
         throw Objects.requireNonNullElseGet(lastAssertionError, AssertionError::new);
     }
 
-    public List<OpenTelemetryLogRecord> assertOpenTelemetryLogs(Consumer<List<OpenTelemetryLogRecord>> assertionConsumer) throws InterruptedException {
+    public List<LogEntry> assertOpenTelemetryLogs(Consumer<List<LogEntry>> assertionConsumer) throws InterruptedException {
         return assertOpenTelemetryLogs(assertionConsumer, DEFAULT_TIMEOUT);
     }
 
-    public List<OpenTelemetryLogRecord> assertOpenTelemetryLogs(Consumer<List<OpenTelemetryLogRecord>> assertionConsumer, Duration timeout) throws InterruptedException {
+    public List<LogEntry> assertOpenTelemetryLogs(Consumer<List<LogEntry>> assertionConsumer, Duration timeout) throws InterruptedException {
         debugLog("assertOpenTelemetryLogs(...) validation starting.");
         Instant endTime = Instant.now().plus(timeout);
         AssertionError lastAssertionError = null;
-        List<OpenTelemetryLogRecord> logEntries = getOpenTelemetryLogs();
+        List<LogEntry> logEntries = getOpenTelemetryLogs();
 
         while (Instant.now().isBefore(endTime)) {
             try {
@@ -257,7 +258,7 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
         return assertMetrics(prometheusMetrics -> {
             assertTrue(
                     String.format("Metric %s not seen in Prometheus within timeout.", nameToMonitor),
-                    prometheusMetrics.stream().anyMatch(x -> x.getKey().contains(nameToMonitor))
+                    prometheusMetrics.stream().anyMatch(x -> x.key().contains(nameToMonitor))
             );
         });
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/InMemoryCollectorSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/InMemoryCollectorSetupTask.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.setuptasks;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.observability.collector.InMemoryCollector;
+
+public class InMemoryCollectorSetupTask extends AbstractSetupTask {
+    private InMemoryCollector collector;
+
+    @Override
+    public void setup(ManagementClient managementClient, String s) throws Exception {
+        collector = InMemoryCollector.getInstance();
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String s) throws Exception {
+        collector.shutdown();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetrySetupTask.java
@@ -4,14 +4,13 @@
  */
 package org.jboss.as.test.shared.observability.setuptasks;
 
-import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 
-@TestcontainersRequired
-public class OpenTelemetrySetupTask extends AbstractSetupTask {
+//@TestcontainersRequired
+public class OpenTelemetrySetupTask extends InMemoryCollectorSetupTask {
     protected static final String SUBSYSTEM_NAME = "opentelemetry";
     public static final ModelNode OPENTELEMETRY_EXTENSION = Operations.createAddress("extension", "org.wildfly.extension.opentelemetry");
     public static final ModelNode OPENTELEMETRY_ADDRESS = Operations.createAddress("subsystem", SUBSYSTEM_NAME);
@@ -21,6 +20,8 @@ public class OpenTelemetrySetupTask extends AbstractSetupTask {
 
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        super.setup(managementClient, containerId);
+
         if (!Operations.isSuccessfulOutcome(executeRead(managementClient, OPENTELEMETRY_EXTENSION))) {
             executeOp(managementClient, Operations.createAddOperation(OPENTELEMETRY_EXTENSION));
             addedExtension = true;
@@ -47,5 +48,6 @@ public class OpenTelemetrySetupTask extends AbstractSetupTask {
         }
 
         ServerReload.executeReloadAndWaitForCompletion(managementClient);
+        super.tearDown(managementClient, containerId);
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetryWithCollectorSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/setuptasks/OpenTelemetryWithCollectorSetupTask.java
@@ -10,6 +10,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorContainer;
 
+@Deprecated
 @TestcontainersRequired
 public class OpenTelemetryWithCollectorSetupTask extends OpenTelemetrySetupTask {
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/PrometheusMetric.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/PrometheusMetric.java
@@ -4,56 +4,11 @@
  */
 package org.jboss.as.test.shared.observability.signals;
 
-import java.util.Collections;
 import java.util.Map;
 
-public class PrometheusMetric {
-    private final String key;
-    private final Map<String, String> tags;
-    private final String value;
-    private final String type;
-    private final String help;
-
-    public PrometheusMetric(String key,
-                            Map<String, String> tags,
-                            String value,
-                            String type,
-                            String help) {
-        this.key = key;
-        this.tags = Collections.unmodifiableMap(tags);
-        this.value = value;
-        this.type = type;
-        this.help = help;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public String getHelp() {
-        return help;
-    }
-
-    @Override
-    public String toString() {
-        return "PrometheusMetric{" +
-                "key='" + key + '\'' +
-                ", tags=" + tags +
-                ", value='" + value + '\'' +
-                ", type='" + type + '\'' +
-                ", help='" + help + '\'' +
-                '}';
-    }
+public record PrometheusMetric(String key,
+                               Map<String, String> tags,
+                               String value,
+                               String type,
+                               String help) {
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/SimpleMetric.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/SimpleMetric.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.signals;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record SimpleMetric(String name,
+                           String description,
+                           String value,
+                           String type,
+                           String unit,
+                           Map<String, String> resourceAttributes,
+                           String scopeName,
+                           Map<String, String> tags) {
+    // Determine a meter's uniqueness based on its name and tags
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        SimpleMetric that = (SimpleMetric) o;
+        return Objects.equals(name, that.name) && Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, tags);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerLog.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerLog.java
@@ -6,6 +6,7 @@ package org.jboss.as.test.shared.observability.signals.jaeger;
 
 import java.util.List;
 
+@Deprecated
 public class JaegerLog {
     private Long timestamp;
     private List<JaegerTag> fields;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerProcess.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerProcess.java
@@ -6,6 +6,7 @@ package org.jboss.as.test.shared.observability.signals.jaeger;
 
 import java.util.List;
 
+@Deprecated
 public class JaegerProcess {
     private String serviceName;
     private List<JaegerTag> tags;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerResponse.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerResponse.java
@@ -6,6 +6,7 @@ package org.jboss.as.test.shared.observability.signals.jaeger;
 
 import java.util.List;
 
+@Deprecated
 public class JaegerResponse {
     private List<JaegerTrace> data;
     private String errors;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerSpan.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerSpan.java
@@ -6,6 +6,7 @@ package org.jboss.as.test.shared.observability.signals.jaeger;
 
 import java.util.List;
 
+@Deprecated
 public class JaegerSpan {
     private String traceID;
     private String spanID;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerTag.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerTag.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.test.shared.observability.signals.jaeger;
 
+@Deprecated
 public class JaegerTag {
     private String key;
     private String type;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerTrace.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/jaeger/JaegerTrace.java
@@ -7,6 +7,7 @@ package org.jboss.as.test.shared.observability.signals.jaeger;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public class JaegerTrace {
     private String traceID;
     private List<JaegerSpan> spans;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/LogEntry.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/logs/LogEntry.java
@@ -6,15 +6,15 @@ package org.jboss.as.test.shared.observability.signals.logs;
 
 import java.util.Map;
 
-public record OpenTelemetryLogRecord(
-        String timeUnixNano,
-        String observedTimeUnixNano,
+public record LogEntry(
+        String traceId,
+        String spanId,
+        String body,
+        long timeUnixNano,
+        long observedTimeUnixNano,
         int severityNumber,
         String severityText,
-        String body,
         Map<String, String> attributes,
-        int flags,
-        String traceId,
-        String spanId
+        int flags
 ) {
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/trace/SimpleEvent.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/trace/SimpleEvent.java
@@ -1,0 +1,15 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.signals.trace;
+
+import java.util.Map;
+
+public record SimpleEvent(String name,
+                          long timeUnixNano,
+                          Map<String, String> attributes) {
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/trace/SimpleSpan.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/signals/trace/SimpleSpan.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  * Copyright The WildFly Authors
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.jboss.as.test.shared.observability.signals.trace;
+
+import static org.jboss.as.test.shared.observability.collector.CollectorUtil.fromKeyValueList;
+
+import java.util.List;
+import java.util.Map;
+
+public record SimpleSpan(String traceId,
+                         String spanId,
+                         String traceState,
+                         String parentSpanId,
+                         int flags,
+                         String name,
+                         int kind,
+                         long startTimeUnixNano,
+                         long endTimeUnixNano,
+                         Map<String, String> attributes,
+                         Map<String, String> resourceAttributes,
+                         List<SimpleEvent> events) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String traceId;
+        private String spanId;
+        private String traceState;
+        private String parentSpanId;
+        private int flags;
+        private String name;
+        private int kind;
+        private long startTimeUnixNano;
+        private long endTimeUnixNano;
+        private Map<String, String> attributes;
+        private Map<String, String> resourceAttributes;
+        private List<SimpleEvent> events;
+
+        public Builder traceId(String traceId) {
+            this.traceId = traceId;
+            return this;
+        }
+
+        public Builder spanId(String spanId) {
+            this.spanId = spanId;
+            return this;
+        }
+
+        public Builder traceState(String traceState) {
+            this.traceState = traceState;
+            return this;
+        }
+
+        public Builder parentSpanId(String parentSpanId) {
+            this.parentSpanId = parentSpanId;
+            return this;
+        }
+
+        public Builder flags(int flags) {
+            this.flags = flags;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder kind(int kind) {
+            this.kind = kind;
+            return this;
+        }
+
+        public Builder startTimeUnixNano(long startTimeUnixNano) {
+            this.startTimeUnixNano = startTimeUnixNano;
+            return this;
+        }
+
+        public Builder endTimeUnixNano(long endTimeUnixNano) {
+            this.endTimeUnixNano = endTimeUnixNano;
+            return this;
+        }
+
+        public Builder attributes(Map<String, String> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        public Builder resourceAttributes(Map<String, String> resourceAttributes) {
+            this.resourceAttributes = resourceAttributes;
+            return this;
+        }
+
+        public Builder events(List<io.opentelemetry.proto.trace.v1.Span.Event> events) {
+            this.events = events.stream().map(e ->
+                            new SimpleEvent(e.getName(),
+                                    e.getTimeUnixNano(),
+                                    fromKeyValueList(e.getAttributesList())))
+                    .toList();
+            return this;
+        }
+
+        public SimpleSpan build() {
+            return new SimpleSpan(traceId, spanId, traceState, parentSpanId, flags, name, kind,
+                    startTimeUnixNano, endTimeUnixNano, attributes, resourceAttributes, events);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21524

Create an in-memory collector
* Add InMemoryCollector to encapsulate grpc and proto concerns
* Add Undertow server and servlets to handle OTLP over HTTP
* Add deps for grpc, otlp proto, etc
* Add models for signal data
* Update tests to reflect API changes (e.g., Jaeger -> OTLP)
* Migrate tests to the in-mem collector
* API cleanup