### PR TITLE
[WFLY-21571] Create test cases for Elytron Audit Logging using digest method

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/AbstractAuditLogTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/AbstractAuditLogTestCase.java
@@ -16,7 +16,7 @@ import org.jboss.as.test.shared.ServerReload;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
-import org.wildfly.test.security.common.elytron.UndertowDomainMapper;
+import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
 
 /**
  * Abstract class for Elytron Audit Logging tests. It provides a deployment with {@link SimpleServlet} and a couple of helper
@@ -39,8 +39,10 @@ public abstract class AbstractAuditLogTestCase {
     protected static final String PASSWORD = "password1";
     protected static final String WRONG_PASSWORD = "wrongPassword";
     protected static final String EMPTY_PASSWORD = "";
-    protected static final String SD_DEFAULT = "other";
-    protected static final String SD_WITHOUT_LOGIN_PERMISSION = "no-login-permission";
+    protected static final String SD_DEFAULT_BASIC = "other";
+    protected static final String SD_WITHOUT_LOGIN_PERMISSION_BASIC = "no-login-permission";
+    protected static final String SD_DEFAULT_DIGEST = "other-digest";
+    protected static final String SD_WITHOUT_LOGIN_PERMISSION_DIGEST = "no-login-permission-digest";
 
     private static final String NAME = "AuditlogTestCase";
 
@@ -48,19 +50,47 @@ public abstract class AbstractAuditLogTestCase {
      * Creates WAR with a secured servlet and BASIC authentication configured in web.xml deployment descriptor.
      * It uses default security domain.
      */
-    @Deployment(testable = false, name = SD_DEFAULT)
+    @Deployment(testable = false, name = SD_DEFAULT_BASIC)
     public static WebArchive standardDeployment() {
-        return createWar(SD_DEFAULT);
+        return createWar(SD_DEFAULT_BASIC);
     }
 
     /**
-     * Creates WAR with a secured servlet and BASIC authentication configured in web.xml deployment descriptor.
-     * It uses newly created security domain {@link SD_WITHOUT_LOGIN_PERMISSION}.
+     * Creates WAR with a secured servlet and BASIC authentication configured in
+     * web.xml deployment descriptor. It uses newly created security domain
+     * {@link #SD_WITHOUT_LOGIN_PERMISSION_BASIC}.
      */
-    @Deployment(testable = false, name = SD_WITHOUT_LOGIN_PERMISSION)
+    @Deployment(testable = false, name = SD_WITHOUT_LOGIN_PERMISSION_BASIC)
     public static WebArchive customizedDeployment() {
-        return createWar(SD_WITHOUT_LOGIN_PERMISSION)
-                .addAsWebInfResource(Utils.getJBossWebXmlAsset(SD_WITHOUT_LOGIN_PERMISSION), "jboss-web.xml");
+        return createWar(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(SD_WITHOUT_LOGIN_PERMISSION_BASIC), "jboss-web.xml");
+    }
+
+    /**
+     * Creates WAR with a secured servlet and DIGEST authentication configured in
+     * web.xml deployment descriptor.
+     * It uses default security domain.
+     */
+    @Deployment(testable = false, name = SD_DEFAULT_DIGEST)
+    public static WebArchive digestDeployment() {
+        return ShrinkWrap.create(WebArchive.class, SD_DEFAULT_DIGEST + ".war")
+                .addClasses(SimpleServlet.class)
+                .addAsWebInfResource(AbstractAuditLogTestCase.class.getPackage(), "DigestAuthentication-web.xml",
+                        "web.xml");
+    }
+
+    /**
+     * Creates WAR with a secured servlet and DIGEST authentication configured in
+     * web.xml deployment descriptor. It uses the security domain without a
+     * permission mapper ({@link #SD_WITHOUT_LOGIN_PERMISSION_DIGEST}).
+     */
+    @Deployment(testable = false, name = SD_WITHOUT_LOGIN_PERMISSION_DIGEST)
+    public static WebArchive digestCustomizedDeployment() {
+        return ShrinkWrap.create(WebArchive.class, SD_WITHOUT_LOGIN_PERMISSION_DIGEST + ".war")
+                .addClasses(SimpleServlet.class)
+                .addAsWebInfResource(AbstractAuditLogTestCase.class.getPackage(), "DigestAuthentication-web.xml",
+                        "web.xml")
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(SD_WITHOUT_LOGIN_PERMISSION_DIGEST), "jboss-web.xml");
     }
 
     /**
@@ -68,18 +98,31 @@ public abstract class AbstractAuditLogTestCase {
      * permission check fail event.
      */
     static class SecurityDomainSetupTask implements ServerSetupTask {
-        SimpleSecurityDomain securityDomain;
-        UndertowDomainMapper applicationSecurityDomain;
+        SimpleSecurityDomain basicSecurityDomain;
+        UndertowApplicationSecurityDomain basicApplicationSecurityDomain;
+        SimpleSecurityDomain digestSecurityDomain;
+        UndertowApplicationSecurityDomain digestApplicationSecurityDomain;
 
         @Override
         public void setup(ManagementClient managementClient, String string) throws Exception {
             try (CLIWrapper cli = new CLIWrapper(true)) {
-                securityDomain = createSecurityDomainWithoutPermissionMapper(SD_WITHOUT_LOGIN_PERMISSION);
-                securityDomain.create(managementClient.getControllerClient(), cli);
+                basicSecurityDomain = createSecurityDomainWithoutPermissionMapper(SD_WITHOUT_LOGIN_PERMISSION_BASIC);
+                basicSecurityDomain.create(managementClient.getControllerClient(), cli);
 
-                applicationSecurityDomain =  UndertowDomainMapper.builder().withName(SD_WITHOUT_LOGIN_PERMISSION)
-                        .withApplicationDomains(SD_WITHOUT_LOGIN_PERMISSION).build();
-                applicationSecurityDomain.create(cli);
+                basicApplicationSecurityDomain = UndertowApplicationSecurityDomain.builder()
+                        .withName(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
+                        .withSecurityDomain(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
+                        .build();
+                basicApplicationSecurityDomain.create(managementClient.getControllerClient(), cli);
+
+                digestSecurityDomain = createSecurityDomainWithoutPermissionMapper(SD_WITHOUT_LOGIN_PERMISSION_DIGEST);
+                digestSecurityDomain.create(managementClient.getControllerClient(), cli);
+
+                digestApplicationSecurityDomain = UndertowApplicationSecurityDomain.builder()
+                        .withName(SD_WITHOUT_LOGIN_PERMISSION_DIGEST)
+                        .withSecurityDomain(SD_WITHOUT_LOGIN_PERMISSION_DIGEST)
+                        .build();
+                digestApplicationSecurityDomain.create(managementClient.getControllerClient(), cli);
             }
             ServerReload.reloadIfRequired(managementClient);
         }
@@ -87,17 +130,17 @@ public abstract class AbstractAuditLogTestCase {
         @Override
         public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
             try (CLIWrapper cli = new CLIWrapper(true)) {
-                applicationSecurityDomain.remove(cli);
-                securityDomain.remove(managementClient.getControllerClient(), cli);
+                basicApplicationSecurityDomain.remove(managementClient.getControllerClient(), cli);
+                basicSecurityDomain.remove(managementClient.getControllerClient(), cli);
+                digestApplicationSecurityDomain.remove(managementClient.getControllerClient(), cli);
+                digestSecurityDomain.remove(managementClient.getControllerClient(), cli);
             }
             ServerReload.reloadIfRequired(managementClient);
         }
-
     }
 
     protected static void setDefaultEventListenerOfApplicationDomain(CLIWrapper cli) {
         setEventListenerOfApplicationDomain(cli, "local-audit");
-
     }
 
     protected static void setEventListenerOfApplicationDomain(CLIWrapper cli, String auditlog) {
@@ -106,7 +149,10 @@ public abstract class AbstractAuditLogTestCase {
                 auditlog));
         cli.sendLine(String.format(
                 "/subsystem=elytron/security-domain=%s:write-attribute(name=security-event-listener,value=%s)",
-                SD_WITHOUT_LOGIN_PERMISSION, auditlog));
+                SD_WITHOUT_LOGIN_PERMISSION_BASIC, auditlog));
+        cli.sendLine(String.format(
+                "/subsystem=elytron/security-domain=%s:write-attribute(name=security-event-listener,value=%s)",
+                SD_WITHOUT_LOGIN_PERMISSION_DIGEST, auditlog));
     }
 
     protected static SimpleSecurityDomain createSecurityDomainWithoutPermissionMapper(String domainName) {

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/AbstractSyslogAuditLogTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/AbstractSyslogAuditLogTestCase.java
@@ -32,7 +32,7 @@ public abstract class AbstractSyslogAuditLogTestCase extends AbstractAuditLogTes
      * Tests whether successful authentication was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testSuccessfulAuthAndPermissionCheck(@ArquillianResource URL url) throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
@@ -48,7 +48,7 @@ public abstract class AbstractSyslogAuditLogTestCase extends AbstractAuditLogTes
      * Tests whether failed authentication with wrong user was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testFailedAuthWrongUser(@ArquillianResource URL url) throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
@@ -63,7 +63,7 @@ public abstract class AbstractSyslogAuditLogTestCase extends AbstractAuditLogTes
      * Tests whether failed authentication with wrong password was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testFailedAuthWrongPassword(@ArquillianResource URL url) throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
@@ -78,7 +78,7 @@ public abstract class AbstractSyslogAuditLogTestCase extends AbstractAuditLogTes
      * Tests whether failed authentication with empty password was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testFailedAuthEmptyPassword(@ArquillianResource URL url) throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
@@ -93,7 +93,7 @@ public abstract class AbstractSyslogAuditLogTestCase extends AbstractAuditLogTes
      * Tests whether failed permission check was logged.
      */
     @Test
-    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION)
+    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
     public void testFailedPermissionCheck() throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/CustomSecurityEventListenerTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/CustomSecurityEventListenerTestCase.java
@@ -43,7 +43,7 @@ public class CustomSecurityEventListenerTestCase extends AbstractAuditLogTestCas
      * Tests whether successful authentication was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testSuccessfulAuth() throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
 
@@ -57,7 +57,7 @@ public class CustomSecurityEventListenerTestCase extends AbstractAuditLogTestCas
      * Tests whether failed authentication with wrong user was logged.
      */
     @Test
-    @OperateOnDeployment(SD_DEFAULT)
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
     public void testFailedAuthWrongUser() throws Exception {
         final URL servletUrl = new URL(url.toExternalForm() + "role1");
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/DigestAuthentication-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/DigestAuthentication-web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <servlet>
+        <servlet-name>SimpleServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.security.common.servlets.SimpleServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>SimpleServlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Role1</web-resource-name>
+            <url-pattern>/role1</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role1</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>DIGEST</auth-method>
+        <realm-name>Secured kingdom</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>Role1</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/FileAuditLogTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/FileAuditLogTestCase.java
@@ -4,6 +4,7 @@
  */
 package org.wildfly.test.integration.elytron.audit;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.jboss.as.test.shared.CliUtils.asAbsolutePath;
@@ -12,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -29,6 +30,7 @@ import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.ServerReload;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.security.common.elytron.FileAuditLog;
@@ -49,105 +51,138 @@ public class FileAuditLogTestCase extends AbstractAuditLogTestCase {
     private static final File AUDIT_LOG_FILE = new File(WORK_DIR, AUDIT_LOG_NAME);
     private static final String ENCODING_16BE = "UTF-16BE";
 
-    /**
-     * Tests whether successful authentication was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_DEFAULT)
-    public void testSuccessfulAuth() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
+    @Before
+    public void before() throws Exception {
         discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, SC_OK);
+    }
 
+    private void runTestSuccessfulAuth() throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, PASSWORD, SC_OK);
         assertTrue("Successful authentication was not logged", loggedSuccessfulAuth(AUDIT_LOG_FILE, USER));
     }
 
-    /**
-     * Tests whether failed authentication with wrong user was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_DEFAULT)
-    public void testFailedAuthWrongUser() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, UNKNOWN_USER, PASSWORD, SC_UNAUTHORIZED);
-
-        assertTrue("Failed authentication with wrong user was not logged", loggedFailedAuth(AUDIT_LOG_FILE, UNKNOWN_USER));
+    private void runTestFailedAuthWrongUser() throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), UNKNOWN_USER, PASSWORD,
+                SC_UNAUTHORIZED);
+        assertTrue("Failed authentication with wrong user was not logged",
+                loggedFailedAuth(AUDIT_LOG_FILE, UNKNOWN_USER));
     }
 
-    /**
-     * Tests whether failed authentication with wrong password was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_DEFAULT)
-    public void testFailedAuthWrongPassword() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, WRONG_PASSWORD, SC_UNAUTHORIZED);
-
+    private void runTestFailedAuthWrongPassword() throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, WRONG_PASSWORD,
+                SC_UNAUTHORIZED);
         assertTrue("Failed authentication with wrong password was not logged", loggedFailedAuth(AUDIT_LOG_FILE, USER));
     }
 
-    /**
-     * Tests whether failed authentication with empty password was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_DEFAULT)
-    public void testFailedAuthEmptyPassword() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, EMPTY_PASSWORD, SC_UNAUTHORIZED);
-
+    private void runTestFailedAuthEmptyPassword() throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, EMPTY_PASSWORD,
+                SC_UNAUTHORIZED);
         assertTrue("Failed authentication with empty password was not logged", loggedFailedAuth(AUDIT_LOG_FILE, USER));
     }
 
-    /**
-     * Tests whether successful permission check was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_DEFAULT)
-    public void testSuccessfulPermissionCheck() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, SC_OK);
-
+    private void runTestSuccessfulPermissionCheck() throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, PASSWORD, SC_OK);
         assertTrue("Successful permission check was not logged", loggedSuccessfulPermissionCheck(AUDIT_LOG_FILE, USER));
     }
 
-    /**
-     * Tests whether failed permission check was logged.
-     */
-    @Test
-    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION)
-    public void testFailedPermissionCheck() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
-
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, SC_UNAUTHORIZED);
-
-        assertTrue("Failed permission check was not logged", loggedFailedPermissionCheck(AUDIT_LOG_FILE, USER));
+    private void runTestFailedPermissionCheck(int expectedStatusCode) throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, PASSWORD,
+                expectedStatusCode);
+        assertTrue("Failed permission check was not logged",
+                loggedFailedPermissionCheck(AUDIT_LOG_FILE, USER));
     }
 
-    /**
-     * Tests audit log file encoding.
-     */
+    private void runTestAuditLogFileEncoding(int expectedStatusCode) throws Exception {
+        Utils.makeCallWithBasicAuthn(new URI(url.toExternalForm() + "role1").toURL(), USER, PASSWORD,
+                expectedStatusCode);
+        assertTrue(
+                loggedAuthResult(AUDIT_LOG_FILE, USER, UNSUCCESSFUL_PERMISSION_CHECK_EVENT, StandardCharsets.UTF_16BE));
+        assertFalse(
+                loggedAuthResult(AUDIT_LOG_FILE, USER, UNSUCCESSFUL_PERMISSION_CHECK_EVENT, StandardCharsets.UTF_8));
+    }
+
     @Test
-    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION)
-    public void testAuditLogFileEncoding() throws Exception {
-        final URL servletUrl = new URL(url.toExternalForm() + "role1");
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
+    public void testSuccessfulAuthBasic() throws Exception {
+        runTestSuccessfulAuth();
+    }
 
-        discardCurrentContents(AUDIT_LOG_FILE);
-        Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, SC_UNAUTHORIZED);
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
+    public void testFailedAuthWrongUserBasic() throws Exception {
+        runTestFailedAuthWrongUser();
+    }
 
-        //Read the logged event using the same encoding "UTF-16BE" as the audit log file setup
-        assertTrue(loggedAuthResult(AUDIT_LOG_FILE, USER, UNSUCCESSFUL_PERMISSION_CHECK_EVENT, StandardCharsets.UTF_16BE));
-        //Read the logged event using different encoding
-        assertFalse(loggedAuthResult(AUDIT_LOG_FILE, USER, UNSUCCESSFUL_PERMISSION_CHECK_EVENT, StandardCharsets.UTF_8));
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
+    public void testFailedAuthWrongPasswordBasic() throws Exception {
+        runTestFailedAuthWrongPassword();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
+    public void testFailedAuthEmptyPasswordBasic() throws Exception {
+        runTestFailedAuthEmptyPassword();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_BASIC)
+    public void testSuccessfulPermissionCheckBasic() throws Exception {
+        runTestSuccessfulPermissionCheck();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
+    public void testFailedPermissionCheckBasic() throws Exception {
+        runTestFailedPermissionCheck(SC_UNAUTHORIZED);
+    }
+
+    @Test
+    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION_BASIC)
+    public void testAuditLogFileEncodingBasic() throws Exception {
+        runTestAuditLogFileEncoding(SC_UNAUTHORIZED);
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_DIGEST)
+    public void testSuccessfulAuthDigest() throws Exception {
+        runTestSuccessfulAuth();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_DIGEST)
+    public void testFailedAuthWrongUserDigest() throws Exception {
+        runTestFailedAuthWrongUser();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_DIGEST)
+    public void testFailedAuthWrongPasswordDigest() throws Exception {
+        runTestFailedAuthWrongPassword();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_DIGEST)
+    public void testFailedAuthEmptyPasswordDigest() throws Exception {
+        runTestFailedAuthEmptyPassword();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_DEFAULT_DIGEST)
+    public void testSuccessfulPermissionCheckDigest() throws Exception {
+        runTestSuccessfulPermissionCheck();
+    }
+
+    @Test
+    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION_DIGEST)
+    public void testFailedPermissionCheckDigest() throws Exception {
+        runTestFailedPermissionCheck(SC_FORBIDDEN);
+    }
+
+    @Test
+    @OperateOnDeployment(SD_WITHOUT_LOGIN_PERMISSION_DIGEST)
+    public void testAuditLogFileEncodingDigest() throws Exception {
+        runTestAuditLogFileEncoding(SC_FORBIDDEN);
     }
 
     /**
@@ -159,9 +194,8 @@ public class FileAuditLogTestCase extends AbstractAuditLogTestCase {
 
         @Override
         public void setup(ManagementClient managementClient, String string) throws Exception {
+            createEmptyDirectory(WORK_DIR);
             try (CLIWrapper cli = new CLIWrapper(true)) {
-                createEmptyDirectory(WORK_DIR);
-
                 auditLog = FileAuditLog.builder().withName(NAME)
                         .withPath(asAbsolutePath(AUDIT_LOG_FILE))
                         .withEncoding(ENCODING_16BE)


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-21571

Few notes:
- `makeCallWithBasicAuthn` seem to also support [Digest](https://github.com/wildfly/wildfly/blob/841fb9b9bba20abbbe6f3cd4fd606357f68eca50/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java#L451), so the method name might be bit misleading - but again I am no expert.

- I noticed that BASIC and DIGEST behave differently for `runTestAuditLogFileEncoding` and `runTestFailedPermissionCheck`, mainly former returns a 401 and latter returns a 403. With that said, the events are properly logged in the `audit.log`.

- I changed some deprecated stuff too: `UndertowDomainMapper`, `new URL`.