### PR TITLE
WFLY-21629 Server entries auto-generated from listener socket bindings should reflect port-offset.

### DIFF
--- a/microprofile/openapi-smallrye/host/src/main/java/org/wildfly/microprofile/openapi/host/HostOpenAPIProviderServiceInstaller.java
+++ b/microprofile/openapi-smallrye/host/src/main/java/org/wildfly/microprofile/openapi/host/HostOpenAPIProviderServiceInstaller.java
@@ -104,7 +104,7 @@ public class HostOpenAPIProviderServiceInstaller implements ResourceServiceInsta
                         }
 
                         for (String virtualHost : virtualHosts) {
-                            Server server = createServer(listener.getProtocol(), virtualHost, binding.getPort());
+                            Server server = createServer(listener.getProtocol(), virtualHost, binding.getAbsolutePort());
                             if (server != null) {
                                 servers.add(server);
                             }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21629


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21629](https://issues.redhat.com/browse/WFLY-21629)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)