### PR TITLE
[WFLY-21678] Remove use of deprecated RestartParentResourceAddHandler…

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/MailServerAdd.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailServerAdd.java
@@ -8,9 +8,6 @@ package org.jboss.as.mail.extension;
 import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
 import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
 
-import java.util.List;
-import java.util.Set;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -24,12 +21,15 @@ import org.jboss.msc.service.ServiceName;
 
 /**
  * @author Tomaz Cerar
- * @created 8.12.11 0:19
  */
 class MailServerAdd extends RestartParentResourceAddHandler {
 
+    // TODO when WFCORE-7545 is done, remove this and rely on auto-population by the superclass
+    private final AttributeDefinition[] attributes;
+
     MailServerAdd(AttributeDefinition[] attributes) {
-        super(MailSubsystemModel.MAIL_SESSION, Set.of(), List.of(attributes));
+        super(MailSubsystemModel.MAIL_SESSION);
+        this.attributes = attributes;
     }
 
     @Override
@@ -38,6 +38,14 @@ class MailServerAdd extends RestartParentResourceAddHandler {
         populateModel(operation, resource.getModel());
         handleCredentialReferenceUpdate(context, resource.getModel());
         recordCapabilitiesAndRequirements(context, operation, resource);
+    }
+
+    // TODO when WFCORE-7545 is done, remove this and rely on auto-population by the superclass
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for (AttributeDefinition def : attributes) {
+            def.validateAndSet(operation, model);
+        }
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/WebsocketsDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/WebsocketsDefinition.java
@@ -10,7 +10,6 @@ import static org.wildfly.extension.undertow.Capabilities.REF_IO_WORKER;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -117,7 +116,7 @@ class WebsocketsDefinition extends PersistentResourceDefinition {
 
     private static class WebsocketsAdd extends RestartParentResourceAddHandler {
         protected WebsocketsAdd() {
-            super(ServletContainerDefinition.PATH_ELEMENT.getKey(), Collections.singleton(WEBSOCKET_CAPABILITY), ATTRIBUTES);
+            super(ServletContainerDefinition.PATH_ELEMENT.getKey());
         }
 
         @Override


### PR DESCRIPTION
… constructor

https://redhat.atlassian.net/browse/WFLY-21678

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21678](https://issues.redhat.com/browse/WFLY-21678)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)