### PR TITLE
WFLY-21506 Revert "Leverage IntermittentFailure#thisTestIsFailingInte…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/ClusteredJPA2LCTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa/ClusteredJPA2LCTestCase.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.ClusterDatabaseTestUtil;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
-import org.jboss.as.test.shared.IntermittentFailure;
 import org.jboss.as.test.shared.ManagementServerSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -67,7 +66,6 @@ public class ClusteredJPA2LCTestCase extends AbstractClusteringTestCase {
     @BeforeAll
     static void beforeClass() throws Exception {
         ClusterDatabaseTestUtil.startH2();
-        IntermittentFailure.thisTestIsFailingIntermittently("https://issues.redhat.com/browse/WFLY-21506");
     }
 
     @AfterAll


### PR DESCRIPTION
…rmittently to suppress frequently failing ClusteredJPA2LCTestCase"

This reverts commit b50036d506bce59475925cfeddff44998e55e2ef.

Jira
https://issues.redhat.com/browse/WFLY-21506?focusedId=29231950&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-29231950