### PR TITLE
[WFLY-21647] Implict security roles missing from Web App MetaData.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarAnnotationDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarAnnotationDeploymentProcessor.java
@@ -390,19 +390,13 @@ public class WarAnnotationDeploymentProcessor implements DeploymentUnitProcessor
         // @DeclareRoles
         final List<AnnotationInstance> declareRolesAnnotations = index.getAnnotations(declareRoles);
         if (declareRolesAnnotations != null && !declareRolesAnnotations.isEmpty()) {
-            SecurityRolesMetaData securityRoles = metaData.getSecurityRoles();
-            if (securityRoles == null) {
-               securityRoles = new SecurityRolesMetaData();
-               metaData.setSecurityRoles(securityRoles);
-            }
+            SecurityRolesMetaData securityRoles = getSecurityRolesMetaData(metaData);
             for (final AnnotationInstance annotation : declareRolesAnnotations) {
                 if (annotation.value() == null) {
                     throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.invalidDeclareRolesAnnotation(annotation.target()));
                 }
                 for (String role : annotation.value().asStringArray()) {
-                    SecurityRoleMetaData sr = new SecurityRoleMetaData();
-                    sr.setRoleName(role);
-                    securityRoles.add(sr);
+                    addSecurityRole(securityRoles, role);
                 }
             }
         }
@@ -481,8 +475,10 @@ public class WarAnnotationDeploymentProcessor implements DeploymentUnitProcessor
                     }
                     AnnotationValue rolesAllowedValue = httpConstraint.value("rolesAllowed");
                     if (rolesAllowedValue != null) {
+                        SecurityRolesMetaData securityRoles = getSecurityRolesMetaData(metaData);
                         for (String role : rolesAllowedValue.asStringArray()) {
                             rolesAllowed.add(role);
+                            addSecurityRole(securityRoles, role);
                         }
                     }
                 }
@@ -509,8 +505,10 @@ public class WarAnnotationDeploymentProcessor implements DeploymentUnitProcessor
                             AnnotationValue rolesAllowedValue = httpMethodConstraint.value("rolesAllowed");
                             rolesAllowed = new ArrayList<String>();
                             if (rolesAllowedValue != null) {
+                                SecurityRolesMetaData securityRoles = getSecurityRolesMetaData(metaData);
                                 for (String role : rolesAllowedValue.asStringArray()) {
                                     rolesAllowed.add(role);
+                                    addSecurityRole(securityRoles, role);
                                 }
                             }
                             methodConstraint.setRolesAllowed(rolesAllowed);
@@ -601,6 +599,24 @@ public class WarAnnotationDeploymentProcessor implements DeploymentUnitProcessor
                 dg.setIcons(icons);
         }
         return dg;
+    }
+
+    private static SecurityRolesMetaData getSecurityRolesMetaData(WebMetaData metaData) {
+        SecurityRolesMetaData securityRoles = metaData.getSecurityRoles();
+        if (securityRoles == null) {
+            securityRoles = new SecurityRolesMetaData();
+            metaData.setSecurityRoles(securityRoles);
+        }
+        return securityRoles;
+    }
+
+    private static void addSecurityRole(SecurityRolesMetaData securityRoles, String role) {
+        if (role == null || role.isEmpty() || "*".equals(role) || "**".equals(role)) {
+            return;
+        }
+        SecurityRoleMetaData sr = new SecurityRoleMetaData();
+        sr.setRoleName(role);
+        securityRoles.add(sr);
     }
 
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21647

The servlet specification describes @DeclareRoles handling as:

"This annotation is used to define the security roles that comprise the security model of the application. This annotation is specified on a class, and it is used to define roles that could be tested (i.e., by calling isUserInRole) from within the methods of the annotated class. Roles that are implicitly declared as a result of their use in a @RolesAllowed need not be explicitly declared using the @DeclareRoles annotaion."

The handling of implicitly defined roles was missing.




____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21647](https://issues.redhat.com/browse/WFLY-21647)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)