### PR TITLE
WFLY-21627 Upgrade SmallRye Fault Tolerance from 6.10.0 to 6.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
         <version.io.smallrye.open-api>4.2.4</version.io.smallrye.open-api>
         <version.io.smallrye.reactive-utils>2.6.0</version.io.smallrye.reactive-utils>
         <version.io.smallrye.smallrye-config>3.15.1</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>6.10.0</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>6.11.0</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>4.3.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>4.3.1</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-mutiny>3.1.1</version.io.smallrye.smallrye-mutiny>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21627

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21627](https://issues.redhat.com/browse/WFLY-21627)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)