### PR TITLE
WFLY-21000 Make sure FunctionMapperImpl marshaller writing conforms to its buffer allocations.

### DIFF
--- a/clustering/el/expressly/src/main/java/org/wildfly/clustering/el/expressly/lang/FunctionMapperImplMarshaller.java
+++ b/clustering/el/expressly/src/main/java/org/wildfly/clustering/el/expressly/lang/FunctionMapperImplMarshaller.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.glassfish.expressly.lang.FunctionMapperImpl;
 import org.glassfish.expressly.lang.FunctionMapperImpl.Function;
@@ -66,7 +67,8 @@ public class FunctionMapperImplMarshaller implements ProtoStreamMarshaller<Funct
         Map<String, Function> functions = (Map<String, Function>) objects[0];
 
         if (functions != null) {
-            for (Function function : functions.values()) {
+            // Use reproducible ordering, since buffers were allocated based on size(...)
+            for (Function function : new TreeMap<>(functions).values()) {
                 writer.writeObject(FUNCTION_INDEX, function);
             }
         }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21000

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21000](https://issues.redhat.com/browse/WFLY-21000)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)