### PR TITLE
[WFLY-21528] Disable scanning client WebSocket endpoints by default. …

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
@@ -8,6 +8,7 @@ package org.jboss.as.test.integration.web.websocket;
 import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
 import java.net.SocketPermission;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -62,6 +63,10 @@ public class WebSocketTestCase {
                                 new SocketPermission(
                                         TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort(),
                                         "connect,resolve"),
+                                // These two permissions are required for the serverContainer.connectToServer() until
+                                // UNDERTOW-2715 is fixed
+                                new RuntimePermission("accessDeclaredMembers"),
+                                new ReflectPermission("suppressAccessChecks"),
                                 // Needed for xnio's WorkerThread which binds to Xnio.ANY_INET_ADDRESS, see WFLY-7538
                                 new SocketPermission("*:0", "listen,resolve")),
                         "permissions.xml");


### PR DESCRIPTION
…Added a system property to re-enable this given it has been the default since the introduction of WebSocket into the server.

https://issues.redhat.com/browse/WFLY-21528

Instead of completely deleting the scanning, I opted to disable it by default. We can definitely remove it, but since it's been like this since the introduction of WebSocket into WIldFly, I'm hesitant to remove it.