### PR TITLE
Ignore flaky SingleConnectionActivationPropertyTestCase and fix the memory leak in the test.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/SingleConnectionActivationPropertyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/SingleConnectionActivationPropertyTestCase.java
@@ -28,6 +28,7 @@ import jakarta.jms.Queue;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import org.awaitility.Awaitility;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -227,10 +228,12 @@ public class SingleConnectionActivationPropertyTestCase extends ContainerResourc
     private int countConnectionsOnQueue() throws Exception {
         ModelNode result = executeOperation(listConsumersOnQueueOperation);
         Set<String> connectionSet = new HashSet<>();
-        JsonArray jsonArray = Json.createReader(new StringReader(result.asString())).readArray();
-        for (int i = 0; i < jsonArray.size(); i++) {
-            JsonObject obj = jsonArray.getJsonObject(i);
-            connectionSet.add(obj.getString("connectionID"));
+        try (JsonReader jsonReader = Json.createReader(new StringReader(result.asString()))) {
+            JsonArray jsonArray = jsonReader.readArray();
+            for (int i = 0; i < jsonArray.size(); i++) {
+                JsonObject obj = jsonArray.getJsonObject(i);
+                connectionSet.add(obj.getString("connectionID"));
+            }
         }
         return connectionSet.size();
     }
@@ -241,10 +244,12 @@ public class SingleConnectionActivationPropertyTestCase extends ContainerResourc
     private int countSessionsOnQueue() throws Exception {
         ModelNode result = executeOperation(listConsumersOnQueueOperation);
         Set<String> sessionSet = new HashSet<>();
-        JsonArray jsonArray = Json.createReader(new StringReader(result.asString())).readArray();
-        for (int i = 0; i < jsonArray.size(); i++) {
-            JsonObject obj = jsonArray.getJsonObject(i);
-            sessionSet.add(obj.getString("sessionID"));
+        try (JsonReader jsonReader = Json.createReader(new StringReader(result.asString()))) {
+            JsonArray jsonArray = jsonReader.readArray();
+            for (int i = 0; i < jsonArray.size(); i++) {
+                JsonObject obj = jsonArray.getJsonObject(i);
+                sessionSet.add(obj.getString("sessionID"));
+            }
         }
         return sessionSet.size();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/SingleConnectionActivationPropertyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/SingleConnectionActivationPropertyTestCase.java
@@ -49,6 +49,7 @@ import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.client.WildFlyInitialContextFactory;
@@ -56,7 +57,8 @@ import org.wildfly.naming.client.WildFlyInitialContextFactory;
 /**
  * Tests for singleConnection activation config property with various configurations.
  */
-@RunAsClient()
+@Ignore("WFLY-21701")
+@RunAsClient
 @RunWith(Arquillian.class)
 @ServerSetup(SingleConnectionActivationPropertyTestCase.MessagingResourcesSetupTask.class)
 public class SingleConnectionActivationPropertyTestCase extends ContainerResourceMgmtTestBase {


### PR DESCRIPTION
Ignores https://redhat.atlassian.net/browse/WFLY-21701