### PR TITLE
[WFLY-21747] Wait up to 60 secs for server launch; CI envs can be slow

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
@@ -92,7 +92,7 @@ public abstract class LegacyConfigTest {
     }
 
     private void awaitServerLaunch(ModelControllerClient client, String profile) throws InterruptedException {
-        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(60_000);
         ModelNode op = Util.getReadAttributeOperation(TEST_SERVER, "server-state");
         do {
             try {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21747

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21747](https://issues.redhat.com/browse/WFLY-21747)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)