### PR TITLE
WFLY-21575 Upgrade jgroups-kubernetes to 3.0.0.Final

### DIFF
--- a/docs/src/main/asciidoc/_high-availability/jgroups/Kubernetes.adoc
+++ b/docs/src/main/asciidoc/_high-availability/jgroups/Kubernetes.adoc
@@ -27,4 +27,4 @@ run-batch
 
 NOTE: To be able to query the Kubernetes server ensure view permissions are granted on the service account.
 
-For advanced configuration options, please visit protocol's documentation https://github.com/jgroups-extras/jgroups-kubernetes/blob/main/README.adoc[here].
+For advanced configuration options, please visit protocol's documentation https://github.com/jgroups-extras/jgroups-kubernetes/blob/3.0.0.Final/README.adoc[here].

--- a/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/main/module.xml
+++ b/ee-feature-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jgroups/kubernetes/main/module.xml
@@ -16,6 +16,7 @@
 
     <dependencies>
         <module name="java.logging"/>
+        <module name="jakarta.json.api"/>
         <module name="org.jgroups"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@
         <version.org.jgroups>5.5.4.Final</version.org.jgroups>
         <version.org.jgroups.aws>4.0.1.Final</version.org.jgroups.aws>
         <version.org.jgroups.azure>2.0.2.Final</version.org.jgroups.azure>
-        <version.org.jgroups.kubernetes>2.0.2.Final</version.org.jgroups.kubernetes>
+        <version.org.jgroups.kubernetes>3.0.0.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.jvnet.staxex>2.1.0</version.org.jvnet.staxex>
         <version.org.keycloak.keycloak-saml-wildfly-subsystem>18.0.2</version.org.keycloak.keycloak-saml-wildfly-subsystem>


### PR DESCRIPTION
Jira
https://redhat.atlassian.net/browse/WFLY-21575 Upgrade jgroups-kubernetes to 3.0.0.Final
https://redhat.atlassian.net/browse/WFLY-21574 KUBE_PING fails to authenticate and discover after Kubernetes service account token rotation

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21575](https://issues.redhat.com/browse/WFLY-21575)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)