### PR TITLE
WFLY-21672 Upgrade Elytron Bouncy Castle dependencies to 1.83

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -35,10 +35,7 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
         <security.properties>${project.basedir}/src/test/resources/reenabled_tlsv1.properties</security.properties>
-        <!-- WFLY-16155 temporary pin bouncycastle 1.69 for test only.
-             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests
-             and change to org.bouncycastle:*-jdk18on -->
-        <version.org.bouncycastle>1.69</version.org.bouncycastle>
+        <version.org.bouncycastle>1.83</version.org.bouncycastle>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>
         <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
@@ -305,34 +302,31 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- WFLY-16155 temporary pin bouncycastle 1.69 for test only.
-             Remove pinning with WFLY-15867 upgrading org.xipki.pki tests
-             and change to org.bouncycastle:*-jdk18on -->
         <!-- crl and ocsp -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
+            <artifactId>bcjmail-jdk18on</artifactId>
             <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcutil-jdk15on</artifactId>
+            <artifactId>bcutil-jdk18on</artifactId>
             <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21672

Updated Bouncy Castle dependencies to match Wildfly-Core version.

Jira is not allowing me to create new issue. I will update the title and add in the link to the issue if it is created or when I'm able to create an issue.



____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21672](https://issues.redhat.com/browse/WFLY-21672)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)