### PR TITLE
[WFLY-14980] Update doc content to include default timeout values

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
@@ -260,7 +260,7 @@ set to "true". For example, from the CLI:
         "no-request-timeout" => undefined,
         "processing-time" => 0L,
         "proxy-address-forwarding" => false,
-        "read-timeout" => undefined,
+        "read-timeout" => 90000,
         "receive-buffer" => undefined,
         "record-request-start-time" => false,
         "redirect-socket" => "https",
@@ -273,7 +273,7 @@ set to "true". For example, from the CLI:
         "tcp-keep-alive" => undefined,
         "url-charset" => "UTF-8",
         "worker" => "default",
-        "write-timeout" => undefined
+        "write-timeout" => 90000
     }
 }
 ----
@@ -307,7 +307,7 @@ configuration:
         "max-post-size" => 10485760L,
         "no-request-timeout" => undefined,
         "proxy-address-forwarding" => false,
-        "read-timeout" => undefined,
+        "read-timeout" => 90000,
         "receive-buffer" => undefined,
         "record-request-start-time" => false,
         "redirect-socket" => "https",
@@ -319,7 +319,7 @@ configuration:
         "tcp-keep-alive" => undefined,
         "url-charset" => "UTF-8",
         "worker" => "default",
-        "write-timeout" => undefined
+        "write-timeout" => 90000
     }
 }
 ----

--- a/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/The_HTTP_management_API.adoc
@@ -174,7 +174,7 @@ http://localhost:9990/management/subsystem/undertow/server/default-server?operat
         "max-parameters" : 1000,
         "max-post-size" : 10485760,
         "proxy-address-forwarding" : false,
-        "read-timeout" : null,
+        "read-timeout" : 90000,
         "receive-buffer" : null,
         "record-request-start-time" : false,
         "redirect-socket" : "https",
@@ -184,7 +184,7 @@ http://localhost:9990/management/subsystem/undertow/server/default-server?operat
         "tcp-keep-alive" : null,
         "url-charset" : "UTF-8",
         "worker" : "default",
-        "write-timeout" : null
+        "write-timeout" : 90000
     }},
     "https-listener" : null
 }
@@ -243,7 +243,7 @@ Date: Fri, 01 Aug 2014 13:25:45 GMT
             "max-parameters" : 1000,
             "max-post-size" : 10485760,
             "proxy-address-forwarding" : false,
-            "read-timeout" : null,
+            "read-timeout" : 90000,
             "receive-buffer" : null,
             "record-request-start-time" : false,
             "redirect-socket" : "https",
@@ -253,7 +253,7 @@ Date: Fri, 01 Aug 2014 13:25:45 GMT
             "tcp-keep-alive" : null,
             "url-charset" : "UTF-8",
             "worker" : "default",
-            "write-timeout" : null
+            "write-timeout" : 90000
         }},
         "https-listener" : null
     }
@@ -303,5 +303,5 @@ String response = managementResource.request(MediaType.APPLICATION_JSON_TYPE)
 System.out.println(response);
 
 
-{"outcome" : "success", "result" : {"default-host" : "default-host", "servlet-container" : "default", "ajp-listener" : null, "host" : {"default-host" : {"alias" : ["localhost"], "default-web-module" : "ROOT.war", "filter-ref" : {"server-header" : {"predicate" : null}, "x-powered-by-header" : {"predicate" : null}}, "location" : {"/" : {"handler" : "welcome-content", "filter-ref" : null}}, "setting" : null}}, "http-listener" : {"default" : {"allow-encoded-slash" : false, "allow-equals-in-cookie-value" : false, "always-set-keep-alive" : true, "buffer-pipelined-data" : true, "buffer-pool" : "default", "certificate-forwarding" : false, "decode-url" : true, "enabled" : true, "max-buffered-request-size" : 16384, "max-cookies" : 200, "max-header-size" : 51200, "max-headers" : 200, "max-parameters" : 1000, "max-post-size" : 10485760, "proxy-address-forwarding" : false, "read-timeout" : null, "receive-buffer" : null, "record-request-start-time" : false, "redirect-socket" : "https", "send-buffer" : null, "socket-binding" : "http", "tcp-backlog" : null, "tcp-keep-alive" : null, "url-charset" : "UTF-8", "worker" : "default", "write-timeout" : null}}, "https-listener" : null}}
+{"outcome" : "success", "result" : {"default-host" : "default-host", "servlet-container" : "default", "ajp-listener" : null, "host" : {"default-host" : {"alias" : ["localhost"], "default-web-module" : "ROOT.war", "filter-ref" : {"server-header" : {"predicate" : null}, "x-powered-by-header" : {"predicate" : null}}, "location" : {"/" : {"handler" : "welcome-content", "filter-ref" : null}}, "setting" : null}}, "http-listener" : {"default" : {"allow-encoded-slash" : false, "allow-equals-in-cookie-value" : false, "always-set-keep-alive" : true, "buffer-pipelined-data" : true, "buffer-pool" : "default", "certificate-forwarding" : false, "decode-url" : true, "enabled" : true, "max-buffered-request-size" : 16384, "max-cookies" : 200, "max-header-size" : 51200, "max-headers" : 200, "max-parameters" : 1000, "max-post-size" : 10485760, "proxy-address-forwarding" : false, "read-timeout" : 90000, "receive-buffer" : null, "record-request-start-time" : false, "redirect-socket" : "https", "send-buffer" : null, "socket-binding" : "http", "tcp-backlog" : null, "tcp-keep-alive" : null, "url-charset" : "UTF-8", "worker" : "default", "write-timeout" : 90000}}, "https-listener" : null}}
 ----

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
@@ -253,7 +253,7 @@ that are behind a load balancer that supports the same protocol.
 
 |read-timeout
 |Configure a read timeout for a socket, in milliseconds.  If the given amount of time elapses without a 
-successful read taking place, the socket's next read will throw a {@link ReadTimeoutException}.
+successful read taking place, the socket's next read will throw a {@link ReadTimeoutException}. Default value is currently set to 90000ms(90s). No timeout require value to be set to -1. NOTE: this value applies to all I/O operations, including WebSockets/SSE.
 
 |receive-buffer
 |The receive buffer size, in bytes.
@@ -300,7 +300,7 @@ is not using HTTPS.
 |write-timeout
 |Configure a write timeout for a socket, in milliseconds.  If the given amount of time 
 elapses without a successful write taking place, the socket's next write will throw
-a {@link WriteTimeoutException}.
+a {@link WriteTimeoutException}. Default value is currently set to 90000ms(90s). No timeout require value to be set to -1. NOTE: this value applies to all I/O operations, including WebSockets/SSE.
 
 |=======================================================================
 


### PR DESCRIPTION
 Issue: https://issues.redhat.com/browse/WFLY-14980
 Related: https://issues.redhat.com/browse/EAP7-1835

This is just a followup to adjust doc content.