### PR TITLE
Fix for WFLY-21725, Upgrade to Galleon 7.0.5.Final and WildFly Galleon plugins 8.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,12 @@
         <version.asciidoctor.plugin>2.2.6</version.asciidoctor.plugin>
         <version.central.publishing.maven.plugin>0.9.0</version.central.publishing.maven.plugin>
         <version.org.jacoco>0.8.14</version.org.jacoco>
-        <version.org.jboss.galleon>7.0.4.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>7.0.5.Final</version.org.jboss.galleon>
         <version.org.owasp.dependency-check>12.2.0</version.org.owasp.dependency-check>
         <version.org.wildfly.bom-builder-plugin>2.0.10.Final</version.org.wildfly.bom-builder-plugin>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.galleon-plugins>8.1.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.1.2.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.glow>2.0.0.Beta1</version.org.wildfly.glow>
         <version.org.wildfly.licenses.plugin>2.4.4.Final</version.org.wildfly.licenses.plugin>
         <version.org.wildfly.plugin>6.0.0.Beta2</version.org.wildfly.plugin>


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFLY-21725


____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21725](https://issues.redhat.com/browse/WFLY-21725)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)