### PR TITLE
WFLY-21592 Legacy Node.getSocketAddress() always returns null

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -57,6 +57,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelConfiguration;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactory;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactoryConfiguration;
 import org.wildfly.clustering.jgroups.spi.JGroupsServiceDescriptor;
+import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.common.function.Functions;
 import org.wildfly.service.Installer.StartWhen;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -258,27 +259,33 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
         ServiceDependency<JChannel> registryKey = ServiceDependency.on(JGroupsServiceDescriptor.CHANNEL, name);
         Consumer<JChannel> connect = new Consumer<>() {
             @Override
-            public void accept(JChannel disconnectedChannel) {
-                TP transport = disconnectedChannel.getProtocolStack().getTransport();
+            public void accept(JChannel channel) {
+                TP transport = channel.getProtocolStack().getTransport();
                 ChannelConfiguration configuration = channelConfiguration.get();
-                JGroupsLogger.ROOT_LOGGER.connecting(name, disconnectedChannel.getName(), configuration.getClusterName(), new InetSocketAddress(transport.getBindAddress(), transport.getBindPort()));
+                JGroupsLogger.ROOT_LOGGER.connecting(name, channel.getName(), configuration.getClusterName(), new InetSocketAddress(transport.getBindAddress(), transport.getBindPort()));
                 try {
-                    registry.add(registryKey).accept(disconnectedChannel.connect(configuration.getClusterName()));
+                    registry.add(registryKey).accept(channel.connect(configuration.getClusterName()));
                 } catch (Exception e) {
-                    disconnectedChannel.close();
+                    channel.close();
                     throw new IllegalStateException(e);
                 }
-                JGroupsLogger.ROOT_LOGGER.connected(name, disconnectedChannel.getName(), configuration.getClusterName(), disconnectedChannel.getView());
+                JGroupsLogger.ROOT_LOGGER.connected(name, channel.getName(), configuration.getClusterName(), channel.getView());
+                if (!(channel instanceof ForkChannel)) {
+                    PhysicalAddressCache.INSTANCE.channelConnected(channel);
+                }
             }
         };
         Consumer<JChannel> disconnect = new Consumer<>() {
             @Override
-            public void accept(JChannel connectedChannel) {
+            public void accept(JChannel channel) {
                 registry.remove(registryKey);
                 ChannelConfiguration configuration = channelConfiguration.get();
-                JGroupsLogger.ROOT_LOGGER.disconnecting(name, connectedChannel.getName(), configuration.getClusterName(), connectedChannel.getView());
-                connectedChannel.disconnect();
-                JGroupsLogger.ROOT_LOGGER.disconnected(name, connectedChannel.getName(), configuration.getClusterName());
+                JGroupsLogger.ROOT_LOGGER.disconnecting(name, channel.getName(), configuration.getClusterName(), channel.getView());
+                channel.disconnect();
+                JGroupsLogger.ROOT_LOGGER.disconnected(name, channel.getName(), configuration.getClusterName());
+                if (!(channel instanceof ForkChannel)) {
+                    PhysicalAddressCache.INSTANCE.channelDisconnected(channel);
+                }
             }
         };
         installers.add(CapabilityServiceInstaller.builder(CHANNEL, factory).blocking()

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/PhysicalAddressCache.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/PhysicalAddressCache.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.clustering.jgroups.spi;
+
+import org.jgroups.Address;
+import org.jgroups.ChannelListener;
+import org.jgroups.JChannel;
+import org.jgroups.PhysicalAddress;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Cache of physical addresses.
+ * @author Paul Ferraro
+ */
+public enum PhysicalAddressCache implements Function<Address, PhysicalAddress>, ChannelListener {
+    INSTANCE;
+
+    private final Map<String, Function<Address, PhysicalAddress>> caches = new ConcurrentHashMap<>();
+
+    @Override
+    public PhysicalAddress apply(Address address) {
+        return this.caches.values().stream().map(cache -> cache.apply(address)).filter(Objects::nonNull).findFirst().orElse(null);
+    }
+
+    @Override
+    public void channelConnected(JChannel channel) {
+        this.caches.put(channel.getClusterName(), channel.getProtocolStack().getTransport()::getPhysicalAddressFromCache);
+    }
+
+    @Override
+    public void channelDisconnected(JChannel channel) {
+        this.caches.remove(channel.getClusterName());
+    }
+}

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyCacheContainerGroupMember.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyCacheContainerGroupMember.java
@@ -6,7 +6,12 @@
 package org.wildfly.extension.clustering.server.group.legacy;
 
 import org.infinispan.remoting.transport.Address;
+import org.jgroups.PhysicalAddress;
+import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.clustering.server.infinispan.CacheContainerGroupMember;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * @author Paul Ferraro
@@ -16,6 +21,17 @@ public interface LegacyCacheContainerGroupMember extends LegacyGroupMember<Addre
 
     @Override
     CacheContainerGroupMember unwrap();
+
+    @Override
+    default InetSocketAddress getSocketAddress() {
+        return Optional.ofNullable(this.unwrap().getId())
+                .map(Address::toExtendedUUID)
+                .map(PhysicalAddressCache.INSTANCE)
+                .map(PhysicalAddress::getSocketAddress)
+                .filter(InetSocketAddress.class::isInstance)
+                .map(InetSocketAddress.class::cast)
+                .orElse(null);
+    }
 
     static LegacyCacheContainerGroupMember wrap(CacheContainerGroupMember member) {
         return () -> member;

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyChannelGroupMember.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyChannelGroupMember.java
@@ -6,7 +6,12 @@
 package org.wildfly.extension.clustering.server.group.legacy;
 
 import org.jgroups.Address;
+import org.jgroups.PhysicalAddress;
+import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.clustering.server.jgroups.ChannelGroupMember;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
 
 /**
  * @author Paul Ferraro
@@ -16,6 +21,15 @@ public interface LegacyChannelGroupMember extends LegacyGroupMember<Address> {
 
     @Override
     ChannelGroupMember unwrap();
+
+    @Override
+    default InetSocketAddress getSocketAddress() {
+        return Optional.ofNullable(PhysicalAddressCache.INSTANCE.apply(this.unwrap().getId()))
+                .map(PhysicalAddress::getSocketAddress)
+                .filter(InetSocketAddress.class::isInstance)
+                .map(InetSocketAddress.class::cast)
+                .orElse(null);
+    }
 
     static LegacyChannelGroupMember wrap(ChannelGroupMember member) {
         return () -> member;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/bean/legacy/LegacyGroupBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/group/bean/legacy/LegacyGroupBean.java
@@ -5,6 +5,8 @@
 
 package org.jboss.as.test.clustering.cluster.group.bean.legacy;
 
+import java.net.InetSocketAddress;
+
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -16,6 +18,7 @@ import jakarta.ejb.Local;
 import jakarta.ejb.Singleton;
 import jakarta.ejb.Startup;
 
+import org.jboss.logging.Logger;
 import org.wildfly.clustering.Registration;
 import org.wildfly.clustering.group.GroupListener;
 import org.wildfly.clustering.group.Membership;
@@ -25,6 +28,7 @@ import org.wildfly.clustering.group.Node;
 @Startup
 @Local(LegacyGroup.class)
 public class LegacyGroupBean implements LegacyGroup, GroupListener {
+    private static final Logger LOGGER = Logger.getLogger(LegacyGroupBean.class);
 
     @Resource(name = "clustering/group")
     private org.wildfly.clustering.group.Group group;
@@ -73,6 +77,8 @@ public class LegacyGroupBean implements LegacyGroup, GroupListener {
 
     @Override
     public Membership getMembership() {
+        // WFLY-21592 Verify that legacy Node.getSocketAddress() does not return null
+        LOGGER.infof("%s membership = %s", this.group.getName(), this.group.getMembership().getMembers().stream().map(Node::getSocketAddress).map(InetSocketAddress::toString).toList());
         return this.group.getMembership();
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-21592