### PR TITLE
WFLY-21642 Upgrade wildfly-clustering to 10.0.0.CR4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,7 +583,7 @@
         <version.org.opensaml.opensaml>4.3.2</version.org.opensaml.opensaml>
         <version.org.ow2.asm>9.7.1</version.org.ow2.asm>
         <version.org.reactivestreams>1.0.4</version.org.reactivestreams>
-        <version.org.wildfly.clustering>10.0.0.CR3</version.org.wildfly.clustering>
+        <version.org.wildfly.clustering>10.0.0.CR4</version.org.wildfly.clustering>
         <!--
             Maintain separation between these two frequently updated artifacts to avoid merge conflicts.
         -->


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21642

Fixes a set of TCK failures related to SFSB expiration.

```
[INFO] Running com.sun.ts.tests.ejb30.bb.session.stateful.timeout.annotated.ClientEjblitejspTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 775.7 s -- in com.sun.ts.tests.ejb30.bb.session.stateful.timeout.annotated.ClientEjblitejspTest
[INFO] Running com.sun.ts.tests.ejb30.bb.session.stateful.timeout.descriptor.ClientEjblitejspTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 772.0 s -- in com.sun.ts.tests.ejb30.bb.session.stateful.timeout.descriptor.ClientEjblitejspTest

```

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21642](https://issues.redhat.com/browse/WFLY-21642)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)