### PR TITLE
WFLY-21695 Dependabot Maven update job times out due to outdated JBoss Nexus registry URL causing redirect overhead

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ registries:
     url: https://repo.maven.apache.org/maven2/
   jboss-public-repository-group:
     type: maven-repository
-    url: https://repository.jboss.org/nexus/content/groups/public/
+    url: https://repository.jboss.org/nexus/repository/public/
 updates:
   - package-ecosystem: "maven"
     directory: "/"

--- a/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Example_subsystem.adoc
@@ -25,7 +25,7 @@ mvn archetype:generate \
     -DarchetypeArtifactId=wildfly-subsystem \
     -DarchetypeGroupId=org.wildfly.archetype \
     -DarchetypeVersion=26.1.0.Final \
-    -DarchetypeRepository=https://repository.jboss.org/nexus/content/groups/public
+    -DarchetypeRepository=https://repository.jboss.org/nexus/repository/public
 ----
 
 Maven will download the archetype and it's dependencies, and ask you
@@ -37,7 +37,7 @@ $ mvn archetype:generate \
     -DarchetypeArtifactId=wildfly-subsystem \
     -DarchetypeGroupId=org.wildfly.archetype \
     -DarchetypeVersion=26.1.0.Final \
-    -DarchetypeRepository=https://repository.jboss.org/nexus/content/groups/public
+    -DarchetypeRepository=https://repository.jboss.org/nexus/repository/public
 [INFO] Scanning for projects...
 [INFO]
 [INFO] ------------------------------------------------------------------------

--- a/docs/src/main/asciidoc/_extras/Developing_Jakarta_Faces_Project_Using_Maven_and_IntelliJ.adoc
+++ b/docs/src/main/asciidoc/_extras/Developing_Jakarta_Faces_Project_Using_Maven_and_IntelliJ.adoc
@@ -146,7 +146,7 @@ We should put AS7's repository into pom.xml:
 <repository>
     <id>jboss-public-repository-group</id>
     <name>JBoss Public Repository Group</name>
-    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+    <url>https://repository.jboss.org/nexus/repository/public/</url>
     <layout>default</layout>
     <releases>
         <enabled>true</enabled>
@@ -166,7 +166,7 @@ And also the plugin repository:
 <pluginRepository>
     <id>jboss-public-repository-group</id>
     <name>JBoss Public Repository Group</name>
-    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+    <url>https://repository.jboss.org/nexus/repository/public/</url>
     <releases>
         <enabled>true</enabled>
     </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
              to non-snapshot public maven repos -->
         <maven.repository.protocol>https</maven.repository.protocol>
         <!-- The full remote maven repo URL; can be overridden via -D for special use cases -->
-        <maven.repository.url>${maven.repository.protocol}://repository.jboss.org/nexus/content/groups/public/</maven.repository.url>
+        <maven.repository.url>${maven.repository.protocol}://repository.jboss.org/nexus/repository/public/</maven.repository.url>
 
         <!-- Surefire args -->
         <surefire.extra.args></surefire.extra.args>


### PR DESCRIPTION
As I continued research into why Dependabot is continuing to fail for us and we are hitting the hard coded timeout, here's another piece in the puzzle: we are still hitting the legacy URL and adding 301 timeouts which for ours ~800 dependencies is significant cost penalty.

https://redhat.atlassian.net/browse/WFLY-21695

Looks like this was missed during migration.

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21695](https://issues.redhat.com/browse/WFLY-21695)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)