### PR TITLE
[WFLY-21738] [WFLY-20061] Enable OpenAPI for LRA Coordinator

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_LRA.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_LRA.adoc
@@ -107,13 +107,15 @@ $ docker run -p 8080:8080 quay.io/jbosstm/lra-coordinator
 
 == Management model
 
-The `/subsystem=microprofile-lra-coordinator` resource defines two attributes:
-
-* `host` - Represents the name of the Undertow subsystem 'host' resource that the LRA Coordinator is deployed to.
+The `/subsystem=microprofile-lra-coordinator` resource defines the following attributes:
 
 * `server` - Represents the name of the Undertow subsystem 'server' resource that the LRA Coordinator is deployed to.
 
-The `/subsystem=microprofile-lra-participant` resource defines one attribute:
+* `host` - Represents the name of the Undertow subsystem 'host' resource that the LRA Coordinator is deployed to.
+
+When the MicroProfile OpenAPI subsystem (`microprofile-openapi-smallrye`) is present and the `server` and `host` attributes are explicitly configured, the LRA Coordinator automatically registers its REST endpoint model with the OpenAPI subsystem. The coordinator's endpoints then appear in the OpenAPI document served at `/openapi`. No additional configuration is required.
+
+The `/subsystem=microprofile-lra-participant` resource defines the following attributes:
 
 * `lra-coordinator-url` - The configuration of the LRA Coordinator URL required in order for this participant to connect to the coordinator.
 

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-coordinator/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-coordinator/main/module.xml
@@ -36,5 +36,12 @@
     <module name="org.jboss.modules"/>
     <module name="org.jboss.staxmapper"/>
     <module name="org.wildfly.security.manager"/>
+    <module name="org.wildfly.subsystem"/>
+
+    <!-- Optional OpenAPI integration -->
+    <module name="org.wildfly.microprofile.openapi-smallrye.spi" optional="true"/>
+    <module name="org.eclipse.microprofile.openapi.api" optional="true"/>
+    <module name="io.smallrye.openapi" optional="true"/>
+    <module name="io.smallrye.jandex" optional="true"/>
   </dependencies>
 </module>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/lra-participant/main/module.xml
@@ -43,6 +43,7 @@
     <module name="org.jboss.modules"/>
     <module name="org.jboss.staxmapper"/>
     <module name="org.wildfly.security.manager"/>
+    <module name="org.wildfly.subsystem"/>
 
   </dependencies>
 </module>

--- a/microprofile/lra/coordinator/pom.xml
+++ b/microprofile/lra/coordinator/pom.xml
@@ -98,6 +98,28 @@
       <artifactId>jboss-transaction-spi</artifactId>
     </dependency>
 
+    <!-- Optional OpenAPI integration -->
+    <dependency>
+      <groupId>${ee.maven.groupId}</groupId>
+      <artifactId>wildfly-microprofile-openapi-smallrye-spi</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>jandex</artifactId>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-subsystem-test</artifactId>

--- a/microprofile/lra/coordinator/pom.xml
+++ b/microprofile/lra/coordinator/pom.xml
@@ -58,6 +58,10 @@
       <groupId>${ee.maven.groupId}</groupId>
       <artifactId>wildfly-undertow</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-subsystem</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.undertow.ee</groupId>

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
@@ -9,16 +9,19 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ServiceNameFactory;
 import org.jboss.as.server.Services;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.wildfly.extension.microprofile.lra.coordinator._private.MicroProfileLRACoordinatorLogger;
+import org.wildfly.extension.microprofile.lra.coordinator.service.LRACoordinatorOpenAPIService;
 import org.wildfly.extension.microprofile.lra.coordinator.service.LRACoordinatorService;
 import org.wildfly.extension.microprofile.lra.coordinator.service.LRARecoveryService;
 import org.wildfly.extension.undertow.Capabilities;
 import org.wildfly.extension.undertow.Host;
 import org.wildfly.extension.undertow.UndertowService;
+import org.wildfly.microprofile.openapi.OpenAPIModelRegistry;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
@@ -27,6 +30,8 @@ import java.util.function.Supplier;
 import static org.wildfly.extension.microprofile.lra.coordinator.MicroProfileLRACoordinatorSubsystemDefinition.ATTRIBUTES;
 
 class MicroProfileLRACoordinatorAdd extends AbstractBoottimeAddStepHandler {
+
+    private static final String OPENAPI_CAPABILITY_NAME = "org.wildfly.microprofile.openapi";
 
     MicroProfileLRACoordinatorAdd() {
         super(Arrays.asList(ATTRIBUTES));
@@ -38,6 +43,14 @@ class MicroProfileLRACoordinatorAdd extends AbstractBoottimeAddStepHandler {
 
         registerRecoveryService(context);
         registerCoordinatorService(context, model);
+
+        ModelNode serverNode = MicroProfileLRACoordinatorSubsystemDefinition.SERVER.resolveModelAttribute(context, model);
+        ModelNode hostNode = MicroProfileLRACoordinatorSubsystemDefinition.HOST.resolveModelAttribute(context, model);
+        if (serverNode.isDefined() && hostNode.isDefined()
+                && context.hasOptionalCapability(OPENAPI_CAPABILITY_NAME,
+                        MicroProfileLRACoordinatorSubsystemDefinition.LRA_COORDINATOR_CAPABILITY_NAME, null)) {
+            registerOpenAPIService(context, serverNode.asString(), hostNode.asString());
+        }
 
         MicroProfileLRACoordinatorLogger.LOGGER.activatingSubsystem();
     }
@@ -64,6 +77,18 @@ class MicroProfileLRACoordinatorAdd extends AbstractBoottimeAddStepHandler {
 
         builder.setInstance(lraCoordinatorService);
         builder.setInitialMode(ServiceController.Mode.ACTIVE).install();
+    }
+
+    private void registerOpenAPIService(final OperationContext context, final String serverName, final String hostName) {
+        CapabilityServiceBuilder builder = context.getCapabilityServiceTarget().addService();
+
+        Supplier<OpenAPIModelRegistry> registrySupplier = builder.requires(
+            ServiceNameFactory.resolveServiceName(OpenAPIModelRegistry.SERVICE_DESCRIPTOR, serverName, hostName));
+
+        builder.requiresCapability(MicroProfileLRACoordinatorSubsystemDefinition.LRA_COORDINATOR_CAPABILITY_NAME, null);
+
+        builder.setInstance(new LRACoordinatorOpenAPIService(registrySupplier, LRACoordinatorService.CONTEXT_PATH));
+        builder.setInitialMode(ServiceController.Mode.PASSIVE).install();
     }
 
     private void registerRecoveryService(final OperationContext context) {

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorAdd.java
@@ -47,9 +47,16 @@ class MicroProfileLRACoordinatorAdd extends AbstractBoottimeAddStepHandler {
             .addCapability(MicroProfileLRACoordinatorSubsystemDefinition.LRA_COORDINATOR_CAPABILITY);
 
         builder.requiresCapability(Capabilities.CAPABILITY_UNDERTOW, UndertowService.class);
-        String serverModelValue = MicroProfileLRACoordinatorSubsystemDefinition.SERVER.resolveModelAttribute(context, model).asString();
-        String hostModelValue = MicroProfileLRACoordinatorSubsystemDefinition.HOST.resolveModelAttribute(context, model).asString();
-        Supplier<Host> hostSupplier = builder.requiresCapability(Capabilities.CAPABILITY_HOST, Host.class, serverModelValue, hostModelValue);
+
+        ModelNode serverNode = MicroProfileLRACoordinatorSubsystemDefinition.SERVER.resolveModelAttribute(context, model);
+        ModelNode hostNode = MicroProfileLRACoordinatorSubsystemDefinition.HOST.resolveModelAttribute(context, model);
+
+        Supplier<Host> hostSupplier;
+        if (serverNode.isDefined() && hostNode.isDefined()) {
+            hostSupplier = builder.requiresCapability(Capabilities.CAPABILITY_HOST, Host.class, serverNode.asString(), hostNode.asString());
+        } else {
+            hostSupplier = builder.requires(UndertowService.DEFAULT_HOST);
+        }
 
         final LRACoordinatorService lraCoordinatorService = new LRACoordinatorService(hostSupplier);
 

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorSubsystemDefinition.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorSubsystemDefinition.java
@@ -17,9 +17,10 @@ import org.jboss.as.controller.descriptions.ParentResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.wildfly.extension.undertow.Constants;
+import org.wildfly.extension.undertow.Host;
+import org.wildfly.extension.undertow.Server;
+import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.wildfly.extension.microprofile.lra.coordinator.MicroProfileLRACoordinatorExtension.SUBSYSTEM_NAME;
@@ -45,18 +46,16 @@ public class MicroProfileLRACoordinatorSubsystemDefinition extends SimpleResourc
 
     static final SimpleAttributeDefinition SERVER =
         new SimpleAttributeDefinitionBuilder(CommonAttributes.SERVER, ModelType.STRING, true)
-            .setAllowExpression(true)
             .setXmlName(CommonAttributes.SERVER)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode(Constants.DEFAULT_SERVER))
+            .setCapabilityReference(CapabilityReferenceRecorder.builder(LRA_COORDINATOR_CAPABILITY, Server.SERVICE_DESCRIPTOR).build())
             .build();
 
     static final SimpleAttributeDefinition HOST =
         new SimpleAttributeDefinitionBuilder(CommonAttributes.HOST, ModelType.STRING, true)
-            .setAllowExpression(true)
             .setXmlName(CommonAttributes.HOST)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode(Constants.DEFAULT_HOST))
+            .setCapabilityReference(CapabilityReferenceRecorder.builder(LRA_COORDINATOR_CAPABILITY, Host.SERVICE_DESCRIPTOR).withParentAttribute(SERVER).build())
             .build();
 
     static final AttributeDefinition[] ATTRIBUTES = {SERVER, HOST};

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorSubsystemSchema.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/MicroProfileLRACoordinatorSubsystemSchema.java
@@ -11,8 +11,6 @@ import org.jboss.as.controller.SubsystemSchema;
 import org.jboss.as.controller.xml.VersionedNamespace;
 import org.jboss.staxmapper.IntVersion;
 
-import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
-
 /**
  * Enumerates the supported schemas of the MicroProfile LRA coordinator subsystem.
  *
@@ -35,8 +33,10 @@ public enum MicroProfileLRACoordinatorSubsystemSchema implements PersistentSubsy
 
     @Override
     public PersistentResourceXMLDescription getXMLDescription() {
-        return builder(MicroProfileLRACoordinatorSubsystemDefinition.PATH, this.namespace)
-            .addAttributes(MicroProfileLRACoordinatorSubsystemDefinition.ATTRIBUTES)
-            .build();
+        PersistentResourceXMLDescription.Factory factory = PersistentResourceXMLDescription.factory(this);
+        PersistentResourceXMLDescription.Builder builder = factory.builder(MicroProfileLRACoordinatorSubsystemDefinition.PATH);
+        builder.addAttribute(MicroProfileLRACoordinatorSubsystemDefinition.SERVER);
+        builder.addAttribute(MicroProfileLRACoordinatorSubsystemDefinition.HOST);
+        return builder.build();
     }
 }

--- a/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/service/LRACoordinatorOpenAPIService.java
+++ b/microprofile/lra/coordinator/src/main/java/org/wildfly/extension/microprofile/lra/coordinator/service/LRACoordinatorOpenAPIService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.extension.microprofile.lra.coordinator.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.narayana.lra.coordinator.api.Coordinator;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
+import io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.extension.microprofile.lra.coordinator._private.MicroProfileLRACoordinatorLogger;
+import org.wildfly.microprofile.openapi.OpenAPIModelRegistry;
+
+/**
+ * Service that builds an OpenAPI model from the Narayana LRA Coordinator class annotations
+ * and registers it with the OpenAPI model registry.
+ */
+public final class LRACoordinatorOpenAPIService implements Service {
+
+    private final Supplier<OpenAPIModelRegistry> registrySupplier;
+    private final String contextPath;
+
+    private volatile OpenAPIModelRegistry.Registration registration;
+
+    public LRACoordinatorOpenAPIService(Supplier<OpenAPIModelRegistry> registrySupplier, String contextPath) {
+        this.registrySupplier = registrySupplier;
+        this.contextPath = contextPath;
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        try {
+            OpenAPI model = buildOpenAPIModel();
+            String key = contextPath.startsWith("/") ? contextPath.substring(1) : contextPath;
+            this.registration = registrySupplier.get().register(key, model);
+            MicroProfileLRACoordinatorLogger.LOGGER.debug("Registered LRA Coordinator OpenAPI model");
+        } catch (Exception e) {
+            throw new StartException(e);
+        }
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        if (registration != null) {
+            registration.close();
+            registration = null;
+        }
+    }
+
+    private OpenAPI buildOpenAPIModel() throws IOException {
+        ClassLoader classLoader = Coordinator.class.getClassLoader();
+
+        // Build a Jandex index for the Coordinator class
+        Indexer indexer = new Indexer();
+        try (InputStream stream = classLoader.getResourceAsStream(
+                Coordinator.class.getName().replace('.', '/') + ".class")) {
+            if (stream != null) {
+                indexer.index(stream);
+            }
+        }
+        Index index = indexer.complete();
+
+        SmallRyeOpenAPI.Builder builder = SmallRyeOpenAPI.builder()
+                .withApplicationClassLoader(classLoader)
+                .withScannerClassLoader(AnnotationScanner.class.getClassLoader())
+                .withIndex(index);
+
+        // Normalize context path (should not end in "/")
+        String normalizedContextPath = contextPath.endsWith("/")
+                ? contextPath.substring(0, contextPath.length() - 1)
+                : contextPath;
+
+        // Prepend the deployment context path to scanned paths so they match the actual runtime URLs.
+        // The Coordinator class is annotated with @Path("lra-coordinator"), so the scanner produces
+        // paths like /lra-coordinator/start. Since the coordinator is deployed at context path
+        // /lra-coordinator, the actual URL is /lra-coordinator/lra-coordinator/start.
+        if (normalizedContextPath.length() > 1) {// ignore if it is /
+            builder.addFilter(new OASFilter() {
+                @Override
+                public void filterOpenAPI(OpenAPI model) {
+                    Paths paths = model.getPaths();
+                    if (paths != null) {
+                        Map<String, PathItem> items = Map.copyOf(
+                                Optional.ofNullable(paths.getPathItems()).orElse(Map.of()));
+                        for (Map.Entry<String, PathItem> entry : items.entrySet()) {
+                            paths.removePathItem(entry.getKey());
+                            paths.addPathItem(normalizedContextPath + entry.getKey(), entry.getValue());
+                        }
+                    }
+                }
+            });
+        }
+
+        return builder.build().model();
+    }
+}

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>wildfly-undertow</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-subsystem</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.undertow.ee</groupId>
       <artifactId>undertow-servlet</artifactId>
     </dependency>

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/MicroProfileLRAParticipantAdd.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/MicroProfileLRAParticipantAdd.java
@@ -66,9 +66,16 @@ class MicroProfileLRAParticipantAdd extends AbstractBoottimeAddStepHandler {
             .addCapability(MicroProfileLRAParticipantSubsystemDefinition.LRA_PARTICIPANT_CAPABILITY);
 
         builder.requiresCapability(Capabilities.CAPABILITY_UNDERTOW, UndertowService.class);
-        String serverModelValue = MicroProfileLRAParticipantSubsystemDefinition.PROXY_SERVER.resolveModelAttribute(context, model).asString();
-        String hostModelValue = MicroProfileLRAParticipantSubsystemDefinition.PROXY_HOST.resolveModelAttribute(context, model).asString();
-        Supplier<Host> hostSupplier = builder.requiresCapability(Capabilities.CAPABILITY_HOST, Host.class, serverModelValue, hostModelValue);
+
+        ModelNode serverNode = MicroProfileLRAParticipantSubsystemDefinition.PROXY_SERVER.resolveModelAttribute(context, model);
+        ModelNode hostNode = MicroProfileLRAParticipantSubsystemDefinition.PROXY_HOST.resolveModelAttribute(context, model);
+
+        Supplier<Host> hostSupplier;
+        if (serverNode.isDefined() && hostNode.isDefined()) {
+            hostSupplier = builder.requiresCapability(Capabilities.CAPABILITY_HOST, Host.class, serverNode.asString(), hostNode.asString());
+        } else {
+            hostSupplier = builder.requires(UndertowService.DEFAULT_HOST);
+        }
 
         final LRAParticipantService lraParticipantProxyService = new LRAParticipantService(hostSupplier);
 

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/MicroProfileLRAParticipantSubsystemDefinition.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/MicroProfileLRAParticipantSubsystemDefinition.java
@@ -17,7 +17,9 @@ import org.jboss.as.controller.descriptions.SubsystemResourceDescriptionResolver
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.wildfly.extension.undertow.Constants;
+import org.wildfly.extension.undertow.Host;
+import org.wildfly.extension.undertow.Server;
+import org.wildfly.subsystem.resource.capability.CapabilityReferenceRecorder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,18 +53,16 @@ public class MicroProfileLRAParticipantSubsystemDefinition extends PersistentRes
 
     static final SimpleAttributeDefinition PROXY_SERVER =
         new SimpleAttributeDefinitionBuilder(CommonAttributes.PROXY_SERVER, ModelType.STRING, true)
-            .setAllowExpression(true)
             .setXmlName(CommonAttributes.PROXY_SERVER)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode(Constants.DEFAULT_SERVER))
+            .setCapabilityReference(CapabilityReferenceRecorder.builder(LRA_PARTICIPANT_CAPABILITY, Server.SERVICE_DESCRIPTOR).build())
             .build();
 
     static final SimpleAttributeDefinition PROXY_HOST =
         new SimpleAttributeDefinitionBuilder(CommonAttributes.PROXY_HOST, ModelType.STRING, true)
-            .setAllowExpression(true)
             .setXmlName(CommonAttributes.PROXY_HOST)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode(Constants.DEFAULT_HOST))
+            .setCapabilityReference(CapabilityReferenceRecorder.builder(LRA_PARTICIPANT_CAPABILITY, Host.SERVICE_DESCRIPTOR).withParentAttribute(PROXY_SERVER).build())
             .build();
 
     static final AttributeDefinition[] ATTRIBUTES = {LRA_COORDINATOR_URL, PROXY_SERVER, PROXY_HOST};

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/EnableLRAExtensionsSetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/EnableLRAExtensionsSetupTask.java
@@ -31,13 +31,19 @@ public class EnableLRAExtensionsSetupTask extends SnapshotServerSetupTask {
             builder.addStep(Operations.createAddOperation(Operations.createAddress("extension", MODULE_LRA_COORDINATOR)));
         }
         if (!subsystems.contains(SUBSYSTEM_LRA_COORDINATOR)) {
-            builder.addStep(Operations.createAddOperation(Operations.createAddress("subsystem", SUBSYSTEM_LRA_COORDINATOR)));
+            final ModelNode addOp = Operations.createAddOperation(Operations.createAddress("subsystem", SUBSYSTEM_LRA_COORDINATOR));
+            addOp.get("server").set("default-server");
+            addOp.get("host").set("default-host");
+            builder.addStep(addOp);
         }
         if (!extensions.contains(MODULE_LRA_PARTICIPANT)) {
             builder.addStep(Operations.createAddOperation(Operations.createAddress("extension", MODULE_LRA_PARTICIPANT)));
         }
         if (!subsystems.contains(SUBSYSTEM_LRA_PARTICIPANT)) {
-            builder.addStep(Operations.createAddOperation(Operations.createAddress("subsystem", SUBSYSTEM_LRA_PARTICIPANT)));
+            final ModelNode addParticipantOp = Operations.createAddOperation(Operations.createAddress("subsystem", SUBSYSTEM_LRA_PARTICIPANT));
+            addParticipantOp.get("proxy-server").set("default-server");
+            addParticipantOp.get("proxy-host").set("default-host");
+            builder.addStep(addParticipantOp);
         }
         executeOperation(managementClient, builder.build());
     }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/coordinator/EnableLRAOpenAPISetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/coordinator/EnableLRAOpenAPISetupTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.lra.coordinator;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.integration.microprofile.lra.EnableLRAExtensionsSetupTask;
+
+public class EnableLRAOpenAPISetupTask extends EnableLRAExtensionsSetupTask {
+
+    @Override
+    protected void doSetup(final ManagementClient managementClient, final String containerId) throws Exception {
+        super.doSetup(managementClient, containerId);
+
+        // Ensure server and host attributes are set on the coordinator subsystem.
+        // When provisioned via Glow (e.g. bootable jar), the subsystem may already exist
+        // without these attributes, and the OpenAPI service is only registered when both are defined.
+        ModelNode address = Operations.createAddress("subsystem", "microprofile-lra-coordinator");
+        ModelNode result = executeOperation(managementClient, Operations.createReadAttributeOperation(address, "server"));
+        if (!result.isDefined()) {
+            executeOperation(managementClient, Operations.createWriteAttributeOperation(address, "server", "default-server"));
+            executeOperation(managementClient, Operations.createWriteAttributeOperation(address, "host", "default-host"));
+        }
+
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
+    }
+}

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/coordinator/LRACoordinatorOpenAPITestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/lra/coordinator/LRACoordinatorOpenAPITestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.test.integration.microprofile.lra.coordinator;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.openapi.service.EchoResource;
+import org.wildfly.test.integration.microprofile.openapi.service.TestApplication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Validates that the LRA coordinator exposes its OpenAPI model through the /openapi endpoint
+ * when both the LRA coordinator and OpenAPI subsystems are enabled.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(EnableLRAOpenAPISetupTask.class)
+public class LRACoordinatorOpenAPITestCase {
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "lra-openapi-test.war")
+                .addClasses(TestApplication.class, EchoResource.class)
+                .add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml").addAsManifestResource(
+                        new StringAsset("mp.openapi.extensions.path=/openapi"), "microprofile-config.properties");
+    }
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Test
+    public void testLRACoordinatorOpenAPI() throws IOException, URISyntaxException, InterruptedException {
+        // The LRA coordinator OpenAPI service starts in PASSIVE mode, so it may not have
+        // registered its model by the time the deployment completes. Poll until the paths appear.
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        List<String> pathList = null;
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            while (System.currentTimeMillis() < deadline) {
+                try (CloseableHttpResponse response = client.execute(
+                        new HttpGet(baseURL.toURI().resolve("/openapi?format=JSON")))) {
+                    Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+
+                    JsonNode root = new ObjectMapper().reader().readTree(response.getEntity().getContent());
+                    JsonNode paths = root.get("paths");
+                    if (paths != null) {
+                        pathList = new ArrayList<>();
+                        Iterator<String> pathNames = paths.fieldNames();
+                        while (pathNames.hasNext()) {
+                            pathList.add(pathNames.next());
+                        }
+                        if (pathList.stream().anyMatch(p -> p.startsWith("/lra-coordinator/"))) {
+                            break;
+                        }
+                    }
+                }
+                Thread.sleep(200);
+            }
+        }
+
+        Assert.assertNotNull("OpenAPI document should contain paths", pathList);
+
+        Assert.assertTrue(
+                "OpenAPI document should contain LRA coordinator paths (starting with /lra-coordinator/), but got: " + pathList,
+                pathList.stream().anyMatch(p -> p.startsWith("/lra-coordinator/")));
+
+        Assert.assertTrue(
+                "OpenAPI should contain LRA start endpoint (/lra-coordinator/lra-coordinator/start), but got: " + pathList,
+                pathList.contains("/lra-coordinator/lra-coordinator/start"));
+
+        Assert.assertTrue(
+                "OpenAPI should also contain the deployed application's echo endpoint, but got: " + pathList,
+                pathList.stream().anyMatch(p -> p.contains("/echo/")));
+    }
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-20061
https://redhat.atlassian.net/browse/WFLY-21738

Deployed services can be scanned by openapi but the  LRA coordinator is embedded in WildFly and so the OpenApi scan does not include it.
To enable the OpenApi for it I register a new service called 'LRACoordinatorOpenAPIService' to build the OpenApi model for the LRA coordinator and add it to the OpenAPIModelRegistry