### PR TITLE
[WFLY-21646] - [GSS] jdr.sh fails to start embedded server when Elytron encrypted expressions is used in system-properties

### DIFF
--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
@@ -29,7 +29,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.cli"/>
         <module name="org.jboss.modules"/>


### PR DESCRIPTION
issue: https://redhat.atlassian.net/browse/WFLY-21646

`jdr.sh` script now works as intended:
```sh
[mskaceli ~/dev/ibm/wildfly] (WFLY-21646) % ./build/target/wildfly-40.0.0.Beta1-SNAPSHOT/bin/jdr.sh
Initializing JBoss Diagnostic Reporter...
Trying to connect to remote+http localhost:9990
Starting embedded server
10:25:26,349 INFO  [org.jboss.modules] (CLI command executor) JBoss Modules version 2.1.6.Final
10:25:26,378 INFO  [org.jboss.msc] (CLI command executor) JBoss MSC version 1.5.6.Final
10:25:26,414 INFO  [org.jboss.as] (MSC service thread 1-4) WFLYSRV0049: WildFly 40.0.0.Beta1-SNAPSHOT (WildFly Core 32.0.0.Beta5) starting
10:25:26,870 WARN  [org.wildfly.extension.elytron] (MSC service thread 1-2) WFLYELY00023: KeyStore file '/Users/mskaceli/dev/ibm/wildfly/build/target/wildfly-40.0.0.Beta1-SNAPSHOT/standalone/configuration/application.keystore' does not exist. Used blank.
10:25:26,872 WARN  [org.wildfly.extension.elytron] (MSC service thread 1-2) WFLYELY01084: KeyStore /Users/mskaceli/dev/ibm/wildfly/build/target/wildfly-40.0.0.Beta1-SNAPSHOT/standalone/configuration/application.keystore not found, it will be auto-generated on first use with a self-signed certificate for host localhost
10:25:26,913 INFO  [org.jboss.as.server] (Controller Boot Thread) WFLYSRV0212: Resuming server
10:25:26,915 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly 40.0.0.Beta1-SNAPSHOT (WildFly Core 32.0.0.Beta5) started in 555ms - Started 52 of 75 services (25 services are lazy, passive or on-demand) - Server configuration file in use: standalone.xml - Minimum feature stability level: community
10:25:30,506 INFO  [org.jboss.as] (MSC service thread 1-5) WFLYSRV0050: WildFly 40.0.0.Beta1-SNAPSHOT (WildFly Core 32.0.0.Beta5) stopped in 4ms
JDR started: Fri Mar 20 10:25:26 CET 2026
JDR ended: Fri Mar 20 10:25:30 CET 2026
JDR location: /Users/mskaceli/dev/ibm/wildfly/build/target/wildfly-40.0.0.Beta1-SNAPSHOT/standalone/tmp/embedded-server/jdr_26-03-20_10-25-26_unknown-host.zip
```

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21646](https://issues.redhat.com/browse/WFLY-21646)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)