### PR TITLE
WFLY-21490 Avoid redundant/unsafe per-fork calls to JChannel.addAddressGenerator(...)

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ForkChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ForkChannelFactory.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
 import org.jgroups.JChannel;
+import org.jgroups.stack.AddressGenerator;
 import org.jgroups.stack.Protocol;
 import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
 import org.wildfly.clustering.jgroups.spi.ChannelFactoryConfiguration;
@@ -62,6 +63,13 @@ public class ForkChannelFactory implements org.wildfly.clustering.jgroups.spi.Fo
         @Override
         public JChannel name(String name) {
             // No-op, super implementation logs error
+            return this;
+        }
+
+        @Override
+        public org.jgroups.fork.ForkChannel addAddressGenerator(AddressGenerator generator) {
+            // Default implementation is not thread-safe
+            // Delegating calls to the JChannel does not really make sense
             return this;
         }
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -24,6 +24,7 @@ import org.jgroups.protocols.FORK;
 import org.jgroups.protocols.TP;
 import org.jgroups.stack.Protocol;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
+import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
 import org.wildfly.clustering.jgroups.spi.ChannelFactoryConfiguration;
 import org.wildfly.clustering.jgroups.spi.TLSConfiguration;
@@ -108,6 +109,8 @@ public class JChannelFactory implements ChannelFactory {
         JChannel channel = createChannel(protocols);
 
         channel.setName(this.configuration.getMemberName());
+        // Populate cache of physical addresses
+        channel.addChannelListener(PhysicalAddressCache.INSTANCE);
 
         return channel;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -45,7 +45,6 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jgroups.Address;
 import org.jgroups.JChannel;
-import org.jgroups.fork.ForkChannel;
 import org.jgroups.jmx.JmxConfigurator;
 import org.jgroups.protocols.FORK;
 import org.jgroups.protocols.TP;
@@ -57,6 +56,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelConfiguration;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactory;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactoryConfiguration;
 import org.wildfly.clustering.jgroups.spi.JGroupsServiceDescriptor;
+import org.wildfly.clustering.jgroups.spi.TransportConfiguration;
 import org.wildfly.common.function.Functions;
 import org.wildfly.service.Installer.StartWhen;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -77,6 +77,8 @@ import org.wildfly.subsystem.service.capture.ServiceValueExecutorRegistry;
  * @param <C> the cache configuration type
  */
 public abstract class AbstractChannelResourceDefinitionRegistrar<C extends ChannelConfiguration> implements ChildResourceDefinitionRegistrar, ResourceServiceConfigurator, ResourceOperationRuntimeHandler, UnaryOperator<ResourceDescriptor.Builder> {
+    // Typically contributed by Infinispan subsystem
+    static final AddressFactory ADDRESS_FACTORY = ServiceLoader.load(AddressFactory.class, AddressFactory.class.getClassLoader()).findFirst().orElse(null);
 
     private static final RuntimeCapability<Void> CHANNEL = RuntimeCapability.Builder.of(JGroupsServiceDescriptor.CHANNEL).setAllowMultipleRegistrations(true).build();
     private static final RuntimeCapability<Void> CHANNEL_FACTORY = RuntimeCapability.Builder.of(ForkChannelFactory.SERVICE_DESCRIPTOR).setAllowMultipleRegistrations(true).build();
@@ -235,18 +237,19 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
                     if (JGroupsLogger.ROOT_LOGGER.isTraceEnabled()) {
                         JGroupsLogger.ROOT_LOGGER.tracef("JGroups channel %s created with configuration:%n %s", name, channel.getProtocolStack().printProtocolSpec(true));
                     }
-                    if (!(channel instanceof ForkChannel)) {
-                        ServiceLoader.load(AddressFactory.class, AddressFactory.class.getClassLoader()).findFirst().ifPresent(factory -> channel.addAddressGenerator(new AddressGenerator() {
+                    if (ADDRESS_FACTORY != null) {
+                        TransportConfiguration.Topology topology = configuration.getChannelFactory().getConfiguration().getTransport().getTopology();
+                        channel.addAddressGenerator(new AddressGenerator() {
                             @Override
                             public Address generateAddress(String name) {
-                                return factory.createAddress(name, configuration.getChannelFactory().getConfiguration().getTransport().getTopology());
+                                return ADDRESS_FACTORY.createAddress(name, topology);
                             }
 
                             @Override
                             public Address generateAddress() {
                                 return this.generateAddress(null);
                             }
-                        }));
+                        });
                     }
                     return channel.stats(configuration.isStatisticsEnabled());
                 } catch (Exception e) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractChannelResourceDefinitionRegistrar.java
@@ -57,7 +57,6 @@ import org.wildfly.clustering.jgroups.spi.ChannelConfiguration;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactory;
 import org.wildfly.clustering.jgroups.spi.ForkChannelFactoryConfiguration;
 import org.wildfly.clustering.jgroups.spi.JGroupsServiceDescriptor;
-import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.common.function.Functions;
 import org.wildfly.service.Installer.StartWhen;
 import org.wildfly.subsystem.resource.ChildResourceDefinitionRegistrar;
@@ -270,9 +269,6 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
                     throw new IllegalStateException(e);
                 }
                 JGroupsLogger.ROOT_LOGGER.connected(name, channel.getName(), configuration.getClusterName(), channel.getView());
-                if (!(channel instanceof ForkChannel)) {
-                    PhysicalAddressCache.INSTANCE.channelConnected(channel);
-                }
             }
         };
         Consumer<JChannel> disconnect = new Consumer<>() {
@@ -283,9 +279,6 @@ public abstract class AbstractChannelResourceDefinitionRegistrar<C extends Chann
                 JGroupsLogger.ROOT_LOGGER.disconnecting(name, channel.getName(), configuration.getClusterName(), channel.getView());
                 channel.disconnect();
                 JGroupsLogger.ROOT_LOGGER.disconnected(name, channel.getName(), configuration.getClusterName());
-                if (!(channel instanceof ForkChannel)) {
-                    PhysicalAddressCache.INSTANCE.channelDisconnected(channel);
-                }
             }
         };
         installers.add(CapabilityServiceInstaller.builder(CHANNEL, factory).blocking()

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/PhysicalAddressCache.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/PhysicalAddressCache.java
@@ -4,15 +4,15 @@
  */
 package org.wildfly.clustering.jgroups.spi;
 
-import org.jgroups.Address;
-import org.jgroups.ChannelListener;
-import org.jgroups.JChannel;
-import org.jgroups.PhysicalAddress;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+
+import org.jgroups.Address;
+import org.jgroups.ChannelListener;
+import org.jgroups.JChannel;
+import org.jgroups.PhysicalAddress;
 
 /**
  * Cache of physical addresses.
@@ -20,8 +20,8 @@ import java.util.function.Function;
  */
 public enum PhysicalAddressCache implements Function<Address, PhysicalAddress>, ChannelListener {
     INSTANCE;
-
-    private final Map<String, Function<Address, PhysicalAddress>> caches = new ConcurrentHashMap<>();
+    // Map by local address, rather than cluster name, since JChannel.getClusterName() returns null when disconnected
+    private final Map<Address, Function<Address, PhysicalAddress>> caches = new ConcurrentHashMap<>();
 
     @Override
     public PhysicalAddress apply(Address address) {
@@ -30,11 +30,11 @@ public enum PhysicalAddressCache implements Function<Address, PhysicalAddress>, 
 
     @Override
     public void channelConnected(JChannel channel) {
-        this.caches.put(channel.getClusterName(), channel.getProtocolStack().getTransport()::getPhysicalAddressFromCache);
+        this.caches.put(channel.getAddress(), channel.getProtocolStack().getTransport()::getPhysicalAddressFromCache);
     }
 
     @Override
     public void channelDisconnected(JChannel channel) {
-        this.caches.remove(channel.getClusterName());
+        this.caches.remove(channel.getAddress());
     }
 }

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyCacheContainerGroupMember.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyCacheContainerGroupMember.java
@@ -5,13 +5,13 @@
 
 package org.wildfly.extension.clustering.server.group.legacy;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 import org.infinispan.remoting.transport.Address;
 import org.jgroups.PhysicalAddress;
 import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.clustering.server.infinispan.CacheContainerGroupMember;
-
-import java.net.InetSocketAddress;
-import java.util.Optional;
 
 /**
  * @author Paul Ferraro

--- a/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyChannelGroupMember.java
+++ b/clustering/server/extension/src/main/java/org/wildfly/extension/clustering/server/group/legacy/LegacyChannelGroupMember.java
@@ -5,13 +5,13 @@
 
 package org.wildfly.extension.clustering.server.group.legacy;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 import org.jgroups.Address;
 import org.jgroups.PhysicalAddress;
 import org.wildfly.clustering.jgroups.spi.PhysicalAddressCache;
 import org.wildfly.clustering.server.jgroups.ChannelGroupMember;
-
-import java.net.InetSocketAddress;
-import java.util.Optional;
 
 /**
  * @author Paul Ferraro


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21490

Based on https://github.com/wildfly/wildfly/pull/19752 to avoid conflicts.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21490](https://issues.redhat.com/browse/WFLY-21490)
> * [WFLY-21592](https://issues.redhat.com/browse/WFLY-21592)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)