### PR TITLE
[WFLY-21548] Deployment fails with ConcurrentModificationException when using modcluster capabilities

### DIFF
--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -192,7 +192,7 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
     }
 
     @Override
-    public void resume() {
+    public synchronized void resume() {
         for (Context context : this.contexts) {
             this.configuration.getContainerEventHandler().start(context);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-21548

All access to contexts is sync but resume. This might lead to concurrent modification exception when some operations are happening at the same time.