### PR TITLE
[WFLY-21748] Upgrade ByteBuddy to 1.17.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <version.org.apache.wss4j>3.0.5</version.org.apache.wss4j>
         <version.org.apache.ws.xmlschema>2.3.2</version.org.apache.ws.xmlschema>
         <version.org.bitbucket.jose4j>0.9.6</version.org.bitbucket.jose4j>
-        <version.org.bytebuddy>1.17.5</version.org.bytebuddy>
+        <version.org.bytebuddy>1.17.8</version.org.bytebuddy>
         <version.org.codehaus.woodstox.stax2-api>4.2.2</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>7.0.0</version.org.codehaus.woodstox.woodstox-core>
         <version.org.cryptacular>1.2.5</version.org.cryptacular>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFLY-21748

Needed for SE 26 support

____

> [!WARNING]
This **section** is automatically managed by the **WildFly Bot**. Manual modifications will be **overwritten**.

> Additional WildFly Issue Links Found:
> * [WFLY-21748](https://issues.redhat.com/browse/WFLY-21748)


More information about the [wildfly-bot[bot]](https://github.com/wildfly/wildfly-github-bot)