### PR TITLE
WFLY-21573 Bump org.jgroups:jgroups from 5.5.2.Final to 5.5.3.Final + Revert "WFLY-21180 Fix failures in variants of *WebFailoverTestCase showing inconsistent topology"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
         <version.org.jboss.ws.spi>5.0.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.10.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>4.0.6</version.org.jctools.jctools-core>
-        <version.org.jgroups>5.5.2.Final</version.org.jgroups>
+        <version.org.jgroups>5.5.3.Final</version.org.jgroups>
         <version.org.jgroups.aws>4.0.0.Final</version.org.jgroups.aws>
         <version.org.jgroups.azure>2.0.2.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>2.0.2.Final</version.org.jgroups.kubernetes>

--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -37,12 +37,6 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch
 
-# TODO Remove workaround - WFLY-21180 Failures in variants of *WebFailoverTestCase showing inconsistent topology
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd:add(interface=private,port=57600)
-/subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
-/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd-bridge)
-
 # Remove UDP stack configuration
 /subsystem=jgroups/stack=udp:remove
 /socket-binding-group=standard-sockets/socket-binding=jgroups-udp:remove

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -39,12 +39,6 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch
 
-# TODO Remove workaround - WFLY-21180 Failures in variants of *WebFailoverTestCase showing inconsistent topology
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd:add(interface=private,port=57600)
-/subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
-/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd-bridge)
-
 # Remove UDP stack configuration
 /subsystem=jgroups/stack=udp:remove
 /socket-binding-group=standard-sockets/socket-binding=jgroups-udp:remove
@@ -93,12 +87,6 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=MFC:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch
-
-# TODO Remove workaround - WFLY-21180 Failures in variants of *WebFailoverTestCase showing inconsistent topology
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd:add(interface=private,port=57600)
-/subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
-/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd-bridge)
 
 # Remove UDP stack configuration
 /subsystem=jgroups/stack=udp:remove

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -39,12 +39,6 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=FRAG4:add
 run-batch
 
-# TODO Remove workaround - WFLY-21180 Failures in variants of *WebFailoverTestCase showing inconsistent topology
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd:add(interface=private,port=57600)
-/subsystem=jgroups/stack=tcp/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private,port=57601)
-/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(add-index=3,socket-binding=jgroups-tcp-fd-bridge)
-
 # Remove UDP stack configuration
 /subsystem=jgroups/stack=udp:remove
 /socket-binding-group=standard-sockets/socket-binding=jgroups-udp:remove


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-21573
https://issues.redhat.com/browse/WFLY-21180
https://issues.redhat.com/browse/WFLY-21236

Adaptation https://github.com/wildfly/wildfly/pull/19725 with a revert, will need more runs to verify this works.