### PR TITLE
WFLY-21667 Replace NAKACK4/UNICAST4 with NAKACK2/UNICAST3 in default protocol stacks

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -7,6 +7,7 @@
 <!-- This file supplies the internal defaults per protocol -->
 <config xmlns="urn:org:jgroups">
     <UDP
+        bundler_type="transfer-queue"
         ip_ttl="2"
         mcast_recv_buf_size="25m"
         mcast_send_buf_size="1m"

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -55,6 +55,9 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
                     </feature>
+                    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                        <param name="socket-binding" value="jgroups-tcp-fd"/>
+                    </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="FD_ALL3"/>
                     </feature>

--- a/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -49,6 +49,9 @@
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="MERGE3"/>
                     </feature>
+                    <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                        <param name="socket-binding" value="jgroups-tcp-fd"/>
+                    </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">
                         <param name="protocol" value="FD_ALL3"/>
                     </feature>

--- a/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
+++ b/ee-feature-pack/galleon-local/src/main/resources/packages/docs.examples.configs/pm/wildfly/tasks.xml
@@ -154,6 +154,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -292,6 +295,9 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
+                        </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
@@ -433,6 +439,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -573,6 +582,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -710,6 +722,9 @@
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
                         </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
+                        </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>
                         </feature>
@@ -846,6 +861,9 @@
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="MERGE3"/>
+                        </feature>
+                        <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                            <param name="socket-binding" value="jgroups-tcp-fd"/>
                         </feature>
                         <feature spec="subsystem.jgroups.stack.protocol">
                             <param name="protocol" value="FD_ALL3"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/domain-jgroups-sockets.xml
@@ -17,6 +17,11 @@
         <param name="port" value="7600"/>
     </feature>
     <feature spec="domain.socket-binding-group.socket-binding">
+        <param name="socket-binding" value="jgroups-tcp-fd"/>
+        <param name="interface" value="private"/>
+        <param name="port" value="57600"/>
+    </feature>
+    <feature spec="domain.socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
         <param name="interface" value="private"/>
         <param name="port" value="55200"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups-sockets.xml
@@ -17,6 +17,11 @@
         <param name="port" value="7600"/>
     </feature>
     <feature spec="socket-binding-group.socket-binding">
+        <param name="socket-binding" value="jgroups-tcp-fd"/>
+        <param name="interface" value="private"/>
+        <param name="port" value="57600"/>
+    </feature>
+    <feature spec="socket-binding-group.socket-binding">
         <param name="socket-binding" value="jgroups-udp"/>
         <param name="interface" value="private"/>
         <param name="port" value="55200"/>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
@@ -22,6 +22,9 @@
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="MERGE3"/>
             </feature>
+            <feature spec="subsystem.jgroups.stack.protocol.FD_SOCK2">
+                <param name="socket-binding" value="jgroups-tcp-fd"/>
+            </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="FD_ALL3"/>
             </feature>

--- a/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/feature_groups/jgroups.xml
@@ -29,13 +29,22 @@
                 <param name="protocol" value="VERIFY_SUSPECT2"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
-                <param name="protocol" value="NAKACK4"/>
+                <param name="protocol" value="pbcast.NAKACK2"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
-                <param name="protocol" value="UNICAST4"/>
+                <param name="protocol" value="UNICAST3"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="pbcast.STABLE"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="pbcast.GMS"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="UFC"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="MFC"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="FRAG4"/>
@@ -66,13 +75,22 @@
                 <param name="protocol" value="VERIFY_SUSPECT2"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
-                <param name="protocol" value="NAKACK4"/>
+                <param name="protocol" value="pbcast.NAKACK2"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
-                <param name="protocol" value="UNICAST4"/>
+                <param name="protocol" value="UNICAST3"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="pbcast.STABLE"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="pbcast.GMS"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="UFC"/>
+            </feature>
+            <feature spec="subsystem.jgroups.stack.protocol">
+                <param name="protocol" value="MFC"/>
             </feature>
             <feature spec="subsystem.jgroups.stack.protocol">
                 <param name="protocol" value="FRAG4"/>

--- a/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
+++ b/testsuite/integration/clustering/clustering-ha-bootable-jar.cli
@@ -19,7 +19,8 @@
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -27,6 +28,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/integration/clustering/clustering-ha.cli
+++ b/testsuite/integration/clustering/clustering-ha.cli
@@ -21,7 +21,8 @@ embed-server --server-config=standalone-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -29,6 +30,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add
@@ -70,7 +72,8 @@ embed-server --server-config=standalone-full-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -78,6 +81,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/integration/clustering/clustering-microprofile-ha.cli
+++ b/testsuite/integration/clustering/clustering-microprofile-ha.cli
@@ -21,7 +21,8 @@ embed-server --server-config=standalone-microprofile-ha.xml
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-2-bridge:add(host=${node1},port=7701)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-3-bridge:add(host=${node2},port=7801)
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=node-4-bridge:add(host=${node3},port=7901)
-/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private,port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-bridge:add(interface=private, port=7601)
+/socket-binding-group=standard-sockets/socket-binding=jgroups-tcp-fd-bridge:add(interface=private, port=57601)
 
 batch
 /subsystem=jgroups/stack=tcp-bridge:add
@@ -29,6 +30,7 @@ batch
 /subsystem=jgroups/stack=tcp-bridge/protocol=RED:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=TCPPING:add(socket-bindings=[node-1-bridge,node-2-bridge,node-3-bridge,node-4-bridge])
 /subsystem=jgroups/stack=tcp-bridge/protocol=MERGE3:add
+/subsystem=jgroups/stack=tcp-bridge/protocol=FD_SOCK2:add(socket-binding=jgroups-tcp-fd-bridge)
 /subsystem=jgroups/stack=tcp-bridge/protocol=FD_ALL3:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=VERIFY_SUSPECT2:add
 /subsystem=jgroups/stack=tcp-bridge/protocol=pbcast.NAKACK2:add

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap740/DomainAdjuster740.java
@@ -57,13 +57,10 @@ public class DomainAdjuster740 extends DomainAdjuster {
 
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {
         // Remove protocols that do not exist in EAP 7.4, but don't bother replacing
-        operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", "udp").append("protocol", "FD_SOCK2")));
         for (String stack : Arrays.asList("tcp", "udp")) {
-            for (String protocol : Arrays.asList("RED", "FD_ALL3", "FRAG4", "VERIFY_SUSPECT2", "NAKACK4", "UNICAST4")) {
+            for (String protocol : Arrays.asList("RED", "FD_SOCK2", "FD_ALL3", "FRAG4", "VERIFY_SUSPECT2")) {
                 operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", protocol)));
             }
-            // Remote GMS too - this requires reliable unicast/multicast
-            operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", "pbcast.GMS")));
         }
     }
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap800/DomainAdjuster800.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap800/DomainAdjuster800.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
-import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
 import org.jboss.dmr.ModelNode;
 
@@ -45,11 +44,7 @@ public class DomainAdjuster800 extends DomainAdjuster {
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {
         // Remove protocols that do not exist in EAP 8.0, but don't bother replacing
         for (String stack : Arrays.asList("tcp", "udp")) {
-            for (String protocol : Arrays.asList("NAKACK4", "UNICAST4")) {
-                operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", protocol)));
-            }
-            // Remote GMS too - this requires reliable unicast/multicast
-            operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", "pbcast.GMS")));
+            // Reverted stack changes
         }
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap810/DomainAdjuster810.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap810/DomainAdjuster810.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
-import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
 import org.jboss.dmr.ModelNode;
 
@@ -43,11 +42,7 @@ public class DomainAdjuster810 extends DomainAdjuster {
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {
         // Remove protocols that do not exist in EAP 8.1, but don't bother replacing
         for (String stack : Arrays.asList("tcp", "udp")) {
-            for (String protocol : Arrays.asList("NAKACK4", "UNICAST4")) {
-                operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", protocol)));
-            }
-            // Remote GMS too - this requires reliable unicast/multicast
-            operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", "pbcast.GMS")));
+            // Reverted stack changes
         }
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/wfly31/DomainAdjusterWFLY31.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/wfly31/DomainAdjusterWFLY31.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
-import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
 import org.jboss.dmr.ModelNode;
 
@@ -36,11 +35,7 @@ public class DomainAdjusterWFLY31 extends DomainAdjuster {
     private static void adjustJGroups(List<ModelNode> operations, PathAddress subsystemAddress) {
         // Remove protocols that do not exist in WFLY31, but don't bother replacing
         for (String stack : Arrays.asList("tcp", "udp")) {
-            for (String protocol : Arrays.asList("NAKACK4", "UNICAST4")) {
-                operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", protocol)));
-            }
-            // Remote GMS too - this requires reliable unicast/multicast
-            operations.add(Util.createRemoveOperation(subsystemAddress.append("stack", stack).append("protocol", "pbcast.GMS")));
+            // Reverted stack changes
         }
     }
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21667

Also revert bundler implementation to previous default.
https://redhat.atlassian.net/browse/WFLY-21671

Also, restores FD_SOCK2 to default TCP-based protocol stack.
https://redhat.atlassian.net/browse/WFLY-21675

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21667](https://issues.redhat.com/browse/WFLY-21667)
> * [WFLY-21671](https://issues.redhat.com/browse/WFLY-21671)
> * [WFLY-21675](https://issues.redhat.com/browse/WFLY-21675)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)