### PR TITLE
WFLY-21626 Replace use of deprecated wildfly-subsystem APIs in messaging-activemq subsystem

### DIFF
--- a/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/broadcast/BroadcastCommandDispatcherFactoryInstaller.java
+++ b/messaging-activemq/subsystem/src/main/java/org/wildfly/extension/messaging/activemq/broadcast/BroadcastCommandDispatcherFactoryInstaller.java
@@ -33,7 +33,8 @@ public class BroadcastCommandDispatcherFactoryInstaller implements BiConsumer<Op
         // N.B. BroadcastCommandDispatcherFactory implementations are shared across multiple server resources
         if (this.names.add(name)) {
             ServiceDependency<CommandDispatcherFactory<GroupMember>> factory = ServiceDependency.on(ClusteringServiceDescriptor.COMMAND_DISPATCHER_FACTORY, channelName);
-            ServiceInstaller.builder(ConcurrentBroadcastCommandDispatcherFactory::new, factory)
+            ServiceInstaller.BlockingBuilder.of(factory)
+                    .map(ConcurrentBroadcastCommandDispatcherFactory::new)
                     .provides(name)
                     .requires(factory)
                     .build()


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21626

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21626](https://issues.redhat.com/browse/WFLY-21626)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)