### PR TITLE
WFLY-21432 Upgrade JGroups AWS to 4.0.1.Final and software.amazon.awssdk to 2.42.4

### DIFF
--- a/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/AWS-Discovery.adoc
@@ -18,7 +18,7 @@ The following minimal example updates the existing `tcp` stack to use this disco
 ----
 batch
 /subsystem=jgroups/stack=tcp/protocol=MPING:remove()
-/subsystem=jgroups/stack=tcp/protocol=org.jgroups.protocols.aws.S3_PING:add(add-index=1, module="org.jgroups.aws", properties={region_name="eu-central-1", bucket_name="jgroups-s3", register_shutdown_hook="false"})
+/subsystem=jgroups/stack=tcp/protocol=org.jgroups.protocols.aws.S3_PING:add(add-index=1, module="org.jgroups.aws", properties={region_name="eu-central-1", bucket_name="jgroups-s3"})
 run-batch
 ----
 

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -50,7 +50,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
@@ -95,7 +95,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -44,7 +44,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
@@ -89,7 +89,7 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                         <param name="module" value="org.jgroups.aws"/>
-                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                        <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -428,7 +428,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -473,7 +473,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -568,7 +568,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
@@ -613,7 +613,7 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="org.jgroups.protocols.aws.S3_PING"/>
                             <param name="module" value="org.jgroups.aws"/>
-                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;,register_shutdown_hook=&quot;false&quot;}"/>
+                            <param name="properties" value="{region_name=&quot;${jboss.jgroups.aws.s3_ping.region_name}&quot;,bucket_name=&quot;${jboss.jgroups.aws.s3_ping.bucket_name}&quot;}"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>4.0.6</version.org.jctools.jctools-core>
         <version.org.jgroups>5.5.3.Final</version.org.jgroups>
-        <version.org.jgroups.aws>4.0.0.Final</version.org.jgroups.aws>
+        <version.org.jgroups.aws>4.0.1.Final</version.org.jgroups.aws>
         <version.org.jgroups.azure>2.0.2.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>2.0.2.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21432

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21437](https://issues.redhat.com/browse/WFLY-21437)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)