### PR TITLE
WFLY-21658 Fix the 'expansion' test suite is not portable

### DIFF
--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.java
@@ -17,10 +17,8 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -32,11 +30,10 @@ public class MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase {
     @ContainerResource
     ManagementClient managementClient;
 
+    // Dummy deployment to trigger @ServerSetup
     @Deployment(testable = false)
-    public static Archive<?> deployment() {
-        // Dummy deployment to trigger @ServerSetup
-        return ShrinkWrap.create(JavaArchive.class, "MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.jar")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    public static Archive<?> createDummyDeployment() {
+        return AssumeTestGroupUtil.emptyJar(MicroProfileHealthSecuredHTTPEndpointEmptyMgmtUsersTestCase.class.getSimpleName());
     }
 
     @Test

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/AbstractReactiveMessagingKafkaWithNativeCompressionFailsOnWindowsAndMacTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/AbstractReactiveMessagingKafkaWithNativeCompressionFailsOnWindowsAndMacTestCase.java
@@ -11,10 +11,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -32,9 +31,10 @@ public abstract class AbstractReactiveMessagingKafkaWithNativeCompressionFailsOn
         this.propertiesFileName = propertiesFileName;
     }
 
-    @Deployment
-    public static Archive<?> getDeployment() {
-        return ShrinkWrap.create(JavaArchive.class, "dummy.jar");
+    // Dummy deployment to trigger @ServerSetup
+    @Deployment(testable = false)
+    public static Archive<?> createDummyDeployment() {
+        return AssumeTestGroupUtil.emptyJar(AbstractReactiveMessagingKafkaWithNativeCompressionFailsOnWindowsAndMacTestCase.class.getSimpleName());
     }
 
     @BeforeClass

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/EmptyClass.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/EmptyClass.java
@@ -1,9 +1,0 @@
-/*
- * Copyright The WildFly Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package org.wildfly.test.integration.microprofile.reactive.messaging.multiple.deployment;
-
-public class EmptyClass {
-}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
@@ -34,12 +34,12 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
@@ -83,12 +83,10 @@ public class MultiDeploymentReactiveMessagingTestCase extends AbstractCliTestBas
         closeCLI();
     }
 
+    // Dummy deployment to trigger @ServerSetup
     @Deployment(testable = false)
-    public static Archive<?> getDeployment() {
-        // Empty deployment to satisfy Arquillian
-        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
-        ja.addClass(EmptyClass.class);
-        return ja;
+    public static Archive<?> createDummyDeployment() {
+        return AssumeTestGroupUtil.emptyJar(MultiDeploymentReactiveMessagingTestCase.class.getSimpleName());
     }
 
     private Path createInVmDeployment() throws Exception {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/MultipleMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/MultipleMetricsTestCase.java
@@ -24,8 +24,7 @@ import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.as.test.shared.logging.LoggingUtil;
 import org.jboss.dmr.ModelNode;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,7 +44,7 @@ public class MultipleMetricsTestCase {
     // Dummy deployment to trigger @ServerSetup
     @Deployment(testable = false)
     public static WebArchive createDummyDeployment() {
-        return ShrinkWrap.create(WebArchive.class, MultipleMetricsTestCase.class.getSimpleName() + ".war").addAsWebResource(new StringAsset(""), "index.html");
+        return AssumeTestGroupUtil.emptyWar(MultipleMetricsTestCase.class.getSimpleName());
     }
 
     private static final ModelNode ADDRESS_ROOT_LOGGER = Operations.createAddress("subsystem", "logging", "root-logger", "ROOT");

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/MultipleMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/MultipleMetricsTestCase.java
@@ -9,11 +9,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.io.IOException;
 import java.nio.file.Files;
 
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.setup.SnapshotServerSetupTask;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.shared.ServerReload;
@@ -21,6 +24,9 @@ import org.jboss.as.test.shared.observability.setuptasks.MicrometerSetupTask;
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetrySetupTask;
 import org.jboss.as.test.shared.logging.LoggingUtil;
 import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +38,15 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@ServerSetup(SnapshotServerSetupTask.class)
 public class MultipleMetricsTestCase {
     private static final String MESSAGE_PREAMBLE = "Additional metrics systems discovered";
+
+    // Dummy deployment to trigger @ServerSetup
+    @Deployment(testable = false)
+    public static WebArchive createDummyDeployment() {
+        return ShrinkWrap.create(WebArchive.class, MultipleMetricsTestCase.class.getSimpleName() + ".war").addAsWebResource(new StringAsset(""), "index.html");
+    }
 
     private static final ModelNode ADDRESS_ROOT_LOGGER = Operations.createAddress("subsystem", "logging", "root-logger", "ROOT");
 
@@ -122,13 +135,6 @@ public class MultipleMetricsTestCase {
         } finally {
             removeLogHandler(loggerName);
         }
-    }
-
-    @Test
-    @InSequence(Integer.MAX_VALUE)
-    public void shutdown() {
-        disableOpenTelemetry();
-        disableMicrometer();
     }
 
     private void assertExpectedCount(String loggerName, int expected) throws Exception {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
@@ -45,6 +45,6 @@ class JaegerContainer extends BaseContainer<JaegerContainer> {
     }
 
     private String getJaegerEndpoint() {
-        return "http://localhost:" + getMappedPort(PORT_JAEGER_QUERY);
+        return String.format("http://%s:%d", getHost(), getMappedPort(PORT_JAEGER_QUERY));
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -84,15 +84,15 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     }
 
     public String getOtlpGrpcEndpoint() {
-        return "http://localhost:" + getMappedPort(OTLP_GRPC_PORT);
+        return String.format("http://%s:%d", getHost(), getMappedPort(OTLP_GRPC_PORT));
     }
 
     public String getOtlpHttpEndpoint() {
-        return "http://localhost:" + getMappedPort(OTLP_HTTP_PORT);
+        return String.format("http://%s:%d", getHost(), getMappedPort(OTLP_HTTP_PORT));
     }
 
     public String getPrometheusUrl() {
-        return "http://localhost:" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
+        return String.format("http://%s:%d/metrics", getHost(), getMappedPort(PROMETHEUS_PORT));
     }
 
     public List<JaegerTrace> getTraces(String serviceName) throws InterruptedException {


### PR DESCRIPTION
Resolves
https://redhat.atlassian.net/browse/WFLY-21658

Proved by https://github.com/wildfly/wildfly/pull/19791 that this is a test ordering issue due to tests not cleaning up.

Developers have turned to me for advice about the ‘expansion’ test suite not working on macOS nor podman.

I discovered a lot of problem with this TS in the latest tests, especially MultipleMetricsTestCase

1. containtainers have hard coded ‘localhost' which makes assumptions about containerization networking which is wrong
2. order of the test is required which is different per OS - works with order of fresh checkout on linux but does not work on others, slipping this to random or reversealphabetical will cause tests to fail
3. tests are NOT cleaning after themselves correctly - this is the core bug.

With these changes tests pass on e.g. macOS and with podman.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21658](https://issues.redhat.com/browse/WFLY-21658)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)