### PR TITLE
WFLY-21586 Upgrade Jackson components to 2.21.x (CVE-2026-29062)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.at.yawk.lz4.lz4-java>1.10.4</version.at.yawk.lz4.lz4-java>
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.20.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.21.1</version.com.fasterxml.jackson>
         <version.com.github.ben-manes.caffeine>3.2.3</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21586