### PR TITLE
[WFLY-19876] Deprecate the jaxrs subsystems resteasy-2-0-request-matching attribute

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsAttribute.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsAttribute.java
@@ -100,6 +100,8 @@ public abstract class JaxrsAttribute {
             new SensitivityClassification(JaxrsExtension.SUBSYSTEM_NAME, "tracing-management", false, false, true)
     );
 
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     public static final SimpleAttributeDefinition JAXRS_2_0_REQUEST_MATCHING = new SimpleAttributeDefinitionBuilder(JaxrsConstants.JAXRS_2_0_REQUEST_MATCHING, ModelType.BOOLEAN)
             .setRequired(false)
             .setAllowExpression(true)
@@ -108,6 +110,7 @@ public abstract class JaxrsAttribute {
             .setAttributeGroup(RESTEASY_PARAMETER_GROUP)
             .setAttributeMarshaller(AttributeMarshallers.SIMPLE_ELEMENT)
             .setAttributeParser(AttributeParsers.SIMPLE_ELEMENT)
+            .setDeprecated(JaxrsExtension.JaxrsSubsystemModel.VERSION_6_0_0.getVersion(), true)
             .setRestartAllServices()
             .build();
 

--- a/jaxrs/src/main/resources/org/jboss/as/jaxrs/LocalDescriptions.properties
+++ b/jaxrs/src/main/resources/org/jboss/as/jaxrs/LocalDescriptions.properties
@@ -36,6 +36,7 @@ jaxrs.deployment.sub-resource-locators.java-method=Java method of the Jakarta RE
 jaxrs.deployment.sub-resource-locators.resource-methods=Annotated methods for the Jakarta RESTful Web Services resource.
 
 jaxrs.jaxrs-2-0-request-matching=In searching for a matching resource method with which to respond to a request, consider only resource methods with the best match for the request path.
+jaxrs.jaxrs-2-0-request-matching.deprecated=This attribute has been deprecated and has no effect. It will be removed in a future release.
 jaxrs.resteasy-add-charset=If a resource method returns a text/* or application/xml* media type without an explicit charset, RESTEasy will add "charset=UTF-8" to the returned Content-Type header. Note that the charset defaults to UTF-8 in this case, independent of the setting of this parameter.
 jaxrs.resteasy-buffer-exception-entity=Upon receiving an exception, the client side buffers any response entity before closing the connection.
 jaxrs.resteasy-disable-html-sanitizer=Normally, a response with media type "text/html" and a status of 400 will be processed so that the characters "/", "<", ">", "&", """ (double quote), and "'" (single quote) are escaped to prevent an XSS attack. Setting this parameter to "true", escaping will not occur.


### PR DESCRIPTION
Issue link: https://redhat.atlassian.net/browse/WFLY-19876

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-19876](https://issues.redhat.com/browse/WFLY-19876)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)