### PR TITLE
[WFLY-21644] Bidirectional association management should be disabled if Hibernate Bytecode enhancement is used

### DIFF
--- a/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
+++ b/jpa/hibernate6/src/main/java/org/jboss/as/jpa/hibernate/WildFlyClassTransformer.java
@@ -7,6 +7,7 @@ package org.jboss.as.jpa.hibernate;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
 import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
 
 /**
@@ -19,6 +20,11 @@ public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
 
     public WildFlyClassTransformer() {
         super(new DefaultEnhancementContext() {
+
+            @Override
+            public boolean doBiDirectionalAssociationManagement(UnloadedField field) {
+                return false;
+            }
 
             @Override
             public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {

--- a/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
+++ b/jpa/hibernate7/src/main/java/org/wildfly/persistence/jipijapa/hibernate7/WildFlyClassTransformer.java
@@ -6,6 +6,7 @@ package org.wildfly.persistence.jipijapa.hibernate7;
 
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
 import org.hibernate.jpa.internal.enhance.EnhancingClassTransformerImpl;
 
 /**
@@ -18,6 +19,11 @@ public class WildFlyClassTransformer extends EnhancingClassTransformerImpl {
 
     public WildFlyClassTransformer() {
         super(new DefaultEnhancementContext() {
+
+            @Override
+            public boolean doBiDirectionalAssociationManagement(UnloadedField field) {
+                return false;
+            }
 
             @Override
             public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21644

Disable bytecode enhancement for application entities that have bidirectional associations mapped.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21644](https://issues.redhat.com/browse/WFLY-21644)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)