### PR TITLE
[WFLY-21718] Upgrade Hibernate ORM to 7.3.1.Final, Hibernate Search to 8.3.0.Final, Hibernate Models to 1.1.1, ByteBuddy to 1.18.8

### DIFF
--- a/boms/preview-ee/pom.xml
+++ b/boms/preview-ee/pom.xml
@@ -54,8 +54,8 @@
         <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
         <!-- Required for Hibernate Search -->
         <version.org.apache.lucene>9.12.3</version.org.apache.lucene>
-        <version.org.elasticsearch.client.rest-client>9.2.3</version.org.elasticsearch.client.rest-client>
-        <version.org.bytebuddy>1.17.8</version.org.bytebuddy>
+        <version.org.elasticsearch.client.rest-client>9.3.1</version.org.elasticsearch.client.rest-client>
+        <version.org.bytebuddy>1.18.8</version.org.bytebuddy>
         <version.org.glassfish.concurro>3.1.0</version.org.glassfish.concurro>
         <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.glassfish.jakarta.faces>4.1.7</version.org.glassfish.jakarta.faces>
@@ -66,8 +66,8 @@
         <version.org.jboss.weld.weld-api>6.0.Final</version.org.jboss.weld.weld-api>
         <!-- The ORM version is controlled in the root pom because we need to use its value in contexts not controlled by this bom -->
         <version.org.hibernate>${version.org.hibernate.preview}</version.org.hibernate>
-        <version.org.hibernate.models>1.0.1</version.org.hibernate.models>
-        <version.org.hibernate.search>8.2.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.models>1.1.1</version.org.hibernate.models>
+        <version.org.hibernate.search>8.3.0.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>9.1.0.Final</version.org.hibernate.validator>
         <version.org.wildfly.security.jakarta.elytron-ee>4.0.0.Beta4</version.org.wildfly.security.jakarta.elytron-ee>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
         <version.org.hibernate>6.6.46.Final</version.org.hibernate>
         <!-- We need to use this value in configuring maven plugins, so simply overriding version.org.hibernate
              in boms/preview-ee is inadequate. So we'll declare the value here and reference it in boms/preview-ee. -->
-        <version.org.hibernate.preview>7.2.8.Final</version.org.hibernate.preview>
+        <version.org.hibernate.preview>7.3.1.Final</version.org.hibernate.preview>
         <version.org.hibernate.search>7.2.5.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>8.0.3.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.11.Final</version.org.hornetq>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21718

Upgrade WildFly Preview to Hibernate ORM 7.3.1.Final, Hibernate Search to 8.3.0.Final, Hibernate Models to 1.1.1, ByteBuddy to 1.18.8.

Hibernate ORM changes are described via https://github.com/hibernate/hibernate-orm/compare/7.2.8...7.3.1 and https://hibernate.org/orm/documentation/7.3/

Hibernate Search changes are described via https://github.com/hibernate/hibernate-search/compare/8.2.0.Final...8.3.0.Final and https://hibernate.org/search/documentation/

Hibernate Models changes are described via  https://github.com/hibernate/hibernate-models/compare/1.0.1...1.1.1

ByteBuddy changes are described via  https://github.com/raphw/byte-buddy/compare/byte-buddy-1.17.8...byte-buddy-1.18.8

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21718](https://issues.redhat.com/browse/WFLY-21718)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)