### PR TITLE
WFLY-21643 Upgrade SmallRye Fault Tolerance to 7.0.0-RC1 in Preview

### DIFF
--- a/boms/preview-expansion/pom.xml
+++ b/boms/preview-expansion/pom.xml
@@ -30,6 +30,9 @@
 
     <name>WildFly Preview: Dependency Management (Expansion Dependencies)</name>
 
+    <properties>
+        <version.io.smallrye.smallrye-fault-tolerance>7.0.0-RC1</version.io.smallrye.smallrye-fault-tolerance>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -55,6 +58,63 @@
             </dependency>
 
             <!-- Dependencies specific to this bom. Keep sorted -->
+
+            <!-- SmallRye Fault Tolerance -->
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-api</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-apiimpl</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-core</artifactId>
+                <version>${version.io.smallrye.smallrye-fault-tolerance}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>org.wildfly.extras.vertx</groupId>


### PR DESCRIPTION
This is the EE 11 based version of SR FT; with sec manager support removed among other things.

Resolves
https://redhat.atlassian.net/browse/WFLY-21643

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21643](https://issues.redhat.com/browse/WFLY-21643)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)