### PR TITLE
[WFLY-21677] Remove use of the deprecated OperationDescriptor class

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceAddHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceAddHandler.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationDescriptor;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
@@ -21,17 +20,12 @@ import org.jboss.dmr.ModelNode;
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
  */
 
-public class RemotingProfileChildResourceAddHandler extends RemotingProfileChildResourceHandlerBase implements OperationDescriptor {
+public class RemotingProfileChildResourceAddHandler extends RemotingProfileChildResourceHandlerBase {
 
     private final Collection<AttributeDefinition> attributes;
 
     protected RemotingProfileChildResourceAddHandler(AttributeDefinition... attributes) {
         this.attributes = Arrays.asList(attributes);
-    }
-
-    @Override
-    public Collection<? extends AttributeDefinition> getAttributes() {
-        return this.attributes;
     }
 
     @Override


### PR DESCRIPTION
No code currently calls its methods

https://redhat.atlassian.net/browse/WFLY-21677


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21677](https://issues.redhat.com/browse/WFLY-21677)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)