### PR TITLE
[WFLY-21637] Ensure the Jakata Authorization Context-ID is set for ServletContextListeners.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -1175,7 +1175,8 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
             authenticationManager.configure(deploymentInfo);
         }
 
-        deploymentInfo.addOuterHandlerChainWrapper(JACCContextIdHandler.wrapper(jaccContextId));
+        deploymentInfo.addThreadSetupAction(JACCContextIdHandler.threadSetupHandler(jaccContextId));
+        deploymentInfo.addOuterHandlerChainWrapper(JACCContextIdHandler.handlerWrapper(jaccContextId));
         if(mergedMetaData.isUseJBossAuthorization()) {
             UndertowLogger.ROOT_LOGGER.configurationOptionIgnoredWhenUsingElytron("use-jboss-authorization");
         }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/JACCContextIdHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jacc/JACCContextIdHandler.java
@@ -14,6 +14,7 @@ import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.PredicateHandler;
+import io.undertow.servlet.api.ThreadSetupHandler;
 import io.undertow.servlet.predicate.DispatcherTypePredicate;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -24,35 +25,9 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * </p>
  *
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class JACCContextIdHandler implements HttpHandler {
-
-    private final PrivilegedAction<String> setContextIdAction;
-    private final HttpHandler next;
-
-    public JACCContextIdHandler(String contextId, HttpHandler next) {
-        this.setContextIdAction = new SetContextIDAction(contextId);
-        this.next = next;
-    }
-
-    @Override
-    public void handleRequest(final HttpServerExchange exchange) throws Exception {
-        // set Jakarta Authorization contextID and forward the request to the next handler.
-        String previousContextID = null;
-        try {
-            previousContextID = setContextID(setContextIdAction);
-            next.handleRequest(exchange);
-        }
-        finally {
-            // restore the previous Jakarta Authorization contextID.
-            if(WildFlySecurityManager.isChecking()) {
-                setContextID(new SetContextIDAction(previousContextID));
-            } else {
-                PolicyContext.setContextID(previousContextID);
-            }
-        }
-    }
-
+public class JACCContextIdHandler {
     /**
      * <p>
      * A {@link PrivilegedAction} that sets the contextId in the {@link PolicyContext}.
@@ -74,7 +49,7 @@ public class JACCContextIdHandler implements HttpHandler {
         }
     }
 
-    private String setContextID(PrivilegedAction<String> action) {
+    private static String setContextID(PrivilegedAction<String> action) {
         if(WildFlySecurityManager.isChecking()) {
             return WildFlySecurityManager.doUnchecked(action);
         }else {
@@ -82,14 +57,61 @@ public class JACCContextIdHandler implements HttpHandler {
         }
     }
 
-    public static HandlerWrapper wrapper(final String contextId) {
+    public static HandlerWrapper handlerWrapper(final String contextId) {
+        PrivilegedAction<String> setContextIdAction = new SetContextIDAction(contextId);
         return new HandlerWrapper() {
             @Override
-            public HttpHandler wrap(final HttpHandler handler) {
+            public HttpHandler wrap(final HttpHandler next) {
                 //we only run this on REQUEST or ASYNC invocations
-                return new PredicateHandler(Predicates.or(DispatcherTypePredicate.REQUEST, DispatcherTypePredicate.ASYNC), new JACCContextIdHandler(contextId, handler), handler);
+                return new PredicateHandler(Predicates.or(DispatcherTypePredicate.REQUEST, DispatcherTypePredicate.ASYNC), new HttpHandler() {
+
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        // set Jakarta Authorization contextID and forward the request to the next handler.
+                        String previousContextID = null;
+                        try {
+                            previousContextID = setContextID(setContextIdAction);
+                            next.handleRequest(exchange);
+                        }
+                        finally {
+                            // restore the previous Jakarta Authorization contextID.
+                            if(WildFlySecurityManager.isChecking()) {
+                                setContextID(new SetContextIDAction(previousContextID));
+                            } else {
+                                PolicyContext.setContextID(previousContextID);
+                            }
+                        }
+                    }
+
+                }, next);
             }
         };
     }
 
+    public static ThreadSetupHandler threadSetupHandler(final String contextId) {
+        PrivilegedAction<String> setContextIdAction = new SetContextIDAction(contextId);
+        return new ThreadSetupHandler() {
+
+            @Override
+            public <T, C> Action<T, C> create(final Action<T, C> action) {
+                return new Action<T, C>() {
+                    @Override
+                    public T call(HttpServerExchange exchange, C context) throws Exception {
+                        String previousContextID = null;
+                        try {
+                            previousContextID = setContextID(setContextIdAction);
+                            return action.call(exchange, context);
+                        } finally {
+                            if (WildFlySecurityManager.isChecking()) {
+                                setContextID(new SetContextIDAction(previousContextID));
+                            } else {
+                                PolicyContext.setContextID(previousContextID);
+                            }
+                        }
+                    }
+
+                };
+            }
+        };
+    }
 }


### PR DESCRIPTION

https://redhat.atlassian.net/browse/WFLY-21637

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21637](https://issues.redhat.com/browse/WFLY-21637)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)