### PR TITLE
[WFLY-21080] Move the jakarta-data subsystem to community stability

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Data.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Jakarta_Data.adoc
@@ -15,7 +15,7 @@ The `jakarta-data` subsystem provides support for the use of Jakarta Data in dep
 
 [WARNING]
 
-The `jakarta-data` subsystem is currently provided at xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability]. This means use of the subsystem requires running xref:WildFly_and_WildFly_Preview.adoc[WildFly Preview] or using the `--stability=preview` parameter when starting standard WildFly.
+The `jakarta-data` subsystem is currently provided at xref:Admin_Guide.adoc#Feature_stability_levels[`community` stability]. This means use of the subsystem is not supported when using the `--stability=default` parameter when starting WildFly.
 
 [[jakarta-data-subsystem-provision]]
 == Provisioning the subsystem

--- a/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
+++ b/docs/src/main/asciidoc/_galleon/Galleon_layers.adoc
@@ -286,7 +286,7 @@ link:#gal.naming[naming] +
 link:#gal.base-server[base-server] +
 
 |[[gal.jakarta-data]]jakarta-data
-|Support for Jakarta Data. (xref:Admin_Guide.adoc#Feature_stability_levels[`preview` stability]) The _link:#gal.jpa[jpa]_ dependency can be excluded and _link:#gal.jpa-distributed[jpa-distributed]_ used instead.
+|Support for Jakarta Data. (xref:Admin_Guide.adoc#Feature_stability_levels[`community` stability]) The _link:#gal.jpa[jpa]_ dependency can be excluded and _link:#gal.jpa-distributed[jpa-distributed]_ used instead.
 |
 link:#gal.jpa[jpa] OR +
 link:#gal.jpa-distributed[jpa-distributed]

--- a/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/JakartaDataExtension.java
+++ b/jakarta-data/src/main/java/org/wildfly/extension/jakarta/data/JakartaDataExtension.java
@@ -47,7 +47,7 @@ import org.wildfly.subsystem.resource.SubsystemResourceDefinitionRegistrar;
 
 
 /**
- * WildFly extension that provides Jakarta MVC support based on Eclipse Krazo.
+ * WildFly extension that provides Jakarta Data support based on Hibernate Data Repositories.
  *
  * @author <a href="mailto:brian.stansberry@redhat.com">Brian Stansberry</a>
  */
@@ -58,7 +58,7 @@ public class JakartaDataExtension extends SubsystemExtension<JakartaDataExtensio
      * The name of our subsystem within the model.
      */
     static final String SUBSYSTEM_NAME = "jakarta-data";
-    private static final Stability FEATURE_STABILITY = Stability.PREVIEW;
+    private static final Stability FEATURE_STABILITY = Stability.COMMUNITY;
 
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
 
@@ -98,10 +98,11 @@ public class JakartaDataExtension extends SubsystemExtension<JakartaDataExtensio
      */
     public enum JakartaDataSubsystemSchema implements PersistentSubsystemSchema<JakartaDataSubsystemSchema> {
 
-        VERSION_1_0_PREVIEW(1, 0, FEATURE_STABILITY),
+        VERSION_1_0_PREVIEW(1, 0, Stability.PREVIEW),
+        VERSION_1_0_COMMUNITY(1, 0, Stability.COMMUNITY),
         ;
 
-        static final JakartaDataSubsystemSchema CURRENT = VERSION_1_0_PREVIEW;
+        static final JakartaDataSubsystemSchema CURRENT = VERSION_1_0_COMMUNITY;
 
         private final VersionedNamespace<IntVersion, JakartaDataSubsystemSchema> namespace;
 

--- a/jakarta-data/src/main/resources/schema/wildfly-jakarta-data_community_1_0.xsd
+++ b/jakarta-data/src/main/resources/schema/wildfly-jakarta-data_community_1_0.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:wildfly:jakarta-data:community:1.0"
+           xmlns="urn:wildfly:jakarta-data:community:1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem" type="subsystem-type"/>
+
+    <xs:complexType name="subsystem-type"/>
+
+</xs:schema>

--- a/jakarta-data/src/test/java/org/wildfly/extension/jakarta/data/JakartaDataSubsystemTestCase.java
+++ b/jakarta-data/src/test/java/org/wildfly/extension/jakarta/data/JakartaDataSubsystemTestCase.java
@@ -13,6 +13,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.subsystem.test.AbstractSubsystemSchemaTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.version.Stability;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -26,13 +27,24 @@ public class JakartaDataSubsystemTestCase extends AbstractSubsystemSchemaTest<Ja
         return EnumSet.allOf(JakartaDataExtension.JakartaDataSubsystemSchema.class);
     }
 
+    private final JakartaDataExtension.JakartaDataSubsystemSchema schema;
+
     public JakartaDataSubsystemTestCase(JakartaDataExtension.JakartaDataSubsystemSchema schema) {
         super(JakartaDataExtension.SUBSYSTEM_NAME, new JakartaDataExtension(), schema, JakartaDataExtension.JakartaDataSubsystemSchema.CURRENT);
+        this.schema = schema;
     }
 
     @Override
     protected org.jboss.as.subsystem.test.AdditionalInitialization createAdditionalInitialization() {
         return new AdditionalInit(getSubsystemSchema());
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        // n.b. for preview:1 schema subsystem test, we automatically promote stability to a community:1 schema since they are now effectively equivalent;
+        // thus for this particular schema we need to ignore comparison of the namespace
+        boolean ignoreNamespace = schema.getStability() == Stability.PREVIEW && schema.getVersion().major() == 1;
+        super.compareXml(configId, original, marshalled, ignoreNamespace);
     }
 
     private static class AdditionalInit extends AdditionalInitialization.ManagementAdditionalInitialization {

--- a/jakarta-data/src/test/resources/org/wildfly/extension/jakarta/data/jakarta-data-community-1.0.xml
+++ b/jakarta-data/src/test/resources/org/wildfly/extension/jakarta/data/jakarta-data-community-1.0.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:wildfly:jakarta-data:preview:1.0"/>
+<subsystem xmlns="urn:wildfly:jakarta-data:community:1.0"/>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21080

Part of https://github.com/wildfly/wildfly-proposals/issues/702
Analysis: https://github.com/wildfly/wildfly-proposals/pull/763

Note that quite a bit of what's mentioned in the analysis is already in main (host-excludes, inclusion in OOTB config for EE 11 installations, tests). What was undone is just the stability bump itself.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21080](https://issues.redhat.com/browse/WFLY-21080)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)