### PR TITLE
Workaround for WFLY-21519 StabilityServerSetupSnapshotRestoreTasks.tearDown() fails with ConnectException

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -32,15 +32,14 @@ public class StopCustomContainersOnAfterSuiteExtension implements LoadableExtens
 
     public static class StopCustomContainers {
         public void close(@Observes AfterSuite event, ContainerRegistry registry) {
-            for (Container c: registry.getContainers()) {
-                if (c.getState() == State.STARTED && "custom".equalsIgnoreCase(c.getContainerConfiguration().getMode())) {
+            for (Container<?> container: registry.getContainers()) {
+                if (container.getState() == State.STARTED && "custom".equalsIgnoreCase(container.getContainerConfiguration().getMode())) {
                     try {
-                        log.tracef("Stopping custom container %s", c.getName());
-                        // TODO workaround https://issues.jboss.org/browse/WFARQ-47
-                        c.stop();
-                        log.tracef("Stopped custom container %s", c.getName());
+                        log.tracef("Stopping custom container %s", container.getName());
+                        container.stop();
+                        log.tracef("Stopped custom container %s", container.getName());
                     } catch (LifecycleException e) {
-                        log.errorf("Failed to stop custom container %s: %s", c.getName(), e);
+                        log.errorf("Failed to stop custom container %s: %s", container.getName(), e);
                     }
                 }
             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -164,10 +164,16 @@ public abstract class AbstractClusteringTestCase {
     public void beforeTestMethod() throws Exception {
         this.containerRegistry.getContainers().forEach(container -> {
             if (container.getState() == Container.State.STARTED && !this.containers.contains(container.getName())) {
-                // Even though we should be able to just stop the container object this currently fails with:
-                // WFARQ-47 Calling "container.stop();" always ends exceptionally "Caught exception closing ManagementClient: java.lang.NullPointerException"
-                this.stop(container.getName());
-                log.debugf("Stopped container '%s' which was started but not requested for this test.", container.getName());
+                try {
+                    // Also keep use graceful shutdown here instead of plain "container.stop()"; e.g. for EJB client topology handling
+                    this.stop(container.getName());
+                } catch (Exception ex) {
+                    // TODO Workaround for https://issues.redhat.com/browse/WFLY-21519
+                    // The actual exception is LifecycleException (checked), sneakily rethrown by Arquillian's UncheckedThrow util
+                    // after WildFlyContainerLifecycleController sets the container state to STOPPED_FAILED.
+                    log.errorf(ex, "Failed to stop container %s! This container might be tainted for future tests!", container.getName());
+                }
+                log.infof("Stopped container %s which was started but not requested for this test.", container.getName());
             }
         });
 


### PR DESCRIPTION
Instead of failing the test, catch and log the exception instead warning that the container might be tainted for future tests.

Workaround for https://issues.redhat.com/browse/WFLY-21519